### PR TITLE
Deleted duplicate const specifiers

### DIFF
--- a/arch/cpu/arm/common/usb/cdc-acm/cdc-acm-descriptors.c
+++ b/arch/cpu/arm/common/usb/cdc-acm/cdc-acm-descriptors.c
@@ -122,5 +122,5 @@ const struct configuration_st {
           
   };
 
-const struct usb_st_configuration_descriptor const *configuration_head =
-(struct usb_st_configuration_descriptor const*)&configuration_block;
+const struct usb_st_configuration_descriptor* const configuration_head =
+(const struct usb_st_configuration_descriptor*)&configuration_block;

--- a/arch/cpu/arm/common/usb/descriptors.h
+++ b/arch/cpu/arm/common/usb/descriptors.h
@@ -6,5 +6,5 @@
 #endif
 
 extern const struct usb_st_device_descriptor device_descriptor;
-extern const struct usb_st_configuration_descriptor const *configuration_head;
+extern const struct usb_st_configuration_descriptor* const configuration_head;
 #endif /* DESCRIPTORS_H_RPFUB8O7OV__ */

--- a/arch/cpu/cc2538/usb/cdc-acm-descriptors.c
+++ b/arch/cpu/cc2538/usb/cdc-acm-descriptors.c
@@ -161,7 +161,7 @@ const struct configuration_st {
 
   };
 
-const struct usb_st_configuration_descriptor const *configuration_head =
-(struct usb_st_configuration_descriptor const *)&configuration_block;
+const struct usb_st_configuration_descriptor* const configuration_head =
+(const struct usb_st_configuration_descriptor*)&configuration_block;
 
 /** @} */

--- a/arch/cpu/cc2538/usb/common/descriptors.h
+++ b/arch/cpu/cc2538/usb/common/descriptors.h
@@ -6,5 +6,5 @@
 #endif
 
 extern const struct usb_st_device_descriptor device_descriptor;
-extern const struct usb_st_configuration_descriptor const *configuration_head;
+extern const struct usb_st_configuration_descriptor* const configuration_head;
 #endif /* DESCRIPTORS_H_RPFUB8O7OV__ */


### PR DESCRIPTION
When compiling a custom example, I've encountered the following error which prevented me from compiling:

```
In file included from ../../arch/cpu/cc2538/usb/common/usb-core.c:6:0:
../../arch/cpu/cc2538/usb/common/descriptors.h:9:53: error: duplicate 'const' declaration specifier [-Werror=duplicate-decl-specifier]
 extern const struct usb_st_configuration_descriptor const *configuration_head;
```

This fix removes the double const (`const const *`) and changes the pointer to a `const * const` pointer, which was probably intended.
As I am not that familiar with the code, it is best that this fix is double checked.