### PR TITLE
Fixed all-timers example application

### DIFF
--- a/examples/libs/timers/all-timers.c
+++ b/examples/libs/timers/all-timers.c
@@ -79,7 +79,7 @@ PROCESS_THREAD(timer_process, ev, data)
   PROCESS_BEGIN();
 
   ctimer_set(&timer_ctimer, CLOCK_SECOND, ctimer_callback, NULL);
-  rtimer_set(&timer_rtimer, RTIMER_NOW() + CLOCK_SECOND / 2, 0,
+  rtimer_set(&timer_rtimer, RTIMER_NOW() + RTIMER_SECOND / 2, 0,
              rtimer_callback, NULL);
 
   while(1) {


### PR DESCRIPTION
The all timers example is trying to schedule an rtimer using `CLOCK_SECOND` as part of the trigger time calculation. This results in scheduling the rtimer to trigger at the wrong time in the future.

Reported and fixed by @miromico