### PR TITLE
Reworked busy-wait routines

### DIFF
--- a/arch/platform/cooja/dev/watchdog.c
+++ b/arch/platform/cooja/dev/watchdog.c
@@ -30,8 +30,10 @@
  *
  */
 
- /* Dummy watchdog routines for the Raven 1284p */
+ /* Dummy watchdog routines for Cooja motes */
 #include "dev/watchdog.h"
+#include "lib/simEnvChange.h"
+#include "sys/cooja_mt.h"
 
 /*---------------------------------------------------------------------------*/
 void
@@ -47,6 +49,9 @@ watchdog_start(void)
 void
 watchdog_periodic(void)
 {
+  /* Yield and give control back to the simulator scheduler */
+  simProcessRunValue = 1;
+  cooja_mt_yield();
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/platform/jn516x/dev/micromac-radio.c
+++ b/arch/platform/jn516x/dev/micromac-radio.c
@@ -130,13 +130,6 @@
 #define MICROMAC_CONF_ALWAYS_ON 1
 #endif /* MICROMAC_CONF_ALWAYS_ON */
 
-#define BUSYWAIT_UNTIL(cond, max_time) \
-  do { \
-    rtimer_clock_t t0; \
-    t0 = RTIMER_NOW(); \
-    while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (max_time))) ; \
-  } while(0)
-
 /* Local variables */
 static volatile signed char radio_last_rssi;
 static volatile uint8_t radio_last_correlation; /* LQI */
@@ -377,14 +370,14 @@ transmit(unsigned short payload_len)
                          (send_on_cca ? E_MMAC_TX_USE_CCA : E_MMAC_TX_NO_CCA));
 #endif
   if(poll_mode) {
-    BUSYWAIT_UNTIL(u32MMAC_PollInterruptSource(E_MMAC_INT_TX_COMPLETE), MAX_PACKET_DURATION);
+    RTIMER_BUSYWAIT_UNTIL(u32MMAC_PollInterruptSource(E_MMAC_INT_TX_COMPLETE), MAX_PACKET_DURATION);
   } else {
     if(in_ack_transmission) {
       /* as nested interupts are not possible, the tx flag will never be cleared */
-      BUSYWAIT_UNTIL(FALSE, MAX_ACK_DURATION);
+      RTIMER_BUSYWAIT_UNTIL(FALSE, MAX_ACK_DURATION);
     } else {
       /* wait until the tx flag is cleared */
-      BUSYWAIT_UNTIL(!tx_in_progress, MAX_PACKET_DURATION);
+      RTIMER_BUSYWAIT_UNTIL(!tx_in_progress, MAX_PACKET_DURATION);
     }
   }
 

--- a/arch/platform/jn516x/dev/uart-driver.c
+++ b/arch/platform/jn516x/dev/uart-driver.c
@@ -66,14 +66,6 @@ extern volatile unsigned char xonxoff_state;
 
 #endif /* UART_XONXOFF_FLOW_CTRL */
 
-/***        Macro Definitions                                             ***/
-#define BUSYWAIT_UNTIL(cond, max_time) \
-  do { \
-    rtimer_clock_t t0; \
-    t0 = RTIMER_NOW(); \
-    while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (max_time))) ; \
-  } while(0)
-
 #define DEBUG_UART_BUFFERED FALSE
 
 #define CHAR_DEADLINE (uart_char_delay * 100)
@@ -276,7 +268,7 @@ uart_driver_write_with_deadline(uint8_t uart_dev, uint8_t ch)
   volatile int16_t write = 0;
   watchdog_periodic();
   /* wait until there is space in tx fifo */
-  BUSYWAIT_UNTIL(write = (uart_driver_get_tx_fifo_available_space(uart_dev) > 0),
+  RTIMER_BUSYWAIT_UNTIL(write = (uart_driver_get_tx_fifo_available_space(uart_dev) > 0),
                  CHAR_DEADLINE);
   /* write only if there is space so we do not get stuck */
   if(write) {

--- a/arch/platform/zoul/dev/cc1200-zoul-arch.c
+++ b/arch/platform/zoul/dev/cc1200-zoul-arch.c
@@ -76,18 +76,8 @@
 /*---------------------------------------------------------------------------*/
 #if DEBUG_CC1200_ARCH > 0
 #define PRINTF(...) printf(__VA_ARGS__)
-#define BUSYWAIT_UNTIL(cond, max_time)                                  \
-  do {                                                                  \
-    rtimer_clock_t t0;                                                  \
-    t0 = RTIMER_NOW();                                                  \
-    while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (max_time))) {} \
-    if(!(RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (max_time)))) { \
-      printf("ARCH: Timeout exceeded in line %d!\n", __LINE__); \
-    } \
-  } while(0)
 #else
 #define PRINTF(...)
-#define BUSYWAIT_UNTIL(cond, max_time) while(!cond)
 #endif
 /*---------------------------------------------------------------------------*/
 extern int cc1200_rx_interrupt(void);
