### PR TITLE
Gitignore doxygen output files in their new location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,7 @@
 *~
 obj_*
 Makefile.target
-doc/html
-doc/latex
+tools/doxygen/html
 patches-*
 tools/tunslip
 tools/tunslip6


### PR DESCRIPTION
We moved doxygen documentation, so build artifacts are no longer being ignored. This commit sets .gitignore all documentation output in its new location.

This should IMHO be included in this release.