### PR TITLE
Readd back 'uip_stat' if UIP_STATISTICS is enabled

### DIFF
--- a/os/net/ipv6/uip6.c
+++ b/os/net/ipv6/uip6.c
@@ -98,6 +98,10 @@
 #define LOG_MODULE "IPv6"
 #define LOG_LEVEL LOG_LEVEL_IPV6
 
+#if UIP_STATISTICS == 1
+struct uip_stats uip_stat;
+#endif /* UIP_STATISTICS == 1 */
+
 /*---------------------------------------------------------------------------*/
 /**
  * \name Layer 2 variables


### PR DESCRIPTION
At the moment, trying to build with UIP_CONF_STATISTICS enabled leads to linking error. Looks like one variable too many was removed when migrating uIPv6 code from Contiki to Contiki-NG.