@@ -105,7 +95,7 @@ cc1200_arch_spi_select(void)
   /* Set CSn to low (0) */
   GPIO_CLR_PIN(CC1200_SPI_CSN_PORT_BASE, CC1200_SPI_CSN_PIN_MASK);
   /* The MISO pin should go low before chip is fully enabled. */
-  BUSYWAIT_UNTIL(
+  RTIMER_BUSYWAIT_UNTIL(
     GPIO_READ_PIN(CC1200_SPI_MISO_PORT_BASE, CC1200_SPI_MISO_PIN_MASK) == 0,
     RTIMER_SECOND / 100);
 }
@@ -288,7 +278,7 @@ cc1200_arch_init(void)
   cc1200_arch_spi_deselect();
 
   /* Ensure MISO is high */
-  BUSYWAIT_UNTIL(
+  RTIMER_BUSYWAIT_UNTIL(
     GPIO_READ_PIN(CC1200_SPI_MISO_PORT_BASE, CC1200_SPI_MISO_PIN_MASK),
     RTIMER_SECOND / 10);
 }
@@ -297,4 +287,3 @@ cc1200_arch_init(void)
  * @}
  * @}
  */
-

--- a/arch/platform/zoul/dev/dht22.c
+++ b/arch/platform/zoul/dev/dht22.c
@@ -51,15 +51,6 @@
 #define PRINTF(...)
 #endif
 /*---------------------------------------------------------------------------*/
-#define BUSYWAIT_UNTIL(max_time) \
-  do { \
-    rtimer_clock_t t0; \
-    t0 = RTIMER_NOW(); \
-    while(RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (max_time))) { \
-      watchdog_periodic(); \
-    } \
-  } while(0)
-/*---------------------------------------------------------------------------*/
 #define DHT22_PORT_BASE          GPIO_PORT_TO_BASE(DHT22_PORT)
 #define DHT22_PIN_MASK           GPIO_PIN_MASK(DHT22_PIN)
 /*---------------------------------------------------------------------------*/
@@ -80,12 +71,12 @@ dht22_read(void)
     /* Exit low power mode and initialize variables */
     GPIO_SET_OUTPUT(DHT22_PORT_BASE, DHT22_PIN_MASK);
     GPIO_SET_PIN(DHT22_PORT_BASE, DHT22_PIN_MASK);
-    BUSYWAIT_UNTIL(DHT22_AWAKE_TIME);
+    RTIMER_BUSYWAIT(DHT22_AWAKE_TIME);
     memset(dht22_data, 0, DHT22_BUFFER);
 
     /* Initialization sequence */
     GPIO_CLR_PIN(DHT22_PORT_BASE, DHT22_PIN_MASK);
-    BUSYWAIT_UNTIL(DHT22_START_TIME);
+    RTIMER_BUSYWAIT(DHT22_START_TIME);
     GPIO_SET_PIN(DHT22_PORT_BASE, DHT22_PIN_MASK);
     clock_delay_usec(DHT22_READY_TIME);
 

--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -50,11 +50,6 @@
 #include "lib/list.h"
 #include "lib/memb.h"
 
-#if CONTIKI_TARGET_COOJA
-#include "lib/simEnvChange.h"
-#include "sys/cooja_mt.h"
-#endif /* CONTIKI_TARGET_COOJA */
-
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "CSMA"
@@ -207,10 +202,7 @@ send_one_packet(void *ptr)
           wt = RTIMER_NOW();
           watchdog_periodic();
           while(RTIMER_CLOCK_LT(RTIMER_NOW(), wt + CSMA_ACK_WAIT_TIME)) {
-#if CONTIKI_TARGET_COOJA
-            simProcessRunValue = 1;
-            cooja_mt_yield();
-#endif /* CONTIKI_TARGET_COOJA */
+            watchdog_periodic();
           }
 
           ret = MAC_TX_NOACK;
