### PR TITLE
Shorter log module names for CoAP/LWM2M/DTLS for nicer log output

### DIFF
--- a/os/net/app-layer/coap/coap-block1.c
+++ b/os/net/app-layer/coap/coap-block1.c
@@ -49,7 +49,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-block1"
+#define LOG_MODULE "coap"
 #define LOG_LEVEL  LOG_LEVEL_COAP
 
 /*---------------------------------------------------------------------------*/

--- a/os/net/app-layer/coap/coap-blocking-api.c
+++ b/os/net/app-layer/coap/coap-blocking-api.c
@@ -51,7 +51,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-blocking-api"
+#define LOG_MODULE "coap"
 #define LOG_LEVEL  LOG_LEVEL_COAP
 
 /*---------------------------------------------------------------------------*/

--- a/os/net/app-layer/coap/coap-callback-api.c
+++ b/os/net/app-layer/coap/coap-callback-api.c
@@ -51,7 +51,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-callback-api"
+#define LOG_MODULE "coap"
 #define LOG_LEVEL  LOG_LEVEL_COAP
 
 /* These should go into the state struct so that we can have multiple

--- a/os/net/app-layer/coap/coap-observe-client.c
+++ b/os/net/app-layer/coap/coap-observe-client.c
@@ -55,7 +55,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-observe-client"
+#define LOG_MODULE "coap"
 #define LOG_LEVEL  LOG_LEVEL_COAP
 
 MEMB(obs_subjects_memb, coap_observee_t, COAP_MAX_OBSERVEES);

--- a/os/net/app-layer/coap/coap-observe.c
+++ b/os/net/app-layer/coap/coap-observe.c
@@ -50,7 +50,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-observe"
+#define LOG_MODULE "coap"
 #define LOG_LEVEL  LOG_LEVEL_COAP
 
 /*---------------------------------------------------------------------------*/

--- a/os/net/app-layer/coap/coap-res-well-known-core.c
+++ b/os/net/app-layer/coap/coap-res-well-known-core.c
@@ -47,7 +47,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-res-well-known-core"
+#define LOG_MODULE "coap"
 #define LOG_LEVEL  LOG_LEVEL_COAP
 
 #define ADD_CHAR_IF_POSSIBLE(char) \

--- a/os/net/app-layer/coap/coap-separate.c
+++ b/os/net/app-layer/coap/coap-separate.c
@@ -49,7 +49,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-separate"
+#define LOG_MODULE "coap"
 #define LOG_LEVEL  LOG_LEVEL_COAP
 
 /*---------------------------------------------------------------------------*/

--- a/os/net/app-layer/coap/coap-timer-default.c
+++ b/os/net/app-layer/coap/coap-timer-default.c
@@ -52,7 +52,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-timer-default"
+#define LOG_MODULE "coap-timer"
 #define LOG_LEVEL  LOG_LEVEL_NONE
 
 PROCESS(coap_timer_process, "coap timer process");

--- a/os/net/app-layer/coap/coap-transactions.c
+++ b/os/net/app-layer/coap/coap-transactions.c
@@ -50,7 +50,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "coap-transactions"
+#define LOG_MODULE "coap"
 #define LOG_LEVEL  LOG_LEVEL_COAP
 
 /*---------------------------------------------------------------------------*/

--- a/os/net/app-layer/coap/tinydtls-support/dtls-support.c
+++ b/os/net/app-layer/coap/tinydtls-support/dtls-support.c
@@ -42,7 +42,7 @@
 #include <stdarg.h>
 
 /* Log configuration */
-#define LOG_MODULE "dtls-support"
+#define LOG_MODULE "dtls"
 #define LOG_LEVEL  LOG_LEVEL_DTLS
 #include "dtls-log.h"
 #include "coap-log.h"

--- a/os/services/lwm2m/lwm2m-device.c
+++ b/os/services/lwm2m/lwm2m-device.c
@@ -48,7 +48,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "lwm2m-device"
+#define LOG_MODULE "lwm2m-dev"
 #define LOG_LEVEL  LOG_LEVEL_LWM2M
 
 static const lwm2m_resource_id_t resources[] =

--- a/os/services/lwm2m/lwm2m-engine.c
+++ b/os/services/lwm2m/lwm2m-engine.c
@@ -63,7 +63,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "lwm2m-engine"
+#define LOG_MODULE "lwm2m-eng"
 #define LOG_LEVEL  LOG_LEVEL_LWM2M
 
 #ifndef LWM2M_ENGINE_CLIENT_ENDPOINT_PREFIX

--- a/os/services/lwm2m/lwm2m-firmware.c
+++ b/os/services/lwm2m/lwm2m-firmware.c
@@ -44,7 +44,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "lwm2m-firmware"
+#define LOG_MODULE "lwm2m-fw"
 #define LOG_LEVEL  LOG_LEVEL_LWM2M
 
 #define UPDATE_PACKAGE     0

--- a/os/services/lwm2m/lwm2m-plain-text.c
+++ b/os/services/lwm2m/lwm2m-plain-text.c
@@ -49,7 +49,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "lwm2m-plain-text"
+#define LOG_MODULE "lwm2m-text"
 #define LOG_LEVEL  LOG_LEVEL_NONE
 
 /*---------------------------------------------------------------------------*/

--- a/os/services/lwm2m/lwm2m-rd-client.c
+++ b/os/services/lwm2m/lwm2m-rd-client.c
@@ -64,7 +64,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "lwm2m-rd-client"
+#define LOG_MODULE "lwm2m-rd"
 #define LOG_LEVEL  LOG_LEVEL_LWM2M
 
 #ifndef LWM2M_DEFAULT_CLIENT_LIFETIME

--- a/os/services/lwm2m/lwm2m-security.c
+++ b/os/services/lwm2m/lwm2m-security.c
@@ -54,7 +54,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "lwm2m-security"
+#define LOG_MODULE "lwm2m-sec"
 #define LOG_LEVEL  LOG_LEVEL_LWM2M
 
 #define MAX_COUNT LWM2M_SERVER_MAX_COUNT

--- a/os/services/lwm2m/lwm2m-server.c
+++ b/os/services/lwm2m/lwm2m-server.c
@@ -51,7 +51,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "lwm2m-server"
+#define LOG_MODULE "lwm2m-srv"
 #define LOG_LEVEL  LOG_LEVEL_LWM2M
 
 #define MAX_COUNT LWM2M_SERVER_MAX_COUNT

--- a/os/services/lwm2m/lwm2m-tlv-writer.c
+++ b/os/services/lwm2m/lwm2m-tlv-writer.c
@@ -47,7 +47,7 @@
 
 /* Log configuration */
 #include "coap-log.h"
-#define LOG_MODULE "lwm2m-tlv-writer"
+#define LOG_MODULE "lwm2m-tlv"
 #define LOG_LEVEL  LOG_LEVEL_NONE
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Fixes #458.