### PR TITLE
sixtop: bugfix adding a missing 'static' modifier

### DIFF
--- a/examples/6tisch/sixtop/node-sixtop.c
+++ b/examples/6tisch/sixtop/node-sixtop.c
@@ -63,7 +63,7 @@ AUTOSTART_PROCESSES(&node_process);
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(node_process, ev, data)
 {
-  int is_coordinator;
+  static int is_coordinator;
   static int added_num_of_links = 0;
   static struct etimer et;
   struct tsch_neighbor *n;


### PR DESCRIPTION
I found a bug in `example/6tisch/sixtop/node-sixtop.c`, which will be resolved by this commit.