### PR TITLE
Generate a descriptive error message in case cc26xxware/cc13xxware does not exist

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/arch/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -1,6 +1,12 @@
 CPU_ABS_PATH       = arch/cpu/cc26xx-cc13xx
 TI_XXWARE = $(CONTIKI_CPU)/$(TI_XXWARE_PATH)
 
+ifeq (,$(wildcard $(TI_XXWARE)))
+    $(warning $(TI_XXWARE) does not exist.)
+    $(warning Did you run 'git submodule update --init' ?)
+    $(error "")
+endif
+
 ### cc26xxware sources under driverlib will be added to the MODULES list
 TI_XXWARE_SRC = $(CPU_ABS_PATH)/$(TI_XXWARE_PATH)/driverlib
 


### PR DESCRIPTION
I think everyone when getting started with CC26xx/CC13xx has seen this error message.

```
In file included from ../../../arch/platform/srf06-cc26xx/./contiki-conf.h:79:0,
                 from ../../../os/contiki.h:37,
                 from node.c:39:
../../../arch/platform/srf06-cc26xx/srf06/cc26xx/board.h:58:17: fatal error: ioc.h: No such file or directory
 #include "ioc.h"
                 ^
compilation terminated.
```

This patch aims to replace it with something more descriptive.