### PR TITLE
Improve command line parsing for platform native

### DIFF
--- a/arch/cpu/native/net/tun6-net.c
+++ b/arch/cpu/native/net/tun6-net.c
@@ -35,10 +35,12 @@
 
 #include "net/ipv6/uip.h"
 #include "net/ipv6/uip-ds6.h"
+#include "net/ipv6/uiplib.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <stdbool.h>
 #include <sys/time.h>
 #include <sys/types.h>
 
@@ -63,12 +65,24 @@
 #include <err.h>
 #include "net/netstack.h"
 #include "net/packetbuf.h"
-
-static const char *config_ipaddr = "fd00::1/64";
-/* Allocate some bytes in RAM and copy the string */
+#include "net/linkaddr.h"
+/*---------------------------------------------------------------------------*/
 static char config_tundev[64] = "tun0";
-
-
+static int log_level = LOG_LEVEL_INFO;
+static const char *config_ipaddr = "fd00::1/64";
+/*---------------------------------------------------------------------------*/
+/*
+ * Default link layer address to fall back to if the user does not specify
+ * one from the command line.
+ */
+#ifdef TUN6_NET_CONF_LL_ADDR
+static const uint8_t ll_addr[] = TUN6_NET_CONF_LL_ADDR;
+#else
+static const uint8_t ll_addr[] = {
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+};
+#endif
+/*---------------------------------------------------------------------------*/
 #ifndef __CYGWIN__
 static int tunfd = -1;
 
@@ -119,7 +133,16 @@ sigcleanup(int signo)
   fprintf(stderr, "signal %d\n", signo);
   exit(0);			/* exit(0) will call cleanup() */
 }
+/*---------------------------------------------------------------------------*/
+static void
+set_lladdr(void)
+{
+  linkaddr_t addr;
 
+  memset(&addr, 0, sizeof(linkaddr_t));
+  memcpy(addr.u8, &ll_addr[sizeof(ll_addr) - LINKADDR_SIZE], sizeof(addr.u8));
+  linkaddr_set_node_addr(&addr);
+}
 /*---------------------------------------------------------------------------*/
 static void
 ifconf(const char *tundev, const char *ipaddr)
@@ -198,8 +221,129 @@ tun_init()
 }
 
 #else
+/*---------------------------------------------------------------------------*/
+static void
+set_log_level(int level)
+{
+  if(level < LOG_LEVEL_NONE || level > LOG_LEVEL_DBG) {
+    return;
+  }
+
+  log_set_level("all", log_level);
+}
+/*---------------------------------------------------------------------------*/
+void
+tun6_net_parse_args(int argc, char **argv)
+{
+  const char *prog;
+  int c;
+  linkaddr_t addr;
+  uip_ip6addr_t prefix;
+  bool use_default_ll_addr = true;
+
+  prog = argv[0];
+
+  while((c = getopt(argc, argv, "hl:t:v::")) != -1) {
+    switch(c) {
+    case 't':
+      if(strncmp("/dev/", optarg, 5) == 0) {
+        strncpy(config_tundev, optarg + 5, sizeof(config_tundev));
+      } else {
+        strncpy(config_tundev, optarg, sizeof(config_tundev));
+      }
+      break;
+
+    case 'l':
+      /* Link layer address */
+      if(linkaddr_from_string(&addr, optarg) == LINKADDR_SIZE) {
+        linkaddr_set_node_addr(&addr);
+        use_default_ll_addr = false;
+      }
+
+      break;
+    case 'v':
+      log_level = 3;
+      if(optarg) {
+        log_level = strtol(optarg, NULL, 10);
+      }
+
+      set_log_level(log_level);
+      break;
+
+    case 'h':
+    default:
+      fprintf(stderr, "usage:  %s [options] [ipaddress]\n", prog);
+      fprintf(stderr, "example: %s -t tun1 -l 01:23:F:7:89:AB:CD:EF -v2 "
+                      "fd00::1/64\n", prog);
+      fprintf(stderr, "If ipaddress is omitted, the default is %s\n", config_ipaddr);
+      fprintf(stderr, "Options are:\n");
+      fprintf(stderr, " -t tundev      Name of interface (default tun0)\n");
+      fprintf(stderr, " -l address     Link layer address to assign to the node.\n");
+      fprintf(stderr, "                Must be of a standard MAC address\n");
+      fprintf(stderr, "                format with groups of two hex digits\n");
+      fprintf(stderr, "                separated by colons (':'). The min\n");
+      fprintf(stderr, "                required length depends on the value\n");
+      fprintf(stderr, "                of LINKADDR_SIZE.\n");
+#ifdef __APPLE__
+      fprintf(stderr, " -v level       Set logging level to level.\n");
+#else
+      fprintf(stderr, " -v[level]      Set logging level to level.\n");
+#endif
+      fprintf(stderr, "                Levels correspond to the values of LOG_LEVEL_ macros.\n");
+      fprintf(stderr, "    -v0         Set debug level to LOG_LEVEL_NONE\n");
+      fprintf(stderr, "    -v1         Set debug level to LOG_LEVEL_ERROR\n");
+      fprintf(stderr, "    -v2         Set debug level to LOG_LEVEL_WARN\n");
+      fprintf(stderr, "    -v3         Set debug level to LOG_LEVEL_INFO (default)\n");
+      fprintf(stderr, "    -v4         Set debug level to LOG_LEVEL_DEBUG\n");
+#ifndef __APPLE__
+      fprintf(stderr, "    -v          Equivalent to -v4\n");
+#endif
+      exit(1);
+      break;
+    }
+  }
+  argc -= optind - 1;
+  argv += optind - 1;
+
+  if(argc == 2) {
+    config_ipaddr = argv[1];
+  }
+
+  /*
+   * The IPv6 address specified in the command line will be used as the
+   * address of the tunnel interface. We need to make sure to use the same
+   * IPv6 prefix for our address auto-configuration, otherwise the process
+   * will not be reachable over the tunnel interface.
+   */
+  if(uiplib_ip6addrconv(config_ipaddr, &prefix)) {
+    /*
+     * The address was parsed successfully. Ideally we would determine the
+     * prefix length from the address (/n) and zero-out the last 128-n bits.
+     * However, we assume /64 in many places, so for now simply zero-out the
+     * last 8 bytes.
+     */
+    memset(&prefix.u16[4], 0, 8);
+
+#if NETSTACK_CONF_WITH_IPV6
+    LOG_INFO("Setting default prefix to ");
+    LOG_INFO_6ADDR(&prefix);
+    LOG_INFO_("\n");
+#endif
+
+    uip_ds6_set_default_prefix(&prefix);
+  }
 
 
+  if(*config_tundev == '\0') {
+    /* Use default. */
+    strcpy(config_tundev, "tun0");
+  }
+
+  if(use_default_ll_addr) {
+    LOG_WARN("Invalid link layer address. Using default\n");
+    set_lladdr();
+  }
+}
 /*---------------------------------------------------------------------------*/
 static void
 tun_init()
