### PR TITLE
missing header inttypes.h

### DIFF
--- a/examples/multicast/root.c
+++ b/examples/multicast/root.c
@@ -45,6 +45,7 @@
 #include "net/ipv6/multicast/uip-mcast6.h"
 
 #include <string.h>
+#include <inttypes.h>
 
 #define DEBUG DEBUG_PRINT
 #include "net/ipv6/uip-debug.h"

--- a/os/net/ipv6/uip-nd6.c
+++ b/os/net/ipv6/uip-nd6.c
@@ -69,6 +69,7 @@
  */
 
 #include <string.h>
+#include <inttypes.h>
 #include "net/ipv6/uip-icmp6.h"
 #include "net/ipv6/uip-nd6.h"
 #include "net/ipv6/uip-ds6.h"

--- a/os/services/lwm2m/lwm2m-tlv.c
+++ b/os/services/lwm2m/lwm2m-tlv.c
@@ -44,6 +44,7 @@
 
 #include <string.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include "lwm2m-tlv.h"
 
 /* Log configuration */


### PR DESCRIPTION
most of the platforms have inttypes.h via the header contiki-conf.h 

but sky and simplelink do not include it by default

this PR adds inttypes.h when needed for these latter platforms...