### PR TITLE
New energest type for deep sleep plus configurable type for Energest time source

### DIFF
--- a/arch/cpu/msp430/f1xxx/clock.c
+++ b/arch/cpu/msp430/f1xxx/clock.c
@@ -32,6 +32,7 @@
 #include "contiki.h"
 #include "sys/clock.h"
 #include "sys/etimer.h"
+#include "sys/energest.h"
 #include "rtimer-arch.h"
 #include "dev/watchdog.h"
 #include "isr_compat.h"
@@ -86,6 +87,7 @@ ISR(TIMERA1, timera1)
 #endif
       if(count % CLOCK_CONF_SECOND == 0) {
         ++seconds;
+        energest_flush();
       }
       last_tar = read_tar();
     }

--- a/arch/cpu/msp430/f5xxx/clock.c
+++ b/arch/cpu/msp430/f5xxx/clock.c
@@ -32,6 +32,7 @@
 #include "contiki.h"
 #include "sys/clock.h"
 #include "sys/etimer.h"
+#include "sys/energest.h"
 #include "rtimer-arch.h"
 #include "dev/watchdog.h"
 #include "isr_compat.h"
@@ -86,6 +87,7 @@ ISR(TIMER1_A1, timera1)
 #endif
       if(count % CLOCK_CONF_SECOND == 0) {
         ++seconds;
+        energest_flush();
       }
       last_tar = read_tar();
     }

--- a/arch/dev/cc1200/cc1200.c
+++ b/arch/dev/cc1200/cc1200.c
@@ -40,6 +40,7 @@
 #include "net/netstack.h"
 #include "net/packetbuf.h"
 #include "dev/watchdog.h"
+#include "sys/energest.h"
 
 #include "dev/leds.h"
 

--- a/arch/dev/cc2420/cc2420.c
+++ b/arch/dev/cc2420/cc2420.c
@@ -36,6 +36,7 @@
 #include <string.h>
 
 #include "contiki.h"
+#include "sys/energest.h"
 
 #include "dev/leds.h"
 #include "dev/spi.h"

--- a/arch/platform/jn516x/dev/micromac-radio.c
+++ b/arch/platform/jn516x/dev/micromac-radio.c
@@ -44,6 +44,7 @@
 #include "contiki.h"
 #include "dev/leds.h"
 #include "sys/rtimer.h"
+#include "sys/energest.h"
 #include "net/packetbuf.h"
 #include "net/netstack.h"
 #include "net/mac/framer/frame802154.h"

--- a/arch/platform/jn516x/platform.c
+++ b/arch/platform/jn516x/platform.c
@@ -52,6 +52,7 @@
 #include "dev/uart-driver.h"
 
 #include "contiki.h"
+#include "sys/energest.h"
 #include "net/netstack.h"
 
 #include "dev/serial-line.h"

--- a/arch/platform/sky/platform.c
+++ b/arch/platform/sky/platform.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "contiki.h"
+#include "sys/energest.h"
 #include "cc2420.h"
 #include "dev/ds2411/ds2411.h"
 #include "dev/leds.h"

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -79,7 +79,6 @@ main(void)
   watchdog_init();
 
   energest_init();
-  ENERGEST_ON(ENERGEST_TYPE_CPU);
 
   platform_init_stage_two();
 

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -43,6 +43,7 @@
 #include "contiki.h"
 #include "contiki-net.h"
 #include "sys/platform.h"
+#include "sys/energest.h"
 #include "dev/watchdog.h"
 
 #if BUILD_WITH_ORCHESTRA

--- a/os/contiki.h
+++ b/os/contiki.h
@@ -49,6 +49,4 @@
 
 #include "sys/clock.h"
 
-#include "sys/energest.h"
-
 #endif /* CONTIKI_H_ */

--- a/os/sys/energest.c
+++ b/os/sys/energest.c
@@ -43,7 +43,7 @@
 #if ENERGEST_CONF_ON
 
 uint64_t energest_total_time[ENERGEST_TYPE_MAX];
-uint64_t energest_current_time[ENERGEST_TYPE_MAX];
+ENERGEST_TIME_T energest_current_time[ENERGEST_TYPE_MAX];
 unsigned char energest_current_mode[ENERGEST_TYPE_MAX];
 
 /*---------------------------------------------------------------------------*/
@@ -52,7 +52,7 @@ energest_init(void)
 {
   int i;
   for(i = 0; i < ENERGEST_TYPE_MAX; ++i) {
-    energest_total_time[i].current = energest_current_time[i] = 0;
+    energest_total_time[i] = energest_current_time[i] = 0;
     energest_current_mode[i] = 0;
   }
 }
@@ -65,10 +65,19 @@ energest_flush(void)
   for(i = 0; i < ENERGEST_TYPE_MAX; i++) {
     if(energest_current_mode[i]) {
       now = ENERGEST_CURRENT_TIME();
-      energest_total_time[i].current += now - energest_current_time[i];
+      energest_total_time[i] +=
+        (ENERGEST_TIME_T)(now - energest_current_time[i]);
       energest_current_time[i] = now;
     }
   }
+}
+/*---------------------------------------------------------------------------*/
+uint64_t
+energest_get_total_time(void)
+{
+  return energest_type_time(ENERGEST_TYPE_CPU) +
+    energest_type_time(ENERGEST_TYPE_LPM) +
+    energest_type_time(ENERGEST_TYPE_DEEP_LPM);
 }
 /*---------------------------------------------------------------------------*/
 #else /* ENERGEST_CONF_ON */
@@ -81,6 +90,12 @@ energest_init(void)
 void
 energest_flush(void)
 {
+}
+
+uint64_t
+energest_get_total_time(void)
+{
+  return 0;
 }
 
 #endif /* ENERGEST_CONF_ON */

--- a/os/sys/energest.c
+++ b/os/sys/energest.c
@@ -37,8 +37,8 @@
  *         Adam Dunkels <adam@sics.se>
  */
 
-#include "sys/energest.h"
 #include "contiki.h"
+#include "sys/energest.h"
 
 #if ENERGEST_CONF_ON
 

--- a/os/sys/energest.c
+++ b/os/sys/energest.c
@@ -55,6 +55,7 @@ energest_init(void)
     energest_total_time[i] = energest_current_time[i] = 0;
     energest_current_mode[i] = 0;
   }
+  ENERGEST_ON(ENERGEST_TYPE_CPU);
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
* Adds new energest type `ENERGEST_TYPE_DEEP_LPM` as discussed in #108.

* Adds function to get the total energest time: `ENERGEST_GET_TOTAL_TIME()`. This is essentially the sum of the times in different CPU modes (CPU + LPM + DEEP_LPM).

* Adds configurable type `ENERGEST_TIME_T` to support for clocks with wrapping time as time source for energest.

* Removes include of `energest.h` from `contiki.h` to avoid circular dependencies.

* Fixes some typos.