### PR TITLE
Add MQTT client execution test

### DIFF
--- a/examples/mqtt-client/mqtt-client.c
+++ b/examples/mqtt-client/mqtt-client.c
@@ -47,7 +47,11 @@
 #include <strings.h>
 /*---------------------------------------------------------------------------*/
 #define LOG_MODULE "mqtt-client"
+#ifdef MQTT_CLIENT_CONF_LOG_LEVEL
+#define LOG_LEVEL MQTT_CLIENT_CONF_LOG_LEVEL
+#else
 #define LOG_LEVEL LOG_LEVEL_NONE
+#endif
 /*---------------------------------------------------------------------------*/
 /* Controls whether the example will work in IBM Watson IoT platform mode */
 #ifdef MQTT_CLIENT_CONF_WITH_IBM_WATSON
@@ -305,6 +309,7 @@ pub_handler(const char *topic, uint16_t topic_len, const uint8_t *chunk,
   }
 
   if(strncmp(&topic[10], "leds", 4) == 0) {
+    LOG_DBG("Received MQTT SUB\n");
     if(chunk[0] == '1') {
       leds_on(LEDS_RED);
     } else if(chunk[0] == '0') {

--- a/examples/mqtt-client/project-conf.h
+++ b/examples/mqtt-client/project-conf.h
@@ -52,7 +52,9 @@
  * devices, set your Org ID here and then make sure you set the correct token
  * through MQTT_CLIENT_CONF_AUTH_TOKEN.
  */
+#ifndef MQTT_CLIENT_CONF_ORG_ID
 #define MQTT_CLIENT_CONF_ORG_ID "quickstart"
+#endif
 
 /*
  * The MQTT username.

--- a/tests/08-native-runs/02-mqtt-client.sh
+++ b/tests/08-native-runs/02-mqtt-client.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+source ../utils.sh
+
+# Contiki directory
+CONTIKI=$1
+
+# Example code directory
+CODE_DIR=$CONTIKI/examples/mqtt-client/
+CODE=mqtt-client
+
+CLIENT_LOG=$CODE.log
+CLIENT_TESTLOG=$CODE.testlog
+CLIENT_ERR=$CODE.err
+MOSQ_SUB_LOG=mosquitto_sub.log
+MOSQ_SUB_ERR=mosquitto_sub.err
+
+# Start mosquitto server
+echo "Starting mosquitto daemon"
+mosquitto &> /dev/null &
+MOSQID=$!
+sleep 2
+
+# Start mosquitto_sub client. Subscribe
+echo "Starting mosquitto subscriber"
+mosquitto_sub -t iot-2/evt/status/fmt/json > $MOSQ_SUB_LOG 2> $MOSQ_SUB_ERR &
+MSUBID=$!
+sleep 2
+
+# Starting Contiki-NG native node
+echo "Starting native node"
+make -C $CODE_DIR TARGET=native \
+  DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG \
+  > make.log 2> make.err
+sudo $CODE_DIR/$CODE.native > $CLIENT_LOG 2> $CLIENT_ERR &
+CPID=$!
+
+# The mqtt-client will publish every 30 secs. Wait for 45
+sleep 45
+
+# Send a publish to the mqtt client
+mosquitto_pub -m "1" -t iot-2/cmd/leds/fmt/json
+
+echo "Closing native node"
+sleep 2
+kill_bg $CPID
+
+echo "Stopping mosquitto daemon"
+kill_bg $MOSQID
+
+echo "Stopping mosquitto subscriber"
+kill_bg $MSUBID
+
+# Success criteria:
+# * mosquitto_sub output not empty
+# * mqtt-client.native output contains "MQTT SUB"
+SUB_RCV=`grep "MQTT SUB" $CLIENT_LOG`
+if [ -s "$MOSQ_SUB_LOG" -a -n "$SUB_RCV" ]
+then
+  cp $CLIENT_LOG $CODE.testlog
+  printf "%-32s TEST OK\n" "$CODE" | tee $CODE.testlog;
+else
+  echo "==== make.log ====" ; cat make.log;
+  echo "==== make.err ====" ; cat make.err;
+  echo "==== $CLIENT_LOG ====" ; cat $CLIENT_LOG;
+  echo "==== $CLIENT_ERR ====" ; cat $CLIENT_ERR;
+  echo "==== $MOSQ_SUB_LOG ====" ; cat $MOSQ_SUB_LOG;
+  echo "==== $MOSQ_SUB_ERR ====" ; cat $MOSQ_SUB_ERR;
+
+  printf "%-32s TEST FAIL\n" "$CODE" | tee $CODE.testlog;
+fi
+
+rm make.log
+rm make.err
+rm $CLIENT_LOG $CLIENT_ERR
+rm $MOSQ_SUB_LOG $MOSQ_SUB_ERR
+
+# We do not want Make to stop -> Return 0
+# The Makefile will check if a log contains FAIL at the end
+exit 0


### PR DESCRIPTION
This adds a travis test for the MQTT client.

1. We start a mosquitto (MQTT) server
2. We then start an MQTT subscriber process
3. We start the MQTT client example, which will subscribe to a topic and periodically publish to a different topic.
4. We send a one-off publish to the topic the MQTT client is subscribed for.

Success criteria:
* MQTT client receives the publish message from 4
* The Mosquitto subscriber receives one or more publish messages from 3

Closes #715 