### PR TITLE
Remove obsolete Makefile

### DIFF
--- a/os/net/mac/tsch/Makefile.tsch
+++ b/os/net/mac/tsch/Makefile.tsch
@@ -1,1 +1,0 @@
-CONTIKI_SOURCEFILES += tsch.c tsch-slot-operation.c tsch-queue.c tsch-packet.c tsch-schedule.c tsch-log.c tsch-rpl.c tsch-adaptive-timesync.c


### PR DESCRIPTION
I cannot immediately see the reason why this Makefile is required.