### PR TITLE
Various SLIP-related improvements

### DIFF
--- a/arch/platform/jn516x/lib/slip.c
+++ b/arch/platform/jn516x/lib/slip.c
@@ -167,7 +167,7 @@ slip_write_char(uint8_t c)
   slip_arch_writeb(c);
 }
 /*---------------------------------------------------------------------------*/
-uint8_t
+void
 slip_write(const void *_ptr, int len)
 {
   const uint8_t *ptr = _ptr;
@@ -181,14 +181,12 @@ slip_write(const void *_ptr, int len)
     slip_write_char(c);
   }
   slip_arch_writeb(SLIP_END);
-
-  return len;
 }
 /*---------------------------------------------------------------------------*/
 /* slip_send: forward (IPv4) packets with {UIP_FW_NETIF(..., slip_send)}
  * was used in slip-bridge.c
  */
-uint8_t
+void
 slip_send(void)
 {
   uint16_t i;
@@ -203,8 +201,6 @@ slip_send(void)
     slip_write_char(c);
   }
   slip_arch_writeb(SLIP_END);
-
-  return UIP_FW_OK;
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/examples/slip-radio/project-conf.h
+++ b/examples/slip-radio/project-conf.h
@@ -37,7 +37,7 @@
 /*---------------------------------------------------------------------------*/
 #define UIP_CONF_ROUTER                 0
 
-#define CMD_CONF_OUTPUT slip_radio_cmd_output
+#define CMD_CONF_OUTPUT slip_write
 
 /* Default CMD handlers if the target did not specify them */
 #ifndef CMD_CONF_HANDLERS

--- a/examples/slip-radio/slip-net.c
+++ b/examples/slip-radio/slip-net.c
@@ -49,27 +49,6 @@ slipnet_init(void)
 {
 }
 /*---------------------------------------------------------------------------*/
-void
-slip_send_packet(const uint8_t *ptr, int len)
-{
-  uint16_t i;
-  uint8_t c;
-
-  slip_arch_writeb(SLIP_END);
-  for(i = 0; i < len; ++i) {
-    c = *ptr++;
-    if(c == SLIP_END) {
-      slip_arch_writeb(SLIP_ESC);
-      c = SLIP_ESC_END;
-    } else if(c == SLIP_ESC) {
-      slip_arch_writeb(SLIP_ESC);
-      c = SLIP_ESC_ESC;
-    }
-    slip_arch_writeb(c);
-  }
-  slip_arch_writeb(SLIP_END);
-}
-/*---------------------------------------------------------------------------*/
 static void
 slipnet_input(void)
 {
@@ -94,7 +73,7 @@ slipnet_input(void)
   }
   LOG_DBG_("\n");
 
-  slip_send_packet(uip_buf, uip_len);
+  slip_write(uip_buf, uip_len);
 }
 /*---------------------------------------------------------------------------*/
 static uint8_t

--- a/examples/slip-radio/slip-radio.c
+++ b/examples/slip-radio/slip-radio.c
@@ -56,8 +56,6 @@
 extern const struct slip_radio_sensors SLIP_RADIO_CONF_SENSORS;
 #endif
 
-void slip_send_packet(const uint8_t *ptr, int len);
-
 /* max 16 packets at the same time??? */
 uint8_t packet_ids[16];
 int packet_pos;
@@ -185,12 +183,6 @@ slip_radio_cmd_handler(const uint8_t *data, int len)
     }
   }
   return 0;
