### PR TITLE
rx full IRQ handling for cc13xx/cc26xx

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/arch/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -263,6 +263,9 @@ typedef struct rf_core_primary_mode_s {
 /* Radio timer register */
 #define RATCNT  0x00000004
 /*---------------------------------------------------------------------------*/
+/* Buffer full flag */
+extern volatile bool rx_is_full;
+/*---------------------------------------------------------------------------*/
 /* Make the main driver process visible to mode drivers */
 PROCESS_NAME(rf_core_process);
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Hello,

now after some problems with the pull request the correct one.

After i testes these pull request from contiki contiki-os/contiki#2161 and it gave at high traffic a huge improvement for me, it should be even changed at contiki-ng.

It only implements the rx full IRQ handling, even the points regarding the bypass of the rf on checks should not apply to it.

Please check the request.

Regards,
Martin