### PR TITLE
shell: add missing UIP_CONF_IPV6_RPL guard

### DIFF
--- a/os/services/shell/shell-commands.c
+++ b/os/services/shell/shell-commands.c
@@ -337,6 +337,7 @@ PT_THREAD(cmd_help(struct pt *pt, shell_output_func output, char *args))
 
   PT_END(pt);
 }
+#if UIP_CONF_IPV6_RPL
 /*---------------------------------------------------------------------------*/
 static
 PT_THREAD(cmd_rpl_set_root(struct pt *pt, shell_output_func output, char *args))
@@ -415,6 +416,7 @@ PT_THREAD(cmd_rpl_local_repair(struct pt *pt, shell_output_func output, char *ar
 
   PT_END(pt);
 }
+#endif /* UIP_CONF_IPV6_RPL */
 /*---------------------------------------------------------------------------*/
 static
 PT_THREAD(cmd_ipaddr(struct pt *pt, shell_output_func output, char *args))


### PR DESCRIPTION
The following three `PT_THREAD` implementations should be surrounded by `#if UIP_CONF_IPV6_RPL` and `#endif` since the corresponding commands are enabled only if `UIP_CONF_IPV6_RPL` is true.

- `cmd_rpl_set_root()`
- `cmd_rpl_local_repair()`
- `cmd_rpl_global_repair()`

```C
[shell-command.c]
 718 struct shell_command_t shell_commands[] = {
(snip)
 725 #if UIP_CONF_IPV6_RPL
 726   { "rpl-set-root",         cmd_rpl_set_root,         "'> rpl-set-root 0/1 [prefix]': Sets node as root (1) or not (0). A /64 prefix can be optionally specified." },
 727   { "rpl-local-repair",     cmd_rpl_local_repair,     "'> rpl-local-repair': Triggers a RPL local repair" },
 728   { "rpl-global-repair",    cmd_rpl_global_repair,    "'> rpl-global-repair': Triggers a RPL global repair" },
 729 #endif /* UIP_CONF_IPV6_RPL */
(snip)
 743 };
```