### PR TITLE
RPL local repair

### DIFF
--- a/os/net/mac/tsch/tsch-rpl.c
+++ b/os/net/mac/tsch/tsch-rpl.c
@@ -50,6 +50,7 @@
 #include "net/mac/tsch/tsch-schedule.h"
 #include "net/mac/tsch/tsch-log.h"
 #include "net/mac/tsch/tsch-rpl.h"
+#include "net/link-stats.h"
 
 #if ROUTING_CONF_RPL_LITE
 #include "net/routing/rpl-lite/rpl.h"
@@ -83,6 +84,11 @@ tsch_rpl_callback_joining_network(void)
 void
 tsch_rpl_callback_leaving_network(void)
 {
+  /* Forget past link statistics. If we are leaving a TSCH
+  network, there are changes we've been out of sync in the recent past, and
+  as a result have irrelevant link statistices. */
+  link_stats_reset();
+  /* RPL local repair */
   NETSTACK_ROUTING.local_repair("TSCH leaving");
 }
 /*---------------------------------------------------------------------------*/

--- a/os/net/routing/rpl-lite/rpl-dag.c
+++ b/os/net/routing/rpl-lite/rpl-dag.c
@@ -220,7 +220,6 @@ rpl_local_repair(const char *str)
       curr_instance.dag.state = DAG_INITIALIZED; /* Reset DAG state */
     }
     curr_instance.of->reset(); /* Reset OF */
-    link_stats_reset(); /* Forget past link statistics */
     rpl_neighbor_remove_all(); /* Remove all neighbors */
     rpl_timers_dio_reset("Local repair"); /* Reset Trickle timer */
     rpl_timers_schedule_state_update();


### PR DESCRIPTION
Do not reset link stats on RPL local repair. There is no reason to assume these need a reset. RPL operates a layer above. By not doing the reset, we allow local repair and global repair to go through a bit faster (no need to rebuilt fresh link estimates).

In the particular case of TSCH+RPL, make sure to reset link stats when leaving the TSCH network, right before a local repair. TSCH link statistics tend to get broken under de-synchronized operation.