### PR TITLE
CC13x0/CC26x0 building: also fail with descriptive error message when cc13xxware/cc26xxware exists, but is empty

### DIFF
--- a/arch/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/arch/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -1,8 +1,8 @@
 CPU_ABS_PATH       = arch/cpu/cc26xx-cc13xx
 TI_XXWARE = $(CONTIKI_CPU)/$(TI_XXWARE_PATH)
 
-ifeq (,$(wildcard $(TI_XXWARE)))
-    $(warning $(TI_XXWARE) does not exist.)
+ifeq (,$(wildcard $(TI_XXWARE)/*))
+    $(warning $(TI_XXWARE) does not exist or is empty.)
     $(warning Did you run 'git submodule update --init' ?)
     $(error "")
 endif


### PR DESCRIPTION
A small update upon #640