### PR TITLE
Add CI compile test for TSCH with logging

### DIFF
--- a/tests/03-compile-arm-ports-02/Makefile
+++ b/tests/03-compile-arm-ports-02/Makefile
@@ -28,6 +28,7 @@ storage/antelope-shell/zoul \
 6tisch/simple-node/zoul:MAKE_WITH_ORCHESTRA=1 \
 6tisch/simple-node/zoul:MAKE_WITH_SECURITY=1 \
 libs/logging/zoul \
+libs/logging/zoul:MAKE_MAC=MAKE_MAC_TSCH \
 6tisch/etsi-plugtest-2017/zoul:BOARD=remote \
 6tisch/6p-packet/zoul \
 6tisch/sixtop/zoul \


### PR DESCRIPTION
Compiles TSCH with all logs enabled, as this can cause issues, as reported in https://github.com/contiki-ng/contiki-ng/issues/705