### PR TITLE
Fix build under GNU make v3.81

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -54,7 +54,7 @@ endif
 
 MODULES += os os/net os/net/mac os/net/mac/framer os/net/routing os/storage
 
-define oname =
+define oname
 ${patsubst %.c,%.o, \
 ${patsubst %.S,%.o, \
 ${patsubst %.s,%.o, \


### PR DESCRIPTION
#321 broke the build system under GNU Make v3.81. Absolutely nothing will build.

```
$ make TARGET=zoul
  CC        ../../arch/cpu/cc2538/cc2538.lds
  CC        hello-world.c
  LD        hello-world.elf
/usr/local/gcc-arm-none-eabi-5_2-2015q4/bin/../lib/gcc/arm-none-eabi/5.2.1/../../../../arm-none-eabi/bin/ld: warning: cannot find entry symbol flash_cca_lock_page; defaulting to 0000000000202000
arm-none-eabi-objcopy -O ihex hello-world.elf hello-world.i16hex
arm-none-eabi-objcopy: error: the input file 'hello-world.elf' has no sections
make: *** [hello-world.i16hex] Error 1
rm hello-world.o
```
```
$ make -version
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for i386-apple-darwin11.3.0
```

The reason is that under this version of Make:
> The define directive is followed on the same line by the name of the variable and nothing more.

Whereas from 3.82 onwards:
> The define directive is followed on the same line by the name of the variable being defined and an (optional) assignment operator, and nothing more.
> ...
> You may omit the variable assignment operator if you prefer. If omitted, make assumes it to be ‘=’ ...

This pull restores compatibility with 3.81 by removing the assignment operator.