### PR TITLE
rtimer issues: redundant calls to rtimer_arch_schedule

### DIFF
--- a/os/sys/rtimer.c
+++ b/os/sys/rtimer.c
@@ -62,12 +62,10 @@ rtimer_set(struct rtimer *rtimer, rtimer_clock_t time,
 	   rtimer_clock_t duration,
 	   rtimer_callback_t func, void *ptr)
 {
-  int first = 0;
-
   PRINTF("rtimer_set time %d\n", time);
 
-  if(next_rtimer == NULL) {
-    first = 1;
+  if(next_rtimer) {
+    return RTIMER_ERR_ALREADY_SCHEDULED;
   }
 
   rtimer->func = func;
@@ -76,9 +74,7 @@ rtimer_set(struct rtimer *rtimer, rtimer_clock_t time,
   rtimer->time = time;
   next_rtimer = rtimer;
 
-  if(first == 1) {
-    rtimer_arch_schedule(time);
-  }
+  rtimer_arch_schedule(time);
   return RTIMER_OK;
 }
 /*---------------------------------------------------------------------------*/
@@ -92,10 +88,6 @@ rtimer_run_next(void)
   t = next_rtimer;
   next_rtimer = NULL;
   t->func(t, t->ptr);
-  if(next_rtimer != NULL) {
-    rtimer_arch_schedule(next_rtimer->time);
-  }
-  return;
 }
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
When calling `rtimer_set` from within the rtimer ISR, `rtimer_arch_schedule` gets called twice, even though there is code that tries to prevent this from happening. This PR provides a fix through small changes to `rtimer.c`.