### PR TITLE
Update protocol field in remove_ext_hdr()

### DIFF
--- a/os/net/ipv6/tcpip.c
+++ b/os/net/ipv6/tcpip.c
@@ -472,12 +472,7 @@ output_fallback(void)
 #ifdef UIP_FALLBACK_INTERFACE
   LOG_INFO("fallback: removing ext hdrs & setting proto %d %d\n",
          uip_ext_len, *((uint8_t *)UIP_IP_BUF + 40));
-  if(uip_ext_len > 0) {
-    uint8_t proto = *((uint8_t *)UIP_IP_BUF + 40);
-    remove_ext_hdr();
-    /* This should be copied from the ext header... */
-    UIP_IP_BUF->proto = proto;
-  }
+  remove_ext_hdr();
   /* Inform the other end that the destination is not reachable. If it's
    * not informed routes might get lost unexpectedly until there's a need
    * to send a new packet to the peer */

--- a/os/net/ipv6/uip6.c
+++ b/os/net/ipv6/uip6.c
@@ -523,6 +523,7 @@ uip_connect(const uip_ipaddr_t *ripaddr, uint16_t rport)
 void
 remove_ext_hdr(void)
 {
+  int last_uip_ext_len;
   /* Remove ext header before TCP/UDP processing. */
   if(uip_ext_len > 0) {
     LOG_DBG("Cutting ext-header before processing (extlen: %d, uiplen: %d)\n",
@@ -532,15 +533,17 @@ remove_ext_hdr(void)
       uip_clear_buf();
       return;
     }
-    memmove(((uint8_t *)UIP_TCP_BUF), (uint8_t *)UIP_TCP_BUF + uip_ext_len,
-            uip_len - UIP_IPH_LEN - uip_ext_len);
+    last_uip_ext_len = uip_ext_len;
+    uip_ext_len = 0;
+    UIP_IP_BUF->proto = UIP_EXT_BUF->next;
+    memmove(((uint8_t *)UIP_TCP_BUF), (uint8_t *)UIP_TCP_BUF + last_uip_ext_len,
+	    uip_len - UIP_IPH_LEN - last_uip_ext_len);
 
-    uip_len -= uip_ext_len;
+    uip_len -= last_uip_ext_len;
 
     /* Update the IP length. */
     UIP_IP_BUF->len[0] = (uip_len - UIP_IPH_LEN) >> 8;
     UIP_IP_BUF->len[1] = (uip_len - UIP_IPH_LEN) & 0xff;
-    uip_ext_len = 0;
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -1494,7 +1497,6 @@ uip_process(uint8_t flag)
   udp_input:
 
   remove_ext_hdr();
-  UIP_IP_BUF->proto = UIP_PROTO_UDP;
 
   LOG_INFO("Receiving UDP packet\n");
 
@@ -1607,7 +1609,6 @@ uip_process(uint8_t flag)
   tcp_input:
 
   remove_ext_hdr();
-  UIP_IP_BUF->proto = UIP_PROTO_TCP;
 
   UIP_STAT(++uip_stat.tcp.recv);
   LOG_INFO("Receiving TCP packet\n");


### PR DESCRIPTION
The current remove_ext_hdr() do remove the extension header, but keep the protocol field of the IPv6 header unchanged. This force the calling function to manually set the protocol field afterwards.

With this PR, remove_ext_hdr() updates also the protocol field which is much safer.