### PR TITLE
Remove nrf52832.a on make clean

### DIFF
--- a/arch/cpu/nrf52832/Makefile.nrf52832
+++ b/arch/cpu/nrf52832/Makefile.nrf52832
@@ -178,6 +178,8 @@ vpath %.s $(ASM_PATHS)
 
 OBJECTS = $(C_OBJECTS) $(ASM_OBJECTS)
 
+CLEAN += nrf52832.a
+
 TARGET_LIBS= nrf52832.a $(NRF52_SDK_ROOT)/components/iot/ble_6lowpan/lib/ble_6lowpan.a
 
 nrf52832.a: $(OBJECTS)


### PR DESCRIPTION
When building for nrf52dk, `make clean` does not remove `nrf52832.a`. This commit fixes this.