### PR TITLE
minor refactoring of hdc-1000-sensor following commit f4a8cba37

### DIFF
--- a/arch/platform/srf06-cc26xx/sensortag/hdc-1000-sensor.c
+++ b/arch/platform/srf06-cc26xx/sensortag/hdc-1000-sensor.c
@@ -205,7 +205,7 @@ notify_ready(void *not_used)
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Returns a reading from the sensor
- * \param type HDC_1000_SENSOR_TYPE_TEMP or HDC_1000_SENSOR_TYPE_HUMIDITY
+ * \param type HDC_1000_SENSOR_TYPE_TEMP or HDC_1000_SENSOR_TYPE_HUMID
  * \return Temperature (centi degrees C) or Humidity (centi %RH)
  */
 static int
@@ -221,7 +221,7 @@ value(int type)
   }
 
   if((type != HDC_1000_SENSOR_TYPE_TEMP) &&
-     type != HDC_1000_SENSOR_TYPE_HUMIDITY) {
+     type != HDC_1000_SENSOR_TYPE_HUMID) {
     PRINTF("Invalid type\n");
     return CC26XX_SENSOR_READING_ERROR;
   } else {
@@ -231,7 +231,7 @@ value(int type)
 
     if(type == HDC_1000_SENSOR_TYPE_TEMP) {
       rv = (int)(temp * 100);
-    } else if(type == HDC_1000_SENSOR_TYPE_HUMIDITY) {
+    } else if(type == HDC_1000_SENSOR_TYPE_HUMID) {
       rv = (int)(hum * 100);
     }
   }

--- a/arch/platform/srf06-cc26xx/sensortag/hdc-1000-sensor.h
+++ b/arch/platform/srf06-cc26xx/sensortag/hdc-1000-sensor.h
@@ -45,7 +45,7 @@
  * and latch them. It will then generate a sensors_changed event.
  *
  * The user can then retrieve readings by calling .value() and by passing
- * either HDC_1000_SENSOR_TYPE_TEMP or HDC_1000_SENSOR_TYPE_HUMIDITY as the
+ * either HDC_1000_SENSOR_TYPE_TEMP or HDC_1000_SENSOR_TYPE_HUMID as the
  * argument. Multiple calls to value() will not trigger new readings, they will
  * simply return the most recent latched values.
  *
@@ -65,7 +65,7 @@
 #include "lib/sensors.h"
 /*---------------------------------------------------------------------------*/
 #define HDC_1000_SENSOR_TYPE_TEMP        1
-#define HDC_1000_SENSOR_TYPE_HUMIDITY    2
+#define HDC_1000_SENSOR_TYPE_HUMID       2
 /*---------------------------------------------------------------------------*/
 /**
  * \name HDC1000 driver states

--- a/examples/lwm2m-ipso-objects/example-ipso-objects.c
+++ b/examples/lwm2m-ipso-objects/example-ipso-objects.c
@@ -77,7 +77,7 @@ read_temp_value(const ipso_sensor_t *s, int32_t *value)
 static lwm2m_status_t
 read_hum_value(const ipso_sensor_t *s, int32_t *value)
 {
-  *value = 10 * hdc_1000_sensor.value(HDC_1000_SENSOR_TYPE_HUMIDITY);
+  *value = 10 * hdc_1000_sensor.value(HDC_1000_SENSOR_TYPE_HUMID);
   return LWM2M_STATUS_OK;
 }
 /* Lux reading */

--- a/examples/platform-specific/cc26xx/cc26xx-demo.c
+++ b/examples/platform-specific/cc26xx/cc26xx-demo.c
@@ -203,7 +203,7 @@ get_hdc_reading()
     printf("HDC: Temp Read Error\n");
   }
 
-  value = hdc_1000_sensor.value(HDC_1000_SENSOR_TYPE_HUMIDITY);
+  value = hdc_1000_sensor.value(HDC_1000_SENSOR_TYPE_HUMID);
   if(value != CC26XX_SENSOR_READING_ERROR) {
     printf("HDC: Humidity=%d.%02d %%RH\n", value / 100, value % 100);
   } else {

--- a/examples/platform-specific/cc26xx/cc26xx-web-demo/cc26xx-web-demo.c
+++ b/examples/platform-specific/cc26xx/cc26xx-web-demo/cc26xx-web-demo.c
@@ -636,7 +636,7 @@ get_hdc_reading()
   }
 
   if(hdc_hum_reading.publish) {
-    value = hdc_1000_sensor.value(HDC_1000_SENSOR_TYPE_HUMIDITY);
+    value = hdc_1000_sensor.value(HDC_1000_SENSOR_TYPE_HUMID);
     if(value != CC26XX_SENSOR_READING_ERROR) {
       hdc_hum_reading.raw = value;
 


### PR DESCRIPTION
since commit f4a8cba37, 

HDC_1000_SENSOR_TYPE_HUMIDITY is renamed  HDC_1000_SENSOR_TYPE_HUMID

this PR removes a building error in examples/lwm2m-ipso-objects


```
example-ipso-objects.c: In function 'read_hum_value':
example-ipso-objects.c:80:39: error: 'HDC_1000_SENSOR_TYPE_HUMIDITY' undeclared (first use in this function); did you mean 'HDC_1000_SENSOR_TYPE_HUMID'?
   *value = 10 * hdc_1000_sensor.value(HDC_1000_SENSOR_TYPE_HUMIDITY);
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                       HDC_1000_SENSOR_TYPE_HUMID
example-ipso-objects.c:80:39: note: each undeclared identifier is reported only once for each function it appears in
make: *** [../../Makefile.include:355: example-ipso-objects.o] Error 1

```

