### PR TITLE
More README.md work for the examples

### DIFF
--- a/examples/rpl-border-router/README.md
+++ b/examples/rpl-border-router/README.md
@@ -1,0 +1,27 @@
+This is the Contiki-NG border router. It supports two main modes of operation:
+embedded and native. In both cases, the border router runs a simple Web server
+that exposes a list of currently connected nodes via HTTP.
+
+See https://github.com/contiki-ng/contiki-ng/wiki/Tutorial:-RPL-border-router
+
+# Embedded border router
+
+The embedded border router runs on a node. It is connected to the host via SLIP.
+The host simply runs a tun gateway (`tunslip6`). To use, program a node, and
+then start `tunslip6` on the host via the make command `connect-router`.
+See embedded/README.md for more.
+
+# Native border router
+
+The native border router runs directly at the host. The node simply runs a
+SLIP-radio interface (`examples/slip-radio`). The host, on the other hand, runs
+a full 6LoWPAN stack.
+See native/README.md for more.
+
+# RPL node
+
+As RPL node, you may use any Contiki-NG example with RPL enabled, but which
+does not start its own DAG (as this is the responsibility of the border router).
+For instance `examples/hello-world` or `examples-coap` are great starting
+points. This is not intended to run with `examples/rpl-udp` however, as this
+examples builds its own stand-alone, border-router-free RPL network.

--- a/examples/rpl-border-router/embedded/README.md
+++ b/examples/rpl-border-router/embedded/README.md
@@ -1,0 +1,5 @@
+This is a border router that runs embedded in a node. The node runs a full
+6LoWPAN stack, and acts as a DAG root. It interfaces to the outside world
+via a serial line. On the host Operating System, `tunslip6` is used to create
+a tun interface and bridge it to the RPL border router. This is achieved with
+makefile targets `connect-router` and `connect-router-cooja`.

--- a/examples/rpl-border-router/native/README.md
+++ b/examples/rpl-border-router/native/README.md
@@ -1,5 +1,5 @@
 This code connects a 802.15.4 radio over TTY with the full uIPv6 stack of
-Contiki including 6LoWPAN and 802.15.4 framing / parsing. The native border
+Contiki-NG including 6LoWPAN and 802.15.4 framing / parsing. The native border
 router also acts as a RPL Root and handles the routing and maintains the RPL
 network. Finally the native border router connects the full 6LoWPAN/RPL
 network to the host (linux/os-x) network stack making it possible for
@@ -11,9 +11,9 @@ mote that is either directly USB/TTY connected, or is remote via a TCP
 connect.  What's on the SLIP interface is really not Serial Line IP, but SLIP
 framed 15.4 packets.
 
-The border router supports a number of commands on it's stdin.
+The native border router supports a number of commands on its stdin.
 Each are prefixed by !:
-* !G - global RPL repair root.
+* !G - global RPL repair root
 * !M - set MAC address (if coming from RADIO, i.e. SLIP link)
 * !C - show channel (if coming from RADIO, i.e. SLIP link)
 * !D - sensor data received
@@ -25,4 +25,3 @@ Queries are prefixed by ?:
 * ?C is used for requesting the currently used channel for the slip-radio. The response is !C with a channel number (from the slip-radio).
 
 * !C is used for setting the channel of the slip-radio (useful if the motes are using another channel than the one used in the slip-radio).
-

--- a/examples/rpl-udp/README.md
+++ b/examples/rpl-udp/README.md
@@ -1,6 +1,10 @@
-A simple RPL network with UDP communication. The DAG root also acts as
-UDP server. All other nodes are client. The clients send a UDP request
-that simply includes a counter as payload. When receiving a request, The
-server sends a reply with the same counter back to the originator.
+A simple RPL network with UDP communication. This is a self-contained example:
+it includes a DAG root (`udp-server.c`) and DAG nodes (`udp-clients.c`).
+This example runs without a border router -- this is a stand-alone RPL network.
+
+The DAG root also acts as UDP server. The DAG nodes are UDP client. The clients
+send a UDP request periodically, that simply includes a counter as payload.
+When receiving a request, The server sends a response with the same counter
+back to the originator.
 
 The simulation files show example networks, for sky motes and for cooja motes.

--- a/examples/slip-radio/README.md
+++ b/examples/slip-radio/README.md
@@ -1,6 +1,5 @@
-This project is intended to run on a mode that is connected to a native host system
-by SLIP.  The SLIP is really SERIAL LINE 15.4, as this just turns the mote into a smart
-radio, running the RPL and 6lowpan stack on the Host.  This goes with native-border-router.
-
-
-
+This example is intended to run on a mode that is connected to a native host
+system by SLIP. Full IEEE 802.15.4 packets are transmitted over slip, turning
+the mote into a simple radio, with the RPL and 6LoWPAN stack running on the
+host. This is typically used with the native border router (example
+`rpl-border-router` on target native).


### PR DESCRIPTION
This updates and adds missing README.md, with main focus on RPL BR, slip-radio and rpl-udp, with the main aim to help the user know what is meant for use with what.