### PR TITLE
Avoid tsch crash when losing timesource

### DIFF
--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -313,7 +313,7 @@ keepalive_send(void *ptr)
         LOG_INFO_LLADDR(&n->addr);
         LOG_INFO_("\n");
     } else {
-        LOG_INFO("no timesource - KA not sent\n");
+        LOG_ERR("no timesource - KA not sent\n");
     }
   }
 }

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -304,13 +304,17 @@ keepalive_send(void *ptr)
 {
   if(tsch_is_associated) {
     struct tsch_neighbor *n = tsch_queue_get_time_source();
-    /* Simply send an empty packet */
-    packetbuf_clear();
-    packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, &n->addr);
-    NETSTACK_MAC.send(keepalive_packet_sent, NULL);
-    LOG_INFO("sending KA to ");
-    LOG_INFO_LLADDR(&n->addr);
-    LOG_INFO_("\n");
+    if(n != NULL) {
+        /* Simply send an empty packet */
+        packetbuf_clear();
+        packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, &n->addr);
+        NETSTACK_MAC.send(keepalive_packet_sent, NULL);
+        LOG_INFO("sending KA to ");
+        LOG_INFO_LLADDR(&n->addr);
+        LOG_INFO_("\n");
+    } else {
+        LOG_INFO("no timesource - KA not sent\n");
+    }
   }
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR resolves a particularly annoying bug that happens under some occations, for instance a lost sync just before trying to send KA. (This has been seen in cooja on repeated occasions)

In cooja this results in segfault, and on taret it results in data abort exception.

The reason is the fail-to-check-for-NULL-pointer in the code that sends the KA. I don't know if there might be a race condition since this apparently happens when tsch_is_associated is set, but there still is no timesouce. However, since the tsch_queue_get_time_source explicitly returns NULL in some cases, the calling code should check for NULL.