### PR TITLE
Tidy-up MODULES

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -52,7 +52,7 @@ ifneq ("$(wildcard project-conf.h)","")
 CFLAGS += -DPROJECT_CONF_PATH=\"project-conf.h\"
 endif
 
-MODULES += os os/net os/net/mac os/net/routing os/storage
+MODULES += os os/net os/net/mac os/net/mac/framer os/net/routing os/storage
 
 oname = ${patsubst %.c,%.o,${patsubst %.S,%.o,$(1)}}
 

--- a/arch/platform/cc2538dk/Makefile.cc2538dk
+++ b/arch/platform/cc2538dk/Makefile.cc2538dk
@@ -19,8 +19,7 @@ CLEAN += *.cc2538dk
 CONTIKI_CPU=$(CONTIKI)/arch/cpu/cc2538
 include $(CONTIKI_CPU)/Makefile.cc2538
 
-MODULES += os/net os/net/mac os/net/mac/framer \
-  os/storage/cfs
+MODULES += os/storage/cfs
 
 PYTHON = python
 BSL_FLAGS += -e -w -v

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -40,9 +40,6 @@ ARCHIVE = $(OBJECTDIR)/$(LIBNAME).a
 JNILIB = $(OBJECTDIR)/$(LIBNAME).$(TARGET)
 CONTIKI_APP_OBJ = $(CONTIKI_APP).o
 
-# Modules
-MODULES += os/net os/net/mac os/net/mac/framer
-
 ### COOJA platform sources
 COOJA = $(CONTIKI)/arch/platform/$(TARGET)
 CONTIKI_TARGET_DIRS = . dev lib sys cfs net

--- a/arch/platform/jn516x/Makefile.jn516x
+++ b/arch/platform/jn516x/Makefile.jn516x
@@ -143,8 +143,6 @@ endif
 CLEAN += *.jn516x
 CLEAN += *.jn516x.bin
 
-MODULES += os/net os/net/mac os/net/mac/framer
-
 CONTIKI_TARGET_SOURCEFILES += $(ARCH)
 CONTIKI_SOURCEFILES        += $(CONTIKI_TARGET_SOURCEFILES)
 

--- a/arch/platform/native/Makefile.native
+++ b/arch/platform/native/Makefile.native
@@ -33,5 +33,3 @@ MAKE_MAC ?= MAKE_MAC_NULLMAC
 ### Define the CPU directory
 CONTIKI_CPU=$(CONTIKI)/arch/cpu/native
 include $(CONTIKI)/arch/cpu/native/Makefile.native
-
-MODULES+=os/net os/net/mac os/net/mac/framer

--- a/arch/platform/nrf52dk/Makefile.nrf52dk
+++ b/arch/platform/nrf52dk/Makefile.nrf52dk
@@ -27,5 +27,3 @@ SMALL ?= 0
 ### Define the CPU directory and pull in the correct CPU makefile.
 CONTIKI_CPU=$(CONTIKI)/arch/cpu/nrf52832
 include $(CONTIKI_CPU)/Makefile.nrf52832
-
-MODULES += os/net os/net/mac os/net/mac/framer

--- a/arch/platform/openmote-cc2538/Makefile.openmote-cc2538
+++ b/arch/platform/openmote-cc2538/Makefile.openmote-cc2538
@@ -26,8 +26,7 @@ CLEAN += *.openmote-cc2538
 CONTIKI_CPU=$(CONTIKI)/arch/cpu/cc2538
 include $(CONTIKI_CPU)/Makefile.cc2538
 
-MODULES += os/net os/net/mac os/net/mac/framer \
-  os/storage/cfs
+MODULES += os/storage/cfs
 
 PYTHON = python
 BSL_FLAGS += -e --bootloader-invert-lines -w -v -b 450000

--- a/arch/platform/sky/Makefile.sky
+++ b/arch/platform/sky/Makefile.sky
@@ -6,6 +6,4 @@ CONTIKI_TARGET_SOURCEFILES += contiki-sky-platform.c \
 
 include $(CONTIKI)/arch/platform/sky/Makefile.common
 
-MODULES += os/net/mac os/net/mac/framer os/net \
-           arch/dev/cc2420 arch/dev/sht11 arch/dev/ds2411 \
-					 os/storage/cfs
+MODULES += arch/dev/cc2420 arch/dev/sht11 arch/dev/ds2411 os/storage/cfs

--- a/arch/platform/srf06-cc26xx/Makefile.srf06-cc26xx
+++ b/arch/platform/srf06-cc26xx/Makefile.srf06-cc26xx
@@ -30,5 +30,3 @@ SMALL ?= 0
 ### Makefile.cc26xx or Makefile.cc13xx
 CONTIKI_CPU=$(CONTIKI)/arch/cpu/cc26xx-cc13xx
 include $(CONTIKI_CPU)/Makefile.$(CPU_FAMILY)
-
-MODULES += os/net os/net/mac os/net/mac/framer

--- a/arch/platform/zoul/Makefile.zoul
+++ b/arch/platform/zoul/Makefile.zoul
@@ -44,9 +44,7 @@ CLEAN += *.zoul
 CONTIKI_CPU=$(CONTIKI)/arch/cpu/cc2538
 include $(CONTIKI_CPU)/Makefile.cc2538
 
-MODULES += os/net os/net/mac os/net/mac/framer \
-           arch/dev/cc1200 \
-           os/storage/cfs
+MODULES += arch/dev/cc1200 os/storage/cfs
 
 BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
 


### PR DESCRIPTION
This pull adds `os/net/mac/framer` to `MODULES` in the top-level `Makefile.include`, since we always need it. The pull also removes unnecessary `MODULES` from various platform Makefiles.

Closes #298