### PR TITLE
Sicslowpan UDP decompression fails when UIP_LLH_LEN != 0

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -123,7 +123,7 @@
 /* NOTE: In the multiple-reassembly context there is only room for the header / first fragment */
 #define SICSLOWPAN_IP_BUF(buf)   ((struct uip_ip_hdr *)buf)
 #define SICSLOWPAN_UDP_BUF(buf)  ((struct uip_udp_hdr *)&buf[UIP_IPH_LEN])
-#define SICSLOWPAN_IPPAYLOAD_BUF(buf) (&buf[UIP_LLIPH_LEN])
+#define SICSLOWPAN_IPPAYLOAD_BUF(buf) (&buf[UIP_IPH_LEN])
 
 
 #define UIP_IP_BUF          ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])


### PR DESCRIPTION
Sicslowpan places the UDP header at the wrong place when decompressing a packet when UIP_LLH_LEN is non-zero.

This is due to IPPAYLOAD_BUF macro adding a second time UIP_LLH_LEN : The buffer received by uncompress_hdr_iphc() is already offset by UIP_LLH_LEN as buffer is assigned to UIP_IP_BUF, which starts at UIP_LLH_LEN.