### PR TITLE
Remove LED undefs

### DIFF
--- a/arch/platform/cc2538dk/dev/board.h
+++ b/arch/platform/cc2538dk/dev/board.h
@@ -71,13 +71,6 @@
  * @{
  */
 /*---------------------------------------------------------------------------*/
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_YELLOW             2 /**< LED2 (Yellow) -> PC1 */
 #define LEDS_GREEN              4 /**< LED3 (Green)  -> PC2 */
 #define LEDS_ORANGE             8 /**< LED4 (Orange) -> PC3 */

--- a/arch/platform/openmote-cc2538/board.h
+++ b/arch/platform/openmote-cc2538/board.h
@@ -63,13 +63,6 @@
  * @{
  */
 /*---------------------------------------------------------------------------*/
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED       16  /**< LED1 (Red)    -> PC4 */
 #define LEDS_YELLOW    64  /**< LED2 (Yellow) -> PC6 */
 #define LEDS_GREEN     128 /**< LED3 (Green)  -> PC7 */

--- a/arch/platform/srf06-cc26xx/launchpad/cc1310/board.h
+++ b/arch/platform/srf06-cc26xx/launchpad/cc1310/board.h
@@ -60,13 +60,6 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED       1
 #define LEDS_GREEN     2
 #define LEDS_YELLOW    LEDS_GREEN

--- a/arch/platform/srf06-cc26xx/launchpad/cc1350/board.h
+++ b/arch/platform/srf06-cc26xx/launchpad/cc1350/board.h
@@ -60,13 +60,6 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED       1
 #define LEDS_GREEN     2
 #define LEDS_YELLOW    LEDS_GREEN

--- a/arch/platform/srf06-cc26xx/launchpad/cc2650/board.h
+++ b/arch/platform/srf06-cc26xx/launchpad/cc2650/board.h
@@ -60,13 +60,6 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED       1
 #define LEDS_GREEN     2
 #define LEDS_YELLOW    LEDS_GREEN

--- a/arch/platform/srf06-cc26xx/sensortag/cc1350/board.h
+++ b/arch/platform/srf06-cc26xx/sensortag/cc1350/board.h
@@ -63,13 +63,6 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED       1
 #define LEDS_GREEN     LEDS_RED
 #define LEDS_YELLOW    LEDS_RED

--- a/arch/platform/srf06-cc26xx/sensortag/cc2650/board.h
+++ b/arch/platform/srf06-cc26xx/sensortag/cc2650/board.h
@@ -63,13 +63,6 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED       1
 #define LEDS_GREEN     2
 #define LEDS_YELLOW    LEDS_GREEN

--- a/arch/platform/srf06-cc26xx/srf06/cc13xx/board.h
+++ b/arch/platform/srf06-cc26xx/srf06/cc13xx/board.h
@@ -63,13 +63,6 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED       1 /**< LED1 (Red)    */
 #define LEDS_YELLOW    2 /**< LED2 (Yellow) */
 #define LEDS_GREEN     4 /**< LED3 (Green)  */

--- a/arch/platform/srf06-cc26xx/srf06/cc26xx/board.h
+++ b/arch/platform/srf06-cc26xx/srf06/cc26xx/board.h
@@ -63,13 +63,6 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED       1 /**< LED1 (Red)    */
 #define LEDS_YELLOW    2 /**< LED2 (Yellow) */
 #define LEDS_GREEN     4 /**< LED3 (Green)  */

--- a/arch/platform/zoul/firefly-reva/board.h
+++ b/arch/platform/zoul/firefly-reva/board.h
@@ -98,14 +98,6 @@
  * @{
  */
 /*---------------------------------------------------------------------------*/
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_BLUE
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 /* In leds.h the LEDS_BLUE is defined by LED_YELLOW definition */
 #define LEDS_GREEN    (1 << 4) /**< LED1 (Green) -> PD4 */
 #define LEDS_BLUE     (1 << 3) /**< LED2 (Blue)  -> PD3 */

--- a/arch/platform/zoul/firefly/board.h
+++ b/arch/platform/zoul/firefly/board.h
@@ -98,14 +98,6 @@
  * @{
  */
 /*---------------------------------------------------------------------------*/
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_BLUE
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 /* In leds.h the LEDS_BLUE is defined by LED_YELLOW definition */
 #define LEDS_GREEN    (1 << 4) /**< LED1 (Green) -> PD4 */
 #define LEDS_BLUE     (1 << 3) /**< LED2 (Blue)  -> PD3 */

--- a/arch/platform/zoul/orion/board.h
+++ b/arch/platform/zoul/orion/board.h
@@ -67,14 +67,6 @@
  * @{
  */
 /*---------------------------------------------------------------------------*/
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_BLUE
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 /* In leds.h the LEDS_BLUE is defined by LED_YELLOW definition */
 #define LEDS_GREEN    (1 << 4) /**< LED1 (Green) -> PD4 */
 #define LEDS_BLUE     (1 << 3) /**< LED2 (Blue)  -> PD3 */

--- a/arch/platform/zoul/remote-reva/board.h
+++ b/arch/platform/zoul/remote-reva/board.h
@@ -102,14 +102,6 @@
  * @{
  */
 /*---------------------------------------------------------------------------*/
-/* Some files include leds.h before us, so we need to get rid of defaults in
- * leds.h before we provide correct definitions */
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_BLUE
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 /* In leds.h the LEDS_BLUE is defined by LED_YELLOW definition */
 #define LEDS_GREEN    (1 << 4) /**< LED1 (Green) -> PD4 */
 #define LEDS_BLUE     (1 << 3) /**< LED2 (Blue)  -> PD3 */

--- a/arch/platform/zoul/remote-revb/board.h
+++ b/arch/platform/zoul/remote-revb/board.h
@@ -105,12 +105,6 @@
  * @{
  */
 /*---------------------------------------------------------------------------*/
-#undef LEDS_GREEN
-#undef LEDS_YELLOW
-#undef LEDS_BLUE
-#undef LEDS_RED
-#undef LEDS_CONF_ALL
-
 #define LEDS_RED              1           /**< LED1 (Red)   -> PD4 */
 #define LEDS_RED_PIN_MASK     (1 << 4)
 #define LEDS_RED_PORT_BASE    GPIO_D_BASE


### PR DESCRIPTION
At some point in the distant past those `#undef`s were necessary. Not any more, so this pull removes them.