### PR TITLE
Feedback in CoAP send request 

### DIFF
--- a/os/net/app-layer/coap/coap-callback-api.c
+++ b/os/net/app-layer/coap/coap-callback-api.c
@@ -65,7 +65,7 @@ static void coap_request_callback(void *callback_data, coap_message_t *response)
 
 /*---------------------------------------------------------------------------*/
 
-static void
+static int
 progress_request(coap_request_state_t *state) {
   coap_message_t *request = state->request;
   request->mid = coap_get_mid();
@@ -83,7 +83,9 @@ progress_request(coap_request_state_t *state) {
 
     coap_send_transaction(state->transaction);
     LOG_DBG("Requested #%"PRIu32" (MID %u)\n", state->block_num, request->mid);
+    return 1;
   }
+  return 0;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -134,7 +136,7 @@ coap_request_callback(void *callback_data, coap_message_t *response)
 
 /*---------------------------------------------------------------------------*/
 
-void
+int
 coap_send_request(coap_request_state_t *state, coap_endpoint_t *endpoint,
                   coap_message_t *request,
                   void (*callback)(coap_request_state_t *state))
@@ -151,7 +153,7 @@ coap_send_request(coap_request_state_t *state, coap_endpoint_t *endpoint,
   state->remote_endpoint = endpoint;
   state->callback = callback;
 
-  progress_request(state);
+  return progress_request(state);
 }
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/os/net/app-layer/coap/coap-callback-api.h
+++ b/os/net/app-layer/coap/coap-callback-api.h
@@ -65,6 +65,14 @@ struct coap_request_state {
   void (*callback)(coap_request_state_t *state);
 };
 
+/**
+ * \brief Send a CoAP request to a remote endpoint
+ * \param state The state to handle the CoAP request
+ * \param endpoint The destination endpoint
+ * \param request The request to be sent
+ * \param callback callback to execute when the response arrives or the timeout expires
+ * \return 1 if there is a transaction available to send, 0 otherwise
+ */
 int coap_send_request(coap_request_state_t *state, coap_endpoint_t *endpoint,
                        coap_message_t *request,
                        void (*callback)(coap_request_state_t *state));

--- a/os/net/app-layer/coap/coap-callback-api.h
+++ b/os/net/app-layer/coap/coap-callback-api.h
@@ -65,7 +65,7 @@ struct coap_request_state {
   void (*callback)(coap_request_state_t *state);
 };
 
-void coap_send_request(coap_request_state_t *state, coap_endpoint_t *endpoint,
+int coap_send_request(coap_request_state_t *state, coap_endpoint_t *endpoint,
                        coap_message_t *request,
                        void (*callback)(coap_request_state_t *state));
 


### PR DESCRIPTION
Hi All!

Right now the function `coap_send_request` does not give any feedback in case there is no available transaction available to use (if `coap_new_transaction` returns NULL). Therefore, the applications on top cannot know if the request is actually been sent or not. 

Therefore, this small PR makes the `coap_send_request` return 1 if there is a transaction available and 0 otherwise, so that applications running on top can know if the request is actually sent.