### PR TITLE
add cfs support for srf06-cc26xx

### DIFF
--- a/arch/platform/srf06-cc26xx/cfs-coffee-arch.h
+++ b/arch/platform/srf06-cc26xx/cfs-coffee-arch.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008, Swedish Institute of Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Coffee architecture-dependent header for the srf06-cc2650 sensortag platform.
+ * \author
+ *         Dongda Lee <dongdongbhbh@gmail.com>
+ */
+
+#ifndef CFS_COFFEE_ARCH_H
+#define CFS_COFFEE_ARCH_H
+
+#include "contiki-conf.h"
+#include "dev/xmem.h"
+
+/*** MX25R8035F Memory Organization
+The memory is organized as: 
+8Mbit = 1048576 bytes (8 bits each) 
+256 sectors (32 Kbits, 4096 bytes each) 
+4096 pages (256 bytes each). 
+Each page can be individually programmed (bits are programmed from 1 to 0). The device is 
+sector or bulk erasable (bits are erased from 0 to 1) but not page erasable
+*/
+#define COFFEE_XMEM_TOTAL_SIZE_KB       1024UL  //Total size of the External Flash Memory in the Z1
+
+/* Coffee configuration parameters. */
+#define COFFEE_SECTOR_SIZE      4096UL  
+#define COFFEE_PAGE_SIZE        256UL
+#define COFFEE_START            0UL             //COFFEE_SECTOR_SIZE
+#define COFFEE_SIZE             (COFFEE_XMEM_TOTAL_SIZE_KB * 1024UL - COFFEE_START)
+#define COFFEE_NAME_LENGTH      16
+#define COFFEE_MAX_OPEN_FILES   6
+#define COFFEE_FD_SET_SIZE      8
+#define COFFEE_LOG_TABLE_LIMIT  256
+#define COFFEE_DYN_SIZE         2*1024
+#define COFFEE_LOG_SIZE         1024
+
+#define COFFEE_MICRO_LOGS       1
+
+
+
+
+
+
+/* Flash operations. */
+#define COFFEE_WRITE(buf, size, offset)             \
+        xmem_pwrite((char *)(buf), (size), COFFEE_START + (offset))
+
+#define COFFEE_READ(buf, size, offset)              \
+        xmem_pread((char *)(buf), (size), COFFEE_START + (offset))
+
+#define COFFEE_ERASE(sector)                    \
+        xmem_erase(COFFEE_SECTOR_SIZE, COFFEE_START + (sector) * COFFEE_SECTOR_SIZE)
+
+/* Coffee types. */
+typedef int16_t coffee_page_t;
+
+#endif /* !COFFEE_ARCH_H */

