### PR TITLE
Travis Docker push fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 # Environment setup before test script. Runs for each build
 before_install:
   # Check if anything has changed within the docker directory
-  - DOCKER_CHANGED=`git diff --name-only $TRAVIS_BRANCH...HEAD -- tools/docker | wc -l`
+  - DOCKER_CHANGED=`git diff --name-only $TRAVIS_COMMIT_RANGE -- tools/docker | wc -l`
   # If Docker directory has not changed, pull image from Dockerhub. Else, build
   # image from Dockerifle. This needs to be done for each job. Any build error
   # will count as Travis test failure. In case this updates develop, push new


### PR DESCRIPTION
As it turns out, https://github.com/contiki-ng/contiki-ng/pull/554, failed to push the new Dockerfile to Dockerhub. No real harm, in that this does not break anything, but let's get this fixed.

The issue was in the test for changes in the `tools/docker` directory, done as follows:
```
git diff --name-only $TRAVIS_BRANCH...HEAD -- tools/docker | wc -l
```

This worked fine in PRs, but failed to detect the Dockerfile change on the merge CI run.

This PR fixes the issue by using this instead:
```
git diff --name-only $TRAVIS_COMMIT_RANGE -- tools/docker | wc -l
```

# Test

I tested this on my own repo, as follows:
* Do a PR that changes the Dockerfile: https://travis-ci.org/simonduq/contiki-ng/builds/387999221
The PR test issues:
```
Docker image changed, build from Dockerfile
```
* Merge the PR: https://travis-ci.org/simonduq/contiki-ng/builds/388000449
The merge test issues:
```
Docker image changed, build from Dockerfile
This build is for an update of branch develop. Push image to Dockerhub
```
* Do a PR that changes just a readme file: https://travis-ci.org/simonduq/contiki-ng/builds/388000632
The second PR test issues:
```
Docker image unchanged, pull from Dockerhub
```
* Merge the second PR: https://travis-ci.org/simonduq/contiki-ng/builds/388001120
The second merge test issues:
```
Docker image unchanged, pull from Dockerhub
```

All as intended.