### PR TITLE
Set correct DNS record expiration time

### DIFF
--- a/os/net/ipv6/resolv.c
+++ b/os/net/ipv6/resolv.c
@@ -1017,7 +1017,8 @@ newdata(void)
 
     namemapptr->state = STATE_DONE;
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
-    namemapptr->expiration = ans->ttl[1] + (ans->ttl[0] << 8);
+    namemapptr->expiration = (uint32_t) uip_ntohs(ans->ttl[0]) << 16 |
+        (uint32_t) uip_ntohs(ans->ttl[1]);
     namemapptr->expiration += clock_seconds();
 #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
 


### PR DESCRIPTION
When receiving a DNS response, the TTL field is parsed and used to determine when a record should be flagged as expired. This parsing seems to assume the TTL is stored in an _uint8_t_ array, while it is actually in an _uint16_t_ array - and thus record expirations are incorrect. This PR fixes this.

Some extra scrutiny might be warranted here, since this code is  ~6 years old, and as far as I can tell it has always been like this... 🤔 

Disclaimer: I currently live in contiki - not tested on contiki-ng