### PR TITLE
exclude sky platform for examples/libs/shell

### DIFF
--- a/examples/libs/shell/Makefile
+++ b/examples/libs/shell/Makefile
@@ -3,4 +3,7 @@ all: $(CONTIKI_PROJECT)
 
 MODULES += os/services/shell
 CONTIKI = ../../..
+
+PLATFORMS_EXCLUDE = sky
+
 include $(CONTIKI)/Makefile.include


### PR DESCRIPTION
Dear all,

The shell example introduced recently in 77939f421 does not link for the sky platform : 

```
user@3cdf6ad03a12:~/contiki-ng$ make -C examples/libs/shell/ -j TARGET=sky BOARD=default all
make: Entering directory '/home/user/contiki-ng/examples/libs/shell'
mkdir obj_sky
  CC        example.c
...
  LD        example.sky
/usr/local/bin/../lib/gcc/msp430/4.7.2/../../../../msp430/bin/ld: example.sky section `.rodata' will not fit in region `rom'
/usr/local/bin/../lib/gcc/msp430/4.7.2/../../../../msp430/bin/ld: section .vectors loaded at [0000ffe0,0000ffff] overlaps section .rodata loaded at [0000f4e4,0001031a]
/usr/local/bin/../lib/gcc/msp430/4.7.2/../../../../msp430/bin/ld: region `rom' overflowed by 1222 bytes
/usr/local/bin/../lib/gcc/msp430/4.7.2/mmpy-16/libcrt0.a(_copy_data.o): In function `__do_copy_data':
/home/user/tmp/gcc-4.7.2-msp430/msp430/mmpy-16/libgcc/../../../../gcc-4.7.2/libgcc/config/msp430/crt0.S:208:(.init4+0x12): relocation truncated to fit: R_MSP430_16_BYTE against symbol `__data_load_start' defined in *ABS* section in example.sky
contiki-ng-sky.a(csma.o): In function `input_packet':
/home/user/contiki-ng/examples/libs/shell/../../../os/net/mac/csma/csma.c:73:(.text.input_packet+0xc): relocation truncated to fit: R_MSP430_16 against symbol `framer_802154' defined in .rodata section in contiki-ng-sky.a(framer-802154.o)
contiki-ng-sky.a(csma-output.o): In function `csma_output_init':
/home/user/contiki-ng/examples/libs/shell/../../../os/net/mac/csma/csma-output.c:563:(.text.transmit_from_queue+0x3c): relocation truncated to fit: R_MSP430_16 against symbol `framer_802154' defined in .rodata section in contiki-ng-sky.a(framer-802154.o)
contiki-ng-sky.a(sicslowpan.o): In function `sicslowpan_get_last_rssi':
/home/user/contiki-ng/examples/libs/shell/../../../os/net/ipv6/sicslowpan.c:2075:(.text.output+0x62): relocation truncated to fit: R_MSP430_16 against symbol `framer_802154' defined in .rodata section in contiki-ng-sky.a(framer-802154.o)
/home/user/contiki-ng/examples/libs/shell/../../../os/net/ipv6/sicslowpan.c:2075:(.text.output+0x666): relocation truncated to fit: R_MSP430_16 against symbol `framer_802154' defined in .rodata section in contiki-ng-sky.a(framer-802154.o)
contiki-ng-sky.a(shell-commands.): In function `shell_commands_init':
/home/user/contiki-ng/examples/libs/shell/../../../os/services/shell/shell-commands.c:733:(.data+0x3a): relocation truncated to fit: R_MSP430_16_BYTE against `no symbol'
/home/user/contiki-ng/examples/libs/shell/../../../os/services/shell/shell-commands.c:733:(.data+0x3c): relocation truncated to fit: R_MSP430_16_BYTE against `no symbol'
/home/user/contiki-ng/examples/libs/shell/../../../os/services/shell/shell-commands.c:733:(.data+0x40): relocation truncated to fit: R_MSP430_16_BYTE against `no symbol'
/home/user/contiki-ng/examples/libs/shell/../../../os/services/shell/shell-commands.c:733:(.data+0x42): relocation truncated to fit: R_MSP430_16_BYTE against `no symbol'
/home/user/contiki-ng/examples/libs/shell/../../../os/services/shell/shell-commands.c:733:(.data+0x46): relocation truncated to fit: R_MSP430_16_BYTE against `no symbol'
/home/user/contiki-ng/examples/libs/shell/../../../os/services/shell/shell-commands.c:733:(.data+0x48): additional relocation overflows omitted from the output
collect2: error: ld returned 1 exit status
../../../Makefile.include:386: recipe for target 'example.sky' failed
make: *** [example.sky] Error 1
rm example.o
make: Leaving directory '/home/user/contiki-ng/examples/libs/shell'
```

Don't know if you want to fix this or if this functionality should be excluded for the sky platform...