### PR TITLE
Native border router: clearer error messages

### DIFF
--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -562,7 +562,7 @@ slip_init(void)
   slip_send(slipfd, SLIP_END);
   inslip = fdopen(slipfd, "r");
   if(inslip == NULL) {
-    err(1, "main: fdopen");
+    err(1, "slip_init: fdopen");
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -210,7 +210,7 @@ tun_init()
   tunfd = tun_alloc(slip_config_tundev);
 
   if(tunfd == -1) {
-    err(1, "main: open");
+    err(1, "tun_init: open");
   }
 
   select_set_callback(tunfd, &tun_select_callback);


### PR DESCRIPTION
This PR clarifies error messages of the native BR, to more easily distinguish errors related to opening the serial device or the tun file.