### PR TITLE
CoAP: auto-initialize module

### DIFF
--- a/examples/coap/coap-example-client.c
+++ b/examples/coap/coap-example-client.c
@@ -92,9 +92,6 @@ PROCESS_THREAD(er_example_client, ev, data)
 
   coap_endpoint_parse(SERVER_EP, strlen(SERVER_EP), &server_ep);
 
-  /* receives all CoAP messages */
-  coap_engine_init();
-
   etimer_set(&et, TOGGLE_INTERVAL * CLOCK_SECOND);
 
 #if PLATFORM_HAS_BUTTON

--- a/examples/coap/coap-example-server.c
+++ b/examples/coap/coap-example-server.c
@@ -119,15 +119,12 @@ PROCESS_THREAD(er_example_server, ev, data)
   PRINTF("IP+UDP header: %u\n", UIP_IPUDPH_LEN);
   PRINTF("CoAP max chunk: %u\n", COAP_MAX_CHUNK_SIZE);
 
-  /* Initialize the REST engine. */
-  coap_engine_init();
-
   /*
    * Bind the resources to their Uri-Path.
    * WARNING: Activating twice only means alternate path, not two instances!
    * All static variables are the same for each URI path.
    */
-  coap_activate_resource(&res_hello, "test/hello");
+ coap_activate_resource(&res_hello, "test/hello");
  coap_activate_resource(&res_mirror, "debug/mirror");
  coap_activate_resource(&res_chunks, "test/chunks");
  coap_activate_resource(&res_separate, "test/separate");

--- a/examples/coap/plugtest-server.c
+++ b/examples/coap/plugtest-server.c
@@ -94,9 +94,6 @@ PROCESS_THREAD(plugtest_server, ev, data)
   PRINTF("IP+UDP header: %u\n", UIP_IPUDPH_LEN);
   PRINTF("REST max chunk: %u\n", REST_MAX_CHUNK_SIZE);
 
-  /* Initialize the REST engine. */
-  coap_engine_init();
-
   /* Activate the application-specific resources. */
   coap_activate_resource(&res_plugtest_test, "test");
   coap_activate_resource(&res_plugtest_validate, "validate");

--- a/examples/ipso-objects/example-server.c
+++ b/examples/ipso-objects/example-server.c
@@ -267,9 +267,6 @@ PROCESS_THREAD(router_process, ev, data)
 
   PROCESS_PAUSE();
 
