### PR TITLE
Gitignore saved defines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *~
 obj_*
 Makefile.target
+Makefile.*.defines
 tools/doxygen/html
 patches-*
 tools/tunslip


### PR DESCRIPTION
`make TARGET=foo DEFINES=bar savedefines` will create a file called `Makefile.foo.defines`. This needs gitignored.