### PR TITLE
Differentiate flash part across sensortag/cc2650 versions

### DIFF
--- a/arch/platform/srf06-cc26xx/sensortag/cc2650/board.h
+++ b/arch/platform/srf06-cc26xx/sensortag/cc2650/board.h
@@ -149,8 +149,13 @@
 #define EXT_FLASH_SPI_PIN_MISO      18
 #define EXT_FLASH_SPI_PIN_CS        14
 
+#if SENSORTAG_CC2650_REV_1_2_0
+#define EXT_FLASH_DEVICE_ID         0x12
+#define EXT_FLASH_MID               0xEF
+#else
 #define EXT_FLASH_DEVICE_ID         0x14
 #define EXT_FLASH_MID               0xC2
+#endif
 
 #define EXT_FLASH_PROGRAM_PAGE_SIZE 256
 #define EXT_FLASH_ERASE_SECTOR_SIZE 4096

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/README.md
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/README.md
@@ -10,11 +10,17 @@ demonstrate the CC26xx capability. The applications are:
 * A web server which can be used to display sensor readings but also to
   configure MQTT functionality
 
-The example has been configured to run for all CC26xx-based boards: i) The
-SensorTag 2.0 and ii) The Srf06EB with a CC26xx or CC13xx EM mounted on it.
+The example has been configured to run for all CC26xx-based boards.
 
-To change between target boards, follow the instructions in the platform's
-REDME file. Do not forget to `make clean` when switching between the boards.
+To change between target boards, follow the instructions in the wiki.
+Do not forget to `make clean` when switching between the boards.
+
+Specifically for some older CC2650 SensorTags, you may also need to change
+`project-conf.h` such that `SENSORTAG_CC2650_REV_1_2_0` is defined as 1. To
+check if your sensortag is one of those older ones, look for "REV: 1.2"
+printed on the PCB. There may also be a sticker that reads "HW Rev 1.2.0". An
+indication that you may need to do this is if you get a "Could not open flash
+to load config" error on device startup.
 
 You can disable some of those individual components by changing the respective
 defines in `project-conf.h`. For instance, to disable the CoAP functionality,

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/project-conf.h
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/project-conf.h
@@ -53,6 +53,16 @@
  */
 #define CC26XX_WEB_DEMO_CONF_ADC_DEMO         0
 /*---------------------------------------------------------------------------*/
+/*
+ * Change to 1 if you are using an older CC2650 Sensortag (look for Rev: 1.2
+ * printed on the PCB, or for a sticker reading "HW Rev 1.2.0").
+ *
+ * This may be the case if you are getting this error:
+ * "Could not open flash to load config"
+ * when your sensortag is starting up.
+ */
+#define SENSORTAG_CC2650_REV_1_2_0            0
+/*---------------------------------------------------------------------------*/
 /* Enable the ROM bootloader */
 #define ROM_BOOTLOADER_ENABLE                 1
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Older CC2650 sensortags have a Winbond W25X40CL 4MBit SPI flash. Newer ones have a Macronix MX25R8035F 8MBit part. The parts have almost identical instruction sets and are both supported by our generic external flash driver. The key difference between the two parts is that they have different Manufacturer and Device IDs.

This commit allows us to switch between the two: We default to the new revision, and allow users to build for the older one by defining `SENSORTAG_CC2650_REV_1_2_0` to 1.

Current tags are version 1.5.1. Older tags are version 1.2.0. To identify older tags, look for "Rev: 1.2" printed on the PCB. They should also have a sticker that reads "Rev: 1.3.0" and "HW Rev 1.2.0".

Fixes #530 