### PR TITLE
Update soc-rtc.c for use with Sensor Controller

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/dev/soc-rtc.c
+++ b/arch/cpu/cc26xx-cc13xx/dev/soc-rtc.c
@@ -86,7 +86,7 @@ soc_rtc_init(void)
   ti_lib_aon_event_mcu_wake_up_set(AON_EVENT_MCU_WU0, AON_EVENT_RTC_CH0);
   ti_lib_aon_event_mcu_wake_up_set(AON_EVENT_MCU_WU1, AON_EVENT_RTC_CH1);
   ti_lib_aon_event_mcu_wake_up_set(AON_EVENT_MCU_WU2, AON_EVENT_RTC_CH2);
-  ti_lib_aon_rtc_combined_event_config(AON_RTC_CH0 | AON_RTC_CH1 | AON_RTC_CH2);
+  ti_lib_aon_rtc_combined_event_config(AON_RTC_CH0 | AON_RTC_CH1);
 
   HWREG(AON_RTC_BASE + AON_RTC_O_SEC) = SOC_RTC_START_TICK_COUNT;
 


### PR DESCRIPTION
ti_lib_aon_rtc_combined_event_config() should only use event AON_RTC_CH0 & 1. AON_RTC_CH2 is used for the CC2XXX sensor controller. If someone want to use the sensor controller on the cpu, AON_RTC_CH2 can't be used by the soc_rtc.c.