### PR TITLE
Add const to spi_device_t * parameter in SPI functions

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/dev/spi-arch.c
+++ b/arch/cpu/cc26xx-cc13xx/dev/spi-arch.c
@@ -37,7 +37,7 @@
 
 typedef struct spi_locks_s {
   mutex_t lock;
-  spi_device_t *owner;
+  const spi_device_t *owner;
 } spi_locks_t;
 
 /* One lock per SPI controller */
@@ -68,7 +68,7 @@ static const board_spi_controller_t spi_controller[SPI_CONTROLLER_COUNT] = {
 };
 /*---------------------------------------------------------------------------*/
 bool
-spi_arch_has_lock(spi_device_t *dev)
+spi_arch_has_lock(const spi_device_t *dev)
 {
   if(board_spi_locks_spi[dev->spi_controller].owner == dev) {
     return true;
@@ -78,7 +78,7 @@ spi_arch_has_lock(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 bool
-spi_arch_is_bus_locked(spi_device_t *dev)
+spi_arch_is_bus_locked(const spi_device_t *dev)
 {
   if(board_spi_locks_spi[dev->spi_controller].lock == MUTEX_STATUS_LOCKED) {
     return true;
@@ -88,7 +88,7 @@ spi_arch_is_bus_locked(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 static uint32_t
-get_mode(spi_device_t *dev)
+get_mode(const spi_device_t *dev)
 {
   /* Select the correct SPI mode */
   if(dev->spi_pha == 0 && dev->spi_pol == 0) {
@@ -103,7 +103,7 @@ get_mode(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_lock_and_open(spi_device_t *dev)
+spi_arch_lock_and_open(const spi_device_t *dev)
 {
   uint32_t c;
 
@@ -152,7 +152,7 @@ spi_arch_lock_and_open(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_close_and_unlock(spi_device_t *dev)
+spi_arch_close_and_unlock(const spi_device_t *dev)
 {
   if(!spi_arch_has_lock(dev)) {
     return SPI_DEV_STATUS_BUS_NOT_OWNED;
@@ -181,7 +181,7 @@ spi_arch_close_and_unlock(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_transfer(spi_device_t *dev,
+spi_arch_transfer(const spi_device_t *dev,
                   const uint8_t *write_buf, int wlen,
                   uint8_t *inbuf, int rlen, int ignore_len)
 {
@@ -231,7 +231,7 @@ spi_arch_transfer(spi_device_t *dev,
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_select(spi_device_t *dev)
+spi_arch_select(const spi_device_t *dev)
 {
 
   if(!spi_arch_has_lock(dev)) {
@@ -243,7 +243,7 @@ spi_arch_select(spi_device_t *dev)
   return SPI_DEV_STATUS_OK;
 }
 spi_status_t
-spi_arch_deselect(spi_device_t *dev)
+spi_arch_deselect(const spi_device_t *dev)
 {
   ti_lib_gpio_set_dio(dev->pin_spi_cs);
 

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/spi-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/spi-arch.c
@@ -54,7 +54,7 @@
 /*---------------------------------------------------------------------------*/
 typedef struct {
   SPI_Handle handle;
-  spi_device_t *owner;
+  const spi_device_t *owner;
 } spi_arch_t;
 /*---------------------------------------------------------------------------*/
 #if (SPI_CONTROLLER_COUNT > 0)
@@ -96,7 +96,7 @@ convert_frame_format(uint8_t pol, uint8_t pha)
 }
 /*---------------------------------------------------------------------------*/
 bool
-spi_arch_has_lock(spi_device_t *dev)
+spi_arch_has_lock(const spi_device_t *dev)
 {
   /*
    * The SPI device is the owner if the SPI controller returns a valid
@@ -107,7 +107,7 @@ spi_arch_has_lock(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 bool
-spi_arch_is_bus_locked(spi_device_t *dev)
+spi_arch_is_bus_locked(const spi_device_t *dev)
 {
   /*
    * The SPI controller is locked by any device if the SPI controller returns
@@ -118,7 +118,7 @@ spi_arch_is_bus_locked(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_lock_and_open(spi_device_t *dev)
+spi_arch_lock_and_open(const spi_device_t *dev)
 {
   uint_least8_t spi_index;
   spi_arch_t *spi_arch;
@@ -167,7 +167,7 @@ spi_arch_lock_and_open(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_close_and_unlock(spi_device_t *dev)
+spi_arch_close_and_unlock(const spi_device_t *dev)
 {
   spi_arch_t *spi_arch;
 
@@ -196,7 +196,7 @@ spi_arch_close_and_unlock(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_transfer(spi_device_t *dev,
+spi_arch_transfer(const spi_device_t *dev,
                   const uint8_t *write_buf, int wlen,
                   uint8_t *inbuf, int rlen, int ignore_len)
 {
@@ -236,7 +236,7 @@ spi_arch_transfer(spi_device_t *dev,
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_select(spi_device_t *dev)
+spi_arch_select(const spi_device_t *dev)
 {
   if(!spi_arch_has_lock(dev)) {
     return SPI_DEV_STATUS_BUS_NOT_OWNED;
@@ -248,7 +248,7 @@ spi_arch_select(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_arch_deselect(spi_device_t *dev)
+spi_arch_deselect(const spi_device_t *dev)
 {
   if(!spi_arch_has_lock(dev)) {
     return SPI_DEV_STATUS_BUS_NOT_OWNED;

--- a/arch/dev/ext-flash/ext-flash.c
+++ b/arch/dev/ext-flash/ext-flash.c
@@ -99,7 +99,7 @@
 #define VERIFY_PART_POWERED_DOWN     0
 #define VERIFY_PART_OK               1
 /*---------------------------------------------------------------------------*/
-static spi_device_t flash_spi_configuration_default = {
+static const spi_device_t flash_spi_configuration_default = {
   .spi_controller = EXT_FLASH_SPI_CONTROLLER,
   .pin_spi_sck = EXT_FLASH_SPI_PIN_SCK,
   .pin_spi_miso = EXT_FLASH_SPI_PIN_MISO,
@@ -113,8 +113,8 @@ static spi_device_t flash_spi_configuration_default = {
 /**
  * Get spi configuration, return default configuration if NULL
  */
-static spi_device_t *
-get_spi_conf(spi_device_t *conf)
+static const spi_device_t *
+get_spi_conf(const spi_device_t *conf)
 {
   if(conf == NULL) {
     return &flash_spi_configuration_default;
@@ -126,7 +126,7 @@ get_spi_conf(spi_device_t *conf)
  * Clear external flash CSN line
  */
 static bool
-select_on_bus(spi_device_t *flash_spi_configuration)
+select_on_bus(const spi_device_t *flash_spi_configuration)
 {
   if(spi_select(flash_spi_configuration) == SPI_DEV_STATUS_OK) {
     return true;
@@ -138,7 +138,7 @@ select_on_bus(spi_device_t *flash_spi_configuration)
  * Set external flash CSN line
  */
 static void
-deselect(spi_device_t *flash_spi_configuration)
+deselect(const spi_device_t *flash_spi_configuration)
 {
   spi_deselect(flash_spi_configuration);
 }
@@ -148,7 +148,7 @@ deselect(spi_device_t *flash_spi_configuration)
  * \return True when successful.
  */
 static bool
-wait_ready(spi_device_t *flash_spi_configuration)
+wait_ready(const spi_device_t *flash_spi_configuration)
 {
   bool ret;
   const uint8_t wbuf[1] = { BLS_CODE_READ_STATUS };
@@ -196,7 +196,7 @@ wait_ready(spi_device_t *flash_spi_configuration)
  *         was powered down
  */
 static uint8_t
-verify_part(spi_device_t *flash_spi_configuration)
+verify_part(const spi_device_t *flash_spi_configuration)
 {
   const uint8_t wbuf[] = { BLS_CODE_MDID, 0xFF, 0xFF, 0x00 };
   uint8_t rbuf[2] = { 0, 0 };
@@ -230,7 +230,7 @@ verify_part(spi_device_t *flash_spi_configuration)
  *        the status register is accessible.
  */
 static bool
-power_down(spi_device_t *flash_spi_configuration)
+power_down(const spi_device_t *flash_spi_configuration)
 {
   uint8_t cmd;
   uint8_t i;
@@ -271,7 +271,7 @@ power_down(spi_device_t *flash_spi_configuration)
  * \return   True if the command was written successfully
  */
 static bool
-power_standby(spi_device_t *flash_spi_configuration)
+power_standby(const spi_device_t *flash_spi_configuration)
 {
   uint8_t cmd;
   bool success;
@@ -297,7 +297,7 @@ power_standby(spi_device_t *flash_spi_configuration)
  * \return True when successful.
  */
 static bool
-write_enable(spi_device_t *flash_spi_configuration)
+write_enable(const spi_device_t *flash_spi_configuration)
 {
   bool ret;
   const uint8_t wbuf[] = { BLS_CODE_WRITE_ENABLE };
@@ -316,9 +316,9 @@ write_enable(spi_device_t *flash_spi_configuration)
 }
 /*---------------------------------------------------------------------------*/
 bool
-ext_flash_open(spi_device_t *conf)
+ext_flash_open(const spi_device_t *conf)
 {
-  spi_device_t *flash_spi_configuration;
+  const spi_device_t *flash_spi_configuration;
 
   flash_spi_configuration = get_spi_conf(conf);
 
@@ -346,10 +346,10 @@ ext_flash_open(spi_device_t *conf)
 }
 /*---------------------------------------------------------------------------*/
 bool
-ext_flash_close(spi_device_t *conf)
+ext_flash_close(const spi_device_t *conf)
 {
   bool ret;
-  spi_device_t *flash_spi_configuration;
+  const spi_device_t *flash_spi_configuration;
 
   flash_spi_configuration = get_spi_conf(conf);
 
@@ -365,12 +365,12 @@ ext_flash_close(spi_device_t *conf)
 }
 /*---------------------------------------------------------------------------*/
 bool
-ext_flash_read(spi_device_t *conf, uint32_t offset, uint32_t length, uint8_t *buf)
+ext_flash_read(const spi_device_t *conf, uint32_t offset, uint32_t length, uint8_t *buf)
 {
   uint8_t wbuf[4];
   bool ret;
 
-  spi_device_t *flash_spi_configuration;
+  const spi_device_t *flash_spi_configuration;
 
   flash_spi_configuration = get_spi_conf(conf);
 
@@ -406,12 +406,12 @@ ext_flash_read(spi_device_t *conf, uint32_t offset, uint32_t length, uint8_t *bu
 }
 /*---------------------------------------------------------------------------*/
 bool
-ext_flash_write(spi_device_t *conf, uint32_t offset, uint32_t length, const uint8_t *buf)
+ext_flash_write(const spi_device_t *conf, uint32_t offset, uint32_t length, const uint8_t *buf)
 {
   uint8_t wbuf[4];
   uint32_t ilen; /* interim length per instruction */
 
-  spi_device_t *flash_spi_configuration;
+  const spi_device_t *flash_spi_configuration;
 
   flash_spi_configuration = get_spi_conf(conf);
 
@@ -466,7 +466,7 @@ ext_flash_write(spi_device_t *conf, uint32_t offset, uint32_t length, const uint
 }
 /*---------------------------------------------------------------------------*/
 bool
-ext_flash_erase(spi_device_t *conf, uint32_t offset, uint32_t length)
+ext_flash_erase(const spi_device_t *conf, uint32_t offset, uint32_t length)
 {
   /*
    * Note that Block erase might be more efficient when the floor map
@@ -477,7 +477,7 @@ ext_flash_erase(spi_device_t *conf, uint32_t offset, uint32_t length)
   uint32_t i, numsectors;
   uint32_t endoffset = offset + length - 1;
 
-  spi_device_t *flash_spi_configuration;
+  const spi_device_t *flash_spi_configuration;
 
   flash_spi_configuration = get_spi_conf(conf);
 
@@ -518,7 +518,7 @@ ext_flash_erase(spi_device_t *conf, uint32_t offset, uint32_t length)
 }
 /*---------------------------------------------------------------------------*/
 bool
-ext_flash_init(spi_device_t *conf)
+ext_flash_init(const spi_device_t *conf)
 {
   if(ext_flash_open(conf) == false) {
     return false;

--- a/arch/dev/ext-flash/ext-flash.h
+++ b/arch/dev/ext-flash/ext-flash.h
@@ -61,7 +61,7 @@
  * \param conf SPI bus configuration struct. NULL for default.
  * \return True when successful.
  */
-bool ext_flash_open(spi_device_t *conf);
+bool ext_flash_open(const spi_device_t *conf);
 
 /**
  * \brief Close the storage driver
@@ -70,7 +70,7 @@ bool ext_flash_open(spi_device_t *conf);
  *
  * This call will put the device in its lower power mode (power down).
  */
-bool ext_flash_close(spi_device_t *conf);
+bool ext_flash_close(const spi_device_t *conf);
 
 /**
  * \brief Read storage content
@@ -82,7 +82,7 @@ bool ext_flash_close(spi_device_t *conf);
  *
  * buf must be allocated by the caller
  */
-bool ext_flash_read(spi_device_t *conf, uint32_t offset, uint32_t length, uint8_t *buf);
+bool ext_flash_read(const spi_device_t *conf, uint32_t offset, uint32_t length, uint8_t *buf);
 
 /**
  * \brief Erase storage sectors corresponding to the range.
@@ -94,7 +94,7 @@ bool ext_flash_read(spi_device_t *conf, uint32_t offset, uint32_t length, uint8_
  * The erase operation will be sector-wise, therefore a call to this function
  * will generally start the erase procedure at an address lower than offset
  */
-bool ext_flash_erase(spi_device_t *conf, uint32_t offset, uint32_t length);
+bool ext_flash_erase(const spi_device_t *conf, uint32_t offset, uint32_t length);
 
 /**
  * \brief Write to storage sectors.
@@ -105,7 +105,7 @@ bool ext_flash_erase(spi_device_t *conf, uint32_t offset, uint32_t length);
  *
  * \return True when successful.
  */
-bool ext_flash_write(spi_device_t *conf, uint32_t offset, uint32_t length, const uint8_t *buf);
+bool ext_flash_write(const spi_device_t *conf, uint32_t offset, uint32_t length, const uint8_t *buf);
 
 /**
  * \brief Initialise the external flash
@@ -117,7 +117,7 @@ bool ext_flash_write(spi_device_t *conf, uint32_t offset, uint32_t length, const
  * In order to perform any operation, the caller must first wake the device
  * up by calling ext_flash_open()
  */
-bool ext_flash_init(spi_device_t *conf);
+bool ext_flash_init(const spi_device_t *conf);
 /*---------------------------------------------------------------------------*/
 #endif /* EXT_FLASH_H_ */
 /*---------------------------------------------------------------------------*/

--- a/os/dev/spi.c
+++ b/os/dev/spi.c
@@ -43,7 +43,7 @@
 #include <stdbool.h>
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_acquire(spi_device_t *dev)
+spi_acquire(const spi_device_t *dev)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return SPI_DEV_STATUS_EINVAL;
@@ -54,7 +54,7 @@ spi_acquire(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_release(spi_device_t *dev)
+spi_release(const spi_device_t *dev)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return SPI_DEV_STATUS_EINVAL;
@@ -65,19 +65,19 @@ spi_release(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_select(spi_device_t *dev)
+spi_select(const spi_device_t *dev)
 {
   return spi_arch_select(dev);
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_deselect(spi_device_t *dev)
+spi_deselect(const spi_device_t *dev)
 {
   return spi_arch_deselect(dev);
 }
 /*---------------------------------------------------------------------------*/
 bool
-spi_has_bus(spi_device_t *dev)
+spi_has_bus(const spi_device_t *dev)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return false;
@@ -87,7 +87,7 @@ spi_has_bus(spi_device_t *dev)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_write_byte(spi_device_t *dev, uint8_t data)
+spi_write_byte(const spi_device_t *dev, uint8_t data)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return SPI_DEV_STATUS_EINVAL;
@@ -101,7 +101,7 @@ spi_write_byte(spi_device_t *dev, uint8_t data)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_write(spi_device_t *dev, const uint8_t *data, int size)
+spi_write(const spi_device_t *dev, const uint8_t *data, int size)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return SPI_DEV_STATUS_EINVAL;
@@ -115,7 +115,7 @@ spi_write(spi_device_t *dev, const uint8_t *data, int size)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_read_byte(spi_device_t *dev, uint8_t *buf)
+spi_read_byte(const spi_device_t *dev, uint8_t *buf)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return SPI_DEV_STATUS_EINVAL;
@@ -129,7 +129,7 @@ spi_read_byte(spi_device_t *dev, uint8_t *buf)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_read(spi_device_t *dev, uint8_t *buf, int size)
+spi_read(const spi_device_t *dev, uint8_t *buf, int size)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return SPI_DEV_STATUS_EINVAL;
@@ -143,7 +143,7 @@ spi_read(spi_device_t *dev, uint8_t *buf, int size)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_read_skip(spi_device_t *dev, int size)
+spi_read_skip(const spi_device_t *dev, int size)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return SPI_DEV_STATUS_EINVAL;
@@ -157,7 +157,7 @@ spi_read_skip(spi_device_t *dev, int size)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_transfer(spi_device_t *dev,
+spi_transfer(const spi_device_t *dev,
              const uint8_t *wdata, int wsize,
              uint8_t *rbuf, int rsize, int ignore)
 {
@@ -181,7 +181,7 @@ spi_transfer(spi_device_t *dev,
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_read_register(spi_device_t *dev, uint8_t reg, uint8_t *data, int size)
+spi_read_register(const spi_device_t *dev, uint8_t reg, uint8_t *data, int size)
 {
   spi_status_t status;
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
@@ -204,7 +204,7 @@ spi_read_register(spi_device_t *dev, uint8_t reg, uint8_t *data, int size)
 }
 /*---------------------------------------------------------------------------*/
 spi_status_t
-spi_strobe(spi_device_t *dev, uint8_t strobe, uint8_t *result)
+spi_strobe(const spi_device_t *dev, uint8_t strobe, uint8_t *result)
 {
   if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
     return SPI_DEV_STATUS_EINVAL;

--- a/os/dev/spi.h
+++ b/os/dev/spi.h
@@ -115,7 +115,7 @@ typedef struct spi_device {
  * to be locked and the opening configuration.
  * \return SPI return code
  */
-spi_status_t spi_acquire(spi_device_t *dev);
+spi_status_t spi_acquire(const spi_device_t *dev);
 
 /**
  * \brief Closes and then unlocks an SPI controller
@@ -127,7 +127,7 @@ spi_status_t spi_acquire(spi_device_t *dev);
  * This should work only if the device has already locked the SPI
  * controller.
  */
-spi_status_t spi_release(spi_device_t *dev);
+spi_status_t spi_release(const spi_device_t *dev);
 
 /**
  * \brief Selects the SPI peripheral
@@ -137,7 +137,7 @@ spi_status_t spi_release(spi_device_t *dev);
  * Clears the CS pin. This should work only if the device has
  * already locked the SPI controller.
  */
-spi_status_t spi_select(spi_device_t *dev);
+spi_status_t spi_select(const spi_device_t *dev);
 
 /**
  * \brief Deselects the SPI peripheral
@@ -146,14 +146,14 @@ spi_status_t spi_select(spi_device_t *dev);
  *
  * Sets the CS pin. Lock is not required.
  */
-spi_status_t spi_deselect(spi_device_t *dev);
+spi_status_t spi_deselect(const spi_device_t *dev);
 
 /**
  * \brief Checks if a device has locked an SPI controller
  * \param dev An SPI device configuration which defines the controller.
  * \return true if the device has the lock, false otherwise.
  */
-bool spi_has_bus(spi_device_t *dev);
+bool spi_has_bus(const spi_device_t *dev);
 
 /**
  * \brief Writes a single byte to an SPI device
@@ -163,7 +163,7 @@ bool spi_has_bus(spi_device_t *dev);
  *
  * It should work only if the device has already locked the SPI controller.
  */
-spi_status_t spi_write_byte(spi_device_t *dev, uint8_t data);
+spi_status_t spi_write_byte(const spi_device_t *dev, uint8_t data);
 
 /**
  * \brief Reads a single byte from an SPI device
@@ -173,7 +173,7 @@ spi_status_t spi_write_byte(spi_device_t *dev, uint8_t data);
  *
  * It should work only if the device has already locked the SPI controller.
  */
-spi_status_t spi_read_byte(spi_device_t *dev, uint8_t *data);
+spi_status_t spi_read_byte(const spi_device_t *dev, uint8_t *data);
 
 /**
  * \brief Writes a buffer to an SPI device
@@ -184,7 +184,7 @@ spi_status_t spi_read_byte(spi_device_t *dev, uint8_t *data);
  *
  * It should work only if the device has already locked the SPI controller.
  */
-spi_status_t spi_write(spi_device_t *dev,
+spi_status_t spi_write(const spi_device_t *dev,
                        const uint8_t *data, int size);
 
 /**
@@ -196,7 +196,7 @@ spi_status_t spi_write(spi_device_t *dev,
  *
  * It should work only if the device has already locked the SPI controller.
  */
-spi_status_t spi_read(spi_device_t *dev, uint8_t *data, int size);
+spi_status_t spi_read(const spi_device_t *dev, uint8_t *data, int size);
 
 /**
  * \brief Reads and ignores data from an SPI device
@@ -207,7 +207,7 @@ spi_status_t spi_read(spi_device_t *dev, uint8_t *data, int size);
  * Reads size bytes from the SPI and throws them away.
  * It should work only if the device has already locked the SPI controller.
  */
-spi_status_t spi_read_skip(spi_device_t *dev, int size);
+spi_status_t spi_read_skip(const spi_device_t *dev, int size);
 
 /**
  * \brief Performs a generic SPI transfer
@@ -226,7 +226,7 @@ spi_status_t spi_read_skip(spi_device_t *dev, int size);
  * be copied to buf. The remaining ignore_len bytes won't be copied to the
  * buffer. The maximum of wlen and rlen+ignore_len of bytes will be transfered.
  */
-spi_status_t spi_transfer(spi_device_t *dev,
+spi_status_t spi_transfer(const spi_device_t *dev,
                           const uint8_t *data, int wsize,
                           uint8_t *buf, int rsize, int ignore);
 
@@ -239,7 +239,7 @@ spi_status_t spi_transfer(spi_device_t *dev,
  *
  * It should work only if the device has already locked the SPI controller.
  */
-spi_status_t spi_strobe(spi_device_t *dev, uint8_t strobe,
+spi_status_t spi_strobe(const spi_device_t *dev, uint8_t strobe,
                         uint8_t *status);
 
 /**
@@ -252,7 +252,7 @@ spi_status_t spi_strobe(spi_device_t *dev, uint8_t strobe,
  *
  * It should work only if the device has already locked the SPI controller.
  */
-spi_status_t spi_read_register(spi_device_t *dev, uint8_t reg,
+spi_status_t spi_read_register(const spi_device_t *dev, uint8_t reg,
                                uint8_t *data, int size);
 
 /*---------------------------------------------------------------------------*/
@@ -266,7 +266,7 @@ spi_status_t spi_read_register(spi_device_t *dev, uint8_t reg,
  * \return 1 if the device has the lock, 0 otherwise.
  *
  */
-bool spi_arch_has_lock(spi_device_t *dev);
+bool spi_arch_has_lock(const spi_device_t *dev);
 
 /**
  * \brief Checks if an SPI controller is locked by any device
@@ -275,7 +275,7 @@ bool spi_arch_has_lock(spi_device_t *dev);
  * \return 1 if the controller is locked, 0 otherwise.
  *
  */
-bool spi_arch_is_bus_locked(spi_device_t *dev);
+bool spi_arch_is_bus_locked(const spi_device_t *dev);
 
 /**
  * \brief Locks and opens an SPI controller to the configuration specified.
@@ -286,7 +286,7 @@ bool spi_arch_is_bus_locked(spi_device_t *dev);
  * controller.
  *
  */
-spi_status_t spi_arch_lock_and_open(spi_device_t *dev);
+spi_status_t spi_arch_lock_and_open(const spi_device_t *dev);
 
 /**
  * \brief Closes and unlocks an SPI controller
@@ -299,7 +299,7 @@ spi_status_t spi_arch_lock_and_open(spi_device_t *dev);
  * controller.
  *
  */
-spi_status_t spi_arch_close_and_unlock(spi_device_t *dev);
+spi_status_t spi_arch_close_and_unlock(const spi_device_t *dev);
 
 /**
  * \brief Performs an SPI transfer
@@ -318,7 +318,7 @@ spi_status_t spi_arch_close_and_unlock(spi_device_t *dev);
  * be copied to buf. The remaining ignore_len bytes won't be copied to the
  * buffer. The maximum of wlen and rlen+ignore_len of bytes will be transfered.
  */
-spi_status_t spi_arch_transfer(spi_device_t *dev,
+spi_status_t spi_arch_transfer(const spi_device_t *dev,
                                const uint8_t *data, int wlen,
                                uint8_t *buf, int rlen,
                                int ignore_len);
@@ -331,7 +331,7 @@ spi_status_t spi_arch_transfer(spi_device_t *dev,
  * Clears the CS pin. It should work only if the device has already
  * locked the SPI controller.
  */
-spi_status_t spi_arch_select(spi_device_t *dev);
+spi_status_t spi_arch_select(const spi_device_t *dev);
 
 /**
  * \brief Deselects an SPI device
@@ -340,7 +340,7 @@ spi_status_t spi_arch_select(spi_device_t *dev);
  *
  * Set the CS pin. Locking the SPI controller is not needed.
  */
-spi_status_t spi_arch_deselect(spi_device_t *dev);
+spi_status_t spi_arch_deselect(const spi_device_t *dev);
 
 #endif /* SPI_H_ */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The `spi_device_t` passed a parameter to SPI functions is not modified by the functions. So, it should be a constant.

This patch allows to store SPI configs, such as ext-flash default config, in ROM instead of RAM.