### PR TITLE
Fixing cc26xx 6lbr client example

### DIFF
--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/Makefile
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/Makefile
@@ -5,8 +5,13 @@ PLATFORMS_ONLY = srf06-cc26xx
 
 MODULES_REL += ./resources
 
-PROJECT_SOURCEFILES += cetic-6lbr-client.c coap-server.c net-uart.c mqtt-client.c
+PROJECT_SOURCEFILES += coap-server.c net-uart.c mqtt-client.c
 PROJECT_SOURCEFILES += httpd-simple.c
+
+ifeq ($(MAKE_ROUTING),MAKE_ROUTING_RPL_CLASSIC)
+# 6lbr only supports RPL Classic
+PROJECT_SOURCEFILES += cetic-6lbr-client.c
+endif
 
 # REST Engine shall use Erbium CoAP implementation
 MODULES += os/net/app-layer/mqtt

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/cetic-6lbr-client.c
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/cetic-6lbr-client.c
@@ -37,10 +37,11 @@
 #include "contiki-net.h"
 #include "net/routing/routing.h"
 #include "net/ipv6/uip.h"
-#if ROUTING_CONF_RPL_LITE
-#include "net/routing/rpl-lite/rpl.h"
-#elif ROUTING_CONF_RPL_CLASSIC
+#if ROUTING_CONF_RPL_CLASSIC
 #include "net/routing/rpl-classic/rpl.h"
+#include "net/routing/rpl-classic/rpl-private.h"
+#else
+#error The 6LBR client is only meant for RPL Classic. Set MAKE_ROUTING accordingly.
 #endif
 
 #include <string.h>

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/cetic-6lbr-client.c
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/cetic-6lbr-client.c
@@ -161,8 +161,8 @@ timeout_handler(void)
       PRINT6ADDR(&client_conn->ripaddr);
       i = sprintf(buf, "%d | ", ++seq_id);
       instance = rpl_get_default_instance();
-      if(instance && instance->dag.preferred_parent) {
-        add_ipaddr(buf + i, rpl_parent_get_ipaddr(instance->dag.preferred_parent));
+      if(instance && instance->current_dag->preferred_parent) {
+        add_ipaddr(buf + i, rpl_parent_get_ipaddr(instance->current_dag->preferred_parent));
       } else {
         sprintf(buf + i, "(null)");
       }

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/project-conf.h
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/project-conf.h
@@ -42,7 +42,7 @@
 
 /* Enable/Disable Components of this Demo */
 #define CC26XX_WEB_DEMO_CONF_MQTT_CLIENT      1
-#define CC26XX_WEB_DEMO_CONF_6LBR_CLIENT      1
+#define CC26XX_WEB_DEMO_CONF_6LBR_CLIENT      ROUTING_CONF_RPL_CLASSIC
 #define CC26XX_WEB_DEMO_CONF_COAP_SERVER      1
 #define CC26XX_WEB_DEMO_CONF_NET_UART         1
 

--- a/tests/02-compile-arm-ports-01/Makefile
+++ b/tests/02-compile-arm-ports-01/Makefile
@@ -3,6 +3,7 @@ TOOLSDIR=../../tools
 
 EXAMPLES = \
 platform-specific/cc26xx/cc26xx-web-demo/srf06-cc26xx \
+platform-specific/cc26xx/cc26xx-web-demo/srf06-cc26xx:MAKE_ROUTING=MAKE_ROUTING_RPL_CLASSIC \
 platform-specific/cc26xx/very-sleepy-demo/srf06-cc26xx:BOARD=sensortag/cc2650 \
 platform-specific/cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=sensortag/cc2650 \
 platform-specific/cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=sensortag/cc1350 \


### PR DESCRIPTION
The cc26xx 6lbr client example was meant for RPL Classic.
This PR:
* Fixes compilation of the example for RPL Classic
* Only compiles the example when RPL Classic is enabled
* Adds a compile test for this example with RPL Classic

Fixes #442 