### PR TITLE
Shell client with history

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/arch/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -93,10 +93,10 @@ ifeq ($(HOST_OS),Windows)
   SERIALDUMP ?= $(CONTIKI)/tools/sky/serialdump-windows
 else
 ifeq ($(HOST_OS),Darwin)
-  SERIALDUMP ?= $(CONTIKI)/tools/sky/serialdump-macos
+  SERIALDUMP ?= rlwrap $(CONTIKI)/tools/sky/serialdump-macos
 else
   # Else assume Linux
-  SERIALDUMP ?= $(CONTIKI)/tools/sky/serialdump-linux
+  SERIALDUMP ?= rlwrap $(CONTIKI)/tools/sky/serialdump-linux
 endif
 endif
 

--- a/arch/platform/jn516x/Makefile.jn516x
+++ b/arch/platform/jn516x/Makefile.jn516x
@@ -180,12 +180,12 @@ else
 ifeq ($(HOST_OS),Darwin)
   USBDEVPREFIX=
   USBDEVBASENAME=/dev/tty.usbserial-
-  SERIALDUMP ?= $(CONTIKI)/tools/jn516x/serialdump-macos
+  SERIALDUMP ?= rlwrap $(CONTIKI)/tools/jn516x/serialdump-macos
 else
   # Else we assume Linux
   USBDEVPREFIX=
   USBDEVBASENAME=/dev/ttyUSB
-  SERIALDUMP ?= $(CONTIKI)/tools/jn516x/serialdump-linux
+  SERIALDUMP ?= rlwrap $(CONTIKI)/tools/jn516x/serialdump-linux
 endif
 endif
 

--- a/arch/platform/sky/Makefile.common
+++ b/arch/platform/sky/Makefile.common
@@ -54,7 +54,7 @@ else
 ifeq ($(HOST_OS),Darwin)
   ifndef MOTELIST
     USBDEVPREFIX=
-    SERIALDUMP = $(CONTIKI)/tools/sky/serialdump-macos
+    SERIALDUMP = rlwrap $(CONTIKI)/tools/sky/serialdump-macos
     MOTELIST = $(CONTIKI)/tools/sky/motelist-macos
     TMOTE_BSL_FILE = tmote-bsl-linux
     TMOTE_BSL=$(if $(wildcard $(CONTIKI)/tools/sky/$(TMOTE_BSL_FILE)),1,0)
@@ -75,7 +75,7 @@ else
   # Else we assume Linux
   ifndef MOTELIST
     USBDEVPREFIX=
-    SERIALDUMP = $(CONTIKI)/tools/sky/serialdump-linux
+    SERIALDUMP = rlwrap $(CONTIKI)/tools/sky/serialdump-linux
     MOTELIST = $(CONTIKI)/tools/sky/motelist-linux
     TMOTE_BSL_FILE = tmote-bsl-linux
     TMOTE_BSL=$(if $(wildcard $(CONTIKI)/tools/sky/$(TMOTE_BSL_FILE)),1,0)

--- a/arch/platform/zoul/Makefile.zoul
+++ b/arch/platform/zoul/Makefile.zoul
@@ -56,11 +56,11 @@ ifeq ($(HOST_OS),Darwin)
   USBDEVPREFIX=
   MOTELIST := $(CONTIKI)/tools/zolertia/motelist-zolertia-macos
   MOTES := $(shell $(MOTELIST) -c 2>&- | cut -f 2 -d ,)
-  SERIALDUMP := $(CONTIKI)/tools/sky/serialdump-macos
+  SERIALDUMP := rlwrap $(CONTIKI)/tools/sky/serialdump-macos
 else
 ### If we are not running under Mac, we assume Linux
   USBDEVPREFIX=
-  SERIALDUMP := $(CONTIKI)/tools/sky/serialdump-linux
+  SERIALDUMP := rlwrap $(CONTIKI)/tools/sky/serialdump-linux
   MOTELIST := $(CONTIKI)/tools/zolertia/motelist-zolertia
   MOTES := $(shell $(MOTELIST) -b $(MOTELIST_ZOLERTIA) -c 2>&- | cut -f 2 -d , | \
             perl -ne 'print $$1 . " " if(m-(/dev/\w+)-);')

--- a/os/services/rpl-border-router/native/Makefile.native
+++ b/os/services/rpl-border-router/native/Makefile.native
@@ -7,7 +7,7 @@ MAKE_NET = MAKE_NET_IPV6
 
 PREFIX ?= fd00::1/64
 connect-router:	border-router.native
-	sudo ./border-router.native $(PREFIX)
+	sudo rlwrap ./border-router.native $(PREFIX)
 
 connect-router-cooja:	border-router.native
-	sudo ./border-router.native -a localhost $(PREFIX)
+	sudo rlwrap ./border-router.native -a localhost $(PREFIX)

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM 32bit/ubuntu:16.04
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   build-essential doxygen git wget unzip python-serial \
-  default-jdk ant srecord iputils-tracepath && \
+  default-jdk ant srecord iputils-tracepath rlwrap && \
   apt-get clean
 
 # Install ARM toolchain

--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -8,7 +8,7 @@ sudo apt install -y --no-install-recommends \
 
 # Tools
 sudo apt-get install -y --no-install-recommends \
-  build-essential doxygen git wget unzip python-serial \
+  build-essential doxygen git wget unzip python-serial rlwrap \
   default-jdk ant srecord python-pip iputils-tracepath uncrustify python-magic
 sudo apt-get clean
 sudo python2 -m pip install intelhex


### PR DESCRIPTION
This simply adds `rlwrap` to `make login` and the native BR, giving us shell command history for free. With this, we can use move the cursor while in shell via directional arrows. UP gives the last command. CTRL+R does a search. History persists across executions. There are probably more features :)

Also adds the tool to Docker and Vagrant scripts.

The PR adds `rlwrap` to Linux (tested) and OSX (not tested, do not merge before somebody confirms it works!).

If we merge this, the following wiki pages will need updating:
* https://github.com/contiki-ng/contiki-ng/wiki/Toolchain-installation-on-Linux
* https://github.com/contiki-ng/contiki-ng/wiki/Toolchain-installation-on-OS-X