-  /* receives all CoAP messages */
-  coap_engine_init();
-
   setup_network();
 
   while(1) {

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/coap-server.c
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/coap-server.c
@@ -133,9 +133,6 @@ PROCESS_THREAD(coap_server_process, ev, data)
 
   printf("CC26XX CoAP Server\n");
 
-  /* Initialize the REST engine. */
-  coap_engine_init();
-
   coap_activate_resource(&res_batmon_temp, "sen/batmon/temp");
   coap_activate_resource(&res_batmon_volt, "sen/batmon/voltage");
 

--- a/examples/platform-specific/cc26xx/very-sleepy-demo/very-sleepy-demo.c
+++ b/examples/platform-specific/cc26xx/very-sleepy-demo/very-sleepy-demo.c
@@ -344,8 +344,6 @@ PROCESS_THREAD(very_sleepy_demo_process, ev, data)
 
   event_new_config = process_alloc_event();
 
-  coap_engine_init();
-
   readings_resource.flags += IS_OBSERVABLE;
   coap_activate_resource(&readings_resource, "sen/readings");
   coap_activate_resource(&very_sleepy_conf, "very_sleepy_config");

--- a/examples/platform-specific/jn516x/rpl/coap-dongle-node/dongle-node.c
+++ b/examples/platform-specific/jn516x/rpl/coap-dongle-node/dongle-node.c
@@ -135,7 +135,6 @@ PROCESS_THREAD(start_app, ev, data)
   NETSTACK_MAC.on();
   printf("Starting RPL node\n");
 
-  coap_engine_init();
   coap_activate_resource(&resource_led_toggle, "Dongle/LED-toggle");
 
   PROCESS_END();

--- a/examples/platform-specific/jn516x/rpl/coap-dr1175-node/dr1175-node.c
+++ b/examples/platform-specific/jn516x/rpl/coap-dr1175-node/dr1175-node.c
@@ -355,7 +355,6 @@ PROCESS_THREAD(start_app, ev, data)
   NETSTACK_MAC.on();
   printf("Starting RPL node\n");
 
-  coap_engine_init();
   coap_activate_resource(&resource_light_sensor_value, "DR1175/LightSensor/Value");
   coap_activate_resource(&resource_light_sensor_unit, "DR1175/LightSensor/Unit");
   coap_activate_resource(&resource_temperature_unit, "DR1175/Temperature/Unit");

--- a/examples/platform-specific/jn516x/rpl/coap-dr1199-node/dr1199-node.c
+++ b/examples/platform-specific/jn516x/rpl/coap-dr1199-node/dr1199-node.c
@@ -356,7 +356,6 @@ PROCESS_THREAD(start_app, ev, data)
   NETSTACK_MAC.on();
   printf("Starting RPL node\n");
 
-  coap_engine_init();
   coap_activate_resource(&resource_switch_sw1, "DR1199/Switch/SW1");
   coap_activate_resource(&resource_switch_sw2, "DR1199/Switch/SW2");
   coap_activate_resource(&resource_switch_sw3, "DR1199/Switch/SW3");

--- a/examples/platform-specific/jn516x/tsch/tx-power-verification/node/node.c
+++ b/examples/platform-specific/jn516x/tsch/tx-power-verification/node/node.c
@@ -110,7 +110,6 @@ PROCESS_THREAD(start_app, ev, data)
   NETSTACK_MAC.on();
   printf("Starting RPL node\n");
 
-  coap_engine_init();
   coap_activate_resource(&resource_set_tx_power, "Set-TX-Power");
   coap_activate_resource(&resource_get_tx_power, "Get-TX-Power");
 

--- a/examples/platform-specific/jn516x/tsch/uart1-test-node/uart1-test-node.c
+++ b/examples/platform-specific/jn516x/tsch/uart1-test-node/uart1-test-node.c
@@ -151,7 +151,6 @@ PROCESS_THREAD(start_app, ev, data)
   NETSTACK_MAC.on();
   printf("Starting RPL node\n");
 
-  coap_engine_init();
   coap_activate_resource(&resource_coap_rx_uart1, "UART1-RX");
   coap_activate_resource(&resource_coap_tx_uart1, "UART1-TX");
 

--- a/examples/platform-specific/nrf52dk/coap-demo/coap-client/coap-client.c
+++ b/examples/platform-specific/nrf52dk/coap-demo/coap-client/coap-client.c
@@ -148,9 +148,6 @@ PROCESS_THREAD(er_example_observe_client, ev, data)
   static coap_endpoint_t server_endpoint;
   coap_endpoint_parse(SERVER_IPV6_EP, strlen(SERVER_IPV6_EP), &server_endpoint);
 
-  /* receives all CoAP messages */
-  coap_engine_init();
-
 #if PLATFORM_HAS_BUTTON
   SENSORS_ACTIVATE(button_1);
   SENSORS_ACTIVATE(button_2);

--- a/examples/platform-specific/nrf52dk/coap-demo/coap-server/coap-server.c
+++ b/examples/platform-specific/nrf52dk/coap-demo/coap-server/coap-server.c
@@ -103,8 +103,6 @@ PROCESS_THREAD(er_example_server, ev, data)
 
   print_local_addresses();
 
-  /* Initialize the REST engine. */
-  coap_engine_init();
   coap_activate_resource(&res_led3, "lights/led3");
 
   SENSORS_ACTIVATE(button_1);

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -47,6 +47,7 @@
 #include "sys/stack-check.h"
 #include "dev/watchdog.h"
 
+#include "net/app-layer/coap/coap-engine.h"
 #include "services/rpl-border-router/rpl-border-router.h"
 #include "services/orchestra/orchestra.h"
 #include "services/shell/serial-shell.h"
@@ -124,6 +125,11 @@ main(void)
 #if BUILD_WITH_SHELL
   serial_shell_init();
   LOG_DBG("With Shell\n");
+#endif /* BUILD_WITH_SHELL */
+
+#if BUILD_WITH_COAP
+  coap_engine_init();
+  LOG_DBG("With CoAP\n");
 #endif /* BUILD_WITH_SHELL */
 
   autostart_start(autostart_processes);

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -363,7 +363,6 @@ coap_engine_init(void)
 {
   /* avoid initializing twice */
   if(is_initialized) {
-    LOG_DBG("already running - double initialization?\n");
     return;
   }
   is_initialized = 1;

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -1115,13 +1115,10 @@ coap_set_header_size1(coap_message_t *coap_pkt, uint32_t size)
 int
 coap_get_payload(coap_message_t *coap_pkt, const uint8_t **payload)
 {
-  if(coap_pkt->payload) {
+  if(payload != NULL) {
     *payload = coap_pkt->payload;
-    return coap_pkt->payload_len;
-  } else {
-    *payload = NULL;
-    return 0;
   }
+  return coap_pkt->payload != NULL ? coap_pkt->payload_len : 0;
 }
 int
 coap_set_payload(coap_message_t *coap_pkt, const void *payload, size_t length)

--- a/os/net/app-layer/coap/module-macros.h
+++ b/os/net/app-layer/coap/module-macros.h
@@ -1,0 +1,1 @@
+#define BUILD_WITH_COAP 1

--- a/os/services/lwm2m/lwm2m-engine.c
+++ b/os/services/lwm2m/lwm2m-engine.c
@@ -543,6 +543,9 @@ lwm2m_engine_init(void)
 
 #endif /* LWM2M_ENGINE_CLIENT_ENDPOINT_NAME */
 
+  /* Initialize CoAP engine. Contiki-NG already does that from the main,
+   * but for standalone use of lwm2m, this is required here. coap_engine_init()
+   * checks for double-initialization and can be called twice safely. */
   coap_engine_init();
 
   /* Register the CoAP handler for lightweight object handling */


### PR DESCRIPTION
This PR proposes to auto-initialize the CoAP module whenever it is included, so that one does not have to call `coap_engine_init()` in addition to adding the module.