### PR TITLE
RPL Lite: Increment DTSN when no path to destination is found

### DIFF
--- a/os/net/routing/rpl-lite/rpl-dag.c
+++ b/os/net/routing/rpl-lite/rpl-dag.c
@@ -212,6 +212,19 @@ global_repair_non_root(rpl_dio_t *dio)
 }
 /*---------------------------------------------------------------------------*/
 void
+rpl_dag_path_not_found(const uip_ipaddr_t *node_addr)
+{
+  /* At root, increment DTSN as reaction to incomplete path.
+  Will force nodes to re-send DAOs. Useful for instance upon root reboot. */
+  if(rpl_dag_root_is_root() && rpl_is_addr_in_our_dag(node_addr)) {
+    RPL_LOLLIPOP_INCREMENT(curr_instance.dtsn_out);
+    LOG_WARN("incomple path towards ");
+    LOG_WARN_6ADDR(node_addr);
+    LOG_WARN_(". Incrementing DTSN (now is: %u)\n", curr_instance.dtsn_out);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
 rpl_local_repair(const char *str)
 {
   if(curr_instance.used) { /* Check needed because this is a public function */

--- a/os/net/routing/rpl-lite/rpl-dag.h
+++ b/os/net/routing/rpl-lite/rpl-dag.h
@@ -98,6 +98,13 @@ void rpl_global_repair(const char *str);
 void rpl_local_repair(const char *str);
 
 /**
+ * Notifies RPL that no path was found towards a given IPv6 address
+ *
+ * \param node_addr The IPv6 address of the node with incomplete path
+ */
+void rpl_dag_path_not_found(const uip_ipaddr_t *node_addr);
+
+/**
  * Tells whether a given global IPv6 address is in our current DAG
  *
  * \param addr The global IPv6 address to be tested

--- a/os/net/routing/rpl-lite/rpl-ext-header.c
+++ b/os/net/routing/rpl-lite/rpl-ext-header.c
@@ -250,8 +250,10 @@ insert_srh_header(void)
 
   dest_node = uip_sr_get_node(NULL, &UIP_IP_BUF->destipaddr);
   if(dest_node == NULL) {
-    /* The destination is not found, skip SRH insertion */
+    /* The destination is not found, skip SRH insertion. This isn't en
+    error per se, only means that the dest IP address is not in the DODAG. */
     LOG_INFO("SRH node not found, skip SRH insertion\n");
+    rpl_dag_path_not_found(&UIP_IP_BUF->destipaddr);
     return 1;
   }
 
@@ -263,6 +265,7 @@ insert_srh_header(void)
 
   if(!uip_sr_is_addr_reachable(NULL, &UIP_IP_BUF->destipaddr)) {
     LOG_ERR("SRH no path found to destination\n");
+    rpl_dag_path_not_found(&UIP_IP_BUF->destipaddr);
     return 0;
   }
 


### PR DESCRIPTION
When not finding a path towards a node that should be in our DODAG, reset DTSN. This will force the whole to network to re-register their route.

This should mitigate #128. Not as well as with NVM storage of the version prior to reboot. But will accelerate node re-join.