### PR TITLE
Tidy-up AROPTS for cpu native

### DIFF
--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -20,7 +20,7 @@ CFLAGSNO = -Wall -g -I/usr/local/include $(CFLAGSWERROR)
 CFLAGS  += $(CFLAGSNO)
 
 ifeq ($(HOST_OS),Darwin)
-AROPTS = -r
+AROPTS = -rc
 LDFLAGS += -Wl,-flat_namespace,-map,$(CONTIKI_NG_PROJECT_MAP)
 CFLAGS += -DHAVE_SNPRINTF=1 -U__ASSERT_USE_STDERR
 else

--- a/arch/platform/native/Makefile.native
+++ b/arch/platform/native/Makefile.native
@@ -2,9 +2,6 @@ ifndef CONTIKI
   $(error CONTIKI not defined! You must specify where CONTIKI resides!)
 endif
 
-ifeq ($(HOST_OS),Darwin)
-  AROPTS = rc
-endif
 
 CONTIKI_TARGET_DIRS = . dev
 CONTIKI_TARGET_MAIN = ${addprefix $(OBJECTDIR)/,contiki-main.o}


### PR DESCRIPTION
Default `AROPTS` are `rcf`. `ar` on OS X does not like `f`, but there is no reason to remove `c` (in fact it's good to have it cause it suppresses some ar output that personally annoys me 😄 ).

Currently we specify `AROPTS` for OS X in two places: The CPU makefile and the platform makefile, and the two don't even agree.

This pull deletes the snippet from the platform makefile and sets OSX `AROPTS` to  `rc` in the cpu makefile.