### PR TITLE
Make cc26xx radio driver configurable in prop mode operation

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/cc13xx-cc26xx-conf.h
+++ b/arch/cpu/cc26xx-cc13xx/cc13xx-cc26xx-conf.h
@@ -71,7 +71,9 @@
 #endif /* CPU_FAMILY_CC13XX */
 
 #if CC13XX_CONF_PROP_MODE
+#ifndef NETSTACK_CONF_RADIO
 #define NETSTACK_CONF_RADIO        prop_mode_driver
+#endif /* NETSTACK_CONF_RADIO */
 
 /* Channels count from 0 upwards in IEEE 802.15.4g */
 #ifndef IEEE802154_CONF_DEFAULT_CHANNEL


### PR DESCRIPTION
Make cc26xx radio driver configurable in prop mode
    
It's already possible to override the default radio driver when operating in IEEE mode. This patch opens up for users defining their own radio driver when using prop mode. This is useful when overriding certain radio driver functions.
