### PR TITLE
NullNet examples: check paylaod size before reading it

### DIFF
--- a/examples/nullnet/nullnet-broadcast.c
+++ b/examples/nullnet/nullnet-broadcast.c
@@ -65,9 +65,11 @@ AUTOSTART_PROCESSES(&nullnet_example_process);
 void input_callback(const void *data, uint16_t len,
   const linkaddr_t *src, const linkaddr_t *dest)
 {
-  LOG_INFO("Received %u from ", *(unsigned *)data);
-  LOG_INFO_LLADDR(src);
-  LOG_INFO_("\n");
+  if(len == sizeof(unsigned)) {
+    LOG_INFO("Received %u from ", *(unsigned *)data);
+    LOG_INFO_LLADDR(src);
+    LOG_INFO_("\n");
+  }
 }
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(nullnet_example_process, ev, data)

--- a/examples/nullnet/nullnet-unicast.c
+++ b/examples/nullnet/nullnet-unicast.c
@@ -67,9 +67,11 @@ AUTOSTART_PROCESSES(&nullnet_example_process);
 void input_callback(const void *data, uint16_t len,
   const linkaddr_t *src, const linkaddr_t *dest)
 {
-  LOG_INFO("Received %u from ", *(unsigned *)data);
-  LOG_INFO_LLADDR(src);
-  LOG_INFO_("\n");
+  if(len == sizeof(unsigned)) {
+    LOG_INFO("Received %u from ", *(unsigned *)data);
+    LOG_INFO_LLADDR(src);
+    LOG_INFO_("\n");
+  }
 }
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(nullnet_example_process, ev, data)


### PR DESCRIPTION
Adds sanity check to input callback. Without it, the function might be called even with empty payload, e.g. when receiving a TSCH keep-alive.