### PR TITLE
RPL-CLASSIC: Add guard for urgent probing

### DIFF
--- a/os/net/routing/rpl-classic/rpl.c
+++ b/os/net/routing/rpl-classic/rpl.c
@@ -268,9 +268,11 @@ rpl_link_callback(const linkaddr_t *addr, int status, int numtx)
       if(parent != NULL) {
         /* If this is the neighbor we were probing urgently, mark urgent
         probing as done */
+#if RPL_WITH_PROBING
         if(instance->urgent_probing_target == parent) {
           instance->urgent_probing_target = NULL;
         }
+#endif /* RPL_WITH_PROBING */
         /* Trigger DAG rank recalculation. */
         PRINTF("RPL: rpl_link_callback triggering update\n");
         parent->flags |= RPL_PARENT_FLAG_UPDATED;


### PR DESCRIPTION
Compiling with RPL_CONF_WITH_PROBING := 0 was not possible due to `urgent_probing_target`
not present.