### PR TITLE
ignore files produced during coap-lwm2m tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ COOJA.testlog
 *.err
 summary
 tests/[0-9][0-9]-*/org/
+tests/18-coap-lwm2m/Californium.properties
+tests/18-coap-lwm2m/leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
 
 # x86 UEFI files
 cpu/x86/uefi/Makefile.uefi


### PR DESCRIPTION
Currently, after a `make -C tests/` and a `make -C tests/compile-all/`, the git repository is not clean :

```
user@5e5ef3811f69:~/contiki-ng$ git status
On branch develop
Your branch is up-to-date with 'official/develop'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   tools/jn516x/serialdump-linux
	modified:   tools/sky/serialdump-linux

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	tests/18-coap-lwm2m/Californium.properties
	tests/18-coap-lwm2m/leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar

no changes added to commit (use "git add" and/or "git commit -a")
```

Together with the PR #512, this PR will make the .gitignore synchronized with the current battery of tests.