### PR TITLE
Enable the CC13x0/CC26x0 ROM bootloader by default

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/cc13xx-cc26xx-conf.h
+++ b/arch/cpu/cc26xx-cc13xx/cc13xx-cc26xx-conf.h
@@ -190,7 +190,7 @@
  * @{
  */
 #ifndef ROM_BOOTLOADER_ENABLE
-#define ROM_BOOTLOADER_ENABLE              0
+#define ROM_BOOTLOADER_ENABLE              1
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
After having locked myself out of my kit for the gazzillionth time and after multiple complaints by our users, I have decided to change the CC13x0/CC26x0 ROM bootloader default to 'enabled'.

But I have also updated the wiki page with clear instructions that it needs disabled for production/deployment images...

Closes #390 