### PR TITLE
shell improvements

### DIFF
--- a/os/services/shell/shell-commands.c
+++ b/os/services/shell/shell-commands.c
@@ -222,7 +222,7 @@ PT_THREAD(cmd_ping(struct pt *pt, shell_output_func output, char *args))
     SHELL_OUTPUT(output, "Destination IPv6 address is not specified\n");
     PT_EXIT(pt);
   } else if(uiplib_ipaddrconv(args, &remote_addr) == 0) {
-    SHELL_OUTPUT(output, "Invalid IPv6: %s\n", args);
+    SHELL_OUTPUT(output, "Invalid IPv6 address: %s\n", args);
     PT_EXIT(pt);
   }
 

--- a/os/services/shell/shell-commands.c
+++ b/os/services/shell/shell-commands.c
@@ -218,7 +218,10 @@ PT_THREAD(cmd_ping(struct pt *pt, shell_output_func output, char *args))
 
   /* Get argument (remote IPv6) */
   SHELL_ARGS_NEXT(args, next_args);
-  if(uiplib_ipaddrconv(args, &remote_addr) == 0) {
+  if(args == NULL) {
+    SHELL_OUTPUT(output, "Destination IPv6 address is not specified\n");
+    PT_EXIT(pt);
+  } else if(uiplib_ipaddrconv(args, &remote_addr) == 0) {
     SHELL_OUTPUT(output, "Invalid IPv6: %s\n", args);
     PT_EXIT(pt);
   }

--- a/os/services/shell/shell.h
+++ b/os/services/shell/shell.h
@@ -51,28 +51,28 @@
 /* Helper macros to parse arguments */
 #define SHELL_ARGS_INIT(args, next_args) (next_args) = (args);
 
-#define SHELL_ARGS_NEXT(args, next_args) do { \
-						(args) = (next_args); \
-						if((args) != NULL) { \
-							if(*(args) == '\0') { \
-								(args) = NULL; \
-							} else { \
-								(next_args) = strchr((args), ' '); \
-								if((next_args) != NULL) { \
-									*(next_args) = '\0'; \
-									(next_args)++; \
-								} \
-							} \
-						} else { \
-							(next_args) = NULL; \
-						}  \
-		} while(0)
+#define SHELL_ARGS_NEXT(args, next_args) do {   \
+    (args) = (next_args);                       \
+    if((args) != NULL) {                        \
+      if(*(args) == '\0') {                     \
+        (args) = NULL;                          \
+      } else {                                  \
+        (next_args) = strchr((args), ' ');      \
+        if((next_args) != NULL) {               \
+          *(next_args) = '\0';                  \
+          (next_args)++;                        \
+        }                                       \
+      }                                         \
+    } else {                                    \
+      (next_args) = NULL;                       \
+    }                                           \
+  } while(0)
 
 /* Printf-formatted output via a given output function */
-#define SHELL_OUTPUT(output_func, format, ...) do { \
-		char buffer[192]; \
-	  snprintf(buffer, sizeof(buffer), format, ##__VA_ARGS__); \
-		(output_func)(buffer); \
+#define SHELL_OUTPUT(output_func, format, ...) do {             \
+    char buffer[192];                                           \
+    snprintf(buffer, sizeof(buffer), format, ##__VA_ARGS__);    \
+    (output_func)(buffer);                                      \
   } while(0);
 
 typedef void (shell_output_func)(const char *str);
@@ -85,7 +85,7 @@ void shell_init(void);
 /**
  * \brief A protothread that is spawned by a Shell driver when receiving a new line.
  */
- PT_THREAD(shell_input(struct pt *pt, shell_output_func output, const char *cmd));
+PT_THREAD(shell_input(struct pt *pt, shell_output_func output, const char *cmd));
 
 /**
  * Prints an IPv6 address

--- a/os/services/shell/shell.h
+++ b/os/services/shell/shell.h
@@ -70,7 +70,7 @@
 
 /* Printf-formatted output via a given output function */
 #define SHELL_OUTPUT(output_func, format, ...) do { \
-		char buffer[128]; \
+		char buffer[192]; \
 	  snprintf(buffer, sizeof(buffer), format, ##__VA_ARGS__); \
 		(output_func)(buffer); \
   } while(0);


### PR DESCRIPTION
Two (relatively) major things and two trivial things.

### major
1. `ping` command without any argument causes NULL-pointer dereference.
1.  Since `log` command help message doesn't fit the buffer in `SHELL_OUTPUT()`, the new line character (`\n`) is gone. Due to this, `ping` command help message doesn't appear in the next line of `log` command help.

### trivia
1. TAB is used in `shell.h`
1. The shell output message, "Invalid IPv6", would better have "Address" after "IPv6"