### PR TITLE
Various native platform updates

### DIFF
--- a/arch/platform/native/contiki-conf.h
+++ b/arch/platform/native/contiki-conf.h
@@ -69,7 +69,9 @@ typedef  int32_t s32_t;
 
 typedef unsigned short uip_stats_t;
 
+#ifndef UIP_CONF_BYTE_ORDER
 #define UIP_CONF_BYTE_ORDER      UIP_LITTLE_ENDIAN
+#endif
 
 #if NETSTACK_CONF_WITH_IPV6
 

--- a/arch/platform/native/contiki-conf.h
+++ b/arch/platform/native/contiki-conf.h
@@ -67,7 +67,7 @@ typedef uint16_t u16_t;
 typedef uint32_t u32_t;
 typedef  int32_t s32_t;
 
-typedef unsigned short uip_stats_t;
+typedef unsigned int uip_stats_t;
 
 #ifndef UIP_CONF_BYTE_ORDER
 #define UIP_CONF_BYTE_ORDER      UIP_LITTLE_ENDIAN

--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -76,6 +76,12 @@
 #define SELECT_MAX 8
 #endif
 
+#ifdef SELECT_CONF_TIMEOUT
+#define SELECT_TIMEOUT SELECT_CONF_TIMEOUT
+#else
+#define SELECT_TIMEOUT 1000
+#endif
+
 static const struct select_callback *select_callback[SELECT_MAX];
 static int select_max = 0;
 
@@ -252,7 +258,7 @@ platform_main_loop()
     retval = process_run();
 
     tv.tv_sec = 0;
-    tv.tv_usec = retval ? 1 : 1000;
+    tv.tv_usec = retval ? 1 : SELECT_TIMEOUT;
 
     FD_ZERO(&fdr);
     FD_ZERO(&fdw);

--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -82,6 +82,12 @@
 #define SELECT_TIMEOUT 1000
 #endif
 
+#ifdef SELECT_CONF_STDIN
+#define SELECT_STDIN SELECT_CONF_STDIN
+#else
+#define SELECT_STDIN 1
+#endif
+
 static const struct select_callback *select_callback[SELECT_MAX];
 static int select_max = 0;
 
@@ -122,6 +128,7 @@ select_set_callback(int fd, const struct select_callback *callback)
   return 0;
 }
 /*---------------------------------------------------------------------------*/
+#if SELECT_STDIN
 static int
 stdin_set_fd(fd_set *rset, fd_set *wset)
 {
@@ -141,6 +148,7 @@ stdin_handle_fd(fd_set *rset, fd_set *wset)
 const static struct select_callback stdin_fd = {
   stdin_set_fd, stdin_handle_fd
 };
+#endif /* SELECT_STDIN */
 /*---------------------------------------------------------------------------*/
 static void
 set_lladdr(void)
@@ -246,7 +254,9 @@ platform_init_stage_three()
 void
 platform_main_loop()
 {
+#if SELECT_STDIN
   select_set_callback(STDIN_FILENO, &stdin_fd);
+#endif /* SELECT_STDIN */
   while(1) {
     fd_set fdr;
     fd_set fdw;

--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -70,23 +70,43 @@
 #define LOG_MODULE "Native"
 #define LOG_LEVEL LOG_LEVEL_MAIN
 
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Native Platform Configuration
+ *
+ * @{
+ */
+
+/*
+ * Defines the maximum number of file descriptors monitored by the platform
+ * main loop.
+ */
 #ifdef SELECT_CONF_MAX
 #define SELECT_MAX SELECT_CONF_MAX
 #else
 #define SELECT_MAX 8
 #endif
 
+/*
+ * Defines the timeout (in msec) of the select operation if no monitored file
+ * descriptors becomes ready.
+ */
 #ifdef SELECT_CONF_TIMEOUT
 #define SELECT_TIMEOUT SELECT_CONF_TIMEOUT
 #else
 #define SELECT_TIMEOUT 1000
 #endif
 
+/*
+ * Adds the STDIN file descriptor to the list of monitored file descriptors.
+ */
 #ifdef SELECT_CONF_STDIN
 #define SELECT_STDIN SELECT_CONF_STDIN
 #else
 #define SELECT_STDIN 1
 #endif
+/** @} */
+/*---------------------------------------------------------------------------*/
 
 static const struct select_callback *select_callback[SELECT_MAX];
 static int select_max = 0;


### PR DESCRIPTION
This PR contains bunch of small improvements for the native platform :

* Allow to change the duration of the select timeout (useful on low performance routers)
* Make the stdin select callback configurable (otherwise keeping stdin open prevent putting the process in background)
* Allow to change UIP_CONF_BYTE_ORDER
* Change uip_stats_t from short to int (memory is not a constaint on native, and 16bits counter is too short)