### PR TITLE
Specify default tun/tap name on Mac OS

### DIFF
--- a/tools/serial-io/tunslip6.c
+++ b/tools/serial-io/tunslip6.c
@@ -885,6 +885,17 @@ exit(1);
     }
   }
 
+#ifdef __APPLE__
+  if(*tundev == '\0') {
+    /* Use default. */
+    if(tap) {
+      strcpy(tundev, "tap0");
+    } else {
+      strcpy(tundev, "tun0");
+    }
+  }
+#endif
+
   if(host != NULL) {
     struct addrinfo hints, *servinfo, *p;
     int rv;


### PR DESCRIPTION
e5c7437 fixed a bug that was preventing multiple instances of tunslip6 from running. This same commit however broke tunslip6 on Mac OS, as documented in contiki-os/contiki#1560 as well as in contiki-ng/contiki-ng#466

Basically the commit in question merely removed some code. This commit puts that code back in, but makes it conditional for Mac OS.

Fixes #466