### PR TITLE
Refactor packet sent callbacks

### DIFF
--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -64,13 +64,6 @@ void NEIGHBOR_STATE_CHANGED(uip_ds6_nbr_t *n);
 #define NEIGHBOR_STATE_CHANGED(n)
 #endif /* UIP_DS6_CONF_NEIGHBOR_STATE_CHANGED */
 
-#ifdef UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK
-#define LINK_NEIGHBOR_CALLBACK(addr, status, numtx) UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK(addr, status, numtx)
-void LINK_NEIGHBOR_CALLBACK(const linkaddr_t *addr, int status, int numtx);
-#else
-#define LINK_NEIGHBOR_CALLBACK(addr, status, numtx)
-#endif /* UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK */
-
 NBR_TABLE_GLOBAL(uip_ds6_nbr_t, ds6_neighbors);
 
 /*---------------------------------------------------------------------------*/
@@ -205,19 +198,14 @@ uip_ds6_nbr_lladdr_from_ipaddr(const uip_ipaddr_t *ipaddr)
 }
 /*---------------------------------------------------------------------------*/
 void
-uip_ds6_link_neighbor_callback(int status, int numtx)
+uip_ds6_link_callback(int status, int numtx)
 {
+#if UIP_DS6_LL_NUD
   const linkaddr_t *dest = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
   if(linkaddr_cmp(dest, &linkaddr_null)) {
     return;
   }
 
-  /* Update neighbor link statistics */
-  link_stats_packet_sent(dest, status, numtx);
-  /* Call upper-layer callback (e.g. RPL) */
-  LINK_NEIGHBOR_CALLBACK(dest, status, numtx);
-
-#if UIP_DS6_LL_NUD
   /* From RFC4861, page 72, last paragraph of section 7.3.3:
    *
    *         "In some cases, link-specific information may indicate that a path to
@@ -245,7 +233,6 @@ uip_ds6_link_neighbor_callback(int status, int numtx)
     }
   }
 #endif /* UIP_DS6_LL_NUD */
-
 }
 #if UIP_ND6_SEND_NS
 /*---------------------------------------------------------------------------*/

--- a/core/net/ipv6/uip-ds6-nbr.h
+++ b/core/net/ipv6/uip-ds6-nbr.h
@@ -94,7 +94,7 @@ uip_ds6_nbr_t *uip_ds6_nbr_lookup(const uip_ipaddr_t *ipaddr);
 uip_ds6_nbr_t *uip_ds6_nbr_ll_lookup(const uip_lladdr_t *lladdr);
 uip_ipaddr_t *uip_ds6_nbr_ipaddr_from_lladdr(const uip_lladdr_t *lladdr);
 const uip_lladdr_t *uip_ds6_nbr_lladdr_from_ipaddr(const uip_ipaddr_t *ipaddr);
-void uip_ds6_link_neighbor_callback(int status, int numtx);
+void uip_ds6_link_callback(int status, int numtx);
 void uip_ds6_neighbor_periodic(void);
 int uip_ds6_nbr_num(void);
 

