### PR TITLE
Fix neighbor discovery bug

### DIFF
--- a/os/net/ipv6/uip-nd6.c
+++ b/os/net/ipv6/uip-nd6.c
@@ -530,7 +530,7 @@ na_input(void)
     if(nd6_opt_llao != NULL) {
       is_llchange =
         memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET], lladdr,
-               UIP_LLADDR_LEN) ? 1 : 0;
+               UIP_LLADDR_LEN) == 0 ? 0 : 1;
     }
     if(nbr->state == NBR_INCOMPLETE) {
       if(nd6_opt_llao == NULL || !extract_lladdr_from_llao_aligned(&lladdr_aligned)) {

--- a/os/net/ipv6/uip-nd6.c
+++ b/os/net/ipv6/uip-nd6.c
@@ -530,7 +530,7 @@ na_input(void)
     if(nd6_opt_llao != NULL) {
       is_llchange =
         memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET], lladdr,
-               UIP_LLADDR_LEN);
+               UIP_LLADDR_LEN) ? 1 : 0;
     }
     if(nbr->state == NBR_INCOMPLETE) {
       if(nd6_opt_llao == NULL || !extract_lladdr_from_llao_aligned(&lladdr_aligned)) {


### PR DESCRIPTION
Prototype of memcmp is :

`int memcmp(const void *s1, const void *s2, size_t n);`

return value of memcmp is a positive or negative or null integer and so **should not be cast in an uint8_t**, the sign of a non-zero return value is determined by the sign of the difference of the first n bytes of the buffers s1 and s2

Currently, `make -C tests/09-ipv6` works on the docker because the Ubuntu 32 bits uses a version of memcmp that will return 1 0 or -1

but on a Debian 64 bits (GLIBC 2.27-3, gcc 7.3.0-19), I get :

```
$ cat tests/09-ipv6/summary 
01-ping-lla-csma-w-rpl                   TEST OK      1/1
02-ping-ula-csma-w-rpl                   TEST OK      1/1
03-ping-lla-tsch-w-rpl                   TEST OK      1/1
04-ping-ula-tsch-w-rpl                   TEST OK      1/1
05-ping-lla-csma-wo-rpl                  TEST FAIL    0/1 -- failed seeds: 1
06-ping-ula-csma-wo-rpl                  TEST FAIL    0/1 -- failed seeds: 1
07-ping-lla-tsch-wo-rpl                  TEST FAIL    0/1 -- failed seeds: 1
08-ping-ula-tsch-wo-rpl                  TEST FAIL    0/1 -- failed seeds: 1
```
because the version of memcmp will return exactly the difference between the two buffers.

What happen ? In the last 4 tests, we are comparing two buffers :

{0x00, 0x02, 0x00, 0x02, 0x00, 0x02, 0x00, 0x02}
{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}

but in the 32 bits case, memcmp returns 1, assigned to an uint8_t, it's still 1.
and in the 64 bits case, memcmp return 512, assigned to an uint8_t, it's 0 !!!

You can test it with :

```c
#include <stdio.h> 
#include <stdint.h> 
#include <string.h> 

int main (int argc,char *argv[])
{
#define SIZEBUFFER 8
    unsigned char buffer1[SIZEBUFFER] = {0x00,0x02,0x00,0x02,0x00,0x02,0x00,0x02} ;
    unsigned char buffer2[SIZEBUFFER] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00} ;

    int int_result ;
    uint8_t uint8_t_result ;

    int_result = memcmp(buffer1,buffer2,SIZEBUFFER) ;

    uint8_t_result = int_result ;

    printf("%d\n",int_result);
    printf("%d\n",uint8_t_result);

    return 0;
}
```

and a Makefile :

```Makefile
all: clean memcmp-test
	nm -C memcmp-test | grep memcmp
	ldd ./memcmp-test
	./memcmp-test

CFLAGS:=-m32

memcmp-test: memcmp-test.c
	gcc $(CFLAGS) -O0 memcmp-test.c -o memcmp-test

clean:
	rm -f *.[o] memcmp-test
```

then we get in 32 bits :

```
$ make
rm -f *.[o] memcmp-test
gcc -m32 -O0 memcmp-test.c -o memcmp-test
nm -C memcmp-test | grep memcmp
         U memcmp@@GLIBC_2.0
ldd ./memcmp-test
	linux-gate.so.1 (0xf7f8b000)
	libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d87000)
	/lib/ld-linux.so.2 (0xf7f8d000)
./memcmp-test
1
1
```

but in 64 bits :

```
$ make CFLAGS=-m64
rm -f *.[o] memcmp-test
gcc -m64 -O0 memcmp-test.c -o memcmp-test
nm -C memcmp-test | grep memcmp
                 U memcmp@@GLIBC_2.2.5
ldd ./memcmp-test
	linux-vdso.so.1 (0x00007ffcfcdb3000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f9447f73000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f944852f000)
./memcmp-test
512
0
```



