### PR TITLE
Fix get_temp_value for lwm2m-ipso-object example

### DIFF
--- a/os/services/ipso-objects/ipso-temperature.c
+++ b/os/services/ipso-objects/ipso-temperature.c
@@ -74,8 +74,8 @@ static lwm2m_status_t
 get_temp_value(const ipso_sensor_t *s, int32_t *value)
 {
 #ifdef IPSO_TEMPERATURE
-  if(IPSO_TEMPERATURE.read_value == NULL ||
-     IPSO_TEMPERATURE.read_value(value) != 0) {
+  if(IPSO_TEMPERATURE.read_value != NULL &&
+     IPSO_TEMPERATURE.read_value(value) == 0) {
     return LWM2M_STATUS_OK;
   }
 #endif /* IPSO_TEMPERATURE */


### PR DESCRIPTION
With this change resource /3303/0/5700 (Temperature Sensor Value) could be
read and observe without error. 
Tested with TARGET=cc2538dk and Leshan Version 1.0.0-SNAPSHOT

Signed-off-by: Kiril Petrov <contiki@geomi.org>