### PR TITLE
Disable TSCH HW frame filtering on platform sky

### DIFF
--- a/arch/platform/sky/sky-def.h
+++ b/arch/platform/sky/sky-def.h
@@ -52,6 +52,9 @@
 /* Delay between the SFD finishes arriving and it is detected in software */
 #define RADIO_DELAY_BEFORE_DETECT 0
 
+/* Disable TSCH frame filtering */
+#define TSCH_CONF_HW_FRAME_FILTERING  0
+
 #define PLATFORM_HAS_LEDS    1
 #define PLATFORM_HAS_BUTTON  1
 #define PLATFORM_HAS_LIGHT   1


### PR DESCRIPTION
I believe frame filtering for frames v2 used to work on cc2420/MSPSim on earlier TSCH versions, where the format was from IEEE 802.15.4e-2012. Now with the new IEEE 802.15.4-2015 I suspect this might be broken. In MSPSim at least, it is. All other platforms already disable HW frame filtering, because chips do not understand the new format.

This disables HW frame filtering for TSCH on Sky.