### PR TITLE
Fixed wrong PIN configuration for UART0_RX on LaunchPads

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1310/CC1310_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1310/CC1310_LAUNCHXL.c
@@ -498,7 +498,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1310_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low       */
     CC1310_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low       */
     CC1310_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,  /* External flash chip select */
-    CC1310_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                              /* UART RX via debugger back channel */
+    CC1310_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLUP,                                                /* UART RX via debugger back channel */
     CC1310_LAUNCHXL_UART_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                        /* UART TX via debugger back channel */
     CC1310_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master out - slave in */
     CC1310_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master in - slave out */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/CC1312R1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/CC1312R1_LAUNCHXL.c
@@ -619,7 +619,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1312R1_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low       */
     CC1312R1_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low       */
     CC1312R1_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,  /* External flash chip select */
-    CC1312R1_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                              /* UART RX via debugger back channel */
+    CC1312R1_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLUP,                                                /* UART RX via debugger back channel */
     CC1312R1_LAUNCHXL_UART_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                        /* UART TX via debugger back channel */
     CC1312R1_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master out - slave in */
     CC1312R1_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master in - slave out */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1350-4/CC1350_LAUNCHXL_433.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1350-4/CC1350_LAUNCHXL_433.c
@@ -493,7 +493,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1350_LAUNCHXL_433_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low          */
     CC1350_LAUNCHXL_433_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low          */
     CC1350_LAUNCHXL_433_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,     /* External flash chip select    */
-    CC1350_LAUNCHXL_433_UART_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                                 /* UART RX via debugger back channel */
+    CC1350_LAUNCHXL_433_UART_RX | PIN_INPUT_EN | PIN_PULLUP,                                                   /* UART RX via debugger back channel */
     CC1350_LAUNCHXL_433_UART_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                           /* UART TX via debugger back channel */
     CC1350_LAUNCHXL_433_DIO1_RF_SUB1GHZ   | PIN_GPIO_OUTPUT_EN | PIN_GPIO_LOW | PIN_PUSHPULL | PIN_DRVSTR_MAX, /* RF SW Switch defaults to 2.4 GHz path*/
     CC1350_LAUNCHXL_433_DIO30_RF_POWER | PIN_GPIO_OUTPUT_EN | PIN_GPIO_LOW | PIN_PUSHPULL | PIN_DRVSTR_MAX,    /* External RF Switch is powered off by default */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1350/CC1350_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1350/CC1350_LAUNCHXL.c
@@ -498,7 +498,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1350_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low          */
     CC1350_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low          */
     CC1350_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,     /* External flash chip select    */
-    CC1350_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                                 /* UART RX via debugger back channel */
+    CC1350_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLUP,                                                   /* UART RX via debugger back channel */
     CC1350_LAUNCHXL_UART_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                           /* UART TX via debugger back channel */
     CC1350_LAUNCHXL_DIO1_RF_SUB1GHZ   | PIN_GPIO_OUTPUT_EN | PIN_GPIO_LOW | PIN_PUSHPULL | PIN_DRVSTR_MAX, /* RF SW Switch defaults to 2.4 GHz path*/
     CC1350_LAUNCHXL_DIO30_RF_POWER | PIN_GPIO_OUTPUT_EN | PIN_GPIO_LOW | PIN_PUSHPULL | PIN_DRVSTR_MAX,    /* External RF Switch is powered off by default */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p-2/CC1352P_2_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p-2/CC1352P_2_LAUNCHXL.c
@@ -585,7 +585,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1352P_2_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low */
     CC1352P_2_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low */
     CC1352P_2_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,     /* External flash chip select */
-    CC1352P_2_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                                /* UART RX via debugger back channel */
+    CC1352P_2_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLUP,                                                  /* UART RX via debugger back channel */
     CC1352P_2_LAUNCHXL_UART0_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                          /* UART TX via debugger back channel */
     CC1352P_2_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                               /* SPI master out - slave in */
     CC1352P_2_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                               /* SPI master in - slave out */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p-4/CC1352P_4_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p-4/CC1352P_4_LAUNCHXL.c
@@ -585,7 +585,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1352P_4_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low */
     CC1352P_4_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low */
     CC1352P_4_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,     /* External flash chip select */
-    CC1352P_4_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                                /* UART RX via debugger back channel */
+    CC1352P_4_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLUP,                                                  /* UART RX via debugger back channel */
     CC1352P_4_LAUNCHXL_UART0_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                          /* UART TX via debugger back channel */
     CC1352P_4_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                               /* SPI master out - slave in */
     CC1352P_4_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                               /* SPI master in - slave out */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p1/CC1352P1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p1/CC1352P1_LAUNCHXL.c
@@ -585,7 +585,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1352P1_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low */
     CC1352P1_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low */
     CC1352P1_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,     /* External flash chip select */
-    CC1352P1_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                                /* UART RX via debugger back channel */
+    CC1352P1_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLUP,                                                  /* UART RX via debugger back channel */
     CC1352P1_LAUNCHXL_UART0_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                          /* UART TX via debugger back channel */
     CC1352P1_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                               /* SPI master out - slave in */
     CC1352P1_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                               /* SPI master in - slave out */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352r1/CC1352R1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352r1/CC1352R1_LAUNCHXL.c
@@ -609,7 +609,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1352R1_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low */
     CC1352R1_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,             /* Button is active low */
     CC1352R1_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,     /* External flash chip select */
-    CC1352R1_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                                /* UART RX via debugger back channel */
+    CC1352R1_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLUP,                                                  /* UART RX via debugger back channel */
     CC1352R1_LAUNCHXL_UART0_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                          /* UART TX via debugger back channel */
     CC1352R1_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                               /* SPI master out - slave in */
     CC1352R1_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                               /* SPI master in - slave out */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc2650/CC2650_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc2650/CC2650_LAUNCHXL.c
@@ -497,7 +497,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC2650_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low */
     CC2650_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low */
     CC2650_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,  /* External flash chip select */
-    CC2650_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                              /* UART RX via debugger back channel */
+    CC2650_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLUP,                                                /* UART RX via debugger back channel */
     CC2650_LAUNCHXL_UART_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                        /* UART TX via debugger back channel */
     CC2650_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master out - slave in */
     CC2650_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master in - slave out */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc26x2r1/CC26X2R1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc26x2r1/CC26X2R1_LAUNCHXL.c
@@ -619,7 +619,7 @@ const PIN_Config BoardGpioInitTable[] = {
     CC26X2R1_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low */
     CC26X2R1_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low */
     CC26X2R1_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,  /* External flash chip select */
-    CC26X2R1_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                             /* UART RX via debugger back channel */
+    CC26X2R1_LAUNCHXL_UART0_RX | PIN_INPUT_EN | PIN_PULLUP,                                               /* UART RX via debugger back channel */
     CC26X2R1_LAUNCHXL_UART0_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL,                       /* UART TX via debugger back channel */
     CC26X2R1_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master out - slave in */
     CC26X2R1_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master in - slave out */


### PR DESCRIPTION
All LaunchPads drives the UART0_RX pin up, but is configured in the Board file to be pull-down. This PR aligns the UART RX pin configuration with the development board HW.