### PR TITLE
Added a configurable linker flag to enable linker warnings as errors

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -50,7 +50,12 @@ CFLAGS += -DCONTIKI_BOARD_STRING=\"$(BOARD)\"
 endif
 
 CFLAGS += -Wno-unused-const-variable
-LDFLAGS = -Wl,--fatal-warnings
+
+LDFLAGS_WERROR ?= -Wl,--fatal-warnings
+
+ifeq ($(WERROR),1)
+ LDFLAGS += $(LDFLAGS_WERROR)
+endif
 
 MODULES += os os/sys os/dev os/lib os/services
 

--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -22,6 +22,7 @@ CFLAGS  += $(CFLAGSNO)
 
 ifeq ($(HOST_OS),Darwin)
 AROPTS = -rc
+LDFLAGS_WERROR := -Wl,-fatal_warnings
 LDFLAGS += -Wl,-flat_namespace,-map,$(CONTIKI_NG_PROJECT_MAP)
 CFLAGS += -DHAVE_SNPRINTF=1 -U__ASSERT_USE_STDERR
 else


### PR DESCRIPTION
OSX requires a different linker flag to enable linker warnings as errors. The native platform will now set the correct linker flag when compiling under OSX. Also made it possible to disable this feature and allow linker warnings by building with `WERROR` set to 0.