### PR TITLE
cooja: add int-master implementation.

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -47,7 +47,7 @@ CONTIKI_TARGET_DIRS = . dev lib sys cfs net
 # (COOJA_SOURCEDIRS contains additional sources dirs set from simulator)
 vpath %.c $(COOJA_SOURCEDIRS)
 
-COOJA_BASE	= simEnvChange.c cooja_mt.c cooja_mtarch.c rtimer-arch.c slip.c watchdog.c
+COOJA_BASE	= simEnvChange.c cooja_mt.c cooja_mtarch.c rtimer-arch.c slip.c watchdog.c int-master.c
 
 COOJA_INTFS	= beep.c button-sensor.c ip.c leds-arch.c moteid.c \
 		    pir-sensor.c rs232.c vib-sensor.c \

--- a/arch/platform/cooja/int-master.c
+++ b/arch/platform/cooja/int-master.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "sys/int-master.h"
+
+#include <stdbool.h>
+/*---------------------------------------------------------------------------*/
+#define DISABLED 0
+#define ENABLED  1
+/*---------------------------------------------------------------------------*/
+static int_master_status_t stat = DISABLED;
+/*---------------------------------------------------------------------------*/
+void
+int_master_enable(void)
+{
+  stat = ENABLED;
+}
+/*---------------------------------------------------------------------------*/
+int_master_status_t
+int_master_read_and_disable(void)
+{
+  int_master_status_t rv = stat;
+  stat = DISABLED;
+  return rv;
+}
+/*---------------------------------------------------------------------------*/
+void
+int_master_status_set(int_master_status_t status)
+{
+  stat = status;
+}
+/*---------------------------------------------------------------------------*/
+bool
+int_master_is_enabled(void)
+{
+  return stat == DISABLED ? false : true;
+}
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
It's copied from arch/cpu/native/int-master.c, which is just a no-op stub.

See #790