### PR TITLE
Additional cleanup when becoming DODAG Root (rpl-classic)

### DIFF
--- a/os/net/rpl-classic/rpl-dag.c
+++ b/os/net/rpl-classic/rpl-dag.c
@@ -370,6 +370,7 @@ rpl_set_root(uint8_t instance_id, uip_ipaddr_t *dag_id)
         }
         if(dag == dag->instance->current_dag) {
           PRINTF("RPL: Dropping a joined DAG when setting this node as root");
+          rpl_set_default_route(instance, NULL);
           dag->instance->current_dag = NULL;
         } else {
           PRINTF("RPL: Dropping a DAG when setting this node as root");
@@ -665,6 +666,10 @@ rpl_free_dag(rpl_dag_t *dag)
     if(RPL_IS_STORING(dag->instance)) {
       rpl_remove_routes(dag);
     }
+    /* Stop the DAO retransmit timer */
+#if RPL_WITH_DAO_ACK
+    ctimer_stop(&dag->instance->dao_retransmit_timer);
+#endif /* RPL_WITH_DAO_ACK */
 
    /* Remove autoconfigured address */
     if((dag->prefix_info.flags & UIP_ND6_RA_FLAG_AUTONOMOUS)) {
@@ -1323,6 +1328,9 @@ rpl_local_repair(rpl_instance_t *instance)
 
   /* no downward route anymore */
   instance->has_downward_route = 0;
+#if RPL_WITH_DAO_ACK
+  ctimer_stop(&instance->dao_retransmit_timer);
+#endif /* RPL_WITH_DAO_ACK */
 
   rpl_reset_dio_timer(instance);
   if(RPL_IS_STORING(instance)) {

--- a/os/net/rpl-classic/rpl-icmp6.c
+++ b/os/net/rpl-classic/rpl-icmp6.c
@@ -1282,6 +1282,12 @@ dao_ack_input(void)
     parent = NULL;
   }
 
+  if(instance->current_dag->rank == ROOT_RANK(instance)) {
+    PRINTF("RPL: DODAG root received a DAO ACK, ignoring it\n");
+    uip_clear_buf();
+    return;
+  }
+
   PRINTF("RPL: Received a DAO %s with sequence number %d (%d) and status %d from ",
          status < 128 ? "ACK" : "NACK",
          sequence, instance->my_dao_seqno, status);


### PR DESCRIPTION
When a node has joined a DODAG as an intermediate router then later becomes DODAG Root, additional cleanup tasks are needed :

* The default route must be removed
* Any DAO retransmission must be cancelled
* Incoming DAO Ack should be ignored

Additionally, when doing a local repair, any pending DAO retransmission must be cancelled too, as there is no more a preferred parent to send it to.