@@ -226,9 +370,11 @@ tun_init()
   signal(SIGHUP, sigcleanup);
   signal(SIGTERM, sigcleanup);
   signal(SIGINT, sigcleanup);
+
+  LOG_INFO("Assigning address %s to ``%s''\n", config_ipaddr, config_tundev);
+
   ifconf(config_tundev, config_ipaddr);
 }
-
 /*---------------------------------------------------------------------------*/
 static int
 tun_output(uint8_t *data, int len)
@@ -294,7 +440,7 @@ handle_fd(fd_set *rset, fd_set *wset)
     return;
   }
 
-  LOG_INFO("Tun6-handle FD\n");
+  LOG_DBG("Tun6-handle FD\n");
 
   if(FD_ISSET(tunfd, rset)) {
     size = tun_input(uip_buf, sizeof(uip_buf));

--- a/arch/platform/native/contiki-conf.h
+++ b/arch/platform/native/contiki-conf.h
@@ -72,6 +72,10 @@ typedef unsigned int uip_stats_t;
 #define NETSTACK_CONF_NETWORK    tun6_net_driver
 #endif
 
+#ifndef PLATFORM_CONF_PROCESS_ARGS_FUNC
+#define PLATFORM_CONF_PROCESS_ARGS_FUNC tun6_net_parse_args
+#endif
+
 #ifndef NETSTACK_CONF_RADIO
 #define NETSTACK_CONF_RADIO   nullradio_driver
 #endif /* NETSTACK_CONF_RADIO */

--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -113,13 +113,6 @@
 
 static const struct select_callback *select_callback[SELECT_MAX];
 static int select_max = 0;
-
-#ifdef PLATFORM_CONF_MAC_ADDR
-static uint8_t mac_addr[] = PLATFORM_CONF_MAC_ADDR;
-#else /* PLATFORM_CONF_MAC_ADDR */
-static uint8_t mac_addr[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
-#endif /* PLATFORM_CONF_MAC_ADDR */
-
 /*---------------------------------------------------------------------------*/
 int
 select_set_callback(int fd, const struct select_callback *callback)
@@ -174,23 +167,6 @@ const static struct select_callback stdin_fd = {
   stdin_set_fd, stdin_handle_fd
 };
 #endif /* SELECT_STDIN */
-/*---------------------------------------------------------------------------*/
-static void
-set_lladdr(void)
-{
-  linkaddr_t addr;
-
-  memset(&addr, 0, sizeof(linkaddr_t));
-#if NETSTACK_CONF_WITH_IPV6
-  memcpy(addr.u8, mac_addr, sizeof(addr.u8));
-#else
-  int i;
-  for(i = 0; i < sizeof(linkaddr_t); ++i) {
-    addr.u8[i] = mac_addr[7 - i];
-  }
-#endif
-  linkaddr_set_node_addr(&addr);
-}
 /*---------------------------------------------------------------------------*/
 #if NETSTACK_CONF_WITH_IPV6
 static void
@@ -255,7 +231,6 @@ platform_init_stage_one()
 void
 platform_init_stage_two()
 {
-  set_lladdr();
   serial_line_init();
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -218,27 +218,29 @@ set_global_address(void)
 }
 #endif
 /*---------------------------------------------------------------------------*/
-int contiki_argc = 0;
-char **contiki_argv;
+#ifdef PLATFORM_CONF_PROCESS_ARGS_FUNC
+#define PLATFORM_PROCESS_ARGS_FUNC PLATFORM_CONF_PROCESS_ARGS_FUNC
+
+void PLATFORM_PROCESS_ARGS_FUNC(int argc, char**argv);
+#else
+#define PLATFORM_PROCESS_ARGS_FUNC(...)
+#endif
 /*---------------------------------------------------------------------------*/
 void
 platform_process_args(int argc, char**argv)
 {
-  /* crappy way of remembering and accessing argc/v */
-  contiki_argc = argc;
-  contiki_argv = argv;
-
   /* native under windows is hardcoded to use the first one or two args */
   /* for wpcap configuration so this needs to be "removed" from         */
   /* contiki_args (used by the native-border-router) */
 #ifdef __CYGWIN__
-  contiki_argc--;
-  contiki_argv++;
+  argc--;
+  argv++;
 #ifdef UIP_FALLBACK_INTERFACE
-  contiki_argc--;
-  contiki_argv++;
+  argc--;
+  argv++;
 #endif
 #endif
+  PLATFORM_PROCESS_ARGS_FUNC(argc, argv);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/os/net/linkaddr.c
+++ b/os/net/linkaddr.c
@@ -44,6 +44,7 @@
 
 #include "net/linkaddr.h"
 #include <string.h>
+#include <stdio.h>
 
 linkaddr_t linkaddr_node_addr;
 #if LINKADDR_SIZE == 2
@@ -75,6 +76,51 @@ void
 linkaddr_set_node_addr(linkaddr_t *t)
 {
   linkaddr_copy(&linkaddr_node_addr, t);
+}
+/*---------------------------------------------------------------------------*/
+int
+linkaddr_from_string(linkaddr_t *addr, const char *addr_str)
+{
+  unsigned int values[LINKADDR_SIZE];
+  int i;
+  int byte_count;
+
+  /*
+   * End formats with %*c to get rid of any unexpected characters beyond the
+   * end of the expected format.
+   */
+  switch(LINKADDR_SIZE) {
+  case 2:
+    byte_count = sscanf(addr_str, "%2x:%2x%*c", &values[0], &values[1]);
+    break;
+  case 6:
+    byte_count = sscanf(addr_str, "%2x:%2x:%2x:%2x:%2x:%2x%*c",
+                        &values[0], &values[1], &values[2],
+                        &values[3], &values[4], &values[5]);
+    break;
+  case 8:
+    byte_count = sscanf(addr_str, "%2x:%2x:%2x:%2x:%2x:%2x:%2x:%2x%*c",
+                        &values[0], &values[1], &values[2],
+                        &values[3], &values[4], &values[5],
+                        &values[6], &values[7]);
+    break;
+  default:
+    return -1;
+  }
+
+  /*
+   * Return an error unless we converted exactly LINKADDR_SIZE bytes.
+   * Otherwise convert unsigned int to uint8_t before copying to the
+   * destination address.
+   */
+  if(byte_count == LINKADDR_SIZE) {
+    for(i = 0; i < LINKADDR_SIZE; ++i)
+      addr->u8[i] = (uint8_t)values[i];
+
+    return byte_count;
+  }
+
+  return -1;
 }
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/os/net/linkaddr.h
+++ b/os/net/linkaddr.h
@@ -106,6 +106,46 @@ int linkaddr_cmp(const linkaddr_t *addr1, const linkaddr_t *addr2);
 void linkaddr_set_node_addr(linkaddr_t *addr);
 
 /**
+ * \brief          Convert a string to a link address
+ * \param addr     The destination memory where the address will be stored
+ * \param addr_str The string to convert
+ * \retval -1      Conversion failed
+ * \return         The number of bytes retrieved, or -1
+ *
+ *             This function will read a string of a MAC address format and
+ *             attempt to convert it to a linkaddr_t representation.
+ *
+ *             The format of the input string is expected to be of a standard
+ *             human-readable representation of a MAC address: Groups of two
+ *             hex digits, separated by colon ':' characters.
+ *
+ *             Other delimiters (e.g. '.' or '-' are not supported).
+ *
+ *             The function is not case-sensitive. The input strings Ab:cD and
+ *             AB:CD are equivalent. The function will accept single-digit hex
+ *             groups. For example AB:C:DE will be treated the same as
+ *             AB:0C:DE.
+ *
+ *             The function can convert all three supported LINKADDR_SIZE
+ *             values, therefore it can accept an input string that contains
+ *             2, 6 or 8 two-digit groups. However, it will only process
+ *             exactly as many characters as needed to write LINKADDR_SIZE
+ *             bytes to \addr. If the input string does not contain sufficient
+ *             characters to populate all LINKADDR_SIZE bytes, the function
+ *             will return an error. If the input string contains additional
+ *             characters, they will be silently ignored without an error.
+ *
+ *             \e addr must be allocated by the caller.
+ *
+ *             If successful, the return value of this function will be equal
+ *             to LINKADDR_SIZE.
+ *
+ *             On error, the function will return a negative value
+ */
+int linkaddr_from_string(linkaddr_t *addr, const char *addr_str);
+
+
+/**
  * \brief      The link-layer address of the node
  *
  *             This variable contains the link-layer address of the

--- a/os/services/rpl-border-router/native/border-router-native.c
+++ b/os/services/rpl-border-router/native/border-router-native.c
@@ -111,8 +111,6 @@ PROCESS_THREAD(border_router_process, ev, data)
 
   LOG_INFO("RPL-Border router started\n");
 
-  slip_config_handle_arguments(contiki_argc, contiki_argv);
-
   /* tun init is also responsible for setting up the SLIP connection */
   tun_init();
 

--- a/os/services/rpl-border-router/native/border-router.h
+++ b/os/services/rpl-border-router/native/border-router.h
@@ -42,7 +42,6 @@
 #include <stdio.h>
 
 int border_router_cmd_handler(const uint8_t *data, int len);
-int slip_config_handle_arguments(int argc, char **argv);
 void write_to_slip(const uint8_t *buf, int len);
 
 void border_router_set_prefix_64(const uip_ipaddr_t *prefix_64);

--- a/os/services/rpl-border-router/native/module-macros.h
+++ b/os/services/rpl-border-router/native/module-macros.h
@@ -38,6 +38,7 @@
 #define SERIALIZE_ATTRIBUTES 1
 
 #define CMD_CONF_OUTPUT border_router_cmd_output
+#define PLATFORM_CONF_PROCESS_ARGS_FUNC slip_config_handle_arguments
 
 /* used by wpcap (see /cpu/native/net/wpcap-drv.c) */
 #define SELECT_CALLBACK 1


### PR DESCRIPTION
This pull request tidies-up, improves and extends command line parsing for platform native.

* We provide a way to configure the function used to parse the command line. This allows us to use different command line options under different circumstances.
* We make sure that command line parsing takes place first thing in the boot sequence. Our current border router image parses the command line at the point in time when the `border_router_process` is started, which is too late. By parsing the command line early we can configure things before the boot sequence falls back to defaults, which is an improvement over having to re-configure things a posteriori. 
* We use the existing native border router command line parser for any example that includes this module.
* We introduce a different command line option set for all other IPv6/native examples.

The new command line option set for IPv6/native allow us to:

* Specify the name of the tunnel interface in a fashion identical to what the border router does. This allows us to run multiple native processes, each one bound to a different tunnel interface. Hopefully in the future they may even be able to talk to each other!
* Specify the v6 address of the tunnel interface, again in a fashion identical to what the border router does. While at it, we make sure the default v6 prefix used by the native image matches the prefix used by the tunnel interface.
* Specify the link layer address of the native image.
* Set verbosity control (logging level).

This is what it looks like:

```bash
$ ./hello-world.native -h
usage:  ./hello-world.native [options] [ipaddress]
example: ./hello-world.native -t tun1 -l 01:23:F:7:89:AB:CD:EF -v2 fd00::1/64
If ipaddress is omitted, the default is fd00::1/64
Options are:
 -t tundev      Name of interface (default tun0)
 -l address     Link layer address to assign to the node.
                Must be of a standard MAC address
                format with groups of two hex digits
                separated by colons (':'). The min
                required length depends on the value
                of LINKADDR_SIZE.
 -v level       Set logging level to level.
                Levels correspond to the values of LOG_LEVEL_ macros.
    -v0         Set debug level to LOG_LEVEL_NONE
    -v1         Set debug level to LOG_LEVEL_ERROR
    -v2         Set debug level to LOG_LEVEL_WARN
    -v3         Set debug level to LOG_LEVEL_INFO (default)
    -v4         Set debug level to LOG_LEVEL_DEBUG
```

This pull also adds a helper function that can be used to convert a link layer address from a string representation to a `linkaddr_t`.

Requires #752 