### PR TITLE
Remove some dead code from srf06-cc26xx config files

### DIFF
--- a/arch/platform/srf06-cc26xx/contiki-conf.h
+++ b/arch/platform/srf06-cc26xx/contiki-conf.h
@@ -50,23 +50,13 @@
 /**
  * \name Button configurations
  *
- * Configure a button as power on/off: We use the right button for both boards.
  * @{
  */
-#ifndef BUTTON_SENSOR_CONF_ENABLE_SHUTDOWN
-#define BUTTON_SENSOR_CONF_ENABLE_SHUTDOWN 1
-#endif
 
 /* Notify various examples that we have Buttons */
 #define PLATFORM_HAS_BUTTON      1
 #define PLATFORM_SUPPORTS_BUTTON_HAL 1
 
-/*
- * Override button symbols from dev/button-sensor.h, for the examples that
- * include it
- */
-#define button_sensor button_left_sensor
-#define button_sensor2 button_right_sensor
 /** @} */
 /*---------------------------------------------------------------------------*/
 /* Platform-specific define to signify sensor reading failure */

--- a/examples/platform-specific/cc26xx/ble-ipv6/project-conf.h
+++ b/examples/platform-specific/cc26xx/ble-ipv6/project-conf.h
@@ -37,9 +37,6 @@
 #define PROJECT_CONF_H_
 
 /*---------------------------------------------------------------------------*/
-/* Disable button shutdown functionality */
-#define BUTTON_SENSOR_CONF_ENABLE_SHUTDOWN      0
-/*---------------------------------------------------------------------------*/
 /* Change to match your configuration */
 #define BOARD_CONF_DEBUGGER_DEVPACK             1
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This removed BUTTON_SENSOR_CONF_ENABLE_SHUTDOWN and button_sensor definitions: they are dead code since changing to the button HAL.