### PR TITLE
Fix RPL classic compilation for TARGET sky

### DIFF
--- a/os/net/routing/rpl-classic/rpl-dag-root.c
+++ b/os/net/routing/rpl-classic/rpl-dag-root.c
@@ -48,6 +48,7 @@ static void
 set_global_address(uip_ipaddr_t *prefix, uip_ipaddr_t *iid)
 {
   static uip_ipaddr_t root_ipaddr;
+  int i;
 
   /* Assign a unique local address (RFC4193,
      http://tools.ietf.org/html/rfc4193). */
@@ -68,7 +69,7 @@ set_global_address(uip_ipaddr_t *prefix, uip_ipaddr_t *iid)
     uint8_t state;
 
     LOG_DBG("IPv6 addresses: ");
-    for(int i = 0; i < UIP_DS6_ADDR_NB; i++) {
+    for(i = 0; i < UIP_DS6_ADDR_NB; i++) {
       state = uip_ds6_if.addr_list[i].state;
       if(uip_ds6_if.addr_list[i].isused &&
          (state == ADDR_TENTATIVE || state == ADDR_PREFERRED)) {


### PR DESCRIPTION
RPL classic currently fails to compile for TARGET sky.

```
  CC        ../../os/net/routing/rpl-classic/rpl-dag-root.c
../../os/net/routing/rpl-classic/rpl-dag-root.c: In function ‘set_global_address’:
../../os/net/routing/rpl-classic/rpl-dag-root.c:71:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
../../os/net/routing/rpl-classic/rpl-dag-root.c:71:5: note: use option -std=c99 or -std=gnu99 to compile your code
```

We can fix this by compiling with `-std=c99` or `-std=gnu99`, or we can remove the initial declaration from within the for loop. This pull chooses the latter since this is what we do consistently elsewhere in the code.