### PR TITLE
Multicast routes are not renewed before the lifetime is elapsed

### DIFF
--- a/os/net/rpl-classic/rpl-private.h
+++ b/os/net/rpl-classic/rpl-private.h
@@ -199,13 +199,6 @@
 #define RPL_ROUTE_FROM_MULTICAST_DAO    2
 #define RPL_ROUTE_FROM_DIO              3
 
-/* Multicast Route Lifetime as a multiple of the lifetime unit */
-#ifdef RPL_CONF_MCAST_LIFETIME
-#define RPL_MCAST_LIFETIME RPL_CONF_MCAST_LIFETIME
-#else
-#define RPL_MCAST_LIFETIME 3
-#endif
-
 /* DIS related */
 #define RPL_DIS_SEND                    1
 

--- a/os/net/rpl-classic/rpl-timers.c
+++ b/os/net/rpl-classic/rpl-timers.c
@@ -283,7 +283,7 @@ handle_dao_timer(void *ptr)
         if(uip_ds6_if.maddr_list[i].isused
             && uip_is_addr_mcast_global(&uip_ds6_if.maddr_list[i].ipaddr)) {
           dao_output_target(instance->current_dag->preferred_parent,
-              &uip_ds6_if.maddr_list[i].ipaddr, RPL_MCAST_LIFETIME);
+              &uip_ds6_if.maddr_list[i].ipaddr, instance->default_lifetime);
         }
       }
 
@@ -293,7 +293,7 @@ handle_dao_timer(void *ptr)
         /* Don't send if it's also our own address, done that already */
         if(uip_ds6_maddr_lookup(&mcast_route->group) == NULL) {
           dao_output_target(instance->current_dag->preferred_parent,
-                     &mcast_route->group, RPL_MCAST_LIFETIME);
+                     &mcast_route->group, instance->default_lifetime);
         }
         mcast_route = list_item_next(mcast_route);
       }


### PR DESCRIPTION
The default lifetime of the multicast route in the DAO message is currently set to 3 times the default lifetime unit.
However, the DAO scheduling is based solely on the unicast route lifetime, which means that the multicast routes are removed before the renewing DAO is sent.
This PR provides a simple workaround by setting the multicast route lifetime equal to the unicast one.