### PR TITLE
snprintf-based logging for IPv6 and RPL neighbor

### DIFF
--- a/os/net/ipv6/uiplib.c
+++ b/os/net/ipv6/uiplib.c
@@ -156,7 +156,7 @@ uiplib_ip4addrconv(const char *addrstr, uip_ip4addr_t *ipaddr)
 void
 uiplib_ipaddr_print(const uip_ipaddr_t *addr)
 {
-  char buf[40];
+  char buf[UIPLIB_IPV6_MAX_STR_LEN];
   uiplib_ipaddr_snprint(buf, sizeof(buf), addr);
   printf("%s", buf);
 }

--- a/os/net/ipv6/uiplib.c
+++ b/os/net/ipv6/uiplib.c
@@ -3,17 +3,17 @@
  * Computer Science.
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met: 
- * 1. Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
- * 2. Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in the 
- *    documentation and/or other materials provided with the distribution. 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  * 3. The name of the author may not be used to endorse or promote
  *    products derived from this software without specific prior
- *    written permission.  
+ *    written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -25,7 +25,7 @@
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This file is part of the uIP TCP/IP stack and the Contiki operating system.
  *
@@ -117,7 +117,7 @@ uiplib_ip6addrconv(const char *addrstr, uip_ip6addr_t *ipaddr)
 }
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 /*---------------------------------------------------------------------------*/
-/* Parse a IPv4-address from a string. Returns the number of characters read 
+/* Parse a IPv4-address from a string. Returns the number of characters read
  * for the address. */
 int
 uiplib_ip4addrconv(const char *addrstr, uip_ip4addr_t *ipaddr)
@@ -156,48 +156,9 @@ uiplib_ip4addrconv(const char *addrstr, uip_ip4addr_t *ipaddr)
 void
 uiplib_ipaddr_print(const uip_ipaddr_t *addr)
 {
-  uint16_t a;
-  unsigned int i;
-  int f;
-
-  if(addr == NULL) {
-    printf("(NULL IP addr)");
-    return;
-  }
-
-  if(ip64_addr_is_ipv4_mapped_addr(addr)) {
-    /*
-     * Printing IPv4-mapped addresses is done according to RFC 4291 [1]
-     *
-     *     "An alternative form that is sometimes more
-     *     convenient when dealing with a mixed environment
-     *     of IPv4 and IPv6 nodes is x:x:x:x:x:x:d.d.d.d,
-     *     where the 'x's are the hexadecimal values of the
-     *     six high-order 16-bit pieces of the address, and
-     *     the 'd's are the decimal values of the four
-     *     low-order 8-bit pieces of the address (standard
-     *     IPv4 representation)."
-     *
-     * [1] https://tools.ietf.org/html/rfc4291#page-4
-     */
-    printf("::FFFF:%u.%u.%u.%u", addr->u8[12], addr->u8[13], addr->u8[14], addr->u8[15]);
-  } else {
-    for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
-      a = (addr->u8[i] << 8) + addr->u8[i + 1];
-      if(a == 0 && f >= 0) {
-        if(f++ == 0) {
-          printf("::");
-        }
-      } else {
-        if(f > 0) {
-          f = -1;
-        } else if(i > 0) {
-          printf(":");
-        }
-        printf("%x", a);
-      }
-    }
-  }
+  char buf[40];
+  uiplib_ipaddr_snprint(buf, sizeof(buf), addr);
+  printf("%s", buf);
 }
 /*---------------------------------------------------------------------------*/
 int
