### PR TITLE
Fix launchpad LED colour mappings

### DIFF
--- a/arch/platform/srf06-cc26xx/launchpad/cc1310/board.h
+++ b/arch/platform/srf06-cc26xx/launchpad/cc1310/board.h
@@ -62,7 +62,7 @@
  */
 #define LEDS_CONF_COUNT                 2
 #define LEDS_CONF_RED                   1
-#define LEDS_CONF_YELLOW                2
+#define LEDS_CONF_GREEN                 2
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/srf06-cc26xx/launchpad/cc1350/board.h
+++ b/arch/platform/srf06-cc26xx/launchpad/cc1350/board.h
@@ -62,7 +62,7 @@
  */
 #define LEDS_CONF_COUNT                 2
 #define LEDS_CONF_RED                   1
-#define LEDS_CONF_YELLOW                2
+#define LEDS_CONF_GREEN                 2
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/srf06-cc26xx/launchpad/cc2650/board.h
+++ b/arch/platform/srf06-cc26xx/launchpad/cc2650/board.h
@@ -62,7 +62,7 @@
  */
 #define LEDS_CONF_COUNT                 2
 #define LEDS_CONF_RED                   1
-#define LEDS_CONF_YELLOW                2
+#define LEDS_CONF_GREEN                 2
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
Launchpad LED colour mappings are incorrect. This pull fixes this.