### PR TITLE
Fix Antelope issues with memory checking

### DIFF
--- a/os/storage/antelope/aql-adt.c
+++ b/os/storage/antelope/aql-adt.c
@@ -91,6 +91,21 @@ aql_clear(aql_adt_t *adt)
 }
 
 db_result_t
+aql_add_relation(aql_adt_t *adt, const char *name)
+{
+  if(adt->relation_count >= AQL_RELATION_LIMIT) {
+    return DB_LIMIT_ERROR;
+  }
+
+  strncpy(adt->relations[adt->relation_count], name,
+	  sizeof(adt->relations[0]) - 1);
+  adt->relations[adt->relation_count][sizeof(adt->relations[0]) - 1] = '\0';
+  adt->relation_count++;
+
+  return DB_OK;
+}
+
+db_result_t
 aql_add_attribute(aql_adt_t *adt, char *name, domain_t domain,
                    unsigned element_size, int processed_only)
 {

--- a/os/storage/antelope/aql-lexer.c
+++ b/os/storage/antelope/aql-lexer.c
@@ -207,6 +207,10 @@ next_string(lexer_t *lexer, const char *s)
   *lexer->token = STRING_VALUE;
   lexer->input = end + 1; /* Skip the closing delimiter. */
 
+  if(length > DB_MAX_ELEMENT_SIZE - 1) {
+    length = DB_MAX_ELEMENT_SIZE - 1;
+  }
+
   memcpy(lexer->value, s, length);
   (*lexer->value)[length] = '\0';
 
@@ -235,6 +239,10 @@ next_token(lexer_t *lexer, const char *s)
      so we regard it as an identifier. */
 
   *lexer->token = IDENTIFIER;
+
+  if(length > DB_MAX_ELEMENT_SIZE - 1) {
+    length = DB_MAX_ELEMENT_SIZE - 1;
+  }
 
   memcpy(lexer->value, s, length);
   (*lexer->value)[length] = '\0';

--- a/os/storage/antelope/aql-parser.c
+++ b/os/storage/antelope/aql-parser.c
@@ -269,8 +269,10 @@ PARSER(operand)
   NEXT;
   switch(TOKEN) {
   case IDENTIFIER:
-    lvm_register_variable(VALUE, LVM_LONG);
-    lvm_set_variable(&p, VALUE);
+    if(LVM_ERROR(lvm_register_variable(VALUE, LVM_LONG)) ||
+       LVM_ERROR(lvm_set_variable(&p, VALUE))) {
+      RETURN(SYNTAX_ERROR);
+    }
     AQL_ADD_PROCESSING_ATTRIBUTE(adt, VALUE);
     break;
   case STRING_VALUE:
@@ -278,7 +280,9 @@ PARSER(operand)
   case FLOAT_VALUE:
     break;
   case INTEGER_VALUE:
-    lvm_set_long(&p, *(long *)lexer->value);
+    if(LVM_ERROR(lvm_set_long(&p, *(long *)lexer->value))) {
+      RETURN(SYNTAX_ERROR);
+    }
     break;
   default:
     RETURN(SYNTAX_ERROR);
@@ -340,7 +344,9 @@ PARSER(expr)
     default:
       RETURN(SYNTAX_ERROR);
     }
-    lvm_set_op(&p, op);
+    if(LVM_ERROR(lvm_set_op(&p, op))) {
+      RETURN(SYNTAX_ERROR);
+    }
     lvm_set_end(&p, saved_end);
   }
 
@@ -389,7 +395,9 @@ PARSER(comparison)
     RETURN(SYNTAX_ERROR);
   }
 