-}
-/*---------------------------------------------------------------------------*/
-void
-slip_radio_cmd_output(const uint8_t *data, int data_len)
-{
-  slip_send_packet(data, data_len);
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/dev/slip.c
+++ b/os/dev/slip.c
@@ -26,46 +26,42 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- * This file is part of the Contiki operating system.
- *
  */
-
-
-#include <stdio.h>
-#include <string.h>
-
+/*---------------------------------------------------------------------------*/
 #include "contiki.h"
-
 #include "net/ipv6/uip.h"
 #include "dev/slip.h"
 
+#include <stdio.h>
+#include <string.h>
+/*---------------------------------------------------------------------------*/
 #define SLIP_END     0300
 #define SLIP_ESC     0333
 #define SLIP_ESC_END 0334
 #define SLIP_ESC_ESC 0335
-
+/*---------------------------------------------------------------------------*/
 PROCESS(slip_process, "SLIP driver");
 
 uint8_t slip_active;
 
+/*---------------------------------------------------------------------------*/
 #if 1
 #define SLIP_STATISTICS(statement)
 #else
 uint16_t slip_rubbish, slip_twopackets, slip_overflow, slip_ip_drop;
 #define SLIP_STATISTICS(statement) statement
 #endif
-
+/*---------------------------------------------------------------------------*/
 /* Must be at least one byte larger than UIP_BUFSIZE! */
 #define RX_BUFSIZE (UIP_BUFSIZE - UIP_LLH_LEN + 16)
-
+/*---------------------------------------------------------------------------*/
 enum {
-  STATE_TWOPACKETS = 0,	/* We have 2 packets and drop incoming data. */
+  STATE_TWOPACKETS = 0, /* We have 2 packets and drop incoming data. */
   STATE_OK = 1,
   STATE_ESC = 2,
   STATE_RUBBISH = 3,
 };
-
+/*---------------------------------------------------------------------------*/
 /*
  * Variables begin and end manage the buffer space in a cyclic
  * fashion. The first used byte is at begin and end is one byte past
@@ -76,13 +72,12 @@ enum {
  * [pkt_end, end). If more bytes arrive in state STATE_TWOPACKETS
  * they are discarded.
  */
-
 static uint8_t state = STATE_TWOPACKETS;
 static uint16_t begin, next_free;
 static uint8_t rxbuf[RX_BUFSIZE];
-static uint16_t pkt_end;		/* SLIP_END tracker. */
+static uint16_t pkt_end;    /* SLIP_END tracker. */
 
-static void (* input_callback)(void) = NULL;
+static void (*input_callback)(void) = NULL;
 /*---------------------------------------------------------------------------*/
 void
 slip_set_input_callback(void (*c)(void))
@@ -169,7 +164,7 @@ slip_poll_handler(uint8_t *outbuf, uint16_t blen)
           len = 0;
           break;
         }
