### PR TITLE
Link without using an archive file

### DIFF
--- a/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
+++ b/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
@@ -17,7 +17,9 @@ CPU_STARTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(CPU_START_SOURCEFILES
 ### Compilation rules
 CUSTOM_RULE_LINK = 1
 
-%.elf: $(CPU_STARTFILES) %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a $(LDSCRIPT)
+.SECONDEXPANSION:
+
+%.elf: $(CPU_STARTFILES) $$(CONTIKI_OBJECTFILES) %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(LDSCRIPT)
 	$(TRACE_LD)
 	$(Q)$(LD) $(LDFLAGS) ${filter-out $(LDSCRIPT) %.a,$^} ${filter %.a,$^} $(TARGET_LIBFILES) -lm -o $@
 

--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -36,8 +36,6 @@ CPU_START_SOURCEFILES = startup-gcc.c
 CONTIKI_SOURCEFILES += $(CONTIKI_CPU_SOURCEFILES) $(DEBUG_IO_SOURCEFILES)
 CONTIKI_SOURCEFILES += $(USB_SOURCEFILES)
 
-.SECONDEXPANSION:
-
 ### Always re-build ieee-addr.o in case the command line passes a new NODEID
 FORCE:
 

--- a/arch/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/arch/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -209,7 +209,7 @@ static const output_config_t output_power[] = {
 #define OUTPUT_POWER_UNKNOWN 0xFFFF
 
 /* Default TX Power - position in output_power[] */
-const output_config_t *tx_power_current = &output_power[0];
+static const output_config_t *tx_power_current = &output_power[0];
 /*---------------------------------------------------------------------------*/
 static volatile int8_t last_rssi = 0;
 static volatile uint8_t last_corr_lqi = 0;

--- a/arch/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/arch/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -203,7 +203,7 @@ extern const prop_mode_tx_power_config_t TX_POWER_DRIVER[];
 #define OUTPUT_POWER_UNKNOWN 0xFFFF
 
 /* Default TX Power - position in output_power[] */
-const prop_mode_tx_power_config_t *tx_power_current = &TX_POWER_DRIVER[1];
+static const prop_mode_tx_power_config_t *tx_power_current = &TX_POWER_DRIVER[1];
 /*---------------------------------------------------------------------------*/
 #ifdef PROP_MODE_CONF_LO_DIVIDER
 #define PROP_MODE_LO_DIVIDER   PROP_MODE_CONF_LO_DIVIDER


### PR DESCRIPTION
For reasons discussed long ago and that have to do with how `ld` handles weak symbols, it was decided that it was preferable to link using an explicit list of object files, instead of adding object files to an archive first and then linking using this archive. This was applied for the CC2538, but not for CC13xx/CC26xx.

This pull applies this link logic to all CM3s. For this to work with the Contiki-NG build system, we need `.SECONDEXPANSION:`, so this pull moves that to the common CM3 Makefile.