### PR TITLE
Cryptographically-Secure Pseudo-Random Number Generator (CSPRNG)

### DIFF
--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -32,6 +32,7 @@ CONTIKI_CPU_SOURCEFILES += slip-arch.c
 CONTIKI_CPU_SOURCEFILES += i2c.c cc2538-temp-sensor.c vdd3-sensor.c
 CONTIKI_CPU_SOURCEFILES += cfs-coffee-arch.c pwm.c
 CONTIKI_CPU_SOURCEFILES += startup-gcc.c
+CONTIKI_CPU_SOURCEFILES += cc2538-sram-seeder.c
 
 USB_SOURCEFILES += usb-core.c cdc-acm.c usb-arch.c usb-serial.c cdc-acm-descriptors.c
 

--- a/arch/cpu/cc2538/dev/cc2538-rf.c
+++ b/arch/cpu/cc2538/dev/cc2538-rf.c
@@ -49,6 +49,7 @@
 #include "dev/sys-ctrl.h"
 #include "dev/udma.h"
 #include "reg.h"
+#include "lib/iq-seeder.h"
 
 #include <string.h>
 /*---------------------------------------------------------------------------*/
@@ -253,6 +254,42 @@ get_rssi(void)
   }
 
   return rssi;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief       Reads the current I/Q data of the received signal.
+ * \param value The least significant bit (LSB) of the I coordinate and the LSB
+ *              of the Q coordinate are concatenated and stored here.
+ *
+ * If not done already, this function first enables the RX mode and waits for
+ * the RSSI_VALID bit to go high. Hence, this function should only be called
+ * at start up or by the MAC protocol to avoid conflicts.
+ */
+static void
+get_iq_lsbs(radio_value_t *value)
+{
+  uint8_t was_off = 0;
+
+  /* If we are off, turn on first */
+  if((REG(RFCORE_XREG_FSMSTAT0) & RFCORE_XREG_FSMSTAT0_FSM_FFCTRL_STATE) == 0) {
+    was_off = 1;
+    on();
+  }
+
+  /* Wait on RSSI_VALID */
+  while((REG(RFCORE_XREG_RSSISTAT) & RFCORE_XREG_RSSISTAT_RSSI_VALID) == 0);
+
+  /* Wait until the channel seems clear for better randomness */
+  while(!(REG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_CCA));
+
+  /* Read I/Q LSBs */
+  *value = REG(RFCORE_XREG_RFRND)
+      & (RFCORE_XREG_RFRND_IRND | RFCORE_XREG_RFRND_QRND);
+
+  /* If we were off, turn back off */
+  if(was_off) {
+    off();
+  }
 }
 /*---------------------------------------------------------------------------*/
 /* Returns the current CCA threshold in dBm */
@@ -595,6 +632,10 @@ init(void)
 
   set_poll_mode(poll_mode);
 
+#if CSPRNG_ENABLED
+  iq_seeder_seed();
+#endif /* CSPRNG_ENABLED */
+
   process_start(&cc2538_rf_process, NULL);
 
   rf_flags |= RF_ON;
@@ -913,6 +954,9 @@ get_value(radio_param_t param, radio_value_t *value)
     return RADIO_RESULT_OK;
   case RADIO_PARAM_LAST_LINK_QUALITY:
     *value = crc_corr & LQI_BIT_MASK;
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_IQ_LSBS:
+    get_iq_lsbs(value);
     return RADIO_RESULT_OK;
   case RADIO_CONST_CHANNEL_MIN:
     *value = CC2538_RF_CHANNEL_MIN;

