### PR TITLE
Cross-platform MQTT client example

### DIFF
--- a/examples/mqtt-client/Makefile
+++ b/examples/mqtt-client/Makefile
@@ -1,0 +1,13 @@
+CONTIKI_PROJECT = mqtt-client
+all: $(CONTIKI_PROJECT)
+
+MODULES += os/net/app-layer/mqtt
+
+CONTIKI = ../..
+-include $(CONTIKI)/Makefile.identify-target
+
+MODULES_REL += arch/platform/$(TARGET)
+
+PLATFORMS_ONLY = srf06-cc26xx cc2538dk openmote-cc2538 zoul
+
+include $(CONTIKI)/Makefile.include

--- a/examples/mqtt-client/README.md
+++ b/examples/mqtt-client/README.md
@@ -1,14 +1,17 @@
-MQTT Demo
-=========
+MQTT Client Example
+===================
 The MQTT client can be used to:
 
 * Publish sensor readings to an MQTT broker.
 * Subscribe to a topic and receive commands from an MQTT broker
 
-The demo will give some visual feedback with the green LED:
+The demo will give some visual feedback with a LED (configurable):
 * Very fast blinking: Searching for a network
 * Fast blinking: Connecting to broker
 * Slow, long blinking: Sending a publish message
+
+This example is known to work with all platforms that support the new button
+API.
 
 Publishing
 ----------
@@ -20,7 +23,7 @@ running on the IPv6 address specified as `MQTT_DEMO_BROKER_IP_ADDR` in
 The publish messages include sensor readings but also some other information,
 such as device uptime in seconds and a message sequence number. The demo will
 publish to topic `iot-2/evt/status/fmt/json`. The device will connect using
-client-id `d:quickstart:cc2538:<device-id>`, where `<device-id>` gets
+client-id `d:contiki-ng:mqtt-client:<device-id>`, where `<device-id>` gets
 constructed from the device's IEEE address.
 
 Subscribing

--- a/examples/mqtt-client/arch/cpu/cc2538/builtin-sensors.c
+++ b/examples/mqtt-client/arch/cpu/cc2538/builtin-sensors.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,54 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
-/*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "dev/cc2538-sensors.h"
+#include "mqtt-client.h"
+
+#include <string.h>
+#include <stdio.h>
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+#define TMP_BUF_SZ 32
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
+char tmp_buf[TMP_BUF_SZ];
 /*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
+static char *
+temp_reading(void)
+{
+  memset(tmp_buf, 0, TMP_BUF_SZ);
+  snprintf(tmp_buf, TMP_BUF_SZ, "\"On-Chip Temp (mC)\":%d",
+           cc2538_temp_sensor.value(CC2538_SENSORS_VALUE_TYPE_CONVERTED));
+  return tmp_buf;
+}
 /*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */
+static void
+temp_init(void)
+{
+  SENSORS_ACTIVATE(cc2538_temp_sensor);
+}
+/*---------------------------------------------------------------------------*/
+const mqtt_client_extension_t builtin_sensors_cc2538_temp = {
+  temp_init,
+  temp_reading,
+};
+/*---------------------------------------------------------------------------*/
+static char *
+vdd3_reading(void)
+{
+  memset(tmp_buf, 0, TMP_BUF_SZ);
+  snprintf(tmp_buf, TMP_BUF_SZ, "\"VDD3 (mV)\":%d",
+           vdd3_sensor.value(CC2538_SENSORS_VALUE_TYPE_CONVERTED));
+  return tmp_buf;
+}
+/*---------------------------------------------------------------------------*/
+static void
+vdd3_init(void)
+{
+  SENSORS_ACTIVATE(vdd3_sensor);
+}
+/*---------------------------------------------------------------------------*/
+const mqtt_client_extension_t builtin_sensors_vdd3 = {
+  vdd3_init,
+  vdd3_reading,
+};
+/*---------------------------------------------------------------------------*/

