### PR TITLE
Fixed driver for DHT22 sensor in zoul platform 

### DIFF
--- a/arch/platform/zoul/dev/dht22.c
+++ b/arch/platform/zoul/dev/dht22.c
@@ -72,7 +72,7 @@ dht22_read(void)
 {
   uint8_t i;
   uint8_t j = 0;
-  uint8_t last_state;
+  uint8_t last_state = 0xFF;
   uint8_t counter = 0;
   uint8_t checksum = 0;
 
@@ -95,7 +95,6 @@ dht22_read(void)
      * if the line is high between 70-74us the bit sent will be "1" (one).
      */
     GPIO_SET_INPUT(DHT22_PORT_BASE, DHT22_PIN_MASK);
-    last_state = GPIO_READ_PIN(DHT22_PORT_BASE, DHT22_PIN_MASK);
 
     for(i = 0; i < DHT22_MAX_TIMMING; i++) {
       counter = 0;

--- a/arch/platform/zoul/dev/dht22.c
+++ b/arch/platform/zoul/dev/dht22.c
@@ -207,8 +207,8 @@ value(int type)
   }
 }
 /*---------------------------------------------------------------------------*/
-int
-dht22_read_all(int *temperature, int *humidity)
+int16_t
+dht22_read_all(int16_t *temperature, int16_t *humidity)
 {
   if((temperature == NULL) || (humidity == NULL)) {
     PRINTF("DHT22: Invalid arguments\n");

--- a/arch/platform/zoul/dev/dht22.h
+++ b/arch/platform/zoul/dev/dht22.h
@@ -99,7 +99,7 @@
  * \name DHT22 auxiliary functions
  * @{
  */
-int dht22_read_all(int *temperature, int *humidity);
+int16_t dht22_read_all(int16_t *temperature, int16_t *humidity);
 /** @} */
 /* -------------------------------------------------------------------------- */
 #define DHT22_SENSOR "DHT22 sensor"

--- a/arch/platform/zoul/dev/dht22.h
+++ b/arch/platform/zoul/dev/dht22.h
@@ -90,7 +90,7 @@
 #define DHT22_COUNT             8    /**< Minimum ticks to detect a "1" bit   */
 #define DHT22_MAX_TIMMING       85   /**< Maximum ticks in a single operation */
 #define DHT22_READING_DELAY     1                                 /**< 1 us   */
-#define DHT22_READY_TIME        20                                /**< 40 us  */
+#define DHT22_READY_TIME        40                                /**< 40 us  */
 #define DHT22_START_TIME        (RTIMER_SECOND / 50)              /**< 20 ms  */
 #define DHT22_AWAKE_TIME        (RTIMER_SECOND / 4)               /**< 250 ms */
 /** @} */

--- a/examples/platform-specific/zoul/Makefile
+++ b/examples/platform-specific/zoul/Makefile
@@ -1,9 +1,9 @@
-CONTIKI_PROJECT = test-tsl256x test-sht25 test-servo.c
+CONTIKI_PROJECT = test-tsl256x test-sht25 test-servo
 CONTIKI_PROJECT += test-bmp085-bmp180 test-motion test-rotation-sensor
 CONTIKI_PROJECT += test-grove-light-sensor test-grove-loudness-sensor
 CONTIKI_PROJECT += test-weather-meter test-grove-gyro test-lcd test-iaq
 CONTIKI_PROJECT += test-pm10-sensor test-vac-sensor test-aac-sensor
-CONTIKI_PROJECT += test-zonik test-dht22.c test-ac-dimmer.c
+CONTIKI_PROJECT += test-zonik test-dht22 test-ac-dimmer
 CONTIKI_PROJECT += test-bme280
 
 CONTIKI_TARGET_SOURCEFILES += tsl256x.c sht25.c bmpx8x.c motion-sensor.c

--- a/examples/platform-specific/zoul/test-dht22.c
+++ b/examples/platform-specific/zoul/test-dht22.c
@@ -55,7 +55,7 @@ static struct etimer et;
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(remote_dht22_process, ev, data)
 {
-  int16_t temperature, humidity;
+  int temperature, humidity;
 
   PROCESS_BEGIN();
   SENSORS_ACTIVATE(dht22);

--- a/examples/platform-specific/zoul/test-dht22.c
+++ b/examples/platform-specific/zoul/test-dht22.c
@@ -55,7 +55,7 @@ static struct etimer et;
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(remote_dht22_process, ev, data)
 {
-  int temperature, humidity;
+  int16_t temperature, humidity;
 
   PROCESS_BEGIN();
   SENSORS_ACTIVATE(dht22);


### PR DESCRIPTION
The DHT22 driver did not work.
The example in `examples/platform-specific/zoul/test-dht22.c` was not compiling because of wrong types.
However, also with fixed types the driver was not able to read the sensor properly. The output of the example above was just `Failed to read the sensor`.
The culprits were some parameters slightly off, and a misplaced pin reading. 
Now it is fixed.

(Tested with "ReMote rev b" and "Grove Temperature and Humidity Sensor Pro").