### PR TITLE
sys/process: thread-safe event queue

### DIFF
--- a/os/sys/process.h
+++ b/os/sys/process.h
@@ -80,6 +80,14 @@ typedef unsigned char process_num_events_t;
  *             not be posted.
  */
 #define PROCESS_ERR_FULL      1
+/**
+ * \brief      Return value indicating that the event queue was locked.
+ *
+ *             This value is returned from process_post() to indicate
+ *             that the event queue was locked and that an event could
+ *             not be posted.
+ */
+#define PROCESS_ERR_LOCKED    2
 /* @} */
 
 #define PROCESS_NONE          NULL
@@ -361,6 +369,9 @@ void process_start(struct process *p, process_data_t data);
  *
  * \retval PROCESS_ERR_FULL The event queue was full and the event could
  * not be posted.
+ *
+ * \retval PROCESS_ERR_LOCKED The event queue was locked and the event
+ * could not be posted.
  */
 int process_post(struct process *p, process_event_t ev, process_data_t data);
 


### PR DESCRIPTION
This p-r fixes #764, i.e. it makes it safe to call `process_post` in an interrupt handler.

To protect access to the event queue (the shared resource), I used sys/mutex. I could use sys/critical instead. They have different pros and cons.

- Use sys/mutex

    - (pro) Duration where interrupts are disabled is relatively short, or on some platforms (such as arm) there is even no need to disable interrupts.
    - (con) We need to add a new return code to `process_post`, `PROCESS_ERR_LOCKED`, which means the mutex is locked when it's called.

- Use sys/critical

    - (pro) We don't need to change any external API of sys/process.
    - (con) We would need to disable interrupts to manipulate the event queue. This could affect accuracy of tsch-slot-operation.

I think adding `PROCESS_ERR_LOCKED` has little impact because `process_post` could return `PROCESS_ERR_FULL` anyway. So, I chose sys/mutex.

I ran an experiment with real devices in which it called `process_post` rapidly in a sys/rtimer callback. With this p-r, no events were lost or duplicated.