--- a/examples/mqtt-client/arch/cpu/cc2538/builtin-sensors.h
+++ b/examples/mqtt-client/arch/cpu/cc2538/builtin-sensors.h
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,14 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
+#ifndef BUILTIN_SENSORS_H_
+#define BUILTIN_SENSORS_H_
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "mqtt-client.h"
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+extern const mqtt_client_extension_t builtin_sensors_vdd3;
+extern const mqtt_client_extension_t builtin_sensors_cc2538_temp;
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
+#endif /* BUILTIN_SENSORS_H_ */
 /*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
-/*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */

--- a/examples/mqtt-client/arch/cpu/cc26xx-cc13xx/builtin-sensors.c
+++ b/examples/mqtt-client/arch/cpu/cc26xx-cc13xx/builtin-sensors.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,54 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
-/*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "batmon-sensor.h"
+#include "mqtt-client.h"
+
+#include <string.h>
+#include <stdio.h>
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+#define TMP_BUF_SZ 32
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
+char tmp_buf[TMP_BUF_SZ];
 /*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
+static char *
+temp_reading(void)
+{
+  memset(tmp_buf, 0, TMP_BUF_SZ);
+  snprintf(tmp_buf, TMP_BUF_SZ, "\"On-Chip Temp (mC)\":%d",
+           batmon_sensor.value(BATMON_SENSOR_TYPE_TEMP));
+  return tmp_buf;
+}
 /*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */
+static void
+temp_init(void)
+{
+  SENSORS_ACTIVATE(batmon_sensor);
+}
+/*---------------------------------------------------------------------------*/
+const mqtt_client_extension_t builtin_sensors_batmon_temp = {
+  temp_init,
+  temp_reading,
+};
+/*---------------------------------------------------------------------------*/
+static char *
+volt_reading(void)
+{
+  memset(tmp_buf, 0, TMP_BUF_SZ);
+  snprintf(tmp_buf, TMP_BUF_SZ, "\"Volt (mV)\":%d",
+           (batmon_sensor.value(BATMON_SENSOR_TYPE_VOLT) * 125) >> 5);
+  return tmp_buf;
+}
+/*---------------------------------------------------------------------------*/
+static void
+volt_init(void)
+{
+  SENSORS_ACTIVATE(batmon_sensor);
+}
+/*---------------------------------------------------------------------------*/
+const mqtt_client_extension_t builtin_sensors_batmon_volt = {
+  volt_init,
+  volt_reading,
+};
+/*---------------------------------------------------------------------------*/

--- a/examples/mqtt-client/arch/cpu/cc26xx-cc13xx/builtin-sensors.h
+++ b/examples/mqtt-client/arch/cpu/cc26xx-cc13xx/builtin-sensors.h
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,14 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
+#ifndef BUILTIN_SENSORS_H_
+#define BUILTIN_SENSORS_H_
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "mqtt-client.h"
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+extern const mqtt_client_extension_t builtin_sensors_batmon_temp;
+extern const mqtt_client_extension_t builtin_sensors_batmon_volt;
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
+#endif /* BUILTIN_SENSORS_H_ */
 /*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
-/*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */

--- a/examples/mqtt-client/arch/platform/cc2538dk/Makefile.cc2538dk
+++ b/examples/mqtt-client/arch/platform/cc2538dk/Makefile.cc2538dk
@@ -1,0 +1,1 @@
+MODULES_REL += arch/cpu/cc2538

--- a/examples/mqtt-client/arch/platform/cc2538dk/als-extend.c
+++ b/examples/mqtt-client/arch/platform/cc2538dk/als-extend.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2018, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,33 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
-/*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "als-extend.h"
+#include "dev/als-sensor.h"
+
+#include <string.h>
+#include <stdio.h>
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+#define TMP_BUF_SZ 32
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
+char tmp_buf[TMP_BUF_SZ];
 /*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
+static void
+als_init(void)
+{
+  SENSORS_ACTIVATE(als_sensor);
+}
 /*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */
