### PR TITLE
CC26xx: increase size of the region reserved for stack from 256 bytes to 1024 bytes

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/cc26xx.ld
+++ b/arch/cpu/cc26xx-cc13xx/cc26xx.ld
@@ -56,7 +56,7 @@ _estack = ORIGIN(SRAM) + LENGTH(SRAM); /* End of SRAM */
 
 /*. Generate a link error if heap and stack don’t fit into RAM .*/
 _Min_Heap_Size = 0;
-_Min_Stack_Size = 0x100;
+_Min_Stack_Size = 0x400;
 
 SECTIONS
 {

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/project-conf.h
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/project-conf.h
@@ -60,9 +60,9 @@
  * Shrink the size of the uIP buffer, routing table and ND cache.
  * Set the TCP MSS
  */
-#define UIP_CONF_BUFFER_SIZE                900
-#define NETSTCK_ROUTING_STATE_SIZE            5
-#define NBR_TABLE_CONF_MAX_NEIGHBORS         5
+#define UIP_CONF_BUFFER_SIZE                500
+#define NETSTACK_MAX_ROUTE_ENTRIES            5
+#define NBR_TABLE_CONF_MAX_NEIGHBORS          5
 #define UIP_CONF_TCP_MSS                    128
 /*---------------------------------------------------------------------------*/
 #endif /* PROJECT_CONF_H_ */


### PR DESCRIPTION
As previously discussed in the Contiki issue tracker, the size of memory reserved for stack region on CC26xx is inadequately small.

For example, the cc26xx-web-demo to process some simple CoAP requests use 768 bytes of stack (measured with the stack check library). It has >1000 bytes of stack memory actually available, so it doesn't crash, but this is still bad. Custom applications developed on top of this demo may compile and link, give their developers false sense of security, but then fail at runtime.

This PR proposes to increase it to 1024 bytes (In SPHERE, we're using ~2000 bytes). With the new "build all" script I tested that this setting does not cause build failures on any examples - all examples that build with 256 byte setting also build with 1024 byte setting.