### PR TITLE
Warnings gcc6.3.1

### DIFF
--- a/os/net/mac/ble/ble-l2cap.c
+++ b/os/net/mac/ble/ble-l2cap.c
@@ -512,7 +512,6 @@ const struct mac_driver ble_l2cap_driver = {
   input,
   on,
   off,
-  NULL,
 };
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(ble_l2cap_tx_process, ev, data)

--- a/os/services/ip64/ip64-arp.c
+++ b/os/services/ip64/ip64-arp.c
@@ -94,7 +94,6 @@ struct arp_entry {
 
 static const struct ip64_eth_addr broadcast_ethaddr =
   {{0xff,0xff,0xff,0xff,0xff,0xff}};
-static const uint16_t broadcast_ipaddr[2] = {0xffff,0xffff};
 
 static struct arp_entry arp_table[UIP_ARPTAB_SIZE];
 


### PR DESCRIPTION
Despite the recent introduction of the `-Wno-unused-const-variable` flag in commit 15a3f32b29
and waiting for the new version of the compilers suggested in #517, we can nevertheless remove already some bugs and unused codes caught by more recent versions of arm-none-eabi-gcc (currently in Debian unstable 15:6.3.1+svn253039-1+b1 6.3.1 20170620 instead of the 5.2.1 20151202 revision 231848 in the docker).