+static char *
+als_reading(void)
+{
+  memset(tmp_buf, 0, TMP_BUF_SZ);
+  snprintf(tmp_buf, TMP_BUF_SZ, "\"ALS (raw)\":%d", als_sensor.value(0));
+  return tmp_buf;
+}
+/*---------------------------------------------------------------------------*/
+const mqtt_client_extension_t als_extend = {
+  als_init,
+  als_reading,
+};
+/*---------------------------------------------------------------------------*/

--- a/examples/mqtt-client/arch/platform/cc2538dk/als-extend.h
+++ b/examples/mqtt-client/arch/platform/cc2538dk/als-extend.h
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2018, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,13 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
+#ifndef ALS_EXTEND_H_
+#define ALS_EXTEND_H_
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "mqtt-client.h"
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+extern const mqtt_client_extension_t als_extend;
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
+#endif /* ALS_EXTEND_H_ */
 /*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
-/*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */

--- a/examples/mqtt-client/arch/platform/cc2538dk/mqtt-client-extensions.c
+++ b/examples/mqtt-client/arch/platform/cc2538dk/mqtt-client-extensions.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,13 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
-/*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "builtin-sensors.h"
+#include "als-extend.h"
+#include "mqtt-client.h"
+
+#include <string.h>
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+MQTT_CLIENT_EXTENSIONS(&builtin_sensors_vdd3, &builtin_sensors_cc2538_temp,
+                       &als_extend);
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
-/*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
-/*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */

--- a/examples/mqtt-client/arch/platform/openmote-cc2538/Makefile.openmote-cc2538
+++ b/examples/mqtt-client/arch/platform/openmote-cc2538/Makefile.openmote-cc2538
@@ -1,0 +1,1 @@
+MODULES_REL += arch/cpu/cc2538

--- a/examples/mqtt-client/arch/platform/openmote-cc2538/mqtt-client-extensions.c
+++ b/examples/mqtt-client/arch/platform/openmote-cc2538/mqtt-client-extensions.c
@@ -1,16 +1,16 @@
 /*
- * Copyright (c) 2012, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *
  * 3. Neither the name of the copyright holder nor the names of its
  *    contributors may be used to endorse or promote products derived
  *    from this software without specific prior written permission.
@@ -29,26 +29,11 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc2538-mqtt-demo
- * @{
- *
- * \file
- * Project specific configuration defines for the MQTT demo
- */
-/*---------------------------------------------------------------------------*/
-#ifndef PROJECT_CONF_H_
-#define PROJECT_CONF_H_
-/*---------------------------------------------------------------------------*/
-/* Enable TCP */
-#define UIP_CONF_TCP 1
+#include "contiki.h"
+#include "builtin-sensors.h"
+#include "mqtt-client.h"
 
-/* User configuration */
-#define MQTT_DEMO_STATUS_LED      LEDS_GREEN
-
-/* If undefined, the demo will attempt to connect to IBM's quickstart */
-#define MQTT_DEMO_BROKER_IP_ADDR "fd00::1"
+#include <string.h>
 /*---------------------------------------------------------------------------*/
-#endif /* PROJECT_CONF_H_ */
+MQTT_CLIENT_EXTENSIONS(&builtin_sensors_vdd3, &builtin_sensors_cc2538_temp);
 /*---------------------------------------------------------------------------*/
-/** @} */

--- a/examples/mqtt-client/arch/platform/srf06-cc26xx/Makefile.srf06-cc26xx
+++ b/examples/mqtt-client/arch/platform/srf06-cc26xx/Makefile.srf06-cc26xx
@@ -1,0 +1,1 @@
+MODULES_REL += arch/cpu/cc26xx-cc13xx

