### PR TITLE
exclude some platforms from benchmarks

### DIFF
--- a/examples/benchmarks/rpl-req-resp/Makefile
+++ b/examples/benchmarks/rpl-req-resp/Makefile
@@ -1,6 +1,9 @@
 CONTIKI_PROJECT = node
 all: $(CONTIKI_PROJECT)
 
+PLATFORMS_EXCLUDE = sky nrf52dk native simplelink
+BOARDS_EXCLUDE = srf06/cc13xx launchpad/cc1310 launchpad/cc1350 sensortag/cc2650 sensortag/cc1350
+
 MODULES_REL += ../testbeds
 MODULES += os/services/deployment
 MODULES += os/services/simple-energest


### PR DESCRIPTION
examples/benchmarks/rpl-req-resp 

doesn't compile for TARGET =  native  nrf52dk  simplelink

and doesn't link for TARGET =  sky

Is this an omission of PLATFORMS_EXCLUDE and BOARDS_EXCLUDE ? I removed the ones I found in examples/6tisch/{6p-packet/  etsi-plugtest-2017/  simple-node/  sixtop/} 

