### PR TITLE
Improve doxygen module structure and content

### DIFF
--- a/arch/dev/ext-flash/ext-flash.c
+++ b/arch/dev/ext-flash/ext-flash.c
@@ -29,11 +29,11 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup sensortag-cc26xx-ext-flash
+ * \addtogroup ext-flash
  * @{
  *
  * \file
- * Sensortag/LaunchPad External Flash Driver
+ * Implementation of a generic external SPI flash driver
  */
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"

--- a/arch/dev/ext-flash/ext-flash.h
+++ b/arch/dev/ext-flash/ext-flash.h
@@ -29,14 +29,23 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup common-cc26xx-peripherals
+ * \addtogroup dev
  * @{
  *
- * \defgroup sensortag-cc26xx-ext-flash SensorTag/LaunchPad External Flash
+ * \defgroup ext-flash Generic external SPI flash driver
+ *
+ * This is a generic driver for external SPI flash memories. The driver has
+ * been tested and works with multiple external SPI flash parts. The list of
+ * parts the driver has been tested against is shown in the README in this
+ * directory.
+ *
+ * If you successfully use this driver with a part that is not listed in the
+ * README, please let us know so we can update it.
+ *
  * @{
  *
  * \file
- * Header file for the Sensortag/LaunchPad External Flash Driver
+ * Header file for the external SPI flash API
  */
 /*---------------------------------------------------------------------------*/
 #ifndef EXT_FLASH_H_

--- a/os/net/ipv6/uiplib.c
+++ b/os/net/ipv6/uiplib.c
@@ -33,8 +33,11 @@
  */
 
 /**
+ * \addtogroup uip-addr-lib
+ * @{
+ *
  * \file
- *         Various uIP library functions.
+ *         Implementation of the IP address manipulation library
  * \author
  *         Nicolas Tsiftes <nvt@sics.se>
  *         Niclas Finne <nfi@sics.se>
@@ -223,3 +226,6 @@ uiplib_ipaddr_snprint(char *buf, size_t size, const uip_ipaddr_t *addr)
   return n;
 }
 /*---------------------------------------------------------------------------*/
+/**
+ * @}
+ */

--- a/os/net/ipv6/uiplib.h
+++ b/os/net/ipv6/uiplib.h
@@ -31,23 +31,24 @@
  *
  *
  */
-
-/**
- * \file
- * Various uIP library functions.
- * \author
- * Adam Dunkels <adam@sics.se>
- *
- */
-
 #ifndef UIPLIB_H_
 #define UIPLIB_H_
 
 #include "net/ipv6/uip.h"
 
 /**
- * \addtogroup uipconvfunc
+ * \addtogroup uip
  * @{
+ *
+ * \defgroup uip-addr-lib uIP address manipulation library
+ *
+ * A library with various IP address manipulation functions
+ * @{
+ *
+ * \file
+ * Header file for the IP address manipulation library
+ * \author
+ * Adam Dunkels <adam@sics.se>
  */
 
 /**
@@ -77,10 +78,6 @@ int uiplib_ip4addrconv(const char *addrstr, uip_ip4addr_t *addr);
 int uiplib_ip6addrconv(const char *addrstr, uip_ip6addr_t *addr);
 /** @} */
 
-/**
- * \addtogroup uiplib
- * @{
- */
 
 /* The maxium length of an IPv6 string, including terminating null bytes
  * fd01:0002:0003:0004:0005:0006:0007:0008 => 39 + 1 bytes */
@@ -103,6 +100,8 @@ void uiplib_ipaddr_print(const uip_ipaddr_t *addr);
  */
 int uiplib_ipaddr_snprint(char *buffer, size_t size, const uip_ipaddr_t *addr);
 
-/** @} */
-
 #endif /* UIPLIB_H_ */
+/**
+ * @}
+ * @}
+ */


### PR DESCRIPTION
The documentation for `/arch/dev/ext-flash` and ` os/net/ipv6/uiplib.[ch]` was placing the modules at the wrong position in the doxygen module hierarchy. This pull fixes this, and adds a little bit of content to both.