--- a/examples/mqtt-client/arch/platform/srf06-cc26xx/mqtt-client-extensions.c
+++ b/examples/mqtt-client/arch/platform/srf06-cc26xx/mqtt-client-extensions.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,12 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
-/*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "builtin-sensors.h"
+#include "mqtt-client.h"
+
+#include <string.h>
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+MQTT_CLIENT_EXTENSIONS(&builtin_sensors_batmon_temp,
+                       &builtin_sensors_batmon_volt);
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
-/*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
-/*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */

--- a/examples/mqtt-client/arch/platform/zoul/Makefile.zoul
+++ b/examples/mqtt-client/arch/platform/zoul/Makefile.zoul
@@ -1,0 +1,1 @@
+MODULES_REL += arch/cpu/cc2538

--- a/examples/mqtt-client/arch/platform/zoul/mqtt-client-extensions.c
+++ b/examples/mqtt-client/arch/platform/zoul/mqtt-client-extensions.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,11 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
-/*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
-/*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "lib/sensors.h"
+#include "builtin-sensors.h"
+#include "mqtt-client.h"
+
+#include <string.h>
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+MQTT_CLIENT_EXTENSIONS(&builtin_sensors_vdd3, &builtin_sensors_cc2538_temp);
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
-/*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
-/*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */

--- a/examples/mqtt-client/mqtt-client.h
+++ b/examples/mqtt-client/mqtt-client.h
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
@@ -28,33 +29,20 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
+#ifndef MQTT_CLIENT_H_
+#define MQTT_CLIENT_H_
 /*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
+#include <string.h>
 /*---------------------------------------------------------------------------*/
-#include "contiki.h"
-#include "lib/sensors.h"
+typedef struct mqtt_client_extension_s {
+  void (*init)(void);
+  char *(*value)(void);
+} mqtt_client_extension_t;
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
+#define MQTT_CLIENT_EXTENSIONS(...) \
+  const mqtt_client_extension_t *mqtt_client_extensions[] = {__VA_ARGS__}; \
+  const uint8_t mqtt_client_extension_count = \
+    (sizeof(mqtt_client_extensions) / sizeof(mqtt_client_extensions[0]));
 /*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
+#endif /* MQTT_CLIENT_H_ */
 /*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
-/*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */

--- a/examples/mqtt-client/project-conf.h
+++ b/examples/mqtt-client/project-conf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2012, Texas Instruments Incorporated - http://www.ti.com/
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -10,6 +10,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
+ *
  * 3. Neither the name of the copyright holder nor the names of its
  *    contributors may be used to endorse or promote products derived
  *    from this software without specific prior written permission.
@@ -28,33 +29,15 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-/**
- * \addtogroup cc26xx
- * @{
- *
- * \defgroup cc26xx-batmon CC13xx/CC26xx BatMon sensor driver
- *
- * Driver for the on-chip battery voltage and chip temperature sensor.
- * @{
- *
- * \file
- * Header file for the CC13xx/CC26xx battery monitor
- */
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
 /*---------------------------------------------------------------------------*/
-#ifndef BATMON_SENSOR_H_
-#define BATMON_SENSOR_H_
+/* Enable TCP */
+#define UIP_CONF_TCP 1
+
+/* If undefined, the demo will attempt to connect to IBM's quickstart */
+#define MQTT_CLIENT_CONF_BROKER_IP_ADDR "fd00::1"
 /*---------------------------------------------------------------------------*/
-#include "contiki.h"
-#include "lib/sensors.h"
+#endif /* PROJECT_CONF_H_ */
 /*---------------------------------------------------------------------------*/
-#define BATMON_SENSOR_TYPE_TEMP    1
-#define BATMON_SENSOR_TYPE_VOLT    2
-/*---------------------------------------------------------------------------*/
-extern const struct sensors_sensor batmon_sensor;
-/*---------------------------------------------------------------------------*/
-#endif /* BATMON_SENSOR_H_ */
-/*---------------------------------------------------------------------------*/
-/**
- * @}
- * @}
- */
+/** @} */

