### PR TITLE
fixed platforms to build for in Makefile

### DIFF
--- a/examples/storage/antelope-shell/Makefile
+++ b/examples/storage/antelope-shell/Makefile
@@ -3,7 +3,7 @@ CONTIKI = ../../..
 MODULES += os/storage/antelope os/services/unit-test
 
 # does not fit on Sky
-PLATFORMS_ONLY= cc2538
+PLATFORMS_ONLY= cc2538dk zoul
 
 CONTIKI_PROJECT = shell-db
 all: $(CONTIKI_PROJECT)

--- a/examples/storage/cfs-coffee/Makefile
+++ b/examples/storage/cfs-coffee/Makefile
@@ -1,6 +1,6 @@
 CONTIKI = ../../..
 
-PLATFORMS_ONLY= cc2538 sky
+PLATFORMS_ONLY= cc2538dk zoul sky
 
 MODULES += os/services/unit-test
 MODULES += os/storage/cfs


### PR DESCRIPTION
Fixed the Makefiles of the storage examples as they did not support Zoul and missed a dk in the cc2538dk platform. 