### PR TITLE
Shell: do not disable logging at init

### DIFF
--- a/os/services/shell/shell-commands.c
+++ b/os/services/shell/shell-commands.c
@@ -712,11 +712,6 @@ shell_commands_init(void)
   /* Set up Ping Reply callback */
   uip_icmp6_echo_reply_callback_add(&echo_reply_notification,
                                     echo_reply_handler);
-  /* Start with soft log level 0 so as to minimize interference with shell */
-  log_set_level("all", LOG_LEVEL_NONE);
-#if MAC_CONF_WITH_TSCH && TSCH_LOG_PER_SLOT
-  tsch_log_stop();
-#endif /* MAC_CONF_WITH_TSCH && TSCH_LOG_PER_SLOT */
 }
 /*---------------------------------------------------------------------------*/
 struct shell_command_t shell_commands[] = {


### PR DESCRIPTION
This has already gotten enough people confused... with this PR the logging module will start as usual even when the shell is used. Use the shell command "log all 0" to disable logging at runtime.