--- a/examples/platform-specific/cc2538-common/mqtt-demo/Makefile
+++ b/examples/platform-specific/cc2538-common/mqtt-demo/Makefile
@@ -1,9 +1,0 @@
-CONTIKI_PROJECT = mqtt-demo
-all: $(CONTIKI_PROJECT)
-
-PLATFORMS_ONLY = cc2538dk openmote-cc2538 zoul
-
-MODULES += os/net/app-layer/mqtt
-
-CONTIKI = ../../../..
-include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/cc2538-common/mqtt-demo/Makefile.target
+++ b/examples/platform-specific/cc2538-common/mqtt-demo/Makefile.target
@@ -1,1 +1,0 @@
-TARGET = cc2538dk

--- a/tests/02-compile-arm-ports-01/Makefile
+++ b/tests/02-compile-arm-ports-01/Makefile
@@ -31,6 +31,10 @@ dev/leds/srf06-cc26xx:BOARD=launchpad/cc1310 \
 dev/leds/srf06-cc26xx:BOARD=launchpad/cc1350 \
 dev/leds/srf06-cc26xx:BOARD=launchpad/cc2650 \
 6tisch/etsi-plugtest-2017/srf06-cc26xx:BOARD=launchpad/cc2650 \
+mqtt-client/srf06-cc26xx:BOARD=srf06/cc26xx \
+mqtt-client/srf06-cc26xx:BOARD=launchpad/cc2650 \
+mqtt-client/srf06-cc26xx:BOARD=sensortag/cc2650 \
+mqtt-client/cc2538dk \
 storage/cfs-coffee/cc2538dk \
 sensniff/cc2538dk \
 rpl-udp/cc2538dk \
@@ -41,7 +45,6 @@ multicast/cc2538dk \
 dev/gpio-hal/cc2538dk \
 dev/leds/cc2538dk \
 platform-specific/cc2538-common/cc2538dk \
-platform-specific/cc2538-common/mqtt-demo/cc2538dk \
 platform-specific/cc2538-common/crypto/cc2538dk \
 platform-specific/cc2538-common/pka/cc2538dk \
 hello-world/cc2538dk \

--- a/tests/03-compile-arm-ports-02/Makefile
+++ b/tests/03-compile-arm-ports-02/Makefile
@@ -4,7 +4,6 @@ TOOLSDIR=../../tools
 EXAMPLES = \
 rpl-border-router/zoul \
 platform-specific/cc2538-common/zoul \
-platform-specific/cc2538-common/mqtt-demo/zoul \
 platform-specific/cc2538-common/crypto/zoul \
 platform-specific/cc2538-common/pka/zoul \
 platform-specific/zoul/orion/ip64-router/zoul:BOARD=orion \
@@ -51,6 +50,8 @@ dev/rgb-led/zoul:BOARD=remote-revb \
 dev/rgb-led/zoul:BOARD=firefly-reva \
 dev/rgb-led/zoul:BOARD=firefly \
 dev/rgb-led/zoul:BOARD=orion \
+mqtt-client/zoul:BOARD=firefly \
+mqtt-client/openmote-cc2538 \
 storage/cfs-coffee/openmote-cc2538 \
 sensniff/openmote-cc2538 \
 hello-world/openmote-cc2538 \


### PR DESCRIPTION
This pull proposes a cross-platform MQTT client example and deletes the respective example under `cc2538-common`.

The example will work on all platforms that support the button HAL. With a little hacking it also works with native.

Easiest way to test is to run a mosquitto broker on a linux/OSX device and by setting `MQTT_CLIENT_CONF_BROKER_IP_ADDR` to the v6 address of said device.

Still somewhat of a WiP / need to test for various boards, but I thought I'd throw it out here for comment.

Requires #365 