-        if (esc) {
+        if(esc) {
           if(rxbuf[i] == SLIP_ESC_ESC) {
             outbuf[len] = SLIP_ESC;
             len++;
@@ -193,7 +188,7 @@ slip_poll_handler(uint8_t *outbuf, uint16_t blen)
           len = 0;
           break;
         }
-        if (esc) {
+        if(esc) {
           if(rxbuf[i] == SLIP_ESC_ESC) {
             outbuf[len] = SLIP_ESC;
             len++;
@@ -214,7 +209,7 @@ slip_poll_handler(uint8_t *outbuf, uint16_t blen)
           len = 0;
           break;
         }
-        if (esc) {
+        if(esc) {
           if(rxbuf[i] == SLIP_ESC_ESC) {
             outbuf[len] = SLIP_ESC;
             len++;
@@ -280,7 +275,7 @@ PROCESS_THREAD(slip_process, ev, data)
 
     /* Move packet from rxbuf to buffer provided by uIP. */
     uip_len = slip_poll_handler(&uip_buf[UIP_LLH_LEN],
-				UIP_BUFSIZE - UIP_LLH_LEN);
+                                UIP_BUFSIZE - UIP_LLH_LEN);
 
     if(uip_len > 0) {
       if(input_callback) {
@@ -308,7 +303,7 @@ slip_input_byte(unsigned char c)
     if(c != SLIP_ESC_END && c != SLIP_ESC_ESC) {
       state = STATE_RUBBISH;
       SLIP_STATISTICS(slip_rubbish++);
-      next_free = pkt_end;		/* remove rubbish */
+      next_free = pkt_end;    /* remove rubbish */
       return 0;
     }
     state = STATE_OK;

--- a/os/dev/slip.c
+++ b/os/dev/slip.c
@@ -110,7 +110,7 @@ slip_send(void)
   return UIP_FW_OK;
 }
 /*---------------------------------------------------------------------------*/
-uint8_t
+void
 slip_write(const void *_ptr, int len)
 {
   const uint8_t *ptr = _ptr;
@@ -130,9 +130,8 @@ slip_write(const void *_ptr, int len)
     }
     slip_arch_writeb(c);
   }
-  slip_arch_writeb(SLIP_END);
 
-  return len;
+  slip_arch_writeb(SLIP_END);
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/dev/slip.c
+++ b/os/dev/slip.c
@@ -87,27 +87,7 @@ slip_set_input_callback(void (*c)(void))
 void
 slip_send(void)
 {
-  uint16_t i;
-  uint8_t *ptr;
-  uint8_t c;
-
-  slip_arch_writeb(SLIP_END);
-
-  ptr = &uip_buf[UIP_LLH_LEN];
-  for(i = 0; i < uip_len; ++i) {
-    c = *ptr++;
-    if(c == SLIP_END) {
-      slip_arch_writeb(SLIP_ESC);
-      c = SLIP_ESC_END;
-    } else if(c == SLIP_ESC) {
-      slip_arch_writeb(SLIP_ESC);
-      c = SLIP_ESC_ESC;
-    }
-    slip_arch_writeb(c);
-  }
-  slip_arch_writeb(SLIP_END);
-
-  return UIP_FW_OK;
+  slip_write(&uip_buf[UIP_LLH_LEN], uip_len);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/os/dev/slip.c
+++ b/os/dev/slip.c
@@ -44,11 +44,11 @@ PROCESS(slip_process, "SLIP driver");
 /*---------------------------------------------------------------------------*/
 static uint8_t slip_active;
 /*---------------------------------------------------------------------------*/
-#if 1
-#define SLIP_STATISTICS(statement)
-#else
+#if SLIP_CONF_WITH_STATS
 static uint16_t slip_rubbish, slip_twopackets, slip_overflow, slip_ip_drop;
 #define SLIP_STATISTICS(statement) statement
+#else
+#define SLIP_STATISTICS(statement)
 #endif
 /*---------------------------------------------------------------------------*/
 /* Must be at least one byte larger than UIP_BUFSIZE! */

--- a/os/dev/slip.c
+++ b/os/dev/slip.c
@@ -84,7 +84,7 @@ slip_set_input_callback(void (*c)(void))
   input_callback = c;
 }
 /*---------------------------------------------------------------------------*/
-uint8_t
+void
 slip_send(void)
 {
   uint16_t i;

--- a/os/dev/slip.c
+++ b/os/dev/slip.c
@@ -41,14 +41,13 @@
 #define SLIP_ESC_ESC 0335
 /*---------------------------------------------------------------------------*/
 PROCESS(slip_process, "SLIP driver");
-
-uint8_t slip_active;
-
+/*---------------------------------------------------------------------------*/
+static uint8_t slip_active;
 /*---------------------------------------------------------------------------*/
 #if 1
 #define SLIP_STATISTICS(statement)
 #else
-uint16_t slip_rubbish, slip_twopackets, slip_overflow, slip_ip_drop;
+static uint16_t slip_rubbish, slip_twopackets, slip_overflow, slip_ip_drop;
 #define SLIP_STATISTICS(statement) statement
 #endif
 /*---------------------------------------------------------------------------*/

--- a/os/dev/slip.h
+++ b/os/dev/slip.h
@@ -41,7 +41,7 @@ PROCESS_NAME(slip_process);
 /**
  * Send an IP packet from the uIP buffer with SLIP.
  */
-uint8_t slip_send(void);
+void slip_send(void);
 
 /**
  * Input a SLIP byte.

--- a/os/dev/slip.h
+++ b/os/dev/slip.h
@@ -62,6 +62,9 @@ void slip_send(void);
  */
 int slip_input_byte(unsigned char c);
 
+/**
+ * Send using SLIP len bytes starting from the location pointed to by ptr
+ */
 void slip_write(const void *ptr, int len);
 
 /**

--- a/os/dev/slip.h
+++ b/os/dev/slip.h
@@ -62,7 +62,7 @@ uint8_t slip_send(void);
  */
 int slip_input_byte(unsigned char c);
 
-uint8_t slip_write(const void *ptr, int len);
+void slip_write(const void *ptr, int len);
 
 /**
  * Set a function to be called when there is activity on the SLIP

--- a/os/dev/slip.h
+++ b/os/dev/slip.h
@@ -64,12 +64,6 @@ int slip_input_byte(unsigned char c);
 
 uint8_t slip_write(const void *ptr, int len);
 
-/* Did we receive any bytes lately? */
-extern uint8_t slip_active;
-
-/* Statistics. */
-extern uint16_t slip_rubbish, slip_twopackets, slip_overflow, slip_ip_drop;
-
 /**
  * Set a function to be called when there is activity on the SLIP
  * interface; used for detecting if a node is a gateway node.


### PR DESCRIPTION
This pull recommends the following changes to SLIP-related code:

* We have three places in the tree where the SLIP framing code is duplicated:
  * `slip_write()`: Outputs over SLIP an arbitrary number of bytes from a memory location. This is the one we keep.
  * `slip_send()`: Outputs the L3 contents of `uip_buf`. Now simply calls .`slip_write(&uip_buf[UIP_LLH_LEN], uip_len);`.
  * `slip_send_packet`: Provided by the slip-radio example. This is being removed and all calls now call `slip_write` instead.
* All calls to `slip_send` and `slip_write` were ignoring the return value, so the return type for both functions has been changed to `void`.
* SLIP statistics are now possible to turn on/off through a configuration define (were previously hard-coded to off).
* There was some dead code wrapped inside `#ifdef SLIP_CONF_MICROSOFT_CHAT` and `#ifdef SLIP_CONF_ANSWER_MAC_REQUEST.
`. These things don't seem to exist any more, so the respective blocks have been removed.
* Some variables changed to static.
* Code style fixes.
* Some documentation improvements.
