### PR TITLE
More gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 *.ihex
 *.pyc
 *~
-.DS_Store
 obj_*
 Makefile.target
 doc/html
@@ -70,13 +69,6 @@ summary
 *.faillog
 tests/[0-9][0-9]-*/report
 tests/[0-9][0-9]-*/org/
-
-# cscope files
-cscope.*
-
-# vim swap files
-*.swp
-*.swo
 
 # x86 UEFI files
 cpu/x86/uefi/Makefile.uefi


### PR DESCRIPTION
Just removing some more unnecessary entries from gitignore.

Please note that I am also removing some OS- / editor-specific lines. Users should really be adding those to their local .git/info/exclude. We should only ignore tokens that we are generating ourselves.