### PR TITLE
Change the cc26x0 web demo default channel

### DIFF
--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/project-conf.h
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/project-conf.h
@@ -33,7 +33,7 @@
 /*---------------------------------------------------------------------------*/
 /* Change to match your configuration */
 #define IEEE802154_CONF_PANID            0xABCD
-#define RF_CORE_CONF_CHANNEL                 25
+#define RF_CORE_CONF_CHANNEL                 26
 #define RF_BLE_CONF_ENABLED                   1
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
This pull changes the cc26xx web demo to default to channel 26, which is the default everywhere else.