### PR TITLE
Remove gcc-8 warnings

### DIFF
--- a/tools/serial-io/tunslip6.c
+++ b/tools/serial-io/tunslip6.c
@@ -579,8 +579,10 @@ tun_alloc(char *dev, int tap)
    *        IFF_NO_PI - Do not provide packet information
    */
   ifr.ifr_flags = (tap ? IFF_TAP : IFF_TUN) | IFF_NO_PI;
-  if(*dev != 0)
-    strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+  if(*dev != 0) {
+    strncpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name)-1);
+    ifr.ifr_name[sizeof(ifr.ifr_name)-1] = '\0';
+  }
 
   if((err = ioctl(fd, TUNSETIFF, (void *) &ifr)) < 0 ) {
     close(fd);
@@ -806,10 +808,11 @@ main(int argc, char **argv)
 
     case 't':
       if(strncmp("/dev/", optarg, 5) == 0) {
-	strncpy(tundev, optarg + 5, sizeof(tundev));
+        strncpy(tundev, optarg + 5, sizeof(tundev)-1);
       } else {
-	strncpy(tundev, optarg, sizeof(tundev));
+        strncpy(tundev, optarg, sizeof(tundev)-1);
       }
+      tundev[sizeof(tundev)-1] = '\0';
       break;
 
     case 'a':

--- a/tools/serial-io/tunslip6.c
+++ b/tools/serial-io/tunslip6.c
@@ -795,9 +795,9 @@ main(int argc, char **argv)
 
     case 's':
       if(strncmp("/dev/", optarg, 5) == 0) {
-	siodev = optarg + 5;
+        siodev = optarg + 5;
       } else {
-	siodev = optarg;
+        siodev = optarg;
       }
       break;
 


### PR DESCRIPTION
Dear all, 

As you may know, gcc-8 introduced a new Warning : stringop-truncation

https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/

It's intended to detect misused of some string.h functions
This PR is what I currently do with gcc-8 to get ''make -C tests/'' and ''make -C tests/compile-all'' working.

I use :
`strncpy => memcpy` 

and

```c
strncpy(dest,source,sizeof(dest)-1) ;
dest[sizeof(dest)-1]='\0' ;
```

which are two possible ways of dealing with these warnings depending on the situation

for example 

https://github.com/tpetazzoni/libfaketime/commit/0d964363a4352b7ee358f523c3416d07378d4583

and

https://patchwork.kernel.org/patch/10311553/

Can someone have a look at examples/rpl-border-router/webserver/httpd-simple.c since I don't use the webserver feature and I am not sure what is the correct thing to do here. (in my case sizeof(s->filename)=2)




