### PR TITLE
Fix bug in CoAP retransmission policy

### DIFF
--- a/os/net/app-layer/coap/coap-transactions.c
+++ b/os/net/app-layer/coap/coap-transactions.c
@@ -98,12 +98,11 @@ coap_send_transaction(coap_transaction_t *t)
 {
   LOG_DBG("Sending transaction %u\n", t->mid);
 
-  coap_sendto(&t->endpoint, t->message, t->message_len);
-
   if(COAP_TYPE_CON ==
      ((COAP_HEADER_TYPE_MASK & t->message[0]) >> COAP_HEADER_TYPE_POSITION)) {
-    if(t->retrans_counter < COAP_MAX_RETRANSMIT) {
+    if(t->retrans_counter <= COAP_MAX_RETRANSMIT) {
       /* not timed out yet */
+      coap_sendto(&t->endpoint, t->message, t->message_len);
       LOG_DBG("Keeping transaction %u\n", t->mid);
 
       if(t->retrans_counter == 0) {
@@ -138,6 +137,7 @@ coap_send_transaction(coap_transaction_t *t)
       }
     }
   } else {
+    coap_sendto(&t->endpoint, t->message, t->message_len);
     coap_clear_transaction(t);
   }
 }


### PR DESCRIPTION
I'm new to Contiki, but I think I found a bug in the CoAP implementation.

When sending a CON request for which no ACK is received, this is what I observe:

1. Packet is sent
2. Wait for ~3 s
3. Packet is retransmitted
4. Wait for ~6 s
5. Packet is retransmitted
6. Wait for ~12 s
7. Packet is retransmitted
8. Wait for ~24 s
9. Packet is retransmitted
10. Transaction times out

Between steps 9 and 10, I would expect the system to wait for ~48 s, but that does not happen. I think this is a bug.

This pull request proposes a simple fix.