### PR TITLE
CC26xx RF: in polling mode, disable the CPE0 radio interrupt completely

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/arch/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -512,8 +512,12 @@ rf_core_setup_interrupts(void)
 void
 rf_core_cmd_done_en(bool fg)
 {
-  uint32_t irq = fg ? IRQ_LAST_FG_COMMAND_DONE : IRQ_LAST_COMMAND_DONE;
+  uint32_t irq = 0;
   const uint32_t enabled_irqs = rf_core_poll_mode ? ENABLED_IRQS_POLL_MODE : ENABLED_IRQS;
+
+  if(!rf_core_poll_mode) {
+    irq = fg ? IRQ_LAST_FG_COMMAND_DONE : IRQ_LAST_COMMAND_DONE;
+  }
 
   HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = enabled_irqs;
   HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = enabled_irqs | irq;


### PR DESCRIPTION
The polling mode on CC26xx is not behaving as it should. The code that puts the radio in poll mode disables CPE0 on `RX_FRAME_IRQ`. However, we still get loads of CPE0 interrupts on  `IRQ_LAST_FG_COMMAND_DONE` and `IRQ_LAST_COMMAND_DONE` (apparently they are enabled by default).

Now, the ISR looks at the flag status, sees that the `RX_FRAME_IRQ` flag is set, calls     `process_poll(&rf_core_process);` which feeds the packet to the MAC protocol. This is not what we want. At best, it's just more energy consumed, at worst, it could break TSCH which expects to receive packets by itself instead of receiving them directly from the radio driver.

The need for the CPE0 interrupt in the polling mode at all is not clear to me. So I disabled it, tested this change for a while, and it does not seem to break things.