### PR TITLE
Bugfix in HAL for LEDs (leds.c)

### DIFF
--- a/os/dev/leds.c
+++ b/os/dev/leds.c
@@ -33,22 +33,11 @@
 #include "dev/leds.h"
 #include "sys/clock.h"
 
-static unsigned char leds;
-/*---------------------------------------------------------------------------*/
-static inline void
-show_leds(unsigned char new_leds)
-{
-
-  leds = new_leds;
-
-  leds_arch_set(new_leds);
-}
 /*---------------------------------------------------------------------------*/
 void
 leds_init(void)
 {
   leds_arch_init();
-  leds = 0;
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -56,7 +45,7 @@ leds_blink(void)
 {
   /* Blink all leds that were initially off. */
   unsigned char blink;
-  blink = ~leds;
+  blink = ~leds_arch_get();
   leds_toggle(blink);
 
   clock_delay(400);
@@ -72,24 +61,24 @@ leds_get(void) {
 void
 leds_set(unsigned char ledv)
 {
-  show_leds(ledv);
+  leds_arch_set(ledv);
 }
 /*---------------------------------------------------------------------------*/
 void
 leds_on(unsigned char ledv)
 {
-  show_leds(leds | ledv);
+  leds_arch_set(leds_arch_get() | ledv);
 }
 /*---------------------------------------------------------------------------*/
 void
 leds_off(unsigned char ledv)
 {
-  show_leds(leds & ~ledv);
+  leds_arch_set(leds_arch_get() & ~ledv);
 }
 /*---------------------------------------------------------------------------*/
 void
 leds_toggle(unsigned char ledv)
 {
-  show_leds(leds ^ ledv);
+  leds_arch_set(leds_arch_get() ^ ledv);
 }
 /*---------------------------------------------------------------------------*/

--- a/os/dev/leds.c
+++ b/os/dev/leds.c
@@ -38,6 +38,9 @@ static unsigned char leds;
 static inline void
 show_leds(unsigned char new_leds)
 {
+
+  leds = new_leds;
+
   leds_arch_set(new_leds);
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This pull request fixes a bug in the HAL for the LEDs (leds.c). 

The static variable `leds` did not get updated resulting to misbehaviour, such as `leds_toggle()` not working (led always stays on) and `leds_on()` turning off other leds.

The fix removes the static variable `leds` and, instead, uses `leds_arch_get()` to get the state of the leds.