### PR TITLE
Fix the nrf52dk .jlink and .flash make targets

### DIFF
--- a/arch/cpu/nrf52832/Makefile.nrf52832
+++ b/arch/cpu/nrf52832/Makefile.nrf52832
@@ -185,10 +185,12 @@ $(OBJECT_DIRECTORY)/%.o: %.s
 	$(TRACE_CC)
 	$(Q)$(CC) $(ASMFLAGS) $(addprefix -I$(NRF52_SDK_ROOT)/, $(INC_PATHS)) -c -o $@ $<
 
-%.jlink:
-	sed -e 's/#OUTPUT_FILENAME#/$*.hex/' $(CONTIKI_CPU)/flash.jlink > $@
+include $(ARCH_PATH)/cpu/arm/cortex-m/cm4/Makefile.cm4
 
-%.flash: %.hex %.jlink
+%.jlink: $(OUT_HEX)
+	sed -e 's,#OUTPUT_FILENAME#,$<,' $(CONTIKI_CPU)/flash.jlink > $@
+
+%.flash: %.jlink
 	@echo Flashing: $^
 	$(JLINK) $(JLINK_OPTS) -CommanderScript $*.jlink
 
@@ -203,5 +205,3 @@ erase:
 	$(JLINK) $(JLINK_OPTS) -CommanderScript $(CONTIKI_CPU)/erase.jlink
 
 .PHONY: softdevice.jlink
-
-include $(ARCH_PATH)/cpu/arm/cortex-m/cm4/Makefile.cm4


### PR DESCRIPTION
#698 introduced some bugs to the nrf52dk build system. This pull fixes them.

* The `%.jlink` assumes a fixed location for the output hex file. This location is no longer valid, so we fix this.
* The new location of the hex file contains slashes in the path, so we change the sed delimiter to something other than the `/` character
* We include `Makefile.cm4` earlier. This allows us to use some Make variables defined therein.
* We improve rule dependencies: `%.jlink` and `%.flash`

Fixes #782 
