### PR TITLE
Native border router SLIP fix

### DIFF
--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -336,7 +336,7 @@ slip_flushbuf(int fd)
     if(slip_begin == slip_packet_end) {
       slip_packet_count--;
       if(slip_end > slip_packet_end) {
-        memcpy(slip_buf, slip_buf + slip_packet_end,
+        memmove(slip_buf, slip_buf + slip_packet_end,
                slip_end - slip_packet_end);
       }
       slip_end -= slip_packet_end;

--- a/tests/17-tun-rpl-br/09-native-border-router-cooja-frag.sh
+++ b/tests/17-tun-rpl-br/09-native-border-router-cooja-frag.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Contiki directory
+CONTIKI=$1
+
+# Simulation file
+BASENAME=07-native-border-router-cooja
+
+bash test-native-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60 600 2

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -12,6 +12,12 @@ IPADDR=$3
 # Time allocated for convergence
 WAIT_TIME=$4
 
+# Payload len. Default is ping6's default, 56.
+PING_SIZE=${5:-56}
+
+# Inter-ping delay. Default is ping6's default, 1s.
+PING_DELAY=${6:-1}
+
 # ICMP request-reply count
 COUNT=5
 
@@ -30,7 +36,7 @@ sleep $WAIT_TIME
 
 # Do ping
 echo "Pinging"
-ping6 $IPADDR -c $COUNT | tee $BASENAME.scriptlog
+ping6 $IPADDR -c $COUNT -s $PING_SIZE -i $PING_DELAY | tee $BASENAME.scriptlog
 # Fetch ping6 status code (not $? because this is piped)
 STATUS=${PIPESTATUS[0]}
 REPLIES=`grep -c 'icmp_seq=' $BASENAME.scriptlog`


### PR DESCRIPTION
`memcpy` was used where `memmove` was required. Caused a bug whenever the amount of data left in Tx buffer was greater than what we just sent. Depending on timing of calls to `slip_flushbuf`, the node might end up sending broken packets.

As a result, fragmentation with more than two packets did not work on NBR+slip-radio in Cooja.
This PR adds a CI test accordingly.