### PR TITLE
Change RPL_LEAF_ONLY flag to a run-time flag

### DIFF
--- a/os/net/routing/rpl-lite/rpl-conf.h
+++ b/os/net/routing/rpl-lite/rpl-conf.h
@@ -185,10 +185,10 @@
  * This value decides if this node must stay as a leaf or not
  * as allowed by draft-ietf-roll-rpl-19#section-8.5
  */
-#ifdef RPL_CONF_LEAF_ONLY
-#define RPL_LEAF_ONLY RPL_CONF_LEAF_ONLY
+#ifdef RPL_CONF_DEFAULT_LEAF_ONLY
+#define RPL_DEFAULT_LEAF_ONLY RPL_CONF_DEFAULT_LEAF_ONLY
 #else
-#define RPL_LEAF_ONLY 0
+#define RPL_DEFAULT_LEAF_ONLY 0
 #endif
 
 /******************************************************************************/

--- a/os/net/routing/rpl-lite/rpl-timers.c
+++ b/os/net/routing/rpl-lite/rpl-timers.c
@@ -150,11 +150,11 @@ rpl_timers_dio_reset(const char *str)
 {
   if(rpl_dag_ready_to_advertise()) {
     LOG_INFO("reset DIO timer (%s)\n", str);
-#if !RPL_LEAF_ONLY
-    curr_instance.dag.dio_counter = 0;
-    curr_instance.dag.dio_intcurrent = curr_instance.dio_intmin;
-    new_dio_interval();
-#endif /* RPL_LEAF_ONLY */
+    if(!rpl_get_leaf_only()) {
+        curr_instance.dag.dio_counter = 0;
+        curr_instance.dag.dio_intcurrent = curr_instance.dio_intmin;
+        new_dio_interval();
+    }
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/os/net/routing/rpl-lite/rpl.c
+++ b/os/net/routing/rpl-lite/rpl.c
@@ -50,6 +50,7 @@
 #define LOG_LEVEL LOG_LEVEL_RPL
 
 uip_ipaddr_t rpl_multicast_addr;
+static uint8_t rpl_leaf_only = RPL_DEFAULT_LEAF_ONLY;
 
 /*---------------------------------------------------------------------------*/
 int
@@ -221,6 +222,18 @@ static void
 drop_route(uip_ds6_route_t *route)
 {
   /* Do nothing. RPL-lite only supports non-storing mode, i.e. no routes */
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_set_leaf_only(uint8_t value)
+{
+  rpl_leaf_only = value;
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+rpl_get_leaf_only(void)
+{
+  return rpl_leaf_only;
 }
 /*---------------------------------------------------------------------------*/
 const struct routing_driver rpl_lite_driver = {

--- a/os/net/routing/rpl-lite/rpl.h
+++ b/os/net/routing/rpl-lite/rpl.h
@@ -133,6 +133,20 @@ int rpl_lollipop_greater_than(int a, int b);
  */
 void rpl_refresh_routes(const char *str);
 
+/**
+ * Changes the value of the rpl_leaf_only flag, which determines if a node acts
+ * only as a leaf in the network
+ *
+ * \param value the value to set: 0-disable, 1-enable
+ */
+void rpl_set_leaf_only(uint8_t value);
+
+/**
+ * Get the value of the rpl_leaf_only flag
+ *
+ * \return The value of the rpl_leaf_only flag
+ */
+uint8_t rpl_get_leaf_only(void);
  /** @} */
 
 #endif /* RPL_H */


### PR DESCRIPTION
This PR aims to change the RPL_LEAF_ONLY flag present in RPL-Lite to be a run-time flag so that it can be changed dynamically. The flag is used to force a node to be just a leaf inside the RPL topology, by basically advertsing an infinite rank in the DIO.