### PR TITLE
uiplib: ensure output string is null-terminated when printing the unspecified address

### DIFF
--- a/os/net/ipv6/uiplib.c
+++ b/os/net/ipv6/uiplib.c
@@ -250,9 +250,11 @@ uiplib_ipaddr_snprint(char *buf, size_t size, const uip_ipaddr_t *addr)
     }
   }
 
-  if(n >= size - 1) {
-    buf[size - 1] = '\0';
-  }
+  /*
+   * Make sure the output string is always null-terminated.
+   */
+  buf[MIN(n, size - 1)] = '\0';
+
   return n;
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This fixes `uiplib_ipaddr_snprint()` to null-terminate the output string when printing the unspecified IPv6 address (::).