### PR TITLE
Shell: added ability to trigger a RPL DTSN increment

### DIFF
--- a/os/net/routing/rpl-lite/rpl-dag.c
+++ b/os/net/routing/rpl-lite/rpl-dag.c
@@ -180,6 +180,21 @@ find_objective_function(rpl_ocp_t ocp)
 }
 /*---------------------------------------------------------------------------*/
 void
+rpl_refresh_routes(const char *str)
+{
+  if(rpl_dag_root_is_root()) {
+    LOG_WARN("incrementing DTSN (%s), current %u)\n",
+         str, curr_instance.dtsn_out);
+    if(LOG_INFO_ENABLED) {
+      rpl_neighbor_print_list("Refresh routes (before)");
+    }
+
+    /* Increment DTSN */
+    RPL_LOLLIPOP_INCREMENT(curr_instance.dtsn_out);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
 rpl_global_repair(const char *str)
 {
   if(rpl_dag_root_is_root()) {

--- a/os/net/routing/rpl-lite/rpl.h
+++ b/os/net/routing/rpl-lite/rpl.h
@@ -126,6 +126,13 @@ int rpl_is_reachable(void);
  */
 int rpl_lollipop_greater_than(int a, int b);
 
+/**
+ * Triggers a route fresh via DTSN increment
+ *
+ * \param str a textual description of the cause for refresh
+ */
+void rpl_refresh_routes(const char *str);
+
  /** @} */
 
 #endif /* RPL_H */

--- a/os/services/shell/shell-commands.c
+++ b/os/services/shell/shell-commands.c
@@ -412,6 +412,17 @@ PT_THREAD(cmd_rpl_local_repair(struct pt *pt, shell_output_func output, char *ar
 
   PT_END(pt);
 }
+/*---------------------------------------------------------------------------*/
+static
+PT_THREAD(cmd_rpl_refresh_routes(struct pt *pt, shell_output_func output, char *args))
+{
+  PT_BEGIN(pt);
+
+  SHELL_OUTPUT(output, "Triggering routes refresh\n")
+  rpl_refresh_routes("Shell");
+
+  PT_END(pt);
+}
 #endif /* UIP_CONF_IPV6_RPL */
 /*---------------------------------------------------------------------------*/
 static
@@ -721,6 +732,7 @@ struct shell_command_t shell_commands[] = {
 #if UIP_CONF_IPV6_RPL
   { "rpl-set-root",         cmd_rpl_set_root,         "'> rpl-set-root 0/1 [prefix]': Sets node as root (1) or not (0). A /64 prefix can be optionally specified." },
   { "rpl-local-repair",     cmd_rpl_local_repair,     "'> rpl-local-repair': Triggers a RPL local repair" },
+  { "rpl-refresh-routes",   cmd_rpl_refresh_routes,   "'> rpl-refresh-routes': Refreshes all routes through a DTSN increment" },
   { "rpl-global-repair",    cmd_rpl_global_repair,    "'> rpl-global-repair': Triggers a RPL global repair" },
 #endif /* UIP_CONF_IPV6_RPL */
 #if ROUTING_CONF_RPL_LITE


### PR DESCRIPTION
This is one more PR related to #128. Basically helps fixing a network through a DTSN increment as a shell command. This will ask the whole network to resend DAO. Compared to global repair:
+ No transition to new version means nodes remain connected at all times. In a global repair, nodes may transiently have no preferred parent.
- Slower (no Trickle reset) and less of a clean-slate rebuild (topology remains unchanged, only route registrations are refreshed)