### PR TITLE
Make distclean: less verbose output

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -298,14 +298,15 @@ CONTIKI_NG_PROJECT_MAP = $(addsuffix -$(TARGET).map, $(basename $@))
 .PHONY: clean distclean usage help targets boards savetarget savedefines viewconf
 
 clean:
-	-rm -f *.d *.e *.o $(CONTIKI_NG_TARGET_LIB) $(CLEAN)
-	-rm -rf $(OBJECTDIR)
-	-rm -f $(addsuffix -$(TARGET).map, $(CONTIKI_PROJECT))
-	-rm -f $(addsuffix .$(TARGET), $(CONTIKI_PROJECT))
+	-$(Q)rm -f *.d *.e *.o $(CONTIKI_NG_TARGET_LIB) $(CLEAN)
+	-$(Q)rm -rf $(OBJECTDIR)
+	-$(Q)rm -f $(addsuffix -$(TARGET).map, $(CONTIKI_PROJECT))
+	-$(Q)rm -f $(addsuffix .$(TARGET), $(CONTIKI_PROJECT))
+	@echo Target $(TARGET) cleaned
 
 distclean:
 	@for TARG in `ls $(CONTIKI)/arch/platform $(TARGETDIRS)`; do \
-		echo make $$TARG clean; \
+		echo Running: make TARGET=$$TARG clean; \
 		make TARGET=$$TARG clean; \
 	done
 


### PR DESCRIPTION
Well this really is just a proposal. I found the current `distclean` output too verbose to be readable:
```
...
make openmote-cc2538 clean
make[1]: Entering directory '/home/simon/contiki-ng/examples/hello-world'
rm -f *.d *.e *.o contiki-ng-openmote-cc2538.a *.elf *.bin *.lst *.hex *.i16hex
rm -rf obj_openmote-cc2538
rm -f hello-world-openmote-cc2538.map
rm -f hello-world.openmote-cc2538
make[1]: Leaving directory '/home/simon/contiki-ng/examples/hello-world'
make sky clean
make[1]: Entering directory '/home/simon/contiki-ng/examples/hello-world'
rm -f *.d *.e *.o contiki-ng-sky.a *.firmware *.ihex
rm -rf obj_sky
rm -f hello-world-sky.map
rm -f hello-world.sky
make[1]: Leaving directory '/home/simon/contiki-ng/examples/hello-world'
...
```

With this PR:
```
...
make openmote-cc2538 clean
make sky clean
...
```