### PR TITLE
Allow configurable linker script

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -24,7 +24,7 @@ CFLAGS += -I$(TI_XXWARE) -I$(CONTIKI)/$(TI_XXWARE_SRC)
 CFLAGS += -I$(TI_XXWARE)/inc
 MODULES += $(TI_XXWARE_SRC)
 
-LDSCRIPT = $(CONTIKI_CPU)/cc26xx.ld
+LDSCRIPT ?= $(CONTIKI_CPU)/cc26xx.ld
 
 ### If the user-specified a Node ID, pass a define
 ifdef NODEID

--- a/arch/cpu/nrf52832/Makefile.nrf52832
+++ b/arch/cpu/nrf52832/Makefile.nrf52832
@@ -25,9 +25,9 @@ ifneq ($(NRF52_WITHOUT_SOFTDEVICE),1)
     NRF52_SOFTDEVICE := $(shell find $(NRF52_SDK_ROOT) -name *iot*_softdevice.hex | head -n 1)
   endif
   $(info SoftDevice: $(NRF52_SOFTDEVICE))
-  LDSCRIPT := $(CONTIKI_CPU)/ld/nrf52-$(NRF52_DK_REVISION)-sd.ld
+  LDSCRIPT ?= $(CONTIKI_CPU)/ld/nrf52-$(NRF52_DK_REVISION)-sd.ld
 else
-  LDSCRIPT := $(CONTIKI_CPU)/ld/nrf52.ld
+  LDSCRIPT ?= $(CONTIKI_CPU)/ld/nrf52.ld
 endif
 
 OUTPUT_FILENAME := $(CONTIKI_PROJECT)

--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -120,7 +120,7 @@ LDFLAGS += -nostartfiles
 LDFLAGS += -static
 
 # Linker script
-LDSCRIPT := $(CONTIKI_CPU)/$(SUBFAMILY)/$(SUBFAMILY).lds
+LDSCRIPT ?= $(CONTIKI_CPU)/$(SUBFAMILY)/$(SUBFAMILY).lds
 
 # Globally linked libraries
 TARGET_LIBFILES += -lc -lgcc -lnosys -lm


### PR DESCRIPTION
Make it possible to overwrite `LDSCRIPT` from other Makefiles

Previously only possible to override linker script using from environment. This allows user to set linker script in their project makefile.