### PR TITLE
Reduce docker image build verbosity

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -7,11 +7,30 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
   echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list && \
   apt-get -qq update && \
   apt-get -qq -y --no-install-recommends install \
-    build-essential doxygen git wget unzip python-serial python-pip \
-    default-jdk ant srecord iputils-tracepath rlwrap \
-    mosquitto mosquitto-clients gdb npm \
-    mono-complete gksu libgtk2.0-0 screen uml-utilities gtk-sharp2 \
-    libcanberra-gtk-module:i386 > /dev/null \
+    ant \
+    build-essential \
+    default-jdk \
+    doxygen \
+    gdb \
+    git \
+    gksu \
+    gtk-sharp2 \
+    iputils-tracepath \
+    libcanberra-gtk-module:i386 \
+    libgtk2.0-0 \
+    mono-complete \
+    mosquitto \
+    mosquitto-clients \
+    npm \
+    python-pip \
+    python-serial \
+    rlwrap \
+    screen \
+    srecord \
+    uml-utilities \
+    unzip \
+    wget \
+    > /dev/null \
   && apt-get -qq clean
 
 # Install coap-cli

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -39,7 +39,7 @@ ENV PATH="/usr/ba-elf-gcc/bin:${PATH}"
 ## Install nRF52 SDK
 RUN wget -nv https://developer.nordicsemi.com/nRF5_IoT_SDK/nRF5_IoT_SDK_v0.9.x/nrf5_iot_sdk_3288530.zip && \
     mkdir /usr/nrf52-sdk && \
-    unzip nrf5_iot_sdk_3288530.zip -d /usr/nrf52-sdk && \
+    unzip -q nrf5_iot_sdk_3288530.zip -d /usr/nrf52-sdk && \
     rm nrf5_iot_sdk_3288530.zip
 
 ENV NRF52_SDK_ROOT /usr/nrf52-sdk

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     default-jdk ant srecord iputils-tracepath rlwrap \
     mosquitto mosquitto-clients gdb npm \
     mono-complete gksu libgtk2.0-0 screen uml-utilities gtk-sharp2 \
-    libcanberra-gtk-module:i386 \
+    libcanberra-gtk-module:i386 > /dev/null \
   && apt-get -qq clean
 
 # Install coap-cli

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM 32bit/ubuntu:16.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Tools
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -3,12 +3,20 @@ FROM 32bit/ubuntu:16.04
 ENV DEBIAN_FRONTEND noninteractive
 
 # Tools
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-  build-essential doxygen git wget unzip python-serial python-pip \
-  default-jdk ant srecord iputils-tracepath rlwrap \
-  mosquitto mosquitto-clients gdb \
-  && apt-get clean
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+  echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list && \
+  apt-get -qq update && \
+  apt-get -qq -y --no-install-recommends install \
+    build-essential doxygen git wget unzip python-serial python-pip \
+    default-jdk ant srecord iputils-tracepath rlwrap \
+    mosquitto mosquitto-clients gdb npm \
+    mono-complete gksu libgtk2.0-0 screen uml-utilities gtk-sharp2 \
+    libcanberra-gtk-module:i386 \
+  && apt-get -qq clean
+
+# Install coap-cli
+RUN npm -q install coap-cli -g \
+  && sudo ln -s /usr/bin/nodejs /usr/bin/node
 
 # Install ARM toolchain
 RUN wget -nv https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2 && \
@@ -74,19 +82,6 @@ WORKDIR                 ${HOME}
 # Create Cooja shortcut
 RUN echo "#!/bin/bash\nant -Dbasedir=${COOJA} -f ${COOJA}/build.xml run" > ${HOME}/cooja && \
   chmod +x ${HOME}/cooja
-
-# Install coap-cli
-RUN sudo apt-get install -y npm \
-  && sudo apt-get clean \
-  && sudo npm install coap-cli -g \
-  && sudo ln -s /usr/bin/nodejs /usr/bin/node
-
-# Install Mono and libcanberra-gtk:i386 (for Renode)
-RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb http://download.mono-project.com/repo/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list \
-  && sudo apt-get update \
-  && sudo apt-get install -y mono-complete gksu libgtk2.0-0 screen uml-utilities gtk-sharp2 libcanberra-gtk-module:i386 \
-  && sudo apt-get clean
 
 # Download, build and install Renode
 RUN git clone --quiet https://github.com/renode/renode.git \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,21 +11,21 @@ RUN apt-get update && \
   && apt-get clean
 
 # Install ARM toolchain
