### PR TITLE
Add option to validate dio before init dag

### DIFF
--- a/os/net/routing/rpl-lite/rpl-conf.h
+++ b/os/net/routing/rpl-lite/rpl-conf.h
@@ -191,6 +191,13 @@
 #define RPL_DEFAULT_LEAF_ONLY 0
 #endif
 
+/*
+ * Function used to validate dio before using it to init dag
+ */
+#ifdef RPL_CONF_VALIDATE_DIO_FUNC
+#define RPL_VALIDATE_DIO_FUNC RPL_CONF_VALIDATE_DIO_FUNC
+#endif
+
 /******************************************************************************/
 /********************************** Timing ************************************/
 /******************************************************************************/

--- a/os/net/routing/rpl-lite/rpl-dag.c
+++ b/os/net/routing/rpl-lite/rpl-dag.c
@@ -62,6 +62,12 @@ static int init_dag_from_dio(rpl_dio_t *dio);
 rpl_instance_t curr_instance;
 
 /*---------------------------------------------------------------------------*/
+
+#ifdef RPL_VALIDATE_DIO_FUNC
+int RPL_VALIDATE_DIO_FUNC(rpl_dio_t *dio);
+#endif /* RPL_PROBING_SELECT_FUNC */
+
+/*---------------------------------------------------------------------------*/
 const char *
 rpl_dag_state_to_str(enum rpl_dag_state state)
 {
@@ -542,6 +548,13 @@ init_dag_from_dio(rpl_dio_t *dio)
 static int
 process_dio_init_dag(uip_ipaddr_t *from, rpl_dio_t *dio)
 {
+#ifdef RPL_VALIDATE_DIO_FUNC
+  if(!RPL_VALIDATE_DIO_FUNC(dio)) {
+    LOG_WARN("DIO validation failed\n");
+    return 0;
+  }
+#endif
+
   /* Check MOP */
   if(dio->mop != RPL_MOP_NO_DOWNWARD_ROUTES && dio->mop != RPL_MOP_NON_STORING) {
     LOG_WARN("ignoring DIO with an unsupported MOP: %d\n", dio->mop);


### PR DESCRIPTION
This gives the developer the tools to validate a dio before using it to init the dag. If 0 is returned then the dag will not be initiated.

Main use case for this is preventing the device from joining certain networks.

**Some background:** 

We are creating a product that has a local server that the nodes in the network need to communicate with. The server has a whitelist of devices that are allowed to communicate with it. It is possible that more then one network is running (one in company a, the other in company b across the street for example). If the server tells the device it will not communicate with it because it is not whitelisted the device should leave the network and try another one. This validation function will allow us to control if the device should join the network or not, if the dag id is one we have already tried we return 0 and the dio will be skipped.