### PR TITLE
Updated lwm2m-ipso-object server-example for latest RPL/CoAP APIs

### DIFF
--- a/examples/lwm2m-ipso-objects/Makefile
+++ b/examples/lwm2m-ipso-objects/Makefile
@@ -12,16 +12,3 @@ MODULES += os/services/ipso-objects
 
 CONTIKI=../..
 include $(CONTIKI)/Makefile.include
-
-# border router rules
-$(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c
-	(cd $(CONTIKI)/tools && $(MAKE) tunslip6)
-
-connect-router:	$(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 aaaa::1/64
-
-connect-router-cooja:	$(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 -p 60001 aaaa::1/64
-
-connect-router-native:	$(CONTIKI)/examples/native-border-router/border-router.native
-	sudo $(CONTIKI)/examples/native-border-router/border-router.native -a 127.0.0.1 -p 60001 aaaa::1/64

--- a/examples/lwm2m-ipso-objects/README.md
+++ b/examples/lwm2m-ipso-objects/README.md
@@ -3,8 +3,8 @@ LWM2M with IPSO Objects Example
 
 This is an OMA LWM2M example implementing IPSO Objects.
 It can connect to a Leshan server out-of-the-box.
-Important configuration paramters:
-* `LWM2M_SERVER_ADDRESS`: the address of the server to register to (or bosstrap from)
+Important configuration parameters:
+* `LWM2M_SERVER_ADDRESS`: the address of the server to register to (or bootstrap from)
 * `REGISTER_WITH_LWM2M_BOOTSTRAP_SERVER`: set to bootstrap via `LWM2M_SERVER_ADDRESS` and then obtain the registration server address
 
 A tutorial for setting up this example is provided on the wiki.

--- a/examples/lwm2m-ipso-objects/serial-protocol.c
+++ b/examples/lwm2m-ipso-objects/serial-protocol.c
@@ -60,7 +60,7 @@ find_next_sep(const char *str, char sep, int pos)
 /*
  * l - list all discovered devices
  * s - set <IP> <URI> <value>
- * d - get <IP> <URI>
+ * g - get <IP> <URI>
  */
 void
 serial_protocol_input(char *data)
@@ -119,8 +119,12 @@ serial_protocol_input(char *data)
     }
     break;
   }
+  case '\0':
+    /* Ignore empty lines */
+    break;
   default:
     printf("Unknown command\n");
   }
+  printf("> ");
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The server-example in lwm2m-ipso-object example was using old APIs for listing routes and CoAP blocking requests. This updates the example to use the latest APIs.