@@ -205,15 +166,16 @@ uiplib_ipaddr_snprint(char *buf, size_t size, const uip_ipaddr_t *addr)
 {
   uint16_t a;
   unsigned int i;
-  int f, n;
+  int f;
+  int n = 0;
 
   if(size == 0) {
     return 0;
   }
 
   if(addr == NULL) {
-    n = snprintf(buf, size - 1, "(NULL IP addr)");
-
+    n = snprintf(buf, size, "(NULL IP addr)");
+    return n;
   } else if(ip64_addr_is_ipv4_mapped_addr(addr)) {
     /*
      * Printing IPv4-mapped addresses is done according to RFC 4291 [1]
@@ -229,32 +191,35 @@ uiplib_ipaddr_snprint(char *buf, size_t size, const uip_ipaddr_t *addr)
      *
      * [1] https://tools.ietf.org/html/rfc4291#page-4
      */
-    n = snprintf(buf, size - 1, "::FFFF:%u.%u.%u.%u", addr->u8[12],
+    n = snprintf(buf, size, "::FFFF:%u.%u.%u.%u", addr->u8[12],
                  addr->u8[13], addr->u8[14], addr->u8[15]);
+    return n;
   } else {
-    for(n = 0, i = 0, f = 0; i < sizeof(uip_ipaddr_t) && n < size - 1; i += 2) {
+    for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
       a = (addr->u8[i] << 8) + addr->u8[i + 1];
       if(a == 0 && f >= 0) {
         if(f++ == 0) {
-          buf[n++] = ':';
-          buf[n++] = ':';
+          n += snprintf(buf+n, size-n, "::");
+          if(n >= size) {
+            return n;
+          }
         }
       } else {
         if(f > 0) {
           f = -1;
         } else if(i > 0) {
-          buf[n++] = ':';
+          n += snprintf(buf+n, size-n, ":");
+          if(n >= size) {
+            return n;
+          }
         }
-        n += snprintf(&buf[n], size - n - 1, "%x", a);
+        n += snprintf(buf+n, size-n, "%x", a);
+        if(n >= size) {
+          return n;
+        }
       }
     }
   }
-
-  /*
-   * Make sure the output string is always null-terminated.
-   */
-  buf[MIN(n, size - 1)] = '\0';
-
   return n;
 }
 /*---------------------------------------------------------------------------*/

--- a/os/net/ipv6/uiplib.h
+++ b/os/net/ipv6/uiplib.h
@@ -82,6 +82,10 @@ int uiplib_ip6addrconv(const char *addrstr, uip_ip6addr_t *addr);
  * @{
  */
 
+/* The maxium length of an IPv6 string, including terminating null bytes
+ * fd01:0002:0003:0004:0005:0006:0007:0008 => 39 + 1 bytes */
+#define UIPLIB_IPV6_MAX_STR_LEN 40
+
 /**
  * Print an IP address using printf().
  *

--- a/os/net/ipv6/uiplib.h
+++ b/os/net/ipv6/uiplib.h
@@ -1,19 +1,19 @@
 /*
  * Copyright (c) 2002, Adam Dunkels.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met: 
- * 1. Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above
  *    copyright notice, this list of conditions and the following
  *    disclaimer in the documentation and/or other materials provided
- *    with the distribution. 
+ *    with the distribution.
  * 3. The name of the author may not be used to endorse or promote
  *    products derived from this software without specific prior
- *    written permission.  
+ *    written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -25,7 +25,7 @@
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This file is part of the Contiki desktop environment for the C64.
  *
@@ -65,7 +65,7 @@
  * the numerical representation of the address.
  *
  * \retval 0 If the IP address could not be parsed.
- * \retval Non-zero If the IP address was parsed. 
+ * \retval Non-zero If the IP address was parsed.
  */
 #if NETSTACK_CONF_WITH_IPV6
 #define uiplib_ipaddrconv uiplib_ip6addrconv

--- a/os/net/routing/rpl-lite/rpl-neighbor.c
+++ b/os/net/routing/rpl-lite/rpl-neighbor.c
@@ -46,6 +46,7 @@
 #include "net/routing/rpl-lite/rpl.h"
 #include "net/link-stats.h"
 #include "net/nbr-table.h"
+#include "net/ipv6/uiplib.h"
 
 /* Log configuration */
 #include "sys/log.h"
@@ -85,6 +86,59 @@ acceptable_rank(rpl_rank_t rank)
       && rank <= max_acceptable_rank();
 }
 /*---------------------------------------------------------------------------*/
+int
+rpl_neighbor_snprint(char *buf, int buflen, rpl_nbr_t *nbr)
+{
+  int index = 0;
+  rpl_nbr_t *best = best_parent(0);
+  const struct link_stats *stats = rpl_neighbor_get_link_stats(nbr);
+  clock_time_t clock_now = clock_time();
+
+  index += snprintf(buf+index, buflen-index, "nbr: ");
+  if(index >= buflen) {
+    return index;
+  }
+  index += uiplib_ipaddr_snprint(buf+index, buflen-index, rpl_neighbor_get_ipaddr(nbr));
+  if(index >= buflen) {
+    return index;
+  }
+  index += snprintf(buf+index, buflen-index,
+      "%5u, %5u => %5u -- %2u %c%c%c%c%c",
+      nbr->rank,
+      rpl_neighbor_get_link_metric(nbr),
+      rpl_neighbor_rank_via_nbr(nbr),
+      stats != NULL ? stats->freshness : 0,
+      (nbr->rank == ROOT_RANK) ? 'r' : ' ',
+      nbr == best ? 'b' : ' ',
+      (acceptable_rank(rpl_neighbor_rank_via_nbr(nbr)) && rpl_neighbor_is_acceptable_parent(nbr)) ? 'a' : ' ',
+      link_stats_is_fresh(stats) ? 'f' : ' ',
+      nbr == curr_instance.dag.preferred_parent ? 'p' : ' '
+  );
+  if(index >= buflen) {
+    return index;
+  }
+  if(stats->last_tx_time > 0) {
+    index += snprintf(buf+index, buflen-index,
+                              " (last tx %u min ago",
+                              (unsigned)((clock_now - stats->last_tx_time) / (60 * CLOCK_SECOND)));
+  } else {
+    index += snprintf(buf+index, buflen-index,
+                              " (no tx");
+  }
+  if(index >= buflen) {
+    return index;
+  }
+  if(nbr->better_parent_since > 0) {
+    index += snprintf(buf+index, buflen-index,
+                              ", better since %u min)",
+                              (unsigned)((clock_now - nbr->better_parent_since) / (60 * CLOCK_SECOND)));
+  } else {
+    index += snprintf(buf+index, buflen-index,
+                              ")");
+  }
+  return index;
+}
+/*---------------------------------------------------------------------------*/
 void
 rpl_neighbor_print_list(const char *str)
 {
@@ -92,8 +146,6 @@ rpl_neighbor_print_list(const char *str)
     int curr_dio_interval = curr_instance.dag.dio_intcurrent;
     int curr_rank = curr_instance.dag.rank;
     rpl_nbr_t *nbr = nbr_table_head(rpl_neighbors);
-    rpl_nbr_t *best = best_parent(0);
-    clock_time_t clock_now = clock_time();
 
     LOG_INFO("nbr: own state, addr ");
     LOG_INFO_6ADDR(rpl_get_global_address());
@@ -103,30 +155,9 @@ rpl_neighbor_print_list(const char *str)
         max_acceptable_rank(),
         curr_dio_interval, rpl_neighbor_count(), str);
     while(nbr != NULL) {
-      const struct link_stats *stats = rpl_neighbor_get_link_stats(nbr);
-      LOG_INFO("nbr: ");
-      LOG_INFO_6ADDR(rpl_neighbor_get_ipaddr(nbr));
-      LOG_INFO_(" %5u, %5u => %5u -- %2u %c%c%c%c%c",
-          nbr->rank,
-          rpl_neighbor_get_link_metric(nbr),
-          rpl_neighbor_rank_via_nbr(nbr),
-          stats != NULL ? stats->freshness : 0,
-          (nbr->rank == ROOT_RANK) ? 'r' : ' ',
-          nbr == best ? 'b' : ' ',
-          (acceptable_rank(rpl_neighbor_rank_via_nbr(nbr)) && rpl_neighbor_is_acceptable_parent(nbr)) ? 'a' : ' ',
-          link_stats_is_fresh(stats) ? 'f' : ' ',
-          nbr == curr_instance.dag.preferred_parent ? 'p' : ' '
-      );
-      if(stats->last_tx_time > 0) {
-        LOG_INFO_(" (last tx %u min ago", (unsigned)((clock_now - stats->last_tx_time) / (60 * CLOCK_SECOND)));
-      } else {
-        LOG_INFO_(" (no tx");
-      }
-      if(nbr->better_parent_since > 0) {
-        LOG_INFO_(", better since %u min)\n", (unsigned)((clock_now - nbr->better_parent_since) / (60 * CLOCK_SECOND)));
-      } else {
-        LOG_INFO_(")\n");
-      }
+      char buf[120];
+      rpl_neighbor_snprint(buf, sizeof(buf), nbr);
+      LOG_INFO("%s\n", buf);
       nbr = nbr_table_next(rpl_neighbors, nbr);
     }
     LOG_INFO("nbr: end of list\n");

--- a/os/net/routing/rpl-lite/rpl-neighbor.h
+++ b/os/net/routing/rpl-lite/rpl-neighbor.h
@@ -196,8 +196,8 @@ rpl_nbr_t *rpl_neighbor_select_best(void);
 * Print a textual description of RPL neighbor into a string
 *
 * \param buf The buffer where to write content
-* \param len The buffer len
-* \param addr A pointer to a RPL neighbor that will be written to the buffer
+* \param buflen The buffer len
+* \param nbr A pointer to a RPL neighbor that will be written to the buffer
 * \return Identical to snprintf: number of bytes written excluding ending null
 * byte. A value >= buflen if the buffer was too small.
 */

--- a/os/net/routing/rpl-lite/rpl-neighbor.h
+++ b/os/net/routing/rpl-lite/rpl-neighbor.h
@@ -192,6 +192,17 @@ void rpl_neighbor_remove_all(void);
 */
 rpl_nbr_t *rpl_neighbor_select_best(void);
 
+/**
+* Print a textual description of RPL neighbor into a string
+*
+* \param buf The buffer where to write content
+* \param len The buffer len
+* \param addr A pointer to a RPL neighbor that will be written to the buffer
+* \return Identical to snprintf: number of bytes written excluding ending null
+* byte. A value >= buflen if the buffer was too small.
+*/
+int rpl_neighbor_snprint(char *buf, int buflen, rpl_nbr_t *nbr);
+
 typedef rpl_nbr_t rpl_parent_t;
 #define rpl_parent_get_from_ipaddr(addr) rpl_neighbor_get_from_ipaddr(addr)
 #define rpl_parent_get_ipaddr(nbr) rpl_neighbor_get_ipaddr(nbr)

--- a/os/services/shell/shell-commands.c
+++ b/os/services/shell/shell-commands.c
@@ -146,6 +146,27 @@ rpl_ocp_to_str(int ocp)
 }
 /*---------------------------------------------------------------------------*/
 static
