### PR TITLE
Build system: enable compiling with arch directory at arbitrary paths

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -82,7 +82,10 @@ uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 
 ### Include target makefile (TODO Unsafe?)
 
-target_makefile := $(wildcard $(CONTIKI)/arch/platform/$(TARGET)/Makefile.$(TARGET) ${foreach TDIR, $(TARGETDIRS), $(TDIR)/$(TARGET)/Makefile.$(TARGET)})
+# Configurable arch path
+ARCH_PATH ?= $(CONTIKI)/arch
+
+target_makefile := $(wildcard $(ARCH_PATH)/platform/$(TARGET)/Makefile.$(TARGET) ${foreach TDIR, $(TARGETDIRS), $(TDIR)/$(TARGET)/Makefile.$(TARGET)})
 
 # Check if the target makefile exists, and create the object directory if necessary.
 ifeq ($(strip $(target_makefile)),)
@@ -326,13 +329,13 @@ clean:
 	@echo Target $(TARGET) cleaned
 
 distclean:
-	@for TARG in `ls $(CONTIKI)/arch/platform $(TARGETDIRS)`; do \
+	@for TARG in `ls $(ARCH_PATH)/platform $(TARGETDIRS)`; do \
 		echo Running: $(MAKE) TARGET=$$TARG clean; \
 		$(MAKE) TARGET=$$TARG clean; \
 	done
 	-$(Q)rm -rf $(BUILD_DIR)
 
