### PR TITLE
sicslowpan: fix debug messages and remove TABs

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -353,7 +353,7 @@ add_fragment(uint16_t tag, uint16_t frag_size, uint8_t offset)
     for(i = 0; i < SICSLOWPAN_REASS_CONTEXTS; i++) {
       /* clear all fragment info with expired timer to free all fragment buffers */
       if(frag_info[i].len > 0 && timer_expired(&frag_info[i].reass_timer)) {
-	clear_fragments(i);
+        clear_fragments(i);
       }
 
       /* We use len as indication on used or not used */
@@ -421,12 +421,12 @@ copy_frags2uip(int context)
 
   /* Copy from the fragment context info buffer first */
   memcpy((uint8_t *)UIP_IP_BUF, (uint8_t *)frag_info[context].first_frag,
-	 frag_info[context].first_frag_len);
+         frag_info[context].first_frag_len);
   for(i = 0; i < SICSLOWPAN_FRAGMENT_BUFFERS; i++) {
     /* And also copy all matching fragments */
     if(frag_buf[i].len > 0 && frag_buf[i].index == context) {
       memcpy((uint8_t *)UIP_IP_BUF + (uint16_t)(frag_buf[i].offset << 3),
-	     (uint8_t *)frag_buf[i].data, frag_buf[i].len);
+             (uint8_t *)frag_buf[i].data, frag_buf[i].len);
     }
   }
   /* deallocate all the fragments for this context */
@@ -676,9 +676,9 @@ compress_hdr_iphc(linkaddr_t *link_destaddr)
     LOG_DBG("before compression (%d): ", UIP_IP_BUF->len[1]);
     for(ndx = 0; ndx < UIP_IP_BUF->len[1] + 40; ndx++) {
       uint8_t data = ((uint8_t *) (UIP_IP_BUF))[ndx];
-      LOG_DBG("%02x", data);
+      LOG_DBG_("%02x", data);
     }
-    LOG_DBG("\n");
+    LOG_DBG_("\n");
   }
 
   hc06_ptr = PACKETBUF_IPHC_BUF + 2;
@@ -1000,9 +1000,9 @@ compress_hdr_iphc(linkaddr_t *link_destaddr)
     LOG_DBG("after compression %d: ", (int)(hc06_ptr - packetbuf_ptr));
     for(ndx = 0; ndx < hc06_ptr - packetbuf_ptr; ndx++) {
       uint8_t data = ((uint8_t *) packetbuf_ptr)[ndx];
-      LOG_DBG("%02x", data);
+      LOG_DBG_("%02x", data);
     }
-    LOG_DBG("\n");
+    LOG_DBG_("\n");
   }
 
   packetbuf_hdr_len = hc06_ptr - packetbuf_ptr;
@@ -1059,7 +1059,7 @@ uncompress_hdr_iphc(uint8_t *buf, uint16_t ip_len)
         SICSLOWPAN_IP_BUF(buf)->vtc = 0x60 | ((tmp >> 2) & 0x0f);
         /* ECN rolled down two steps + lowest DSCP bits at top two bits */
         SICSLOWPAN_IP_BUF(buf)->tcflow = ((tmp >> 2) & 0x30) | (tmp << 6) |
-	  (SICSLOWPAN_IP_BUF(buf)->tcflow & 0x0f);
+          (SICSLOWPAN_IP_BUF(buf)->tcflow & 0x0f);
       } else {
         /* Traffic class is compressed (set version and no TC)*/
         SICSLOWPAN_IP_BUF(buf)->vtc = 0x60;
@@ -1074,7 +1074,7 @@ uncompress_hdr_iphc(uint8_t *buf, uint16_t ip_len)
       /* Version and flow label are compressed */
       if((iphc0 & SICSLOWPAN_IPHC_TC_C) == 0) {
         /* Traffic class is inline */
-	SICSLOWPAN_IP_BUF(buf)->vtc = 0x60 | ((*hc06_ptr >> 2) & 0x0f);
+        SICSLOWPAN_IP_BUF(buf)->vtc = 0x60 | ((*hc06_ptr >> 2) & 0x0f);
           SICSLOWPAN_IP_BUF(buf)->tcflow = ((*hc06_ptr << 6) & 0xC0) | ((*hc06_ptr >> 2) & 0x30);
           SICSLOWPAN_IP_BUF(buf)->flow = 0;
           hc06_ptr += 1;
@@ -1902,16 +1902,16 @@ input(void)
     uip_len = packetbuf_payload_len + uncomp_hdr_len;
 #endif /* SICSLOWPAN_CONF_FRAG */
     LOG_INFO("input: IP packet ready (length %d)\n",
-	    uip_len);
+             uip_len);
 
     if(LOG_DBG_ENABLED) {
       uint16_t ndx;
       LOG_DBG("after decompression %u:", UIP_IP_BUF->len[1]);
       for (ndx = 0; ndx < UIP_IP_BUF->len[1] + 40; ndx++) {
         uint8_t data = ((uint8_t *) (UIP_IP_BUF))[ndx];
-        LOG_DBG("%02x", data);
+        LOG_DBG_("%02x", data);
       }
-      LOG_DBG("\n");
+      LOG_DBG_("\n");
     }
 
     /* if callback is set then set attributes and call */


### PR DESCRIPTION
This PR does simply two things:
- use `LOG_DBG_` instead of `LOG_DBG` to print hex decimals of a packet
- replace TABs with spaces