--- a/arch/platform/srf06-cc26xx/common/xmem.c
+++ b/arch/platform/srf06-cc26xx/common/xmem.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/**
+ * \file
+ *         Device driver for the MX25R8035F 1Mbyte external memory.
+ * \author
+ *         Dongda Lee <dongdongbhbh@gmail.com>
+ *
+ *         Data is written bit inverted (~-operator) to flash so that
+ *         unwritten data will read as zeros (UNIX style).
+ */
+
+#include "contiki.h"
+#include "ext-flash.h"
+#include "dev/xmem.h"
+#include "dev/watchdog.h"
+#include "cfs-coffee-arch.h"
+#include <stdio.h> /* For PRINTF() */
+
+#define EXT_ERASE_UNIT_SIZE     4096UL
+
+#define XMEM_BUFF_LENGHT        128
+
+
+#if 0
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...) do {} while (0)
+#endif
+
+
+void
+xmem_init(void)
+{
+  ext_flash_open();
+}
+
+
+int
+xmem_pread(void *_p, int size, unsigned long addr)
+{
+  int rv;
+  uint8_t x;
+  int i;
+
+  rv = ext_flash_open();
+
+  if(!rv) {
+    PRINTF("Could not open flash to save config\n");
+    ext_flash_close();
+    return -1;
+  }
+
+  rv = ext_flash_read(addr, size, _p);
+  for (i = 0; i < size; i++){
+    x = ~*((uint8_t *)_p + i);
+    *((uint8_t *)_p+i) = x;
+  }
+
+  ext_flash_close();
+
+  if(rv)
+    return size;
+
+  PRINTF("Could not read flash memory!\n");
+  return -1;
+} 
+
+
+int
+xmem_pwrite(const void *_buf, int size, unsigned long addr)
+{
+  int rv;
+  int i, j;
+  int remain;
+
+  uint8_t tmp_buf[XMEM_BUFF_LENGHT];
+
+  rv = ext_flash_open();
+
+  if(!rv) {
+    PRINTF("Could not open flash to save config!\n");
+    ext_flash_close();
+    return -1;
+  }
+
+  for (remain = size, j = 0; remain > 0; remain -= XMEM_BUFF_LENGHT, j += XMEM_BUFF_LENGHT) {
+    int to_write = MIN(XMEM_BUFF_LENGHT, remain);
+    for (i = 0; i < to_write; i++) {
+      tmp_buf[i] = ~*((uint8_t *)_buf + j + i);
+    }
+    rv = ext_flash_write(addr + j, to_write, tmp_buf);
+    if (!rv) {
+      PRINTF("Could not write flash memory!\n");
+      return size - remain;
+    }
+  }
+
+  ext_flash_close();
+
+  return size;
+}
+
+
+int
+xmem_erase(long size, unsigned long addr)
+{
+  int rv;
+
+  rv = ext_flash_open();
+
+
+  if(!rv) {
+    PRINTF("Could not open flash to save config\n");
+    ext_flash_close();
+    return -1;
+  }
+
+  if(size % EXT_ERASE_UNIT_SIZE != 0) {
+    PRINTF("xmem_erase: bad size\n");
+    return -1;
+  }
+
+  if(addr % EXT_ERASE_UNIT_SIZE != 0) {
+    PRINTF("xmem_erase: bad offset\n");
+    return -1;
+  }
+
+  rv = ext_flash_erase(addr, size);
+
+  ext_flash_close();
+
+  watchdog_periodic();
+
+  if(rv)
+    return size;
+
+  PRINTF("Could not erase flash memory\n");
+  return -1;
+}

--- a/arch/platform/srf06-cc26xx/launchpad/Makefile.launchpad
+++ b/arch/platform/srf06-cc26xx/launchpad/Makefile.launchpad
@@ -2,7 +2,7 @@ CFLAGS += -DBOARD_LAUNCHPAD=1
 
 CONTIKI_TARGET_DIRS += launchpad common
 
-BOARD_SOURCEFILES += board.c launchpad-sensors.c button-sensor.c
+BOARD_SOURCEFILES += board.c launchpad-sensors.c button-sensor.c xmem.c
 BOARD_SOURCEFILES += ext-flash.c board-spi.c
 
 ### Signal that we can be programmed with cc2538-bsl

--- a/arch/platform/srf06-cc26xx/sensortag/Makefile.sensortag
+++ b/arch/platform/srf06-cc26xx/sensortag/Makefile.sensortag
@@ -5,6 +5,6 @@ CONTIKI_TARGET_DIRS += sensortag common
 
 BOARD_SOURCEFILES += sensortag-sensors.c  sensor-common.c
 BOARD_SOURCEFILES += bmp-280-sensor.c tmp-007-sensor.c opt-3001-sensor.c
-BOARD_SOURCEFILES += hdc-1000-sensor.c mpu-9250-sensor.c button-sensor.c
+BOARD_SOURCEFILES += hdc-1000-sensor.c mpu-9250-sensor.c button-sensor.c xmem.c
 BOARD_SOURCEFILES += reed-relay.c ext-flash.c buzzer.c
 BOARD_SOURCEFILES += board.c board-spi.c board-i2c.c

--- a/examples/storage/cfs-coffee/Makefile
+++ b/examples/storage/cfs-coffee/Makefile
@@ -1,6 +1,7 @@
 CONTIKI = ../../..
 
 MODULES += os/services/unit-test
+MODULES += os/storage/cfs
 
 all: test-cfs test-coffee example-coffee
 

--- a/examples/storage/cfs-coffee/README.md
+++ b/examples/storage/cfs-coffee/README.md
@@ -23,6 +23,9 @@ Supported Hardware (tested or known to work)
 * cc2538dk
 * openmote-cc2538
 * zoul
+* TI srf06-cc26xx
+    - sensortag
+    - launchpad
 
 The examples are known to build for the 'avr-raven' platform. However,
 some of them currently fail at runtime due to file system overflow.


### PR DESCRIPTION
We add cfs support for srf06-cc26xx's ext-flash to contiki-ng, and test it on `sensortag` and `launchpad`, the test project in example/storage/cfs-coffee, and all test passed.  And we also add the tested platforms to the example's README.