### PR TITLE
Renode example in rpl-udp demo

### DIFF
--- a/examples/rpl-udp/Makefile
+++ b/examples/rpl-udp/Makefile
@@ -1,4 +1,19 @@
 all: udp-client udp-server
 
+.PHONY: renode
+renode: all
+ifneq ($(TARGET),cc2538dk)
+	$(error Only the cc2538dk TARGET is supported for Renode demo scripts)
+endif
+ifndef SCRIPT
+	$(warning SCRIPT not defined! Using "rpl-udp.resc" as default)
+	renode rpl-udp.resc
+else
+ifeq ($(wildcard $(SCRIPT)),)
+	$(error SCRIPT "$(SCRIPT)" does not exist!)
+endif
+	renode $(SCRIPT)
+endif
+
 CONTIKI=../..
 include $(CONTIKI)/Makefile.include

--- a/examples/rpl-udp/README.md
+++ b/examples/rpl-udp/README.md
@@ -8,3 +8,9 @@ When receiving a request, The server sends a response with the same counter
 back to the originator.
 
 The simulation files show example networks, for sky motes and for cooja motes.
+
+For this example a "renode" make target is available, to run a two node
+emulation in the Renode framework. For further instructions on installing and
+using Renode please refer to [Contiki-NG wiki][1].
+
+[1]: https://github.com/contiki-ng/contiki-ng/wiki/Tutorial:-Running-Contiki%E2%80%90NG-in-Renode

--- a/examples/rpl-udp/cc2538-node.resc
+++ b/examples/rpl-udp/cc2538-node.resc
@@ -1,0 +1,30 @@
+mach create $name
+using sysbus
+machine LoadPlatformDescription @platforms/cpus/cc2538.repl
+machine SetClockSource sysbus.cpu
+machine SetSyncDomainFromEmulation $domain
+connector Connect radio wireless
+
+machine PyDevFromFile @scripts/pydev/rolling-bit.py 0x400D2004 0x4 True "sysctrl"
+
+$id = `next_value 1`
+
+macro reset
+"""
+    #set node address. 0x00 0x12 0x4B is TI OUI
+    sysbus WriteByte 0x00280028 $id
+    sysbus WriteByte 0x0028002C 0x00
+    sysbus WriteByte 0x00280030 0xAB
+    sysbus WriteByte 0x00280034 0x89
+    sysbus WriteByte 0x00280038 0x00
+    sysbus WriteByte 0x0028003C 0x4B
+    sysbus WriteByte 0x00280040 0x12
+    sysbus WriteByte 0x00280044 0x00
+
+    sysbus LoadBinary @http://antmicro.com/projects/renode/cc2538_rom_dump.bin-s_524288-0c196cdc21b5397f82e0ff42b206d1cc4b6d7522 0x0
+    sysbus LoadELF $bin
+
+    cpu VectorTableOffset 0x200000
+"""
+
+runMacro $reset

--- a/examples/rpl-udp/rpl-udp.resc
+++ b/examples/rpl-udp/rpl-udp.resc
@@ -1,0 +1,45 @@
+:name: cc2538 range medium 2 nodes
+
+######################################################################
+#
+# Sample script creating 1 server node and 1 client node using a
+# range-based medium function - transmission is possible if nodes are
+# in range. Nodes are positioned in a 3D space (x,y,z),
+# at a distance of 10 (units) from each other (on the X axis).
+#
+# Differences in SyncUnit values in machines represent the differences
+# in their relative speed. This prevents the machines from
+# synchronizing in 100%, which is crucial for Contiki network stack
+# stability.
+#
+######################################################################
+
+path add $CWD
+emulation CreateWirelessMedium "wireless"
+$domain = `emulation AddSyncDomain`
+wireless SetSyncDomainFromEmulation $domain
+
+# The radio is using a range-based medium (with the `Range` set to `11`)
+# If not set, the default SimpleMediumFunction will be used (where range is not relevant)
+wireless SetRangeWirelessFunction 11
+
+######################### UDP SERVER - begin #########################
+$bin=@udp-server.cc2538dk
+$name="server"
+i $ORIGIN/cc2538-node.resc
+wireless SetPosition radio 0 0 0
+machine SyncUnit 100
+showAnalyzer sysbus.uart0
+mach clear
+########################## UDP SERVER - end ##########################
+
+######################### UDP CLIENT - begin #########################
+$bin=@udp-client.cc2538dk
+$name="client"
+
+i $ORIGIN/cc2538-node.resc
+wireless SetPosition radio 10 0 0
+machine SyncUnit 110
+showAnalyzer sysbus.uart0
+mach clear
+########################## UDP CLIENT - end ##########################


### PR DESCRIPTION
This PR adds Renode scripts and integration via Makefile, as discussed with Joakim.

This is specific to rpl-udp example on CC2538DK, but may be used for other binaries and boards as well, with little adjustments.

To run Renode in this setup run `make renode TARGET=cc2538dk`.