### PR TITLE
CC26xx/CC13xx: update the TSCH_CONF_ASSOCIATION_POLL_FREQUENCY parameter to make it associate faster

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/cc13xx-cc26xx-def.h
+++ b/arch/cpu/cc26xx-cc13xx/cc13xx-cc26xx-def.h
@@ -85,6 +85,11 @@
 #define TSCH_CONF_CHANNEL_SCAN_DURATION (CLOCK_SECOND / 10)
 #endif
 
+/* Increase this from the default 100 to improve TSCH association speed on this platform */
+#ifndef TSCH_CONF_ASSOCIATION_POLL_FREQUENCY
+#define TSCH_CONF_ASSOCIATION_POLL_FREQUENCY 1000
+#endif
+
 /* Slightly reduce the TSCH guard time (from 2200 usec to 1800 usec) to make sure
  * the CC26xx radio has sufficient time to start up. */
 #ifndef TSCH_CONF_RX_WAIT


### PR DESCRIPTION
The CC26xx/CC13xx nodes have problems joining TSCH networks. The usual way to solve it is by adding busywaiting, which is ugly.

Someone on Gitter suggested that increasing the polling frequency also works - thanks!