### PR TITLE
Fix log output from uip_icmp6_send function.

### DIFF
--- a/os/net/ipv6/uip-icmp6.c
+++ b/os/net/ipv6/uip-icmp6.c
@@ -253,10 +253,6 @@ uip_icmp6_error_output(uint8_t type, uint8_t code, uint32_t param) {
 void
 uip_icmp6_send(const uip_ipaddr_t *dest, int type, int code, int payload_len)
 {
-  LOG_INFO("Sending ICMPv6 packet to ");
-  LOG_INFO_6ADDR(&UIP_IP_BUF->destipaddr);
-  LOG_INFO_(", type %u, code %u, len %u\n", type, code, payload_len);
-
   UIP_IP_BUF->vtc = 0x60;
   UIP_IP_BUF->tcflow = 0;
   UIP_IP_BUF->flow = 0;
@@ -278,6 +274,10 @@ uip_icmp6_send(const uip_ipaddr_t *dest, int type, int code, int payload_len)
 
   UIP_STAT(++uip_stat.icmp.sent);
   UIP_STAT(++uip_stat.ip.sent);
+
+  LOG_INFO("Sending ICMPv6 packet to ");
+  LOG_INFO_6ADDR(&UIP_IP_BUF->destipaddr);
+  LOG_INFO_(", type %u, code %u, len %u\n", type, code, payload_len);
 
   tcpip_ipv6_output();
 }


### PR DESCRIPTION
This patch just moves log message output from the beginning to the end of the function.

It prints `UIP_IP_BUF->destipaddr`, but this is updated in the middle of this function. Before this fix, the address was NOT the destination of the ICMPv6 packet, but was whatever destination that previous operation wrote to uip_buf.
