### PR TITLE
CSMA: Allow transmission of packets with broadcast panid

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -1551,6 +1551,7 @@ output(const linkaddr_t *localdest)
   int framer_hdrlen;
   int max_payload;
   int frag_needed;
+  uint16_t uipflags;
 
   /* The MAC address of the destination of the packet */
   linkaddr_t dest;
@@ -1562,6 +1563,8 @@ output(const linkaddr_t *localdest)
   /* reset packetbuf buffer */
   packetbuf_clear();
   packetbuf_ptr = packetbuf_dataptr();
+
+  uipflags = uipbuf_get_attr(UIPBUF_ATTR_FLAGS);
 
   if(callback) {
     /* call the attribution when the callback comes, but set attributes
@@ -1585,6 +1588,10 @@ output(const linkaddr_t *localdest)
   /* copy over the retransmission count from uipbuf attributes */
   packetbuf_set_attr(PACKETBUF_ATTR_MAX_MAC_TRANSMISSIONS,
                      uipbuf_get_attr(UIPBUF_ATTR_MAX_MAC_TRANSMISSIONS));
+
+  if (UIPBUF_ATTR_FLAGS_FRAMER_BROADCAST & uipflags) {
+    packetbuf_set_attr(PACKETBUF_ATTR_BROADCAST_PAN, 1);
+  }
 
 /* Calculate NETSTACK_FRAMER's header length, that will be added in the NETSTACK_MAC */
   packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, &dest);

--- a/os/net/ipv6/uipbuf.h
+++ b/os/net/ipv6/uipbuf.h
@@ -123,6 +123,7 @@ void uipbuf_clear_attr(void);
 #define UIPBUF_ATTR_FLAGS_6LOWPAN_NO_NHC_COMPRESSION      0x01
 /* Avoid using prefix compression on the packet (6LoWPAN) */
 #define UIPBUF_ATTR_FLAGS_6LOWPAN_NO_PREFIX_COMPRESSION   0x02
+#define UIPBUF_ATTR_FLAGS_FRAMER_BROADCAST                0x04
 
 /**
  * \brief The attributes defined for uipbuf attributes function.

--- a/os/net/mac/framer/framer-802154.c
+++ b/os/net/mac/framer/framer-802154.c
@@ -62,7 +62,8 @@ create_frame(int do_create)
   frame802154_t params;
   int hdr_len;
 
-  if(frame802154_get_pan_id() == 0xffff) {
+
+  if(frame802154_get_pan_id() == 0xffff && 1 != broadcastpan) {
     return -1;
   }
 
@@ -193,7 +194,9 @@ framer_802154_setup_params(packetbuf_attr_t (*get_attr)(uint8_t type),
     }
   }
 
-  params->dest_pid = frame802154_get_pan_id();
+  params->dest_pid = get_attr(PACKETBUF_ATTR_BROADCAST_PAN)
+                      ? FRAME802154_BROADCASTPANDID
+                      : frame802154_get_pan_id();
 
   /* Destination address itself should be set outside this function. */
   if(get_attr(PACKETBUF_ATTR_MAC_NO_DEST_ADDR) == 1) {

--- a/os/net/packetbuf.h
+++ b/os/net/packetbuf.h
@@ -238,6 +238,8 @@ enum {
   PACKETBUF_ATTR_KEY_INDEX,
 #endif /* LLSEC802154_USES_EXPLICIT_KEYS */
 
+  PACKETBUF_ATTR_BROADCAST_PAN,
+
   /* Scope 2 attributes: used between end-to-end nodes. */
   /* These must be last */
   PACKETBUF_ADDR_SENDER,


### PR DESCRIPTION
All outgoing packets with broadcast panid was discarded. This allows caller to tag any packet to be transmitted on the broadcast pan id (0xffff).

This is usefull for building logic for network discovery or for transmitting data to multiple PAN's.