### PR TITLE
Nullrouting: lowercase string description

### DIFF
--- a/os/net/routing/nullrouting/nullrouting.c
+++ b/os/net/routing/nullrouting/nullrouting.c
@@ -149,7 +149,7 @@ drop_route(uip_ds6_route_t *route)
 }
 /*---------------------------------------------------------------------------*/
 const struct routing_driver nullrouting_driver = {
-  "Null Routing",
+  "nullrouting",
   init,
   root_set_prefix,
   root_start,


### PR DESCRIPTION
For consistency with nullnet and nullmac.