### PR TITLE
Use $(MAKE) instead of make to invoke recursively

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -315,8 +315,8 @@ clean:
 
 distclean:
 	@for TARG in `ls $(CONTIKI)/arch/platform $(TARGETDIRS)`; do \
-		echo Running: make TARGET=$$TARG clean; \
-		make TARGET=$$TARG clean; \
+		echo Running: $(MAKE) TARGET=$$TARG clean; \
+		$(MAKE) TARGET=$$TARG clean; \
 	done
 
 -include $(CONTIKI)/arch/platform/$(TARGET)/Makefile.customrules-$(TARGET)

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -11,7 +11,7 @@ TUNSLIP6 = $(SERIAL_IO_TOOL_DIR)/tunslip6
 SERIAL_DUMP_BIN = $(SERIAL_IO_TOOL_DIR)/serialdump
 
 $(SERIAL_DUMP_BIN): $(SERIAL_IO_TOOL_DIR)/serialdump.c $(SERIAL_IO_TOOL_DEPS)
-	make -C $(SERIAL_IO_TOOL_DIR) serialdump
+	$(MAKE) -C $(SERIAL_IO_TOOL_DIR) serialdump
 
 $(TUNSLIP6): $(SERIAL_IO_TOOL_DIR)/tunslip6.c $(SERIAL_IO_TOOL_DEPS)
-	make -C $(SERIAL_IO_TOOL_DIR) tunslip6
+	$(MAKE) -C $(SERIAL_IO_TOOL_DIR) tunslip6

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -36,7 +36,7 @@ summary: $(SUMMARIES)
 	@cat $(SUMMARIES) > $@
 
 %/summary:
-	@make -C $* summary || true
+	@$(MAKE) -C $* summary || true
 
 clean:
 	rm -f $(SUMMARIES) summary

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -40,7 +40,7 @@ get_target_vars = $(wordlist 2,15,$(subst :, ,$1))
 define dooneexample
 @echo -n Building example $(3): $(1) $(4) for target $(2)
 @((cd $(EXAMPLESDIR)/$(1); \
- make $(4) TARGET=$(2) clean && make -j $(4) TARGET=$(2) WERROR=1) > \
+ $(MAKE) $(4) TARGET=$(2) clean && make -j $(4) TARGET=$(2) WERROR=1) > \
       /dev/null 2>make.err && \
  (echo " -> OK" && printf "%-75s %-40s %-20s TEST OK\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog) || \
  (echo " -> FAIL" && printf "%-75s %-40s %-20s TEST FAIL\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog ; cat make.err))
@@ -65,4 +65,4 @@ clean:
 	@rm -f *.testlog summary
 	@$(foreach example, $(EXAMPLES), \
            $(foreach target, $(EXAMPLESTARGETS), \
-             (cd $(EXAMPLESDIR)/$(example); make TARGET=$(target) clean);))
+             (cd $(EXAMPLESDIR)/$(example); $(MAKE) TARGET=$(target) clean);))


### PR DESCRIPTION
So, if the top-level command was something other than `make` (e.g. `gmake`, or `/<path>/make` from some different location), the sub-make invocations will use the same version of make, instead of whatever happens to be in the path.

This also changes make's behaviour slightly, in that some flags are automatically passed to the sub-make.