### PR TITLE
CC26xx/CC13xx GPIO interrupt hal: clear the interrupt flags before calling the callbacks, not after

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/dev/gpio-interrupt.c
+++ b/arch/cpu/cc26xx-cc13xx/dev/gpio-interrupt.c
@@ -52,10 +52,10 @@ gpio_interrupt_isr(void)
   /* Read interrupt flags */
   pin_mask = (HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) & GPIO_DIO_ALL_MASK);
 
-  gpio_hal_event_handler(pin_mask);
-
   /* Clear the interrupt flags */
   HWREG(GPIO_BASE + GPIO_O_EVFLAGS31_0) = pin_mask;
+
+  gpio_hal_event_handler(pin_mask);
 }
 /*---------------------------------------------------------------------------*/
 /** @} */


### PR DESCRIPTION
I think that with the current code some interrupt may be lost, if the callback code takes long time to process the previous one. Even if this is not true, the code looks somewhat suspicious.

Clearing the hardware register before calling the callback functions should have no effect on the client code, since the full information about the interrupt flags is  `pin_mask`, which is passed as a parameter of the callbacks.