--include $(CONTIKI)/arch/platform/$(TARGET)/Makefile.customrules-$(TARGET)
+-include $(ARCH_PATH)/platform/$(TARGET)/Makefile.customrules-$(TARGET)
 
 ifndef CUSTOM_RULE_C_TO_OBJECTDIR_O
 $(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
@@ -414,7 +417,7 @@ endif
 include $(CONTIKI)/Makefile.help
 
 targets:
-	@ls $(CONTIKI)/arch/platform $(TARGETDIRS)
+	@ls $(ARCH_PATH)/platform $(TARGETDIRS)
 
 boards:
 ifdef BOARD

--- a/arch/cpu/arm/cortex-m/Makefile.cortex-m
+++ b/arch/cpu/arm/cortex-m/Makefile.cortex-m
@@ -25,4 +25,4 @@ $(OUT_ELF): $(CPU_STARTFILES) $$(CONTIKI_OBJECTFILES) %.o $(PROJECT_OBJECTFILES)
 	$(TRACE_LD)
 	$(Q)$(LD) $(LDFLAGS) ${filter-out $(LDSCRIPT) %.a,$^} ${filter %.a,$^} $(TARGET_LIBFLAGS) -o $@
 
-include $(CONTIKI)/arch/cpu/arm/Makefile.arm
+include $(ARCH_PATH)/cpu/arm/Makefile.arm

--- a/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
+++ b/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
@@ -6,4 +6,4 @@ LDFLAGS += -mcpu=cortex-m3 -nostartfiles
 
 TARGET_LIBFILES += -lm
 
-include $(CONTIKI)/arch/cpu/arm/cortex-m/Makefile.cortex-m
+include $(ARCH_PATH)/cpu/arm/cortex-m/Makefile.cortex-m

--- a/arch/cpu/arm/cortex-m/cm4/Makefile.cm4
+++ b/arch/cpu/arm/cortex-m/cm4/Makefile.cm4
@@ -4,4 +4,4 @@ CFLAGS += -mcpu=cortex-m4
 
 LDFLAGS += -mcpu=cortex-m4
 
-include $(CONTIKI)/arch/cpu/arm/cortex-m/Makefile.cortex-m
+include $(ARCH_PATH)/cpu/arm/cortex-m/Makefile.cortex-m

--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -52,4 +52,4 @@ $(LDSCRIPT): $(SOURCE_LDSCRIPT) FORCE | $(OBJECTDIR)
 	$(TRACE_CC)
 	$(Q)$(CC) $(LDGENFLAGS) $< | grep -v '^\s*#\s*pragma\>' > $@
 
-include $(CONTIKI)/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
+include $(ARCH_PATH)/cpu/arm/cortex-m/cm3/Makefile.cm3

--- a/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -81,7 +81,7 @@ STACK_SIZE = 0
 	@$(SIZE) -A $< | egrep "data|bss" | awk '{s+=$$2} END {s=s+$(STACK_SIZE); f=$(RAM_SIZE)-s; printf "[RAM]   used %6d, free %6d\n",s,f;}'
 	@$(SIZE) -A $< | egrep "text|isr_vector" | awk '{s+=$$2} END {f=$(FLASH_SIZE)-s; printf "[Flash] used %6d, free %6d\n",s,f;}'
 
-include $(CONTIKI)/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
+include $(ARCH_PATH)/cpu/arm/cortex-m/cm3/Makefile.cm3
 
 ifeq ($(BOARD_SUPPORTS_BSL),1)
 %.upload: $(OUT_BIN)

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -11,7 +11,7 @@ CFLAGS += -gstabs+
 .SUFFIXES:
 
 ### Define the CPU directory
-CONTIKI_CPU=$(CONTIKI)/arch/cpu/msp430
+CONTIKI_CPU=$(ARCH_PATH)/cpu/msp430
 
 ### Define the source files we have in the MSP430 port
 

--- a/arch/cpu/nrf52832/Makefile.nrf52832
+++ b/arch/cpu/nrf52832/Makefile.nrf52832
@@ -204,4 +204,4 @@ erase:
 
 .PHONY: softdevice.jlink
 
-include $(CONTIKI)/arch/cpu/arm/cortex-m/cm4/Makefile.cm4
+include $(ARCH_PATH)/cpu/arm/cortex-m/cm4/Makefile.cm4

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13x0-cc26x0/Makefile.cc13x0-cc26x0
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13x0-cc26x0/Makefile.cc13x0-cc26x0
@@ -8,4 +8,4 @@ TARGET_LIBFILES += $(SDK_DRIVERS)/lib/drivers_$(SDK_LIB_NAME).am3g
 TARGET_LIBFILES += $(SDK_DEVICES)/driverlib/bin/gcc/driverlib.lib
 
 # CC13x0/CC26x0 is a Cortex-M3 architecture
-include $(CONTIKI)/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
+include $(ARCH_PATH)/cpu/arm/cortex-m/cm3/Makefile.cm3

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13x2-cc26x2/Makefile.cc13x2-cc26x2
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13x2-cc26x2/Makefile.cc13x2-cc26x2
@@ -8,4 +8,4 @@ TARGET_LIBFILES += $(SDK_DRIVERS)/lib/drivers_$(SDK_LIB_NAME).am4fg
 TARGET_LIBFILES += $(SDK_DEVICES)/driverlib/bin/gcc/driverlib.lib
 
 # CC13x2/CC26x2 is a Cortex-M4 architecture
-include $(CONTIKI)/arch/cpu/arm/cortex-m/cm4/Makefile.cm4
+include $(ARCH_PATH)/cpu/arm/cortex-m/cm4/Makefile.cm4

--- a/arch/platform/cc2538dk/Makefile.cc2538dk
+++ b/arch/platform/cc2538dk/Makefile.cc2538dk
@@ -14,7 +14,7 @@ CONTIKI_TARGET_SOURCEFILES += board-buttons.c als-sensor.c
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
 ### Define the CPU directory
-CONTIKI_CPU=$(CONTIKI)/arch/cpu/cc2538
+CONTIKI_CPU=$(ARCH_PATH)/cpu/cc2538
 include $(CONTIKI_CPU)/Makefile.cc2538
 
 MODULES += os/storage/cfs

--- a/arch/platform/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/platform/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -11,7 +11,7 @@ BOARDS = srf06/cc26x0 srf06/cc13x0 launchpad/cc2640r2 launchpad/cc2650 launchpad
 CONTIKI_TARGET_DIRS += .
 
 ### Include the board-specific makefile
-PLATFORM_ROOT_DIR = $(CONTIKI)/arch/platform/$(TARGET)
+PLATFORM_ROOT_DIR = $(ARCH_PATH)/platform/$(TARGET)
 -include $(PLATFORM_ROOT_DIR)/$(BOARD)/Makefile.$(notdir $(BOARD))
 
 CONTIKI_TARGET_SOURCEFILES += platform.c leds-arch.c
@@ -25,5 +25,5 @@ SMALL ?= 0
 ### Define the CPU directory and pull in the correct CPU makefile. This will
 ### be defined by one of the makefiles included above and it can be either
 ### Makefile.cc26xx or Makefile.cc13xx
-CONTIKI_CPU=$(CONTIKI)/arch/cpu/cc26x0-cc13x0
+CONTIKI_CPU=$(ARCH_PATH)/cpu/cc26x0-cc13x0
 include $(CONTIKI_CPU)/Makefile.$(CPU_FAMILY)

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -41,7 +41,7 @@ JNILIB = $(BUILD_DIR_BOARD)/$(LIBNAME).$(TARGET)
 CONTIKI_APP_OBJ = $(CONTIKI_APP).o
 
 ### COOJA platform sources
-COOJA = $(CONTIKI)/arch/platform/$(TARGET)
+COOJA = $(ARCH_PATH)/platform/$(TARGET)
 CONTIKI_TARGET_DIRS = . dev lib sys cfs net
 
 # (COOJA_SOURCEDIRS contains additional sources dirs set from simulator)
@@ -67,7 +67,7 @@ CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 CLEAN += COOJA.log
 
 ### Define the CPU directory
-CONTIKI_CPU=$(CONTIKI)/arch/cpu/x86
+CONTIKI_CPU=$(ARCH_PATH)/cpu/x86
 
 ### Compiler arguments
 #CC = gcc

--- a/arch/platform/native/Makefile.native
+++ b/arch/platform/native/Makefile.native
@@ -28,5 +28,5 @@ CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 MAKE_MAC ?= MAKE_MAC_NULLMAC
 
 ### Define the CPU directory
-CONTIKI_CPU=$(CONTIKI)/arch/cpu/native
-include $(CONTIKI)/arch/cpu/native/Makefile.native
+CONTIKI_CPU=$(ARCH_PATH)/cpu/native
+include $(ARCH_PATH)/cpu/native/Makefile.native

--- a/arch/platform/nrf52dk/Makefile.nrf52dk
+++ b/arch/platform/nrf52dk/Makefile.nrf52dk
@@ -3,7 +3,7 @@ ifndef CONTIKI
 endif
 
 ### Include the board-specific makefile
-PLATFORM_ROOT_DIR = $(CONTIKI)/arch/platform/$(TARGET)
+PLATFORM_ROOT_DIR = $(ARCH_PATH)/platform/$(TARGET)
 
 CONTIKI_TARGET_DIRS += . dev config
 CONTIKI_SOURCEFILES += platform.c leds-arch.c nrf52dk-sensors.c button-sensor.c temperature-sensor.c
@@ -21,5 +21,5 @@ endif
 SMALL ?= 0
 
 ### Define the CPU directory and pull in the correct CPU makefile.
-CONTIKI_CPU=$(CONTIKI)/arch/cpu/nrf52832
+CONTIKI_CPU=$(ARCH_PATH)/cpu/nrf52832
 include $(CONTIKI_CPU)/Makefile.nrf52832

--- a/arch/platform/openmote-cc2538/Makefile.openmote-cc2538
+++ b/arch/platform/openmote-cc2538/Makefile.openmote-cc2538
@@ -11,7 +11,7 @@ endif
 
 ### Configure the build for the board and pull in board-specific sources
 CONTIKI_TARGET_DIRS += . dev
-PLATFORM_ROOT_DIR = $(CONTIKI)/arch/platform/$(TARGET)
+PLATFORM_ROOT_DIR = $(ARCH_PATH)/platform/$(TARGET)
 
 ### Include
 CONTIKI_TARGET_SOURCEFILES += platform.c board.c
@@ -21,7 +21,7 @@ CONTIKI_TARGET_SOURCEFILES += antenna.c adxl346.c max44009.c sht21.c tps62730.c
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
 ### Define the CPU directory
-CONTIKI_CPU=$(CONTIKI)/arch/cpu/cc2538
+CONTIKI_CPU=$(ARCH_PATH)/cpu/cc2538
 include $(CONTIKI_CPU)/Makefile.cc2538
 
 MODULES += os/storage/cfs

--- a/arch/platform/simplelink/cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/platform/simplelink/cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -51,7 +51,7 @@ CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 CPU_FAMILY = cc13xx-cc26xx
 
 # Define the CPU directory and pull in the correct CPU Makefile
-CONTIKI_CPU := $(realpath $(CONTIKI)/arch/cpu/simplelink-$(CPU_FAMILY))
+CONTIKI_CPU := $(realpath $(ARCH_PATH)/cpu/simplelink-$(CPU_FAMILY))
 include $(CONTIKI_CPU)/Makefile.$(CPU_FAMILY)
 
 MODULES += os/net os/net/mac os/net/mac/framer

--- a/arch/platform/sky/Makefile.common
+++ b/arch/platform/sky/Makefile.common
@@ -18,7 +18,7 @@ endif
 CONTIKI_TARGET_SOURCEFILES += $(ARCH) $(UIPDRIVERS)
 
 MCU=msp430f1611
-include $(CONTIKI)/arch/cpu/msp430/Makefile.msp430
+include $(ARCH_PATH)/cpu/msp430/Makefile.msp430
 
 
 ifdef IAR

--- a/arch/platform/sky/Makefile.sky
+++ b/arch/platform/sky/Makefile.sky
@@ -4,6 +4,6 @@ CONTIKI_TARGET_SOURCEFILES += contiki-sky-platform.c \
 	sht11.c sht11-sensor.c light-sensor.c battery-sensor.c \
 	button-sensor.c
 
-include $(CONTIKI)/arch/platform/sky/Makefile.common
+include $(ARCH_PATH)/platform/sky/Makefile.common
 
 MODULES += arch/dev/cc2420 arch/dev/sht11 arch/dev/ds2411 os/storage/cfs

--- a/arch/platform/zoul/Makefile.zoul
+++ b/arch/platform/zoul/Makefile.zoul
@@ -25,7 +25,7 @@ CFLAGS += -DDATE="\"`date +"%02u %02d %02m %02y %02H %02M %02S"`\""
 ### Configure the build for the board and pull in board-specific sources
 CONTIKI_TARGET_DIRS += . dev
 CONTIKI_TARGET_DIRS += . $(BOARD)
-PLATFORM_ROOT_DIR = $(CONTIKI)/arch/platform/$(TARGET)
+PLATFORM_ROOT_DIR = $(ARCH_PATH)/platform/$(TARGET)
 
 ### Include the board dir if one exists
 -include $(PLATFORM_ROOT_DIR)/$(BOARD)/Makefile.$(BOARD)
@@ -39,7 +39,7 @@ CONTIKI_TARGET_SOURCEFILES += $(BOARD_SOURCEFILES)
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
 ### Define the CPU directory
-CONTIKI_CPU=$(CONTIKI)/arch/cpu/cc2538
+CONTIKI_CPU=$(ARCH_PATH)/cpu/cc2538
 include $(CONTIKI_CPU)/Makefile.cc2538
 
 MODULES += arch/dev/cc1200 arch/dev/rgb-led os/storage/cfs


### PR DESCRIPTION
This is a proposal to enable compiling with arbitrary arch paths, which is useful for platforms, dev, or cpu outside of the Contiki-NG tree. The PR introduces a variable `ARCH_PATH`, which by default points to `$(CONTIKI)/arch` but can be specified by the user so as to point to any location.

For instance:
```bash
make TARGET=<my-custom-target> ARCH_PATH=<path-to-my-custom-arch>
```