### PR TITLE
Make logging module/level prefix optional

### DIFF
--- a/os/sys/log-conf.h
+++ b/os/sys/log-conf.h
@@ -60,6 +60,13 @@
 #define LOG_WITH_LOC 0
 #endif /* LOG_CONF_WITH_LOC */
 
+/* Prefix all logs with Module name and logging level */
+#ifdef LOG_CONF_WITH_MODULE_PREFIX
+#define LOG_WITH_MODULE_PREFIX LOG_CONF_WITH_MODULE_PREFIX
+#else /* LOG_CONF_WITH_MODULE_PREFIX */
+#define LOG_WITH_MODULE_PREFIX 1
+#endif /* LOG_CONF_WITH_MODULE_PREFIX */
+
 /* Cooja annotations */
 #ifdef LOG_CONF_WITH_ANNOTATE
 #define LOG_WITH_ANNOTATE LOG_CONF_WITH_ANNOTATE

--- a/os/sys/log.h
+++ b/os/sys/log.h
@@ -98,7 +98,9 @@ extern struct log_module all_modules[];
 #define LOG(newline, level, levelstr, ...) do {  \
                             if(level <= (LOG_LEVEL)) { \
                               if(newline) { \
-                                LOG_OUTPUT("[%-4s: %-10s] ", levelstr, LOG_MODULE); \
+                                if(LOG_WITH_MODULE_PREFIX) { \
+                                  LOG_OUTPUT("[%-4s: %-10s] ", levelstr, LOG_MODULE); \
+                                } \
                                 if(LOG_WITH_LOC) { \
                                   LOG_OUTPUT("[%s: %d] ", __FILE__, __LINE__); \
                                 } \


### PR DESCRIPTION
This extends the logging module with a configuration option that allows us to suppress `[LEVEL: Module    ]`. Default: Module/level prefix printed (current behaviour)