### PR TITLE
Switch to renode v1.5

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -90,7 +90,7 @@ RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E
 # Download, build and install Renode
 RUN git clone https://github.com/renode/renode.git \
   && cd ${HOME}/renode \
-  && git checkout v1.3 \
+  && git checkout v1.5 \
   && ./build.sh
 ENV PATH="${HOME}/renode:${PATH}"
 


### PR DESCRIPTION
This pull updates the docker image to Renode v1.5. The main motivation is to attempt to resolve #719 