### PR TITLE
 Move target identification code to separate Makefile

### DIFF
--- a/Makefile.identify-target
+++ b/Makefile.identify-target
@@ -1,0 +1,9 @@
+ifeq ($(TARGET),)
+  -include Makefile.target
+  ifeq ($(TARGET),)
+    ${info TARGET not defined, using target 'native'}
+    TARGET=native
+  else
+    ${info using saved target '$(TARGET)'}
+  endif
+endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -8,15 +8,7 @@ endif
 # Setting this option is also important for tests on Cooja motes to check for warnings.
 WERROR ?= 1
 
-ifeq ($(TARGET),)
-  -include Makefile.target
-  ifeq ($(TARGET),)
-    ${info TARGET not defined, using target 'native'}
-    TARGET=native
-  else
-    ${info using saved target '$(TARGET)'}
-  endif
-endif
+include $(CONTIKI)/Makefile.identify-target 
 
 ifeq ($(DEFINES),)
   -include Makefile.$(TARGET).defines

--- a/examples/sensniff/Makefile
+++ b/examples/sensniff/Makefile
@@ -1,15 +1,10 @@
 CONTIKI_PROJECT = sensniff
+CONTIKI = ../..
 
 PROJECT_SOURCEFILES += sensniff-mac.c netstack.c
 PROJECTDIRS += pool $(TARGET)
 
-ifeq ($(TARGET),)
-  -include Makefile.target
-  ifeq ($(TARGET),)
-    TARGET=srf06-cc26xx
-    $(info TARGET not defined, using target $(TARGET))
-  endif
-endif
+-include $(CONTIKI)/Makefile.identify-target 
 
 ### Optionally, the target can add its own Makefile, to do things like e.g.
 ### add more source files to the build or define make variables.
@@ -19,7 +14,6 @@ all: $(CONTIKI_PROJECT)
 
 # use a custom MAC driver: sensniff_mac_driver
 MAKE_MAC = MAKE_MAC_OTHER
-CONTIKI = ../..
 include $(CONTIKI)/Makefile.include
 
 PYTHON ?= python


### PR DESCRIPTION
For some cross-platform examples, we need to tweak things based on the target platform. For this reason, target identification needs to happen early in the build process, before inclusion of the top-level `Makefile.include`.

Up to now, we had simply been replicating the target-identification code in example Makefiles, leading to code-replication, inconsistency, and on occasion bugs (e.g. ignoring Makefile.target or environment variables).

This pull proposes moving target identification to a separate top-level `Makefile.identify-target`. Example Makefiles can include this early on "as a library" (e.g. the way the sensniff Makefile changes in this pull). If the example Makefile does not need target identification, the top-level `Makefile.include` will always include `Makefile.identify-target`.

In the longer term, this will support easier creation of cross-platform examples that feature a large platform-independent code base and that can be easily extended with platform-dependent specifics.

This is now ready for consideration.

This is a sequel to the discussion in #92