### PR TITLE
Fix BOARDS string in srf06-cc26xx platform makefile

### DIFF
--- a/arch/platform/srf06-cc26xx/Makefile.srf06-cc26xx
+++ b/arch/platform/srf06-cc26xx/Makefile.srf06-cc26xx
@@ -6,7 +6,7 @@ endif
 
 ### Board and BSP selection
 BOARD ?= srf06/cc26xx
-BOARDS = srf06/cc26xx srf06/cc13xx launchpad/cc26xx launchpad/cc13xx sensortag/cc26xx sensortag/cc13xx
+BOARDS = srf06/cc26xx srf06/cc13xx launchpad/cc2650 launchpad/cc1310 launchpad/cc1350 sensortag/cc2650 sensortag/cc1350
 
 CONTIKI_TARGET_DIRS += .
 


### PR DESCRIPTION
Fix BOARDS string in srf06-cc26xx platform makefile to accurately reflect all valid values of the BOARD variable.