### PR TITLE
Only initialize rpl-neighbor module once

### DIFF
--- a/os/net/mac/tsch/sixtop/sixp-nbr.c
+++ b/os/net/mac/tsch/sixtop/sixp-nbr.c
@@ -186,7 +186,7 @@ int
 sixp_nbr_init(void)
 {
   sixp_nbr_t *nbr, *next_nbr;
-  if(nbr_table_is_register(sixp_nbrs) == 0) {
+  if(nbr_table_is_registered(sixp_nbrs) == 0) {
     nbr_table_register(sixp_nbrs, NULL);
   } else {
     /* remove all the existing nbrs */

--- a/os/net/nbr-table.c
+++ b/os/net/nbr-table.c
@@ -303,7 +303,7 @@ nbr_table_register(nbr_table_t *table, nbr_table_callback *callback)
 /*---------------------------------------------------------------------------*/
 /* Test whether a specified table has been registered or not */
 int
-nbr_table_is_register(nbr_table_t *table)
+nbr_table_is_registered(nbr_table_t *table)
 {
   if(table != NULL && all_tables[table->index] == table) {
     return 1;
@@ -490,4 +490,3 @@ handle_periodic_timer(void *ptr)
   ctimer_reset(&periodic_timer);
 }
 #endif
-

--- a/os/net/nbr-table.c
+++ b/os/net/nbr-table.c
@@ -305,7 +305,8 @@ nbr_table_register(nbr_table_t *table, nbr_table_callback *callback)
 int
 nbr_table_is_registered(nbr_table_t *table)
 {
-  if(table != NULL && all_tables[table->index] == table) {
+  if(table != NULL && table->index >= 0 && table->index < MAX_NUM_TABLES
+                   && all_tables[table->index] == table) {
     return 1;
   }
   return 0;

--- a/os/net/nbr-table.c
+++ b/os/net/nbr-table.c
@@ -290,6 +290,13 @@ nbr_table_register(nbr_table_t *table, nbr_table_callback *callback)
     ctimer_set(&periodic_timer, CLOCK_SECOND * 60, handle_periodic_timer, NULL);
   }
 #endif
+
+  if(nbr_table_is_registered(table)) {
+    /* Table already registered, just update callback */
+    table->callback = callback;
+    return 1;
+  }
+
   if(num_tables < MAX_NUM_TABLES) {
     table->index = num_tables++;
     table->callback = callback;

--- a/os/net/nbr-table.h
+++ b/os/net/nbr-table.h
@@ -92,7 +92,7 @@ typedef enum {
 /** \name Neighbor tables: register and loop through table elements */
 /** @{ */
 int nbr_table_register(nbr_table_t *table, nbr_table_callback *callback);
-int nbr_table_is_register(nbr_table_t *table);
+int nbr_table_is_registered(nbr_table_t *table);
 nbr_table_item_t *nbr_table_head(nbr_table_t *table);
 nbr_table_item_t *nbr_table_next(nbr_table_t *table, nbr_table_item_t *item);
 /** @} */

--- a/os/net/routing/rpl-lite/rpl-dag.c
+++ b/os/net/routing/rpl-lite/rpl-dag.c
@@ -716,7 +716,6 @@ void
 rpl_dag_init(void)
 {
   memset(&curr_instance, 0, sizeof(curr_instance));
-  rpl_neighbor_init();
 }
 /*---------------------------------------------------------------------------*/
 /** @} */


### PR DESCRIPTION
In addition, this PR also fixes potential issues with multiple initialization of nbr-table.

Fixes #349 