### PR TITLE
Remove obsolete SLIP_foo_CONF_NO_PUTCHAR

### DIFF
--- a/arch/platform/cc2538dk/contiki-conf.h
+++ b/arch/platform/cc2538dk/contiki-conf.h
@@ -178,10 +178,6 @@ typedef uint32_t rtimer_clock_t;
                                            the uart1_* API */
 #endif
 
-/* Turn off example-provided putchars */
-#define SLIP_BRIDGE_CONF_NO_PUTCHAR 1
-#define SLIP_RADIO_CONF_NO_PUTCHAR  1
-
 #ifndef SLIP_ARCH_CONF_ENABLED
 /*
  * Determine whether we need SLIP

--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -132,10 +132,6 @@ typedef uint64_t rtimer_clock_t;
 #define TSCH_CONF_MAX_EB_PERIOD (4 * CLOCK_SECOND)
 #endif /* MAC_CONF_WITH_TSCH */
 
-/* Turn off example-provided putchars */
-#define SLIP_BRIDGE_CONF_NO_PUTCHAR 1
-
-
 #define CFS_CONF_OFFSET_TYPE	long
 
 #define RF_CHANNEL                     26

--- a/arch/platform/openmote-cc2538/contiki-conf.h
+++ b/arch/platform/openmote-cc2538/contiki-conf.h
@@ -227,10 +227,6 @@ typedef uint32_t rtimer_clock_t;
                                            the uart1_* API */
 #endif
 
-/* Turn off example-provided putchars */
-#define SLIP_BRIDGE_CONF_NO_PUTCHAR 1
-#define SLIP_RADIO_CONF_NO_PUTCHAR  1
-
 #ifndef SLIP_ARCH_CONF_ENABLED
 /*
  * Determine whether we need SLIP

--- a/arch/platform/srf06-cc26xx/contiki-conf.h
+++ b/arch/platform/srf06-cc26xx/contiki-conf.h
@@ -165,10 +165,6 @@
 #define BOARD_CONF_DEBUGGER_DEVPACK        1
 #endif
 
-/* Turn off example-provided putchars */
-#define SLIP_BRIDGE_CONF_NO_PUTCHAR        1
-#define SLIP_RADIO_CONF_NO_PUTCHAR         1
-
 #ifndef SLIP_ARCH_CONF_ENABLED
 /*
  * Determine whether we need SLIP

--- a/arch/platform/zoul/contiki-conf.h
+++ b/arch/platform/zoul/contiki-conf.h
@@ -224,10 +224,6 @@ typedef uint32_t rtimer_clock_t;
                                            the uart1_* API */
 #endif
 
-/* Turn off example-provided putchars */
-#define SLIP_BRIDGE_CONF_NO_PUTCHAR 1
-#define SLIP_RADIO_CONF_NO_PUTCHAR  1
-
 #ifndef SLIP_ARCH_CONF_ENABLED
 /*
  * Determine whether we need SLIP


### PR DESCRIPTION
slip-radio and rpl-border-router have this example-specific putchar which is used to do mux/demux when SLIP is used over the same interface as debug char i/o. As far as I can tell, among our current platforms only sky uses it, so I am moving it to the platform-specific part of the respective examples in #132 and #133. Once those two have been merged, those macros will be obsolete, and this pull removes them.

In terms of the diff, this pull here is orthogonal to the two mentioned above, however there is no point merging this one before merging the above two.