### PR TITLE
minor modifications related to tools/serial-io/tunslip6

### DIFF
--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -22,10 +22,9 @@ java -Xshare:on -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$BASENAME.csc -c
 JPID=$!
 sleep 20
 
-# Connect to the simlation
+# Connect to the simulation
 echo "Starting tunslip6"
-make -C $CONTIKI/tools tunslip6
-make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=zoul >> $BASENAME.tunslip.log 2>&1 &
+make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=zoul >> $BASENAME.tunslip6.log 2>&1 &
 MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME
@@ -49,7 +48,7 @@ if [ $STATUS -eq 0 ] && [ $HOPS -eq $TARGETHOPS ] ; then
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
 else
   echo "==== $BASENAME.coojalog ====" ; cat $BASENAME.coojalog;
-  echo "==== $BASENAME.tunslip.log ====" ; cat $BASENAME.tunslip.log;
+  echo "==== $BASENAME.tunslip6.log ====" ; cat $BASENAME.tunslip6.log;
   echo "==== $BASENAME.scriptlog ====" ; cat $BASENAME.scriptlog;
 
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;

--- a/tests/17-tun-rpl-br/test-border-router.sh
+++ b/tests/17-tun-rpl-br/test-border-router.sh
@@ -28,10 +28,9 @@ java -Xshare:on -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$BASENAME.csc -c
 JPID=$!
 sleep 20
 
-# Connect to the simlation
+# Connect to the simulation
 echo "Starting tunslip6"
-make -C $CONTIKI/tools tunslip6
-make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=zoul >> $BASENAME.tunslip.log 2>&1 &
+make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=zoul >> $BASENAME.tunslip6.log 2>&1 &
 MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME
@@ -55,7 +54,7 @@ if [ $STATUS -eq 0 ] && [ $REPLIES -eq $COUNT ] ; then
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
 else
   echo "==== $BASENAME.coojalog ====" ; cat $BASENAME.coojalog;
-  echo "==== $BASENAME.tunslip.log ====" ; cat $BASENAME.tunslip.log;
+  echo "==== $BASENAME.tunslip6.log ====" ; cat $BASENAME.tunslip6.log;
   echo "==== $BASENAME.scriptlog ====" ; cat $BASENAME.scriptlog;
 
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -28,7 +28,7 @@ java -Xshare:on -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$BASENAME.csc -c
 JPID=$!
 sleep 20
 
-# Connect to the simlation
+# Connect to the simulation
 echo "Starting native border-router"
 nohup make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=native >> $BASENAME.nbr.log 2>&1 &
 MPID=$!


### PR DESCRIPTION
Some minor modifications related to the recent 2605a5174

tunslip6 is already a dependency of the target ''make -C examples/rpl-border-router connect-router-cooja TARGET=zoul''

This PR removes the strange logs in https://travis-ci.org/contiki-ng/contiki-ng/jobs/384851974 

```
========== Running script test 01-border-router-cooja.sh ==========
Starting Cooja simulation 01-border-router-cooja.csc
Starting tunslip6
make[1]: Entering directory '/home/user/contiki-ng/tools'
make[1]: *** No rule to make target 'tunslip6'.  Stop.
make[1]: Leaving directory '/home/user/contiki-ng/tools'
```