-  lvm_set_relation(&p, rel);
+  if(LVM_ERROR(lvm_set_relation(&p, rel))) {
+    RETURN(SYNTAX_ERROR);
+  }
   lvm_set_end(&p, saved_end);
 
   if(!PARSE(expr)) {
@@ -422,7 +430,9 @@ PARSER(where)
     connective = TOKEN == AND ? LVM_AND : LVM_OR;
 
     saved_end = lvm_shift_for_operator(&p, saved_end);
-    lvm_set_relation(&p, connective);
+    if(LVM_ERROR(lvm_set_relation(&p, connective))) {
+      RETURN(SYNTAX_ERROR);
+    }
     lvm_set_end(&p, saved_end);
   
     NEXT;

--- a/os/storage/antelope/aql.h
+++ b/os/storage/antelope/aql.h
@@ -188,10 +188,10 @@ typedef struct aql_adt aql_adt_t;
 
 #define AQL_SET_FLAG(adt, flag)	(((adt)->flags) |= (flag))
 #define AQL_GET_FLAGS(adt)		((adt)->flags)
-#define AQL_ADD_RELATION(adt, rel)					\
-  strcpy((adt)->relations[(adt)->relation_count++], (rel))
 #define AQL_RELATION_COUNT(adt)	((adt)->relation_count)
-#define AQL_ADD_ATTRIBUTE(adt, attr, dom, size)			\
+#define AQL_ADD_RELATION(adt, name) \
+    aql_add_relation(adt, name)
+#define AQL_ADD_ATTRIBUTE(adt, attr, dom, size)	\
     aql_add_attribute(adt, attr, dom, size, 0)
 #define AQL_ADD_PROCESSING_ATTRIBUTE(adt, attr)			\
     aql_add_attribute((adt), (attr), DOMAIN_UNSPECIFIED, 0, 1)
@@ -211,6 +211,7 @@ void lexer_rewind(lexer_t *);
 
 void aql_clear(aql_adt_t *adt);
 aql_status_t aql_parse(aql_adt_t *adt, char *query_string);
+db_result_t aql_add_relation(aql_adt_t *adt, const char *name);
 db_result_t aql_add_attribute(aql_adt_t *adt, char *name,
                                domain_t domain, unsigned element_size,
                                int processed_only);

--- a/os/storage/antelope/db-options.h
+++ b/os/storage/antelope/db-options.h
@@ -108,7 +108,7 @@
 /* The maximum size of the LVM bytecode compiled from a
    single database query. */
 #ifndef DB_VM_BYTECODE_SIZE
-#define DB_VM_BYTECODE_SIZE		128
+#define DB_VM_BYTECODE_SIZE		256
 #endif /* DB_VM_BYTECODE_SIZE */
 
 /*----------------------------------------------------------------------------*/

--- a/os/storage/antelope/lvm.h
+++ b/os/storage/antelope/lvm.h
@@ -45,16 +45,16 @@
 #include "db-options.h"
 
 enum lvm_status {
-  FALSE = 0,
-  TRUE = 1,
-  INVALID_IDENTIFIER = 2,
-  SEMANTIC_ERROR = 3,
-  MATH_ERROR = 4,
-  STACK_OVERFLOW = 5,
-  TYPE_ERROR = 6,
-  VARIABLE_LIMIT_REACHED = 7,
-  EXECUTION_ERROR = 8,
-  DERIVATION_ERROR = 9
+  LVM_FALSE = 0,
+  LVM_TRUE = 1,
+  LVM_INVALID_IDENTIFIER = 2,
+  LVM_SEMANTIC_ERROR = 3,
+  LVM_MATH_ERROR = 4,
+  LVM_STACK_OVERFLOW = 5,
+  LVM_TYPE_ERROR = 6,
+  LVM_VARIABLE_LIMIT_REACHED = 7,
+  LVM_EXECUTION_ERROR = 8,
+  LVM_DERIVATION_ERROR = 9
 };
 
 typedef enum lvm_status lvm_status_t;
@@ -135,10 +135,10 @@ lvm_ip_t lvm_jump_to_operand(lvm_instance_t *p);
 lvm_ip_t lvm_shift_for_operator(lvm_instance_t *p, lvm_ip_t end);
 lvm_ip_t lvm_get_end(lvm_instance_t *p);
 lvm_ip_t lvm_set_end(lvm_instance_t *p, lvm_ip_t end);
-void lvm_set_op(lvm_instance_t *p, operator_t op);
-void lvm_set_relation(lvm_instance_t *p, operator_t op);
-void lvm_set_operand(lvm_instance_t *p, operand_t *op);
-void lvm_set_long(lvm_instance_t *p, long l);
-void lvm_set_variable(lvm_instance_t *p, char *name);
+lvm_status_t lvm_set_op(lvm_instance_t *p, operator_t op);
+lvm_status_t lvm_set_relation(lvm_instance_t *p, operator_t op);
+lvm_status_t lvm_set_operand(lvm_instance_t *p, operand_t *op);
+lvm_status_t lvm_set_long(lvm_instance_t *p, long l);
+lvm_status_t lvm_set_variable(lvm_instance_t *p, char *name);
 
 #endif /* LVM_H */

--- a/os/storage/antelope/relation.c
+++ b/os/storage/antelope/relation.c
@@ -813,9 +813,9 @@ relation_process_select(void *handle_ptr)
     }
   }
 
-  wanted_result = TRUE;
+  wanted_result = LVM_TRUE;
   if(AQL_GET_FLAGS(adt) & AQL_FLAG_INVERSE_LOGIC) {
-    wanted_result = FALSE;
+    wanted_result = LVM_FALSE;
   }
 
   /* Check whether the given predicate is true for this tuple. */


### PR DESCRIPTION
Addresses the issues pointed out in #594, #595, #596, #597, #598, and #599.

The attack vector, as pointed out in the reports, is limited to when an attacker has access to insert DB queries directly, which should not be allowed for multiple reasons. Still, the reports will help remove some crashes on invalid input.

Next on the agenda is to create a new set of tests for storage (including tests for the aforementioned issues), but this will be addressed in a later PR.

Thanks to @cve-reporting for the report, and sorry for the late reply -- a long vacation just ended.

Fixes #594 
Fixes #595
Fixes #596 
Fixes #597 
Fixes #598 
Fixes #599
