### PR TITLE
Added a periodic timer to the hello-world example

### DIFF
--- a/examples/hello-world/hello-world.c
+++ b/examples/hello-world/hello-world.c
@@ -46,10 +46,21 @@ AUTOSTART_PROCESSES(&hello_world_process);
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(hello_world_process, ev, data)
 {
+  static struct etimer timer;
+
   PROCESS_BEGIN();
 
-  printf("Hello, world\n");
-  
+  /* Setup a periodic timer that expires after 10 seconds. */
+  etimer_set(&timer, CLOCK_SECOND * 10);
+
+  while(1) {
+    printf("Hello, world\n");
+
+    /* Wait for the periodic timer to expire and then restart the timer. */
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+    etimer_reset(&timer);
+  }
+
   PROCESS_END();
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Programming a device with the hello-world example and then connect to the device via serial port to see the output normally shows nothing since the example only prints the message once after boot. This might be confusing for new users.

This PR adds a periodic timer to print the message periodically and also replaces the `printf()` with a call to the logging API.