### PR TITLE
Make CSMA stop waiting when ACK is received

### DIFF
--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -207,6 +207,7 @@ send_one_packet(void *ptr)
           wt = RTIMER_NOW();
           watchdog_periodic();
           while(RTIMER_CLOCK_LT(RTIMER_NOW(), wt + CSMA_ACK_WAIT_TIME)) {
+            watchdog_periodic();
 #if CONTIKI_TARGET_COOJA
             simProcessRunValue = 1;
             cooja_mt_yield();
@@ -225,6 +226,7 @@ send_one_packet(void *ptr)
               watchdog_periodic();
               while(RTIMER_CLOCK_LT(RTIMER_NOW(),
                                     wt + CSMA_AFTER_ACK_DETECTED_WAIT_TIME)) {
+                watchdog_periodic();
 #if CONTIKI_TARGET_COOJA
                 simProcessRunValue = 1;
                 cooja_mt_yield();

--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -206,7 +206,8 @@ send_one_packet(void *ptr)
           /* Check for ack */
           wt = RTIMER_NOW();
           watchdog_periodic();
-          while(RTIMER_CLOCK_LT(RTIMER_NOW(), wt + CSMA_ACK_WAIT_TIME)) {
+          while(!NETSTACK_RADIO.pending_packet()
+                && RTIMER_CLOCK_LT(RTIMER_NOW(), wt + CSMA_ACK_WAIT_TIME)) {
             watchdog_periodic();
 #if CONTIKI_TARGET_COOJA
             simProcessRunValue = 1;


### PR DESCRIPTION
This PR aims to address the following issues:

- When the ACK waiting time is large (for example `#define CSMA_CONF_ACK_WAIT_TIME (RTIMER_SECOND / 2)`, the watchdog kicks in before the ACK waiting time is over, resetting the node.

- CSMA uses a fixed period to wait and only then reads the received packet from the cc1200 driver. Therefore, the next scenario could occur: node A sends a message to node B and waits for `CSMA_CONF_ACK_WAIT_TIME` time. In this interval the ACK is send from node B to A, but soon followed with an answer message from node B to A before the `CSMA_CONF_ACK_WAIT_TIME` interval of node A has passed. The ACK comes first and occupies the driver's buffer, causing node A to discard the answer message from node B and thus triggering a retransmission from node B later on.

As CSMA is a widely used base feature of contiki-ng, I urge everyone to test this PR extensively. It helped me achieve better performance and reduced duty cycle, but I've only had limited means (Zolertia Remote with CC1200 chip) to try this out.

With kind regards,

Martijn
