### PR TITLE
CI tests: cleaner compilation artifacts

### DIFF
--- a/tests/00-doxygen/Makefile
+++ b/tests/00-doxygen/Makefile
@@ -30,15 +30,15 @@ DOCDIR=../../tools/doxygen
 all: clean summary
 
 doxygen:
-	@make -C $(DOCDIR) 2> doxygen.runerr > doxygen.runlog
+	@make -C $(DOCDIR) 2> doxygen.err > /dev/null
 
 summary: doxygen
 	@( \
 		1> summary; \
-		if [ -s doxygen.runerr ] ; then \
+		if [ -s doxygen.err ] ; then \
 			echo "Doxygen: TEST FAIL" | tee summary; \
 			echo "Errors:"; \
-			cat doxygen.runerr; \
+			cat doxygen.err; \
 		fi ; \
 		if [ -s $(DOCDIR)/doxygen.log ] ; then \
 			echo "Doxygen: TEST FAIL" | tee summary; \
@@ -49,10 +49,10 @@ summary: doxygen
 			echo "Doxygen: TEST OK (no warning nor error)" | tee summary; \
 		fi ; \
 	)
-	@rm doxygen.runlog doxygen.runerr
+	@rm doxygen.err
 	@echo "========== Summary =========="
 	@cat summary
 
 clean:
-	@rm -f summary doxygen.runlog doxygen.runerr
+	@rm -f summary doxygen.err
 	@make -C $(DOCDIR) clean

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -41,10 +41,10 @@ define dooneexample
 @echo -n Building example $(3): $(1) $(4) for target $(2)
 @((cd $(EXAMPLESDIR)/$(1); \
  make $(4) TARGET=$(2) clean && make -j $(4) TARGET=$(2) WERROR=1) > \
-      /dev/null 2>make.runerr && \
+      /dev/null 2>make.err && \
  (echo " -> OK" && printf "%-75s %-35s %-20s TEST OK\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog) || \
- (echo " -> FAIL" && printf "%-75s %-35s %-20s TEST FAIL\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog ; cat make.runerr))
-@rm -f make.runerr
+ (echo " -> FAIL" && printf "%-75s %-35s %-20s TEST FAIL\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog ; cat make.err))
+@rm -f make.err
 endef
 
 define doexample


### PR DESCRIPTION
This cleans up CI tests artifacts, i.e., uses more consistent extensions (which are gitignored)