### PR TITLE
RPL Lite: disable MRHOF ETX squaring by default

### DIFF
--- a/os/net/link-stats.c
+++ b/os/net/link-stats.c
@@ -64,7 +64,7 @@
 /* ETX fixed point divisor. 128 is the value used by RPL (RFC 6551 and RFC 6719) */
 #define ETX_DIVISOR                     LINK_STATS_ETX_DIVISOR
 /* Number of Tx used to update the ETX EWMA in case of no-ACK */
-#define ETX_NOACK_PENALTY               16
+#define ETX_NOACK_PENALTY               20
 /* Initial ETX value */
 #define ETX_DEFAULT                      2
 

--- a/os/net/routing/rpl-classic/rpl-mrhof.c
+++ b/os/net/routing/rpl-classic/rpl-mrhof.c
@@ -56,14 +56,19 @@
 
 /* RFC6551 and RFC6719 do not mandate the use of a specific formula to
  * compute the ETX value. This MRHOF implementation relies on the value
- * computed by the link-stats module. It has an optional feature,
+ * computed by the link-stats module.It has an optional feature,
  * RPL_MRHOF_CONF_SQUARED_ETX, that consists in squaring this value.
- * This basically penalizes bad links while preserving the semantics of ETX
+ *
+ * Squaring basically penalizes bad links while preserving the semantics of ETX
  * (1 = perfect link, more = worse link). As a result, MRHOF will favor
- * good links over short paths. Recommended when reliability is a priority.
- * Without this feature, a hop with 50% PRR (ETX=2) is equivalent to two
- * perfect hops with 100% PRR (ETX=1+1=2). With this feature, the former
- * path obtains ETX=2*2=4 and the former ETX=1*1+1*1=2. */
+ * good links over short paths. Without this feature, a hop with 50% PRR (ETX=2)
+ * is equivalent to two perfect hops with 100% PRR (ETX=1+1=2). With this
+ * feature, the former path obtains ETX=2*2=4 and the former ETX=1*1+1*1=2.
+ *
+ * While this feature helps achieve extra relaibility, it also results in
+ * added churn. In networks with high congestion or poor links, this can lead
+ * to poor connectivity due to more parent switches, loops, Trickle resets, etc.
+  */
 #ifdef RPL_MRHOF_CONF_SQUARED_ETX
 #define RPL_MRHOF_SQUARED_ETX RPL_MRHOF_CONF_SQUARED_ETX
 #else /* RPL_MRHOF_CONF_SQUARED_ETX */

--- a/os/net/routing/rpl-lite/rpl-mrhof.c
+++ b/os/net/routing/rpl-lite/rpl-mrhof.c
@@ -56,18 +56,23 @@
 
 /* RFC6551 and RFC6719 do not mandate the use of a specific formula to
  * compute the ETX value. This MRHOF implementation relies on the value
- * computed by the link-stats module. It has an optional feature,
+ * computed by the link-stats module.It has an optional feature,
  * RPL_MRHOF_CONF_SQUARED_ETX, that consists in squaring this value.
- * This basically penalizes bad links while preserving the semantics of ETX
+ *
+ * Squaring basically penalizes bad links while preserving the semantics of ETX
  * (1 = perfect link, more = worse link). As a result, MRHOF will favor
- * good links over short paths. Recommended when reliability is a priority.
- * Without this feature, a hop with 50% PRR (ETX=2) is equivalent to two
- * perfect hops with 100% PRR (ETX=1+1=2). With this feature, the former
- * path obtains ETX=2*2=4 and the former ETX=1*1+1*1=2. */
+ * good links over short paths. Without this feature, a hop with 50% PRR (ETX=2)
+ * is equivalent to two perfect hops with 100% PRR (ETX=1+1=2). With this
+ * feature, the former path obtains ETX=2*2=4 and the former ETX=1*1+1*1=2.
+ *
+ * While this feature helps achieve extra relaibility, it also results in
+ * added churn. In networks with high congestion or poor links, this can lead
+ * to poor connectivity due to more parent switches, loops, Trickle resets, etc.
+  */
 #ifdef RPL_MRHOF_CONF_SQUARED_ETX
 #define RPL_MRHOF_SQUARED_ETX RPL_MRHOF_CONF_SQUARED_ETX
 #else /* RPL_MRHOF_CONF_SQUARED_ETX */
-#define RPL_MRHOF_SQUARED_ETX 1
+#define RPL_MRHOF_SQUARED_ETX 0
 #endif /* RPL_MRHOF_CONF_SQUARED_ETX */
 
 /* Configuration parameters of RFC6719. Reject parents that have a higher


### PR DESCRIPTION
As discussed in https://github.com/contiki-ng/contiki-ng/issues/499 , and as reported by other users in the past, the added churn from squared ETX can cause the network to never converge to a stable state. This happens in scenarios with high congestion or poor links, where link estimates keep changing, and the changes are amplified by squaring.

This PR disabled the feature by default. A rule of thumbs is to always start without, and if the network operate stably, try enabling it to push the reliability further. But in more noisy/dense environments, stick to the default.