### PR TITLE
Add missing extern keyword

### DIFF
--- a/os/net/mac/tsch/tsch-private.h
+++ b/os/net/mac/tsch/tsch-private.h
@@ -94,9 +94,9 @@ extern struct tsch_asn_divisor_t tsch_hopping_sequence_length;
 /* TSCH timeslot timing (in rtimer ticks) */
 extern rtimer_clock_t tsch_timing[tsch_ts_elements_count];
 /* Statistics on the current session */
-unsigned long tx_count;
-unsigned long rx_count;
-unsigned long sync_count;
+extern unsigned long tx_count;
+extern unsigned long rx_count;
+extern unsigned long sync_count;
 
 /* TSCH processes */
 PROCESS_NAME(tsch_process);


### PR DESCRIPTION
GCC assumes extern, but other toolchains complain about multiple variable definition at files including this header.

Reported by @serdarkose
