### PR TITLE
Border router tests: make all simulations real-time

### DIFF
--- a/tests/17-tun-rpl-br/01-border-router-cooja.csc
+++ b/tests/17-tun-rpl-br/01-border-router-cooja.csc
@@ -239,7 +239,8 @@ make -j hello-world.cooja TARGET=cooja</commands>
     org.contikios.cooja.plugins.ScriptRunner
     <plugin_config>
       <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
-      </script>
+/* Set simulaion speed to real time */
+sim.setSpeedLimit(1.0);</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/01-border-router-cooja.sh
+++ b/tests/17-tun-rpl-br/01-border-router-cooja.sh
@@ -6,4 +6,4 @@ CONTIKI=$1
 # Simulation file
 BASENAME=01-border-router-cooja
 
-bash test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4
+bash test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60

--- a/tests/17-tun-rpl-br/02-border-router-cooja-tsch.csc
+++ b/tests/17-tun-rpl-br/02-border-router-cooja-tsch.csc
@@ -239,7 +239,8 @@ make -j hello-world.cooja TARGET=cooja MAKE_MAC=MAKE_MAC_TSCH</commands>
     org.contikios.cooja.plugins.ScriptRunner
     <plugin_config>
       <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
-      </script>
+/* Set simulaion speed to real time */
+sim.setSpeedLimit(1.0);</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/02-border-router-cooja-tsch.sh
+++ b/tests/17-tun-rpl-br/02-border-router-cooja-tsch.sh
@@ -6,4 +6,5 @@ CONTIKI=$1
 # Simulation file
 BASENAME=02-border-router-cooja-tsch
 
-bash test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4
+# Add a little extra initial time to account for TSCH association time
+bash test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 120

--- a/tests/17-tun-rpl-br/03-border-router-sky.csc
+++ b/tests/17-tun-rpl-br/03-border-router-sky.csc
@@ -222,7 +222,9 @@ make -j hello-world.sky TARGET=sky</commands>
   <plugin>
     org.contikios.cooja.plugins.ScriptRunner
     <plugin_config>
-      <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */</script>
+      <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
+/* Set simulaion speed to real time */
+sim.setSpeedLimit(1.0);</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/03-border-router-sky.sh
+++ b/tests/17-tun-rpl-br/03-border-router-sky.sh
@@ -6,4 +6,4 @@ CONTIKI=$1
 # Simulation file
 BASENAME=03-border-router-sky
 
-bash test-border-router.sh $CONTIKI $BASENAME fd00::0212:7404:0004:0404
+bash test-border-router.sh $CONTIKI $BASENAME fd00::0212:7404:0004:0404 60

--- a/tests/17-tun-rpl-br/04-border-router-traceroute.csc
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.csc
@@ -239,7 +239,8 @@ make -j hello-world.cooja TARGET=cooja</commands>
     org.contikios.cooja.plugins.ScriptRunner
     <plugin_config>
       <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
-      </script>
+/* Set simulaion speed to real time */
+sim.setSpeedLimit(1.0);</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -8,6 +8,10 @@ BASENAME=04-border-router-traceroute
 
 # Destination IPv6
 IPADDR=fd00::204:4:4:4
+
+# Time allocated for toplogy formation
+WAIT_TIME=60
+
 # The expected hop count
 TARGETHOPS=4
 
@@ -22,8 +26,8 @@ echo "Starting tunslip6"
 make -C $CONTIKI/tools tunslip6
 make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=zoul >> $BASENAME.tunslip.log 2>&1 &
 MPID=$!
-echo "Waiting for network formation"
-sleep 20 # not in real-time, simulates at full speed
+printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
+sleep $WAIT_TIME
 
 # Do ping
 echo "Running Traceroute"

--- a/tests/17-tun-rpl-br/07-native-border-router-cooja.sh
+++ b/tests/17-tun-rpl-br/07-native-border-router-cooja.sh
@@ -6,4 +6,4 @@ CONTIKI=$1
 # Simulation file
 BASENAME=07-native-border-router-cooja
 
-bash test-nbr.sh $CONTIKI $BASENAME fd00::204:4:4:4
+bash test-native-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60

--- a/tests/17-tun-rpl-br/test-border-router.sh
+++ b/tests/17-tun-rpl-br/test-border-router.sh
@@ -9,6 +9,9 @@ BASENAME=$2
 # Destination IPv6
 IPADDR=$3
 
+# Time allocated for convergence
+WAIT_TIME=$4
+
 # ICMP request-reply count
 COUNT=5
 
@@ -23,8 +26,8 @@ echo "Starting tunslip6"
 make -C $CONTIKI/tools tunslip6
 make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=zoul >> $BASENAME.tunslip.log 2>&1 &
 MPID=$!
-echo "Waiting for network formation"
-sleep 20 # not in real-time, simulates at full speed
+printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
+sleep $WAIT_TIME
 
 # Do ping
 echo "Pinging"

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -9,6 +9,9 @@ BASENAME=$2
 # Destination IPv6
 IPADDR=$3
 
+# Time allocated for convergence
+WAIT_TIME=$4
+
 # ICMP request-reply count
 COUNT=5
 
@@ -22,8 +25,8 @@ sleep 20
 echo "Starting native border-router"
 nohup make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=native >> $BASENAME.nbr.log 2>&1 &
 MPID=$!
-echo "Waiting for network formation"
-sleep 60 # runs in real time so we need to wait a bit
+printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
+sleep $WAIT_TIME
 
 # Do ping
 echo "Pinging"

--- a/tests/Makefile.script-test
+++ b/tests/Makefile.script-test
@@ -11,6 +11,7 @@ summary: cooja $(TESTLOGS)
 	@cat summary
 
 %.testlog: %.sh cooja
+	@echo "========== Running script test $(basename $@).sh =========="
 	@bash "$(basename $@).sh" "$(CONTIKI)"
 
 clean:


### PR DESCRIPTION
This makes all simulations real-time for more predictable run-time. Wait times for topology formation are adjusted, from 20s to now 60s or 120s (in the TSCH case). This is an attempt at making the BR tests non-flaky again.