+PT_THREAD(cmd_rpl_nbr(struct pt *pt, shell_output_func output, char *args))
+{
+  PT_BEGIN(pt);
+
+  if(!curr_instance.used || rpl_neighbor_count() == 0) {
+    SHELL_OUTPUT(output, "RPL neighbors: none\n");
+  } else {
+    rpl_nbr_t *nbr = nbr_table_head(rpl_neighbors);
+    SHELL_OUTPUT(output, "RPL neighbors:\n");
+    while(nbr != NULL) {
+      char buf[120];
+      rpl_neighbor_snprint(buf, sizeof(buf), nbr);
+      SHELL_OUTPUT(output, "%s\n", buf);
+      nbr = nbr_table_next(rpl_neighbors, nbr);
+    }
+  }
+
+  PT_END(pt);
+}
+/*---------------------------------------------------------------------------*/
+static
 PT_THREAD(cmd_rpl_status(struct pt *pt, shell_output_func output, char *args))
 {
   PT_BEGIN(pt);
@@ -745,6 +766,7 @@ struct shell_command_t shell_commands[] = {
 #endif /* UIP_CONF_IPV6_RPL */
 #if ROUTING_CONF_RPL_LITE
   { "rpl-status",           cmd_rpl_status,           "'> rpl-status': Shows a summary of the current RPL state" },
+  { "rpl-nbr",              cmd_rpl_nbr,              "'> rpl-nbr': Shows the RPL neighbor table" },
 #endif /* ROUTING_CONF_RPL_LITE */
   { "routes",               cmd_routes,               "'> routes': Shows the route entries" },
 #if MAC_CONF_WITH_TSCH

--- a/os/services/shell/shell.c
+++ b/os/services/shell/shell.c
@@ -50,40 +50,15 @@
 #include "shell-commands.h"
 #include "net/ipv6/uip.h"
 #include "net/ipv6/ip64-addr.h"
+#include "net/ipv6/uiplib.h"
 
 /*---------------------------------------------------------------------------*/
 void
 shell_output_6addr(shell_output_func output, const uip_ipaddr_t *ipaddr)
 {
-  uint16_t a;
-  unsigned int i;
-  int f;
-
-  if(ipaddr == NULL) {
-    SHELL_OUTPUT(output, "(NULL IP addr)");
-    return;
-  }
-
-  if(ip64_addr_is_ipv4_mapped_addr(ipaddr)) {
-    /* Printing IPv4-mapped addresses is done according to RFC 4291 */
-    SHELL_OUTPUT(output, "::FFFF:%u.%u.%u.%u", ipaddr->u8[12], ipaddr->u8[13], ipaddr->u8[14], ipaddr->u8[15]);
-  } else {
-    for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
-      a = (ipaddr->u8[i] << 8) + ipaddr->u8[i + 1];
-      if(a == 0 && f >= 0) {
-        if(f++ == 0) {
-          SHELL_OUTPUT(output, "::");
-        }
-      } else {
-        if(f > 0) {
-          f = -1;
-        } else if(i > 0) {
-          SHELL_OUTPUT(output, ":");
-        }
-        SHELL_OUTPUT(output, "%x", a);
-      }
-    }
-  }
+  char buf[40];
+  uiplib_ipaddr_snprint(buf, sizeof(buf), ipaddr);
+  SHELL_OUTPUT(output, "%s", buf);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/os/services/shell/shell.c
+++ b/os/services/shell/shell.c
@@ -56,7 +56,7 @@
 void
 shell_output_6addr(shell_output_func output, const uip_ipaddr_t *ipaddr)
 {
-  char buf[40];
+  char buf[UIPLIB_IPV6_MAX_STR_LEN];
   uiplib_ipaddr_snprint(buf, sizeof(buf), ipaddr);
   SHELL_OUTPUT(output, "%s", buf);
 }

--- a/os/sys/log.c
+++ b/os/sys/log.c
@@ -50,6 +50,7 @@
 
 #include "sys/log.h"
 #include "net/ipv6/ip64-addr.h"
+#include "net/ipv6/uiplib.h"
 
 int curr_log_level_rpl = LOG_CONF_LEVEL_RPL;
 int curr_log_level_tcpip = LOG_CONF_LEVEL_TCPIP;
@@ -84,35 +85,9 @@ struct log_module all_modules[] = {
 void
 log_6addr(const uip_ipaddr_t *ipaddr)
 {
-  uint16_t a;
-  unsigned int i;
-  int f;
-
-  if(ipaddr == NULL) {
-    LOG_OUTPUT("(NULL IP addr)");
-    return;
-  }
-
-  if(ip64_addr_is_ipv4_mapped_addr(ipaddr)) {
-    /* Printing IPv4-mapped addresses is done according to RFC 4291 */
-    LOG_OUTPUT("::FFFF:%u.%u.%u.%u", ipaddr->u8[12], ipaddr->u8[13], ipaddr->u8[14], ipaddr->u8[15]);
-  } else {
-    for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
-      a = (ipaddr->u8[i] << 8) + ipaddr->u8[i + 1];
-      if(a == 0 && f >= 0) {
-        if(f++ == 0) {
-          LOG_OUTPUT("::");
-        }
-      } else {
-        if(f > 0) {
-          f = -1;
-        } else if(i > 0) {
-          LOG_OUTPUT(":");
-        }
-        LOG_OUTPUT("%x", a);
-      }
-    }
-  }
+  char buf[40];
+  uiplib_ipaddr_snprint(buf, sizeof(buf), ipaddr);
+  LOG_OUTPUT("%s", buf);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/os/sys/log.c
+++ b/os/sys/log.c
@@ -85,7 +85,7 @@ struct log_module all_modules[] = {
 void
 log_6addr(const uip_ipaddr_t *ipaddr)
 {
-  char buf[40];
+  char buf[UIPLIB_IPV6_MAX_STR_LEN];
   uiplib_ipaddr_snprint(buf, sizeof(buf), ipaddr);
   LOG_OUTPUT("%s", buf);
 }


### PR DESCRIPTION
This adds `uiplib_ipaddr_describe` for consistent printing of IPv6 addresses into a string, de-duplicating three code locations. 

Similarly, this adds `rpl_neighbor_describe` to print description of a RPL neighbor into a string. This enable a new shell command `rpl-status`, and might as well be used in the future by Web or CoAP servers to deliver RPL status.