--- a/arch/cpu/cc2538/dev/cc2538-sram-seeder.c
+++ b/arch/cpu/cc2538/dev/cc2538-sram-seeder.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2015, Hasso-Plattner-Institut.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \addtogroup csprng
+ * @{
+ *
+ * \file
+ *         SRAM-based CSPRNG seeder.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#include "dev/cc2538-sram-seeder.h"
+#include "sys/rtimer.h"
+#include "lpm.h"
+#include <string.h>
+
+#define SRAM_BYTES 1024
+
+/* in the middle of the second half of the SRAM */
+static const uint8_t *sram_pointer = (uint8_t *)0x20001FFF;
+
+/*---------------------------------------------------------------------------*/
+static void
+reset_sram(void)
+{
+  /*
+   * Although it should not, the system gets stuck when sleeping less than
+   * two seconds at this point. Sleeping for two seconds seems to be safe.
+   */
+  rtimer_arch_schedule(RTIMER_NOW() + RTIMER_ARCH_SECOND * 2);
+  lpm_enter();
+}
+/*---------------------------------------------------------------------------*/
+void
+cc2538_sram_seeder_seed(void)
+{
+  struct csprng_seed seed;
+  uint16_t byte_pos;
+  uint8_t bit_pos;
+  uint8_t sram_snapshot[SRAM_BYTES];
+  uint16_t i;
+  uint8_t j;
+  int bit1;
+  int bit2;
+
+  byte_pos = 0;
+  bit_pos = 0;
+
+  while(1) {
+    reset_sram();
+    memcpy(sram_snapshot, sram_pointer, SRAM_BYTES);
+    reset_sram();
+
+    /* von Neumann extractor */
+    for(i = 0; i < SRAM_BYTES; i++) {
+      for(j = 0; j < 8; j++) {
+        bit1 = (1 << j) & sram_snapshot[i];
+        bit2 = (1 << j) & sram_pointer[i];
+        if(bit1 < bit2) {
+          seed.u8[byte_pos] |= 1 << bit_pos++;
+        } else if(bit1 > bit2) {
+          seed.u8[byte_pos] &= ~(1 << bit_pos++);
+        }
+        if(bit_pos == 8) {
+          bit_pos = 0;
+          byte_pos++;
+        }
+        if(byte_pos == CSPRNG_SEED_LEN) {
+          csprng_feed(&seed);
+          return;
+        }
+      }
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/arch/cpu/cc2538/dev/cc2538-sram-seeder.h
+++ b/arch/cpu/cc2538/dev/cc2538-sram-seeder.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015, Hasso-Plattner-Institut.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \addtogroup csprng
+ * @{
+ *
+ * \file
+ *         SRAM-based CSPRNG seeder.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#ifndef CC2538_SRAM_SEEDER_H_
+#define CC2538_SRAM_SEEDER_H_
+
+#include "lib/csprng.h"
+
+/**
+ * \brief This function will feed the CSPRNG with a new seed.
+ *
+ *        Its implementation leverages the fact that SRAM cells are partly
+ *        random due to manufacturing variations. For randomness extraction,
+ *        this function uses the well-known von Neumann extractor. Note that
+ *        this function can only be called at start up and only if
+ *        LPM_CONF_MAX_PM >= LPM_PM2.
+ */
+void cc2538_sram_seeder_seed(void);
+
+#endif /* CC2538_SRAM_SEEDER_H_ */
+
+/** @} */

--- a/arch/cpu/cc2538/soc.c
+++ b/arch/cpu/cc2538/soc.c
@@ -45,6 +45,7 @@
 #include "lpm.h"
 #include "reg.h"
 #include "soc.h"
+#include "dev/cc2538-sram-seeder.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -125,6 +126,9 @@ soc_init()
   lpm_init();
   rtimer_init();
   gpio_hal_init();
+#if CSPRNG_ENABLED && LPM_CONF_ENABLE && (LPM_CONF_MAX_PM >= LPM_PM2)
+  cc2538_sram_seeder_seed();
+#endif /* CSPRNG_ENABLED && LPM_CONF_ENABLE && (LPM_CONF_MAX_PM >= LPM_PM2) */
 }
 /*----------------------------------------------------------------------------*/
 /** @} */

--- a/arch/platform/cooja/dev/moteid.c
+++ b/arch/platform/cooja/dev/moteid.c
@@ -31,6 +31,8 @@
 #include "dev/moteid.h"
 #include "lib/simEnvChange.h"
 #include "lib/random.h"
+#include "lib/csprng.h"
+#include <string.h>
 
 const struct simInterface moteid_interface;
 
@@ -44,8 +46,14 @@ static void
 doInterfaceActionsBeforeTick(void)
 {
   if (simMoteIDChanged) {
+    struct csprng_seed csprng_seed = { 0 };
+
     simMoteIDChanged = 0;
-	random_init(simRandomSeed);
+    random_init(simRandomSeed);
+    memcpy(csprng_seed.u8,
+        &simRandomSeed,
+        MIN(sizeof(simRandomSeed), sizeof(csprng_seed.u8)));
+    csprng_feed(&csprng_seed);
   }
 }
 /*-----------------------------------------------------------------------------------*/

--- a/examples/libs/csprng/Makefile
+++ b/examples/libs/csprng/Makefile
@@ -1,0 +1,5 @@
+CONTIKI_PROJECT = example
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/examples/libs/csprng/example.c
+++ b/examples/libs/csprng/example.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, Hasso-Plattner-Institut..
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "contiki.h"
+#include "lib/csprng.h"
+#include "sys/etimer.h"
+#include <stdio.h>
+
+PROCESS(example_process, "example_process");
+AUTOSTART_PROCESSES(&example_process);
+
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(example_process, ev, data)
+{
+  static struct etimer periodic_timer;
+  uint8_t buf[32];
+  uint8_t i;
+
+  PROCESS_BEGIN();
+
+  etimer_set(&periodic_timer, CLOCK_SECOND);
+  while(1) {
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&periodic_timer));
+    etimer_reset(&periodic_timer);
+
+    /* fills buf with cryptographic random numbers */
+    if(!csprng_rand(buf, 32)) {
+      printf("CSPRNG error\n");
+      PROCESS_EXIT();
+    }
+    for(i = 0; i < 32; i++) {
+      printf("%02x", buf[i]);
+    }
+    printf("\n");
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/libs/csprng/project-conf.h
+++ b/examples/libs/csprng/project-conf.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, Hasso-Plattner-Institut..
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#undef CSPRNG_CONF_ENABLED
+#define CSPRNG_CONF_ENABLED 1
+#undef LPM_CONF_MAX_PM
+#define LPM_CONF_MAX_PM 2
+
+#endif /* PROJECT_CONF_H_ */

--- a/os/dev/radio.h
+++ b/os/dev/radio.h
@@ -226,6 +226,14 @@ enum radio_param_e {
   RADIO_PARAM_LAST_RSSI,
 
   /**
+    * The current I/Q LSBs.
+    *
+    * This parameter will only be passed as an argument to the `get_value()`
+    * function.
+    */
+  RADIO_PARAM_IQ_LSBS,
+
+  /**
    * Link quality indicator of the last received packet.
    *
    * The value returned should be an unsigned number between 0x00 and 0xFF.

--- a/os/lib/csprng.c
+++ b/os/lib/csprng.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2013, Hasso-Plattner-Institut.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         An OFB-AES-128-based CSPRNG.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+/**
+ * \addtogroup csprng
+ * @{
+ */
+
+#include "lib/csprng.h"
+#include "lib/aes-128.h"
+#include "sys/cc.h"
+#include <string.h>
+
+/* Log configuration */
+#include "sys/log.h"
+#define LOG_MODULE "CSPRNG"
+#define LOG_LEVEL LOG_LEVEL_NONE
+
+static struct csprng_seed seed;
+static unsigned read_state_bytes;
+static bool seeded;
+
+/*---------------------------------------------------------------------------*/
+void
+csprng_feed(struct csprng_seed *new_seed)
+{
+  uint8_t i;
+
+  /*
+   * By XORing the current seed with the new seed, the seed of this CSPRNG
+   * remains secret as long as any of the mixed seeds remains secret.
+   */
+  for(i = 0; i < CSPRNG_SEED_LEN; i++) {
+    seed.u8[i] ^= new_seed->u8[i];
+  }
+
+  LOG_DBG("key = ");
+  LOG_DBG_BYTES(seed.key, CSPRNG_KEY_LEN);
+  LOG_DBG_("\n");
+  LOG_DBG("state = ");
+  LOG_DBG_BYTES(seed.state, CSPRNG_STATE_LEN);
+  LOG_DBG_("\n");
+
+  seeded = true;
+}
+/*---------------------------------------------------------------------------*/
+bool
+csprng_rand(uint8_t *result, unsigned len)
+{
+  unsigned pos;
+
+  if(!seeded) {
+    return false;
+  }
+
+  pos = MIN(len, CSPRNG_STATE_LEN - read_state_bytes);
+  memcpy(result, seed.state + read_state_bytes, pos);
+  read_state_bytes += pos;
+  if(pos == len) {
+    return true;
+  }
+
+  AES_128.set_key(seed.key);
+  for(; pos < len; pos += CSPRNG_STATE_LEN) {
+    AES_128.encrypt(seed.state);
+    read_state_bytes = MIN(len - pos, CSPRNG_STATE_LEN);
+    memcpy(result + pos, seed.state, read_state_bytes);
+  }
+
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/os/lib/csprng.h
+++ b/os/lib/csprng.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2013, Hasso-Plattner-Institut.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         An OFB-AES-128-based CSPRNG.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+/**
+ * \addtogroup lib
+ * @{
+ */
+
+/**
+ * \defgroup csprng Cryptographically-secure PRNG
+ *
+ * \brief Expands a truly random seed into a stream of pseudo-random numbers.
+ *
+ * In contrast to a normal PRNG, a CSPRNG generates a stream of pseudo-random
+ * numbers that is indistinguishable from the uniform distribution to a
+ * computationally-bounded adversary who does not know the seed.
+ *
+ * @{
+ */
+
+#ifndef CSPRNG_H_
+#define CSPRNG_H_
+
+#include "contiki.h"
+#include "lib/aes-128.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef CSPRNG_CONF_ENABLED
+#define CSPRNG_ENABLED CSPRNG_CONF_ENABLED
+#else /* CSPRNG_CONF_ENABLED */
+#define CSPRNG_ENABLED 0
+#endif /* CSPRNG_CONF_ENABLED */
+
+#define CSPRNG_KEY_LEN AES_128_KEY_LENGTH
+#define CSPRNG_STATE_LEN AES_128_BLOCK_SIZE
+#define CSPRNG_SEED_LEN (CSPRNG_KEY_LEN + CSPRNG_STATE_LEN)
+
+/** This is the structure of a seed. */
+struct csprng_seed {
+  union {
+    struct {
+      uint8_t key[CSPRNG_KEY_LEN]; /**< AES-128 key of the CSPRNG */
+      uint8_t state[CSPRNG_STATE_LEN]; /**< internal state of the CSPRNG */
+    };
+
+    uint8_t u8[CSPRNG_SEED_LEN]; /**< for convenience */
+  };
+};
+
+/**
+ * \brief          Mixes a new seed with the current one.
+ * \param new_seed Pointer to the new seed.
+ *
+ *                 This function is called at start up and/or at runtime by
+ *                 what we call a "seeder". Seeders generate seeds in arbi-
+ *                 trary ways and feed this CSPRNG with their generated seeds.
+ */
+void csprng_feed(struct csprng_seed *new_seed);
+
+/**
+ * \brief        Generates a cryptographic random number.
+ * \param result The place to store the generated cryptographic random number.
+ * \param len    The length of the cryptographic random number to be generated.
+ *
+ *               We use output feedback mode (OFB) for generating cryptographic
+ *               pseudo-random numbers [RFC 4086]. A potential problem with OFB
+ *               is that OFB at some point enters a cycle. However, the
+ *               expected cycle length given a random key and a random state
+ *               is about 2^127 in our case [Davies and Parkin, The Average
+ *               Cycle Size of The Key Stream in Output Feedback Encipherment].
+ * \return       Returns true on success and false otherwise.
+ */
+bool csprng_rand(uint8_t *result, unsigned len);
+
+#endif /* CSPRNG_H_ */
+
+/** @} */
+/** @} */

--- a/os/lib/iq-seeder.c
+++ b/os/lib/iq-seeder.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2015, Hasso-Plattner-Institut.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \addtogroup csprng
+ * @{
+ *
+ * \file
+ *         I/Q data-based seeder.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#include "lib/iq-seeder.h"
+#include "net/netstack.h"
+#include "lib/aes-128.h"
+#include <string.h>
+
+#define COLUMN_COUNT  50
+#define ROW_COUNT     16
+
+static const uint8_t toeplitz[COLUMN_COUNT + ROW_COUNT - 1] =
+    {  93 ,  50 , 210 , 134 ,  79 ,  52 , 237 , 192 ,  40 , 201 ,
+        3 , 184 , 152 ,  74 ,  27 ,  28 ,  32 , 111 ,  79 , 222 ,
+      174 ,  51 , 223 ,  66 , 152 , 211 , 234 , 124 ,  92 ,  64 ,
+      206 , 169 , 227 , 155 , 106 ,  87 , 207 , 135 , 238 , 101 ,
+      254 , 163 ,  55 ,  76 ,  50 ,  40 ,   4 , 149 ,  27 ,   1 ,
+      127 , 159 , 160 ,  91 , 251 , 179 , 186 , 200 , 225 ,  47 ,
+      235 , 223 ,  39 , 117 ,  19 };
+
+/*---------------------------------------------------------------------------*/
+static uint8_t
+get_toeplitz_element(uint8_t row, uint8_t column)
+{
+  uint8_t min;
+
+  min = row < column ? row : column;
+  row -= min;
+  column -= min;
+
+  return toeplitz[row ? COLUMN_COUNT - 1 + row : column];
+}
+/*---------------------------------------------------------------------------*/
+/** Performs a multiplication within GF(256) */
+static uint8_t
+mul_gf_256(uint8_t a, uint8_t b)
+{
+  uint8_t p;
+  uint8_t i;
+
+  p = 0;
+  for(i = 0; i < 8; i++) {
+    if(b & 1) {
+      p ^= a;
+      a <<= 1;
+      if(a & 0x100) {
+        a ^= 0x11b;
+      }
+      b >>= 1;
+    }
+  }
+  return p;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Toeplitz matrix-based extractor. For theory, see [Skorski, True Random Num-
+ * ber Generators Secure in a Changing Environment: Improved Security Bounds]
+ */
+static void
+extract(uint8_t *target, uint8_t *source)
+{
+  uint8_t row;
+  uint8_t column;
+
+  for(row = 0; row < ROW_COUNT; row++) {
+    target[row] = 0;
+    for(column = 0; column < COLUMN_COUNT; column++) {
+      target[row] ^= mul_gf_256(get_toeplitz_element(row, column), source[column]);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+seed_16_bytes(uint8_t *result)
+{
+  uint8_t bit_pos;
+  uint8_t byte_pos;
+  uint16_t iq_count;
+  uint8_t accumulator[COLUMN_COUNT];
+  radio_value_t iq;
+
+  bit_pos = 0;
+  byte_pos = 0;
+  memset(accumulator, 0, COLUMN_COUNT);
+
+  NETSTACK_RADIO.on();
+  for(iq_count = 0; iq_count < (COLUMN_COUNT * 8 / 2); iq_count++) {
+    NETSTACK_RADIO.get_value(RADIO_PARAM_IQ_LSBS, &iq);
+
+    /* append I/Q LSBs to accumulator */
+    accumulator[byte_pos] |= iq << bit_pos;
+    bit_pos += 2;
+    if(bit_pos == 8) {
+      bit_pos = 0;
+      byte_pos++;
+    }
+  }
+  NETSTACK_RADIO.off();
+  extract(result, accumulator);
+}
+/*---------------------------------------------------------------------------*/
+void
+iq_seeder_seed(void)
+{
+  struct csprng_seed seed;
+
+  seed_16_bytes(seed.key);
+  seed_16_bytes(seed.state);
+  csprng_feed(&seed);
+}
+/*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/os/lib/iq-seeder.h
+++ b/os/lib/iq-seeder.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015, Hasso-Plattner-Institut.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \addtogroup csprng
+ * @{
+ *
+ * \file
+ *         I/Q data-based seeder.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#ifndef IQ_SEEDER_H_
+#define IQ_SEEDER_H_
+
+#include "lib/csprng.h"
+
+/**
+ * \brief This function will feed the CSPRNG with a new seed.
+ *
+ *        Many manuals of radio chips from Texas Instruments suggest using I/Q
+*         data (Cartesian representations of the received signal) for
+*         generating true random numbers. This function follows this suggestion
+*         and extracts seeds from I/Q data. However, since those manuals state
+*         that I/Q data is not uniformly distributed, this function does not use
+*         I/Q data directly as seeds, but first applies an extractor function.
+*         Note that this function can only be called at start up.
+ */
+void iq_seeder_seed(void);
+
+#endif /* IQ_SEEDER_H_ */
+
+/** @} */

--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -69,6 +69,7 @@ libs/shell/openmote \
 libs/simple-energest/openmote \
 libs/timers/zoul \
 libs/trickle-library/zoul \
+libs/csprng/openmote \
 lwm2m-ipso-objects/zoul:DEFINES=LWM2M_Q_MODE_CONF_ENABLED=1,LWM2M_Q_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1\
 lwm2m-ipso-objects/zoul:MAKE_WITH_DTLS=1 \
 mqtt-client/simplelink:BOARD=sensortag/cc2650:DEFINES=BOARD_CONF_SENSORS_DISABLE=1,TI_SPI_CONF_ENABLE=0 \


### PR DESCRIPTION
This PR adds a CSPRNG, which, e.g., will come in handy when generating cryptographic keys or hash chains. For generating cryptographic random numbers, it uses AES-128 in OFB mode. For generating an initial seed, it uses an exchangeable `csprng_seeder`.  This PR also includes implementations of `csprng_seeder`s for CC2538-based platforms, such as the `cc2538_sram_seeder`, which extracts seeds from power-up SRAM states. For the time being, this CSPRNG does not provide forward and backward security, i.e., once its internal state leaks to an attacker, he can predict past and future outputs of the CSPRNG. This could be changed by calling the configured `csprng_seeder` not only at startup, but also at runtime once in a while.