### PR TITLE
Include strings.h to access strncasecmp

### DIFF
--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/cc26xx-web-demo.c
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/cc26xx-web-demo.c
@@ -55,6 +55,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include "ti-lib.h"
 /*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/net-uart.c
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/net-uart.c
@@ -71,6 +71,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <strings.h>
 #include <stdio.h>
 #include <stdlib.h>
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This patch fixes a missing include of `strings.h` in two files that make use of the `strncasecmp` function in the cc26xx-web-demo; the missing includes makes the build of the demo fail.