### PR TITLE
Fixed some issues with the LWM2M IPSO and standalone regression tests

### DIFF
--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -3,12 +3,13 @@
 # Contiki directory
 CONTIKI=$1
 # Test basename
-BASENAME=06-lwm2m-test
+BASENAME=06-lwm2m-ipso-test
 
 IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node - lwm2m/ipso objects"
+make -C $CONTIKI/examples/ipso-objects clean >/dev/null
 make -C $CONTIKI/examples/ipso-objects > make.log 2> make.err
 sudo $CONTIKI/examples/ipso-objects/example-ipso-objects.native > node.log 2> node.err &
 CPID=$!
@@ -19,7 +20,15 @@ wget -nc https://joakimeriksson.github.io/resources/leshan-server-demo-1.0.0-SNA
 echo "Starting leshan server"
 java -jar leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar >leshan.log 2>leshan.err &
 LESHID=$!
-sleep 50
+
+COUNTER=10
+while [ $COUNTER -gt 0 ]; do
+    sleep 5
+    if grep -q 'OK' leshan.err ; then
+        break
+    fi
+    let COUNTER-=1
+done
 
 echo "Closing native node"
 sleep 1

--- a/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
+++ b/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
@@ -5,9 +5,10 @@ CONTIKI=$1
 # Test basename
 BASENAME=07-lwm2m-standalone-test
 
-git clone https://github.com/contiki-ng/example-lwm2m-standalone.git
 # Building standalone posix example
-make -C example-lwm2m-standalone/lwm2m > make.log 2> make.err
+echo "Compiling standalone posix example"
+make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m clean >/dev/null
+make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m >make.log 2>make.err
 
 echo "Downloading leshan"
 wget -nc https://joakimeriksson.github.io/resources/leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
@@ -20,11 +21,19 @@ example-lwm2m-standalone/lwm2m/lwm2m-example coap://127.0.0.1:5686 > node.log 2>
 
 CPID=$!
 
-sleep 50
+COUNTER=10
+while [ $COUNTER -gt 0 ]; do
+    sleep 5
+    if grep -q 'OK' leshan.err ; then
+        echo OK with $COUNTER
+        break
+    fi
+    let COUNTER-=1
+done
 
-echo "Closing native node"
+echo "Closing standalone example"
 sleep 1
-pgrep ipso | sudo xargs kill -9
+pgrep lwm2m-example | sudo xargs kill -9
 
 echo "Closing leshan"
 sleep 1


### PR DESCRIPTION
- LWM2M standalone test did not build using the expected source code
- LWM2M standalone test could leave running background processes
- the LWM2M tests now use periodic checks to faster finish successful tests
- the tests now clean before building to ensure the tests are executed with the correct configuration.