### PR TITLE
Change the base URL for CCxxware submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,10 +3,10 @@
 	url = https://github.com/JelmerT/cc2538-bsl.git
 [submodule "arch/cpu/cc26xx-cc13xx/lib/cc26xxware"]
 	path = arch/cpu/cc26xx-cc13xx/lib/cc26xxware
-	url = https://github.com/contiki-os/cc26xxware.git
+	url = https://github.com/contiki-ng/cc26xxware.git
 [submodule "arch/cpu/cc26xx-cc13xx/lib/cc13xxware"]
 	path = arch/cpu/cc26xx-cc13xx/lib/cc13xxware
-	url = https://github.com/contiki-os/cc13xxware.git
+	url = https://github.com/contiki-ng/cc13xxware.git
 [submodule "tools/sensniff"]
 	path = tools/sensniff
 	url = https://github.com/g-oikonomou/sensniff.git


### PR DESCRIPTION
This PR changes the URL of the CC26xxware and CC13xware submodules. Both submodules now exist as repos under /contiki-ng, so we just change the submodule to point to that location.