### PR TITLE
Shell improvements

### DIFF
--- a/os/services/shell/shell.c
+++ b/os/services/shell/shell.c
@@ -106,7 +106,7 @@ shell_output_lladdr(shell_output_func output, const linkaddr_t *lladdr)
 static void
 output_prompt(shell_output_func output)
 {
-  SHELL_OUTPUT(output, "#");
+  SHELL_OUTPUT(output, "\n#");
   shell_output_lladdr(output, &linkaddr_node_addr);
   SHELL_OUTPUT(output, "> ");
 }

--- a/os/services/shell/shell.c
+++ b/os/services/shell/shell.c
@@ -130,20 +130,22 @@ PT_THREAD(shell_input(struct pt *pt, shell_output_func output, const char *cmd))
     args++;
   }
 
-  /* Lookup for command */
-  cmd_ptr = shell_commands;
-  while(cmd_ptr->name != NULL) {
-    if(strcmp(cmd, cmd_ptr->name) == 0) {
-      static struct pt cmd_pt;
-      PT_SPAWN(pt, &cmd_pt, cmd_ptr->func(&cmd_pt, output, args));
-      goto done;
+  /* only process lines with something on them (having removed leading space) */
+  if(strlen(cmd) > 0) { 
+    /* Lookup for command */
+    cmd_ptr = shell_commands;
+    while(cmd_ptr->name != NULL && strcmp(cmd, cmd_ptr->name) != 0) {
+      cmd_ptr++;
     }
-    cmd_ptr++;
+
+    if(cmd_ptr->name != NULL) {
+	static struct pt cmd_pt;
+	PT_SPAWN(pt, &cmd_pt, cmd_ptr->func(&cmd_pt, output, args));
+    } else {
+      SHELL_OUTPUT(output, "Command not found. Type 'help' for a list of commands\n");
+    }
   }
 
-  SHELL_OUTPUT(output, "Command not found. Type 'help' for a list of commands\n");
-
-done:
   output_prompt(output);
   PT_END(pt);
 }

--- a/os/services/shell/shell.c
+++ b/os/services/shell/shell.c
@@ -131,7 +131,7 @@ PT_THREAD(shell_input(struct pt *pt, shell_output_func output, const char *cmd))
   }
 
   /* only process lines with something on them (having removed leading space) */
-  if(strlen(cmd) > 0) { 
+  if(strlen(cmd) > 0) {
     /* Lookup for command */
     cmd_ptr = shell_commands;
     while(cmd_ptr->name != NULL && strcmp(cmd, cmd_ptr->name) != 0) {
@@ -139,8 +139,8 @@ PT_THREAD(shell_input(struct pt *pt, shell_output_func output, const char *cmd))
     }
 
     if(cmd_ptr->name != NULL) {
-	static struct pt cmd_pt;
-	PT_SPAWN(pt, &cmd_pt, cmd_ptr->func(&cmd_pt, output, args));
+      static struct pt cmd_pt;
+      PT_SPAWN(pt, &cmd_pt, cmd_ptr->func(&cmd_pt, output, args));
     } else {
       SHELL_OUTPUT(output, "Command not found. Type 'help' for a list of commands\n");
     }


### PR DESCRIPTION
These three small patches add a second newline to the shell, make the prompt always start on a new line, and skip commands that are empty.
