### PR TITLE
RPL non-storing: ensure routing links are stored for at least their advertised lifetime

### DIFF
--- a/os/net/rpl-classic/rpl-ns.c
+++ b/os/net/rpl-classic/rpl-ns.c
@@ -203,14 +203,8 @@ void
 rpl_ns_periodic(void)
 {
   rpl_ns_node_t *l;
-  /* First pass, decrement lifetime for all nodes with non-infinite lifetime */
-  for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
-    /* Don't touch infinite lifetime nodes */
-    if(l->lifetime != 0xffffffff && l->lifetime > 0) {
-      l->lifetime--;
-    }
-  }
-  /* Second pass, for all expired nodes, deallocate them iff no child points to them */
+
+  /* First pass, for all expired nodes, deallocate them iff no child points to them */
   for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
     if(l->lifetime == 0) {
       rpl_ns_node_t *l2;
@@ -223,6 +217,14 @@ rpl_ns_periodic(void)
       list_remove(nodelist, l);
       memb_free(&nodememb, l);
       num_nodes--;
+    }
+  }
+
+  /* Second pass, decrement lifetime for all nodes with non-infinite lifetime */
+  for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
+    /* Don't touch infinite lifetime nodes */
+    if(l->lifetime != 0xffffffff && l->lifetime > 0) {
+      l->lifetime--;
     }
   }
 }

--- a/os/net/rpl-classic/rpl-ns.c
+++ b/os/net/rpl-classic/rpl-ns.c
@@ -203,9 +203,11 @@ void
 rpl_ns_periodic(void)
 {
   rpl_ns_node_t *l;
+  rpl_ns_node_t *next;
 
   /* First pass, for all expired nodes, deallocate them iff no child points to them */
-  for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
+  for(l = list_head(nodelist); l != NULL; l = next) {
+    next = list_item_next(l);
     if(l->lifetime == 0) {
       rpl_ns_node_t *l2;
       for(l2 = list_head(nodelist); l2 != NULL; l2 = list_item_next(l2)) {
@@ -217,13 +219,8 @@ rpl_ns_periodic(void)
       list_remove(nodelist, l);
       memb_free(&nodememb, l);
       num_nodes--;
-    }
-  }
-
-  /* Second pass, decrement lifetime for all nodes with non-infinite lifetime */
-  for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
-    /* Don't touch infinite lifetime nodes */
-    if(l->lifetime != 0xffffffff && l->lifetime > 0) {
+    } else if(l->lifetime != 0xffffffff) {
+      /* Decrement lifetime for all nodes with non-infinite lifetime */
       l->lifetime--;
     }
   }

--- a/os/net/rpl-lite/rpl-ns.c
+++ b/os/net/rpl-lite/rpl-ns.c
@@ -229,13 +229,7 @@ rpl_ns_periodic(unsigned seconds)
       list_remove(nodelist, l);
       memb_free(&nodememb, l);
       num_nodes--;
-    }
-  }
-
-  /* Second pass, decrement lifetime for all nodes with non-infinite lifetime */
-  for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
-    /* Don't touch infinite lifetime nodes */
-    if(l->lifetime != RPL_ROUTE_INFINITE_LIFETIME) {
+    } else if(l->lifetime != RPL_ROUTE_INFINITE_LIFETIME) {
       l->lifetime = l->lifetime > seconds ? l->lifetime - seconds : 0;
     }
   }

--- a/os/net/rpl-lite/rpl-ns.c
+++ b/os/net/rpl-lite/rpl-ns.c
@@ -207,14 +207,8 @@ rpl_ns_periodic(unsigned seconds)
 {
   rpl_ns_node_t *l;
   rpl_ns_node_t *next;
-  /* First pass, decrement lifetime for all nodes with non-infinite lifetime */
-  for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
-    /* Don't touch infinite lifetime nodes */
-    if(l->lifetime != RPL_ROUTE_INFINITE_LIFETIME) {
-      l->lifetime = l->lifetime > seconds ? l->lifetime - seconds : 0;
-    }
-  }
-  /* Second pass, for all expired nodes, deallocate them iff no child points to them */
+
+  /* First pass, for all expired nodes, deallocate them iff no child points to them */
   for(l = list_head(nodelist); l != NULL; l = next) {
     next = list_item_next(l);
     if(l->lifetime == 0) {
@@ -235,6 +229,14 @@ rpl_ns_periodic(unsigned seconds)
       list_remove(nodelist, l);
       memb_free(&nodememb, l);
       num_nodes--;
+    }
+  }
+
+  /* Second pass, decrement lifetime for all nodes with non-infinite lifetime */
+  for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
+    /* Don't touch infinite lifetime nodes */
+    if(l->lifetime != RPL_ROUTE_INFINITE_LIFETIME) {
+      l->lifetime = l->lifetime > seconds ? l->lifetime - seconds : 0;
     }
   }
 }


### PR DESCRIPTION
In `rpl_ns_periodic` routing links had their lifetime decremented first, and then expired links were removed. The decrement period is 60s. This cause expiry within [period-60s;period[. With this fix, we first remove expired links and second, decrement the lifetimes. This results in an expiry delay within [period;period+60s[