### PR TITLE
Added missing 'extern' qualifier to tsch_timing_us

### DIFF
--- a/os/net/mac/tsch/tsch.h
+++ b/os/net/mac/tsch/tsch.h
@@ -158,7 +158,7 @@ extern uint8_t tsch_current_channel;
 extern uint8_t tsch_hopping_sequence[TSCH_HOPPING_SEQUENCE_MAX_LEN];
 extern struct tsch_asn_divisor_t tsch_hopping_sequence_length;
 /* TSCH timeslot timing (in micro-second) */
-uint16_t tsch_timing_us[tsch_ts_elements_count];
+extern uint16_t tsch_timing_us[tsch_ts_elements_count];
 /* TSCH timeslot timing (in rtimer ticks) */
 extern rtimer_clock_t tsch_timing[tsch_ts_elements_count];
 /* Statistics on the current session */


### PR DESCRIPTION
Solves one of the issues reported in https://github.com/contiki-ng/contiki-ng/issues/705