@@ -225,10 +217,7 @@ send_one_packet(void *ptr)
               watchdog_periodic();
               while(RTIMER_CLOCK_LT(RTIMER_NOW(),
                                     wt + CSMA_AFTER_ACK_DETECTED_WAIT_TIME)) {
-#if CONTIKI_TARGET_COOJA
-                simProcessRunValue = 1;
-                cooja_mt_yield();
-#endif /* CONTIKI_TARGET_COOJA */
+                watchdog_periodic();
               }
             }
 

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -737,7 +737,7 @@ PT_THREAD(tsch_scan(struct pt *pt))
     if(!is_packet_pending && NETSTACK_RADIO.receiving_packet()) {
       /* If we are currently receiving a packet, wait until end of reception */
       t0 = RTIMER_NOW();
-      BUSYWAIT_UNTIL_ABS((is_packet_pending = NETSTACK_RADIO.pending_packet()), t0, RTIMER_SECOND / 100);
+      RTIMER_BUSYWAIT_UNTIL_ABS((is_packet_pending = NETSTACK_RADIO.pending_packet()), t0, RTIMER_SECOND / 100);
     }
 
     if(is_packet_pending) {

--- a/os/net/mac/tsch/tsch.h
+++ b/os/net/mac/tsch/tsch.h
@@ -65,29 +65,11 @@ frequency hopping for enhanced reliability.
 #include "net/mac/tsch/tsch-rpl.h"
 #endif /* UIP_CONF_IPV6_RPL */
 
-#if CONTIKI_TARGET_COOJA
-#include "lib/simEnvChange.h"
-#include "sys/cooja_mt.h"
-#endif /* CONTIKI_TARGET_COOJA */
 
 /* Include Arch-Specific conf */
 #ifdef TSCH_CONF_ARCH_HDR_PATH
 #include TSCH_CONF_ARCH_HDR_PATH
 #endif /* TSCH_CONF_ARCH_HDR_PATH */
-
-/*********** Macros *********/
-
-/* Wait for a condition with timeout t0+offset. */
-#if CONTIKI_TARGET_COOJA
-#define BUSYWAIT_UNTIL_ABS(cond, t0, offset) \
-  while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), (t0) + (offset))) { \
-    simProcessRunValue = 1; \
-    cooja_mt_yield(); \
-  };
-#else
-#define BUSYWAIT_UNTIL_ABS(cond, t0, offset) \
-  while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), (t0) + (offset))) ;
-#endif /* CONTIKI_TARGET_COOJA */
 
 /*********** Callbacks *********/
 

--- a/os/sys/rtimer.h
+++ b/os/sys/rtimer.h
@@ -55,6 +55,7 @@
 
 #include "contiki.h"
 #include "dev/watchdog.h"
+#include <stdbool.h>
 
 /** \brief The rtimer size (in bytes) */
 #ifdef RTIMER_CONF_CLOCK_SIZE
@@ -189,18 +190,20 @@ void rtimer_arch_schedule(rtimer_clock_t t);
 
 /** \brief Busy-wait until a condition. Start time is t0, max wait time is max_time */
 #define RTIMER_BUSYWAIT_UNTIL_ABS(cond, t0, max_time) \
-  do { \
-    while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), (t0) + (max_time))) { \
-      watchdog_periodic(); \
-    } \
-  } while(0)
+  ({                                                                \
+    bool c;                                                         \
+    while(!(c = cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), (t0) + (max_time))) { \
+      watchdog_periodic();                                          \
+    }                                                               \
+    c;                                                              \
+  })
 
 /** \brief Busy-wait until a condition for at most max_time */
-#define RTIMER_BUSYWAIT_UNTIL(cond, max_time) \
-  do { \
-    rtimer_clock_t t0 = RTIMER_NOW(); \
-    RTIMER_BUSYWAIT_UNTIL_ABS(cond, t0, max_time); \
-  } while(0)
+#define RTIMER_BUSYWAIT_UNTIL(cond, max_time)       \
+  ({                                                \
+    rtimer_clock_t t0 = RTIMER_NOW();               \
+    RTIMER_BUSYWAIT_UNTIL_ABS(cond, t0, max_time);  \
+  })
 
 /** \brief Busy-wait for a fixed duration */
 #define RTIMER_BUSYWAIT(duration) RTIMER_BUSYWAIT_UNTIL(0, duration)

--- a/os/sys/rtimer.h
+++ b/os/sys/rtimer.h
@@ -54,6 +54,7 @@
 #define RTIMER_H_
 
 #include "contiki.h"
+#include "dev/watchdog.h"
 
 /** \brief The rtimer size (in bytes) */
 #ifdef RTIMER_CONF_CLOCK_SIZE
@@ -185,6 +186,24 @@ void rtimer_arch_schedule(rtimer_clock_t t);
 #else /* RTIMER_CONF_GUARD_TIME */
 #define RTIMER_GUARD_TIME (RTIMER_ARCH_SECOND >> 14)
 #endif /* RTIMER_CONF_GUARD_TIME */
+
+/** \brief Busy-wait until a condition. Start time is t0, max wait time is max_time */
+#define RTIMER_BUSYWAIT_UNTIL_ABS(cond, t0, max_time) \
+  do { \
+    while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), (t0) + (max_time))) { \
+      watchdog_periodic(); \
+    } \
+  } while(0)
+
+/** \brief Busy-wait until a condition for at most max_time */
+#define RTIMER_BUSYWAIT_UNTIL(cond, max_time) \
+  do { \
+    rtimer_clock_t t0 = RTIMER_NOW(); \
+    RTIMER_BUSYWAIT_UNTIL_ABS(cond, t0, max_time); \
+  } while(0)
+
+/** \brief Busy-wait for a fixed duration */
+#define RTIMER_BUSYWAIT(duration) RTIMER_BUSYWAIT_UNTIL(0, duration)
 
 #endif /* RTIMER_H_ */
 


### PR DESCRIPTION
This PR does a few things:
* Adds common routines for busy-waiting, in `rtimer.h`, thus de-duplicating code
* Makes the busy-wait routing fully portable, i.e. also works in Cooja motes without explicit addition of Cooja-mt-yield instructions
* Reworks CSMA busy-wait logic