### PR TITLE
Extend the logging module to support custom module prefix

### DIFF
--- a/os/sys/log-conf.h
+++ b/os/sys/log-conf.h
@@ -81,7 +81,16 @@
 #define LOG_OUTPUT(...) printf(__VA_ARGS__)
 #endif /* LOG_CONF_OUTPUT */
 
-/* Custom log prefix output function -- default is LOG_OUTPUT */
+/*
+ * Custom output function to prefix logs with level and module.
+ *
+ * This will only be called when LOG_CONF_WITH_MODULE_PREFIX is enabled and
+ * all implementations should be based on LOG_OUTPUT.
+ *
+ * \param level     The log level
+ * \param levelstr  The log level as string
+ * \param module    The module string descriptor
+ */
 #ifdef LOG_CONF_OUTPUT_PREFIX
 #define LOG_OUTPUT_PREFIX(level, levelstr, module) LOG_CONF_OUTPUT_PREFIX(level, levelstr, module)
 #else /* LOG_CONF_OUTPUT_PREFIX */

--- a/os/sys/log-conf.h
+++ b/os/sys/log-conf.h
@@ -81,6 +81,13 @@
 #define LOG_OUTPUT(...) printf(__VA_ARGS__)
 #endif /* LOG_CONF_OUTPUT */
 
+/* Custom log prefix output function -- default is LOG_OUTPUT */
+#ifdef LOG_CONF_OUTPUT_PREFIX
+#define LOG_OUTPUT_PREFIX(level, levelstr, module) LOG_CONF_OUTPUT_PREFIX(level, levelstr, module)
+#else /* LOG_CONF_OUTPUT_PREFIX */
+#define LOG_OUTPUT_PREFIX(level, levelstr, module) LOG_OUTPUT("[%-4s: %-10s] ", levelstr, module)
+#endif /* LOG_CONF_OUTPUT_PREFIX */
+
 /******************************************************************************/
 /********************* A list of currently supported modules ******************/
 /******************************************************************************/

--- a/os/sys/log.h
+++ b/os/sys/log.h
@@ -101,7 +101,7 @@ extern struct log_module all_modules[];
                             if(level <= (LOG_LEVEL)) { \
                               if(newline) { \
                                 if(LOG_WITH_MODULE_PREFIX) { \
-                                  LOG_OUTPUT("[%-4s: %-10s] ", levelstr, LOG_MODULE); \
+                                  LOG_OUTPUT_PREFIX(level, levelstr, LOG_MODULE); \
                                 } \
                                 if(LOG_WITH_LOC) { \
                                   LOG_OUTPUT("[%s: %d] ", __FILE__, __LINE__); \


### PR DESCRIPTION
Adds a configuration option `LOG_CONF_OUTPUT_PREFIX` to specify a custom output function to output the log level and module name in the beginning of each log line. This makes it possible to add a timestamp or use a different log module prefix format than the default.