### PR TITLE
Leshan server qmode fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ COOJA.testlog
 summary
 tests/[0-9][0-9]-*/org/
 tests/18-coap-lwm2m/Californium.properties
-tests/18-coap-lwm2m/leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+tests/18-coap-lwm2m/leshan-server-demo*.jar
 
 # x86 UEFI files
 cpu/x86/uefi/Makefile.uefi

--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -17,9 +17,10 @@ CPID=$!
 sleep 10
 
 echo "Downloading leshan"
-wget -nc https://joakimeriksson.github.io/resources/leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+wget -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server"
-java -jar leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar >leshan.log 2>leshan.err &
+java -jar $LESHAN_JAR >leshan.log 2>leshan.err &
 LESHID=$!
 
 COUNTER=10

--- a/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
+++ b/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
@@ -12,9 +12,10 @@ make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m clean >/dev/nul
 make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m >make.log 2>make.err
 
 echo "Downloading leshan"
-wget -nc https://joakimeriksson.github.io/resources/leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+wget -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server"
-java -jar leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar  -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
+java -jar $LESHAN_JAR -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
 LESHID=$!
 
 echo "Starting lwm2m standalone example"

--- a/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
+++ b/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
@@ -16,9 +16,10 @@ CPID=$!
 sleep 10
 
 echo "Downloading leshan with Q-Mode support"
-wget -nc https://carlosgp143.github.io/resources/leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
+LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
+wget -nc https://carlosgp143.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server with Q-Mode enabled"
-java -jar leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar >leshan.log 2>leshan.err &
+java -jar $LESHAN_JAR >leshan.log 2>leshan.err &
 LESHID=$!
 
 COUNTER=10

--- a/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
+++ b/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
@@ -11,9 +11,10 @@ make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m clean >/dev/nul
 make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 >make.log 2>make.err
 
 echo "Downloading leshan with Q-Mode support"
-wget -nc https://carlosgp143.github.io/resources/leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
+LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
+wget -nc https://carlosgp143.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server with Q-Mode enabled"
-java -jar leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar  -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
+java -jar $LESHAN_JAR -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
 LESHID=$!
 
 echo "Starting lwm2m standalone example"


### PR DESCRIPTION
The leshan server with qmode enabled introduced in 1dfa62fc88 is downloaded in tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh but it's not the one that is actually used in the test...
Update also the .gitignore