### PR TITLE
Add missing case statement

### DIFF
--- a/tools/tools-utils.c
+++ b/tools/tools-utils.c
@@ -104,6 +104,7 @@ select_baudrate(int baudrate) {
     return B115200;
 #endif
 #ifdef B230400
+  case 230400:
     return B230400;
 #endif
 #ifdef B460800


### PR DESCRIPTION
It is currently impossible to specify a baudrate of 230400 because of this missing case statement.