### PR TITLE
Border-router: move border-router.c to top level for cleaner compilation

### DIFF
--- a/examples/rpl-border-router/Makefile
+++ b/examples/rpl-border-router/Makefile
@@ -1,8 +1,8 @@
 PROJECTDIRS += common
+PREFIX ?= fd00::1/64
+CONTIKI = ../..
 
-CONTIKI=../..
-
--include $(CONTIKI)/Makefile.identify-target 
+-include $(CONTIKI)/Makefile.identify-target
 
 all: border-router.$(TARGET)
 
@@ -16,14 +16,5 @@ include $(SOURCES_DIR)/Makefile
 
 PROJECTDIRS += $(SOURCES_DIR)
 CFLAGS += -DPROJECT_CONF_PATH=\"$(SOURCES_DIR)/project-conf.h\"
-
-border-router.$(TARGET): $(SOURCES_DIR)/border-router.$(TARGET)
-	cp $< $@
-
-CLEAN += border-router.$(TARGET) $(SOURCES_DIR)/border-router.$(TARGET)
-
-ifeq ($(PREFIX),)
-  PREFIX = fd00::1/64
-endif
 
 include $(CONTIKI)/Makefile.include

--- a/examples/rpl-border-router/border-router.c
+++ b/examples/rpl-border-router/border-router.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 201, RISE SICS
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+#include "contiki.h"
+
+PROCESS_NAME(border_router_process);
+
+#if BORDER_ROUTER_CONF_WEBSERVER
+PROCESS_NAME(webserver_nogui_process);
+AUTOSTART_PROCESSES(&border_router_process, &webserver_nogui_process);
+#else /* BORDER_ROUTER_CONF_WEBSERVER */
+AUTOSTART_PROCESSES(&border_router_process);
+#endif /* BORDER_ROUTER_CONF_WEBSERVER */

--- a/examples/rpl-border-router/embedded/Makefile
+++ b/examples/rpl-border-router/embedded/Makefile
@@ -4,7 +4,7 @@
 
 PROJECTDIRS += $(SOURCES_DIR)/$(TARGET)
 
-PROJECT_SOURCEFILES += slip-bridge.c httpd-simple.c
+PROJECT_SOURCEFILES += slip-bridge.c httpd-simple.c border-router-embedded.c
 
 $(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c
 	(cd $(CONTIKI)/tools && $(MAKE) tunslip6)

--- a/examples/rpl-border-router/embedded/border-router-embedded.c
+++ b/examples/rpl-border-router/embedded/border-router-embedded.c
@@ -104,7 +104,6 @@ PROCESS_THREAD(webserver_nogui_process, ev, data)
 
   PROCESS_END();
 }
-AUTOSTART_PROCESSES(&border_router_process,&webserver_nogui_process);
 
 static const char *TOP = "<html><head><title>ContikiRPL</title></head><body>\n";
 static const char *BOTTOM = "</body></html>\n";
@@ -344,9 +343,6 @@ httpd_simple_get_script(const char *name)
 {
   return generate_routes;
 }
-#else /* BORDER_ROUTER_CONF_WEBSERVER */
-/* No webserver */
-AUTOSTART_PROCESSES(&border_router_process);
 #endif /* BORDER_ROUTER_CONF_WEBSERVER */
 /*---------------------------------------------------------------------------*/
 static void

--- a/examples/rpl-border-router/native/Makefile
+++ b/examples/rpl-border-router/native/Makefile
@@ -1,5 +1,6 @@
 MODULES += os/services/slip-cmd
 
+PROJECT_SOURCEFILES += border-router-native.c
 PROJECT_SOURCEFILES += border-router-cmds.c tun-bridge.c httpd-simple.c
 PROJECT_SOURCEFILES += slip-config.c slip-dev.c border-router-mac.c
 

--- a/examples/rpl-border-router/native/border-router-native.c
+++ b/examples/rpl-border-router/native/border-router-native.c
@@ -99,8 +99,6 @@ PROCESS_THREAD(webserver_nogui_process, ev, data)
 
   PROCESS_END();
 }
-AUTOSTART_PROCESSES(&border_router_process,&border_router_cmd_process,
-		    &webserver_nogui_process);
 
 static const char *TOP = "<html><head><title>ContikiRPL</title></head><body>\n";
 static const char *BOTTOM = "</body></html>\n";
@@ -204,9 +202,6 @@ httpd_simple_get_script(const char *name)
 {
   return generate_routes;
 }
-#else /* BORDER_ROUTER_CONF_WEBSERVER */
-/* No webserver */
-AUTOSTART_PROCESSES(&border_router_process,&border_router_cmd_process);
 #endif /* BORDER_ROUTER_CONF_WEBSERVER */
 /*---------------------------------------------------------------------------*/
 static void
@@ -298,6 +293,8 @@ PROCESS_THREAD(border_router_process, ev, data)
   prefix_set = 0;
 
   PROCESS_PAUSE();
+
+  process_start(&border_router_cmd_process, NULL);
 
   PRINTF("RPL-Border router started\n");
 


### PR DESCRIPTION
This has two benefits:
* enables compiling the BR in Cooja -- Cooja requires a `.c` project file sitting in the same dir as the makefile and the firmware
* makes for cleaner compilation, now with all artifacts in the common dir, no more need to `cp`
