### PR TITLE
Fix to queuebuf initialization

### DIFF
--- a/arch/platform/nrf52dk/contiki-conf.h
+++ b/arch/platform/nrf52dk/contiki-conf.h
@@ -74,6 +74,10 @@
 
 /* Packet buffer */
 #define PACKETBUF_CONF_SIZE                     1280  /**< Required IPv6 MTU size */
+
+/* Queuebuf */
+#define QUEUEBUF_CONF_ENABLED                   0
+
 /** @} */
 
 /**

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -48,6 +48,7 @@
 #include "sys/stack-check.h"
 #include "dev/watchdog.h"
 
+#include "net/queuebuf.h"
 #include "net/app-layer/coap/coap-engine.h"
 #include "services/rpl-border-router/rpl-border-router.h"
 #include "services/orchestra/orchestra.h"
@@ -89,6 +90,9 @@ main(void)
 
   platform_init_stage_two();
 
+#if QUEUEBUF_ENABLED
+  queuebuf_init();
+#endif /* QUEUEBUF_ENABLED */
   netstack_init();
   node_id_init();
 

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -2061,11 +2061,6 @@ sicslowpan_init(void)
 #endif /* SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS > 1 */
 
 #endif /* SICSLOWPAN_COMPRESSION == SICSLOWPAN_COMPRESSION_IPHC */
-
-  /* We use the queuebuf module if fragmentation is enabled */
-#if SICSLOWPAN_CONF_FRAG
-  queuebuf_init();
-#endif
 }
 /*--------------------------------------------------------------------*/
 int

--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -539,5 +539,4 @@ csma_output_init(void)
   memb_init(&packet_memb);
   memb_init(&metadata_memb);
   memb_init(&neighbor_memb);
-  queuebuf_init();
 }

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -972,8 +972,7 @@ tsch_init(void)
     return;
   }
 
-  /* Init the queuebuf and TSCH sub-modules */
-  queuebuf_init();
+  /* Init TSCH sub-modules */
   tsch_reset();
   tsch_queue_init();
   tsch_schedule_init();

--- a/os/net/queuebuf.h
+++ b/os/net/queuebuf.h
@@ -55,6 +55,12 @@
 
 #include "net/packetbuf.h"
 
+#ifdef QUEUEBUF_CONF_ENABLED
+#define QUEUEBUF_ENABLED QUEUEBUF_CONF_ENABLED
+#else /* QUEUEBUF_CONF_ENABLED */
+#define QUEUEBUF_ENABLED 1
+#endif /* QUEUEBUF_CONF_ENABLED */
+
 /* QUEUEBUF_NUM is the total number of queuebuf */
 #ifdef QUEUEBUF_CONF_NUM
 #define QUEUEBUF_NUM QUEUEBUF_CONF_NUM


### PR DESCRIPTION
Presently, `queubuf_init` is usually called twice at start up, once by the MAC layer and once by `sicslowpan.c`. This gets problematic if the MAC layer immediately begins to use the queuebuf since the second invocation of `queubuf_init` deletes all queued frames. The solution proposed in this PR is to move the initialization of the queuebuf to `contikimac-main.c`.