--- a/core/net/ipv6/uip-ds6.h
+++ b/core/net/ipv6/uip-ds6.h
@@ -233,13 +233,6 @@ typedef struct uip_ds6_maddr {
 #endif /* UIP_CONF_DS6_NEIGHBOR_STATE_CHANGED */
 #endif /* UIP_CONF_IPV6_RPL */
 
-#if UIP_CONF_IPV6_RPL
-#ifndef UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK
-#define UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK rpl_link_neighbor_callback
-#endif /* UIP_CONF_DS6_NEIGHBOR_STATE_CHANGED */
-#endif /* UIP_CONF_IPV6_RPL */
-
-
 /** \brief  Interface structure (contains all the interface variables) */
 typedef struct uip_ds6_netif {
   uint32_t link_mtu;

--- a/core/net/mac/tsch/tsch-rpl.c
+++ b/core/net/mac/tsch/tsch-rpl.c
@@ -48,6 +48,7 @@
 #include "net/mac/tsch/tsch-private.h"
 #include "net/mac/tsch/tsch-schedule.h"
 #include "net/mac/tsch/tsch-log.h"
+#include "net/mac/tsch/tsch-rpl.h"
 #include "tsch-rpl.h"
 
 /* Log configuration */
@@ -55,6 +56,13 @@
 #define LOG_MODULE "TSCH RPL"
 #define LOG_LEVEL MAC_LOG_LEVEL
 
+/*---------------------------------------------------------------------------*/
+/* To use, set #define TSCH_CALLBACK_KA_SENT tsch_rpl_callback_ka_sent */
+void
+tsch_rpl_callback_ka_sent(int status, int transmissions)
+{
+  rpl_link_callback(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), status, transmissions);
+}
 /*---------------------------------------------------------------------------*/
 /* To use, set #define TSCH_CALLBACK_JOINING_NETWORK tsch_rpl_callback_joining_network */
 void

--- a/core/net/mac/tsch/tsch-rpl.h
+++ b/core/net/mac/tsch/tsch-rpl.h
@@ -43,6 +43,9 @@
 
 /********** Functions *********/
 
+/* Keep-alives packet sent callback.
+ * To use, set #define TSCH_CALLBACK_KA_SENT tsch_rpl_callback_ka_sent */
+void tsch_rpl_callback_ka_sent(int status, int transmissions);
 /* To use, set #define TSCH_CALLBACK_JOINING_NETWORK tsch_rpl_callback_joining_network */
 void tsch_rpl_callback_joining_network(void);
 /* Upon leaving a TSCH network, perform a local repair

--- a/core/net/rpl-lite/rpl.c
+++ b/core/net/rpl-lite/rpl.c
@@ -86,7 +86,7 @@ rpl_get_global_address(void)
 }
 /*---------------------------------------------------------------------------*/
 void
-rpl_link_neighbor_callback(const linkaddr_t *addr, int status, int numtx)
+rpl_link_callback(const linkaddr_t *addr, int status, int numtx)
 {
   if(curr_instance.used == 1 ) {
     rpl_nbr_t *nbr = rpl_neighbor_get_from_lladdr((uip_lladdr_t *)addr);

--- a/core/net/rpl-lite/rpl.h
+++ b/core/net/rpl-lite/rpl.h
@@ -68,6 +68,15 @@ extern uip_ipaddr_t rpl_multicast_addr;
 /********** Public functions **********/
 
 /**
+ * Called by lower layers after every packet transmission
+ *
+ * \param addr The link-layer addrress of the packet destination
+ * \param status The transmission status (see core/net/mac/mac.h)
+ * \param numtx The total number of transmission attempts
+ */
+void rpl_link_callback(const linkaddr_t *addr, int status, int numtx);
+
+/**
  * Set prefix from an prefix data structure (from DIO)
  *
  * \param prefix The prefix

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -250,7 +250,7 @@ rpl_add_route(rpl_dag_t *dag, uip_ipaddr_t *prefix, int prefix_len,
 }
 /*---------------------------------------------------------------------------*/
 void
-rpl_link_neighbor_callback(const linkaddr_t *addr, int status, int numtx)
+rpl_link_callback(const linkaddr_t *addr, int status, int numtx)
 {
   uip_ipaddr_t ipaddr;
   rpl_parent_t *parent;
@@ -265,7 +265,7 @@ rpl_link_neighbor_callback(const linkaddr_t *addr, int status, int numtx)
       parent = rpl_find_parent_any_dag(instance, &ipaddr);
       if(parent != NULL) {
         /* Trigger DAG rank recalculation. */
-        PRINTF("RPL: rpl_link_neighbor_callback triggering update\n");
+        PRINTF("RPL: rpl_link_callback triggering update\n");
         parent->flags |= RPL_PARENT_FLAG_UPDATED;
       }
     }

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -292,7 +292,7 @@ uip_ds6_nbr_t *rpl_get_nbr(rpl_parent_t *parent);
 void rpl_print_neighbor_list(void);
 int rpl_ext_header_srh_update(void);
 int rpl_ext_header_srh_get_next_hop(uip_ipaddr_t *ipaddr);
-
+void rpl_link_callback(const linkaddr_t *addr, int status, int numtx);
 /* Per-parent RPL information */
 NBR_TABLE_DECLARE(rpl_parents);
 

--- a/examples/ipv6/rpl-tsch/project-conf.h
+++ b/examples/ipv6/rpl-tsch/project-conf.h
@@ -69,6 +69,7 @@
 /* TSCH and RPL callbacks */
 #define RPL_CALLBACK_PARENT_SWITCH tsch_rpl_callback_parent_switch
 #define RPL_CALLBACK_NEW_DIO_INTERVAL tsch_rpl_callback_new_dio_interval
+#define TSCH_CALLBACK_KA_SENT tsch_rpl_callback_ka_sent
 #define TSCH_CALLBACK_JOINING_NETWORK tsch_rpl_callback_joining_network
 #define TSCH_CALLBACK_LEAVING_NETWORK tsch_rpl_callback_leaving_network
 

--- a/examples/platform-specific/jn516x/rpl/common-conf.h
+++ b/examples/platform-specific/jn516x/rpl/common-conf.h
@@ -65,6 +65,7 @@
 /* TSCH and RPL callbacks */
 #define RPL_CALLBACK_PARENT_SWITCH tsch_rpl_callback_parent_switch
 #define RPL_CALLBACK_NEW_DIO_INTERVAL tsch_rpl_callback_new_dio_interval
+#define TSCH_CALLBACK_KA_SENT tsch_rpl_callback_ka_sent
 #define TSCH_CALLBACK_JOINING_NETWORK tsch_rpl_callback_joining_network
 #define TSCH_CALLBACK_LEAVING_NETWORK tsch_rpl_callback_leaving_network
 

--- a/tools/sky/uip6-bridge/fakeuip.c
+++ b/tools/sky/uip6-bridge/fakeuip.c
@@ -130,7 +130,7 @@ uip_icmp6chksum(void)
 
 /*---------------------------------------------------------------------------*/
 void
-uip_ds6_link_neighbor_callback(int status, int numtx)
+uip_ds6_link_callback(int status, int numtx)
 {
 
 }


### PR DESCRIPTION
Streamlined handling of packet send callbacks across TSCH, RPL, 6LoWPAN and DS6. Most of the work is now done in the `packet_sent` function of `sicslowpan.c`.