### PR TITLE
Add missing inclusions of <inttypes.h>

### DIFF
--- a/examples/benchmarks/rpl-req-resp/node.c
+++ b/examples/benchmarks/rpl-req-resp/node.c
@@ -42,6 +42,8 @@
 #include "contiki-net.h"
 #include "services/deployment/deployment.h"
 
+#include <inttypes.h>
+
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "App"

--- a/os/net/mac/tsch/tsch-adaptive-timesync.c
+++ b/os/net/mac/tsch/tsch-adaptive-timesync.c
@@ -45,6 +45,7 @@
 
 #include "net/mac/tsch/tsch.h"
 #include <stdio.h>
+#include <inttypes.h>
 
 #if TSCH_ADAPTIVE_TIMESYNC
 


### PR DESCRIPTION
Required in these two files, as they use `PRI` macros (`printf` format for fixed-width integers)