### PR TITLE
node killed at the end of 08-native-runs tests

### DIFF
--- a/tests/08-native-runs/01-test-data-structures.sh
+++ b/tests/08-native-runs/01-test-data-structures.sh
@@ -16,7 +16,7 @@ sleep 2
 
 echo "Closing native node"
 sleep 2
-pgrep $CODE | xargs kill -9
+pgrep ${CODE:0:15} | xargs kill -9
 
 if grep -q "=check-me= FAILED" $CODE.log ; then
   echo "==== make.log ====" ; cat make.log;

--- a/tests/08-native-runs/01-test-data-structures.sh
+++ b/tests/08-native-runs/01-test-data-structures.sh
@@ -16,7 +16,7 @@ sleep 2
 
 echo "Closing native node"
 sleep 2
-pgrep ${CODE:0:15} | xargs kill -9
+kill -9 ${CPID}
 
 if grep -q "=check-me= FAILED" $CODE.log ; then
   echo "==== make.log ====" ; cat make.log;

--- a/tests/08-native-runs/01-test-data-structures.sh
+++ b/tests/08-native-runs/01-test-data-structures.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../utils.sh
 
 # Contiki directory
 CONTIKI=$1
@@ -16,7 +17,7 @@ sleep 2
 
 echo "Closing native node"
 sleep 2
-kill -9 ${CPID}
+kill_bg $CPID
 
 if grep -q "=check-me= FAILED" $CODE.log ; then
   echo "==== make.log ====" ; cat make.log;

--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../utils.sh
 
 # Contiki directory
 CONTIKI=$1
@@ -38,8 +39,8 @@ HOPS=`wc $BASENAME.scriptlog -l | cut -f 1 -d ' '`
 
 echo "Closing simulation and tunslip6"
 sleep 1
-kill -9 $JPID
-kill -9 $MPID
+kill_bg $JPID
+kill_bg $MPID
 sleep 1
 rm COOJA.testlog
 rm COOJA.log

--- a/tests/17-tun-rpl-br/05-native-ping.sh
+++ b/tests/17-tun-rpl-br/05-native-ping.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../utils.sh
 
 # Contiki directory
 CONTIKI=$1
@@ -22,7 +23,7 @@ STATUS=${PIPESTATUS[0]}
 
 echo "Closing native node"
 sleep 2
-pgrep hello-world | sudo xargs kill -9
+kill_bg $CPID
 
 if [ $STATUS -eq 0 ] ; then
   cp $BASENAME.log $BASENAME.testlog

--- a/tests/17-tun-rpl-br/06-native-coap.sh
+++ b/tests/17-tun-rpl-br/06-native-coap.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../utils.sh
 
 # Contiki directory
 CONTIKI=$1
@@ -38,7 +39,7 @@ done
 
 echo "Closing native node"
 sleep 2
-pgrep coap-example | sudo xargs kill -9
+kill_bg $CPID
 
 if [ $TESTCOUNT -eq $OKCOUNT ] ; then
   printf "%-32s TEST OK    %3d/%d\n" "$BASENAME" "$OKCOUNT" "$TESTCOUNT" | tee $BASENAME.testlog;

--- a/tests/17-tun-rpl-br/test-border-router.sh
+++ b/tests/17-tun-rpl-br/test-border-router.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../utils.sh
 
 # Contiki directory
 CONTIKI=$1
@@ -44,8 +45,8 @@ REPLIES=`grep -c 'icmp_seq=' $BASENAME.scriptlog`
 
 echo "Closing simulation and tunslip6"
 sleep 1
-kill -9 $JPID
-kill -9 $MPID
+kill_bg $JPID
+kill_bg $MPID
 sleep 1
 rm COOJA.testlog
 rm COOJA.log

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../utils.sh
 
 # Contiki directory
 CONTIKI=$1
@@ -43,8 +44,8 @@ REPLIES=`grep -c 'icmp_seq=' $BASENAME.scriptlog`
 
 echo "Closing simulation and nbr"
 sleep 1
-kill -9 $JPID
-kill -9 $MPID
+kill_bg $JPID
+kill_bg $MPID
 sleep 1
 rm COOJA.testlog
 rm COOJA.log

--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../utils.sh
 
 # Contiki directory
 CONTIKI=$1
@@ -32,11 +33,11 @@ done
 
 echo "Closing native node"
 sleep 1
-pgrep ipso | sudo xargs kill -9
+kill_bg $CPID
 
 echo "Closing leshan"
 sleep 1
-pgrep java | sudo xargs kill -9
+kill_bg $LESHID
 
 
 if grep -q 'OK' leshan.err ; then

--- a/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
+++ b/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source ../utils.sh
 
 # Contiki directory
 CONTIKI=$1
@@ -33,11 +34,11 @@ done
 
 echo "Closing standalone example"
 sleep 1
-pgrep lwm2m-example | sudo xargs kill -9
+kill_bg $CPID
 
 echo "Closing leshan"
 sleep 1
-pgrep java | sudo xargs kill -9
+kill_bg $LESHID
 
 
 if grep -q 'OK' leshan.err ; then

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+function echo_run( )
+{
+    echo $@
+    $@
+}
+
+function kill_bg( )
+{
+    PID=$1
+    CMD=$(ps -p $PID -o cmd=)
+    SUDO=
+    TOKILL=$PID
+    if [[ ${CMD:0:5} == "sudo " ]] ; then
+        SUDO="sudo "
+        TOKILL=$(ps --ppid $PID -o pid=)
+    fi
+    echo_run ${SUDO}kill -9 $TOKILL
+}


### PR DESCRIPTION
pgrep pattern shoud be smaller than 15 characters

Indeed `CODE=test-data-structures` can't be killed with `pgrep $CODE | xargs kill -` as we can see with 

```
user@81958babe9d8:~/contiki-ng$ make -C tests/08-native-runs/
make: Entering directory '/home/user/contiki-ng/tests/08-native-runs'
========== Running script test 01-test-data-structures.sh ==========
Starting native node
Closing native node
test-data-structures             TEST OK
========== Summary ==========
test-data-structures             TEST OK
make: Leaving directory '/home/user/contiki-ng/tests/08-native-runs'
```

and then 

```
user@81958babe9d8:~/contiki-ng$ top

top - 18:51:02 up 3 days, 11:45,  0 users,  load average: 0.70, 0.50, 0.52
Tasks:   4 total,   2 running,   2 sleeping,   0 stopped,   0 zombie
%Cpu(s):  8.2 us, 18.8 sy,  0.0 ni, 72.9 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
KiB Mem :  8109780 total,  2764576 free,  3602476 used,  1742728 buff/cache
KiB Swap:  8203260 total,  7881004 free,   322256 used.  4605484 avail Mem 

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND                               
  578 user      20   0    2412   1452   1364 R  99.7  0.0   0:16.61 test-data-struc                       
    1 user      20   0    2372    568    524 S   0.0  0.0   0:00.01 sh                                    
    7 user      20   0    3764   2988   2672 S   0.0  0.0   0:00.00 bash                                  
  596 user      20   0    5876   3084   2664 R   0.0  0.0   0:00.00 top
```   