### PR TITLE
CoAP: allow observations that do not timeout

### DIFF
--- a/os/net/app-layer/coap/coap-conf.h
+++ b/os/net/app-layer/coap/coap-conf.h
@@ -99,7 +99,9 @@
 #endif /* COAP_MAX_OBSERVERS */
 
 /* Interval in notifies in which NON notifies are changed to CON notifies to check client. */
-#ifndef COAP_OBSERVE_REFRESH_INTERVAL
+#ifdef COAP_CONF_OBSERVE_REFRESH_INTERVAL
+#define COAP_OBSERVE_REFRESH_INTERVAL COAP_CONF_OBSERVE_REFRESH_INTERVAL
+#else
 #define COAP_OBSERVE_REFRESH_INTERVAL  20
 #endif /* COAP_OBSERVE_REFRESH_INTERVAL */
 

--- a/os/net/app-layer/coap/coap-observe.c
+++ b/os/net/app-layer/coap/coap-observe.c
@@ -244,7 +244,9 @@ coap_notify_observers_sub(coap_resource_t *resource, const char *subpath)
       /*TODO implement special transaction for CON, sharing the same buffer to allow for more observers */
 
       if((transaction = coap_new_transaction(coap_get_mid(), &obs->endpoint))) {
-        if(obs->obs_counter % COAP_OBSERVE_REFRESH_INTERVAL == 0) {
+        /* if COAP_OBSERVE_REFRESH_INTERVAL is zero, never send observations as confirmable messages */
+        if(COAP_OBSERVE_REFRESH_INTERVAL != 0
+            && (obs->obs_counter % COAP_OBSERVE_REFRESH_INTERVAL == 0)) {
           LOG_DBG("           Force Confirmable for\n");
           notification->type = COAP_TYPE_CON;
         }


### PR DESCRIPTION
This is just a simple change, but it allows the user to disable a CoAP behavior that is a bit of my personal pet annoyance.

Now, I'm aware that the RFC 7641 uses MUST here. Let me cite it:

>    A server that transmits notifications mostly in non-confirmable
>    messages MUST send a notification in a confirmable message instead of
>    a non-confirmable message at least every 24 hours.  This prevents a
>    client that went away or is no longer interested from remaining in
>    the list of observers indefinitely.
> 

There are two problems with this:
1. The server may use some other mechanism to infer that there is a client willing to get data from it. In many IoT applications "being part of the RPL network is a sufficient condition for this. If not, there are tons of options for out-of-band signaling that bypass CoAP.
2. The periodic switches between  confirmable  and nonconfirmable observations plays very badly with 6top. After sending out a confirmable which needs multiple retries, the 6top scheduling function basically assumes that the game is over and starts deallocating cells. When the node finally gets the ACK, 6top has to redo all the scheduling again.

This PR does not change the default behavior (if smooth support for 6top becomes a priority, maybe it should?), it just allows the user to set `COAP_CONF_OBSERVE_REFRESH_INTERVAL` to zero.