-RUN wget https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2 && \
+RUN wget -nv https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2 && \
   tar xjf gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2 -C /tmp/ && \
   cp -f -r /tmp/gcc-arm-none-eabi-5_2-2015q4/* /usr/local/ && \
   rm -rf /tmp/gcc-arm-none-eabi-* gcc-arm-none-eabi-*-linux.tar.bz2
 
 # Install msp430 toolchain
-RUN wget http://simonduq.github.io/resources/mspgcc-4.7.2-compiled.tar.bz2 && \
+RUN wget -nv http://simonduq.github.io/resources/mspgcc-4.7.2-compiled.tar.bz2 && \
   tar xjf mspgcc*.tar.bz2 -C /tmp/ && \
   cp -f -r /tmp/msp430/* /usr/local/ && \
   rm -rf /tmp/msp430 mspgcc*.tar.bz2
 
 # Install NXP toolchain (partial, with binaries excluded. Download from nxp.com)
-RUN wget http://simonduq.github.io/resources/ba-elf-gcc-4.7.4-part1.tar.bz2 && \
-  wget http://simonduq.github.io/resources/ba-elf-gcc-4.7.4-part2.tar.bz2 && \
-  wget http://simonduq.github.io/resources/jn516x-sdk-4163-1416.tar.bz2 && \
+RUN wget -nv http://simonduq.github.io/resources/ba-elf-gcc-4.7.4-part1.tar.bz2 && \
+  wget -nv http://simonduq.github.io/resources/ba-elf-gcc-4.7.4-part2.tar.bz2 && \
+  wget -nv http://simonduq.github.io/resources/jn516x-sdk-4163-1416.tar.bz2 && \
   mkdir /tmp/jn516x-sdk /tmp/ba-elf-gcc && \
   tar xjf jn516x-sdk-*.tar.bz2 -C /tmp/jn516x-sdk && \
   tar xjf ba-elf-gcc-*part1.tar.bz2 -C /tmp/ba-elf-gcc && \
@@ -37,7 +37,7 @@ RUN wget http://simonduq.github.io/resources/ba-elf-gcc-4.7.4-part1.tar.bz2 && \
 ENV PATH="/usr/ba-elf-gcc/bin:${PATH}"
 
 ## Install nRF52 SDK
-RUN wget https://developer.nordicsemi.com/nRF5_IoT_SDK/nRF5_IoT_SDK_v0.9.x/nrf5_iot_sdk_3288530.zip && \
+RUN wget -nv https://developer.nordicsemi.com/nRF5_IoT_SDK/nRF5_IoT_SDK_v0.9.x/nrf5_iot_sdk_3288530.zip && \
     mkdir /usr/nrf52-sdk && \
     unzip nrf5_iot_sdk_3288530.zip -d /usr/nrf52-sdk && \
     rm nrf5_iot_sdk_3288530.zip

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -46,9 +46,8 @@ ENV NRF52_SDK_ROOT /usr/nrf52-sdk
 
 # Install sphinx and sphinx_rtd_theme, required for building and testing the
 # readthedocs API documentation
-RUN pip install --upgrade pip
-RUN pip install setuptools
-RUN pip install sphinx_rtd_theme sphinx
+RUN pip -q install --upgrade pip
+RUN pip -q install setuptools && pip -q install sphinx_rtd_theme sphinx
 
 # Create user, enable X forwarding, add to group dialout
 # -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -90,7 +90,7 @@ RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E
   && sudo apt-get clean
 
 # Download, build and install Renode
-RUN git clone https://github.com/renode/renode.git \
+RUN git clone --quiet https://github.com/renode/renode.git \
   && cd ${HOME}/renode \
   && git checkout v1.3 \
   && ./build.sh


### PR DESCRIPTION
This pull reduces the docker image build verbosity. We silence git, wget, npm, pip and unzip.

We try and miserably fail to silence apt-get, because apparently dpkg ignores apt-get's verbosity control. That's on their side not ours, but I still think we should run apt-get with -qq.

Nevertheless, this appears enough to keep our output log below the travis log limit.

#719 unresolved, but this can be considered anyway.