### PR TITLE
Allow Shell operaction for CC13xx/CC26xx

### DIFF
--- a/arch/platform/srf06-cc26xx/platform.c
+++ b/arch/platform/srf06-cc26xx/platform.c
@@ -55,6 +55,7 @@
 #include "vims.h"
 #include "dev/cc26xx-uart.h"
 #include "dev/soc-rtc.h"
+#include "dev/serial-line.h"
 #include "rf-core/rf-core.h"
 #include "sys_ctrl.h"
 #include "uart.h"
@@ -167,6 +168,10 @@ platform_init_stage_two()
 #endif
 
   serial_line_init();
+
+#if BUILD_WITH_SHELL
+  cc26xx_uart_set_input(serial_line_input_byte);
+#endif
 
   /* Populate linkaddr_node_addr */
   ieee_addr_cpy_to(linkaddr_node_addr.u8, LINKADDR_SIZE);


### PR DESCRIPTION
As discussed in #187, the CC13xx/CC26xx platform code goes to sleep very aggressively: Unless we have explicitly requested a peripheral to stay on, the code will turn it off when entering a low power mode.

Leaving the UART on during low power increases energy consumption by quite a lot, so the default platform code allows it to go to sleep. This basically means that we lose UART RX in low power, in other words the shell won't work.

This pull implements a temporary workaround: If we are building with Shell support, the platform code will automatically request UART RX while in low-power mode. This makes all affected platforms behave as per the Shell tutorial (which we should update, really, to state that enabling the Shell will increase energy consumption for some platforms).

Fixes #187