### PR TITLE
make compilation with SICSLOWPAN_COMPRESSION_IPV6 possible

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -1397,7 +1397,7 @@ digest_6lorh_hdr(void)
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * \endverbatim
  */
- #if SICSLOWPAN_COMPRESSION == SICSLOWPAN_COMPRESSION_IPV6
+#if SICSLOWPAN_COMPRESSION == SICSLOWPAN_COMPRESSION_IPV6
 static void
 compress_hdr_ipv6(linkaddr_t *link_destaddr)
 {
@@ -1875,13 +1875,11 @@ input(void)
   }
 
   /* Process next dispatch and headers */
-#if SICSLOWPAN_COMPRESSION > SICSLOWPAN_COMPRESSION_IPV6
-  if((PACKETBUF_6LO_PTR[PACKETBUF_6LO_DISPATCH] & SICSLOWPAN_DISPATCH_IPHC_MASK) == SICSLOWPAN_DISPATCH_IPHC) {
+  if(SICSLOWPAN_COMPRESSION > SICSLOWPAN_COMPRESSION_IPV6 &&
+     (PACKETBUF_6LO_PTR[PACKETBUF_6LO_DISPATCH] & SICSLOWPAN_DISPATCH_IPHC_MASK) == SICSLOWPAN_DISPATCH_IPHC) {
     LOG_DBG("uncompression: IPHC dispatch\n");
     uncompress_hdr_iphc(buffer, frag_size);
-  } else
-#endif /* SICSLOWPAN_COMPRESSION > SICSLOWPAN_COMPRESSION_IPV6 */
-    if(PACKETBUF_6LO_PTR[PACKETBUF_6LO_DISPATCH] == SICSLOWPAN_DISPATCH_IPV6) {
+  } else if(PACKETBUF_6LO_PTR[PACKETBUF_6LO_DISPATCH] == SICSLOWPAN_DISPATCH_IPV6) {
     LOG_DBG("uncompression: IPV6 dispatch\n");
     packetbuf_hdr_len += SICSLOWPAN_IPV6_HDR_LEN;
 

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -1875,10 +1875,13 @@ input(void)
   }
 
   /* Process next dispatch and headers */
+#if SICSLOWPAN_COMPRESSION > SICSLOWPAN_COMPRESSION_IPV6
   if((PACKETBUF_6LO_PTR[PACKETBUF_6LO_DISPATCH] & SICSLOWPAN_DISPATCH_IPHC_MASK) == SICSLOWPAN_DISPATCH_IPHC) {
     LOG_DBG("uncompression: IPHC dispatch\n");
     uncompress_hdr_iphc(buffer, frag_size);
-  } else if(PACKETBUF_6LO_PTR[PACKETBUF_6LO_DISPATCH] == SICSLOWPAN_DISPATCH_IPV6) {
+  } else
+#endif /* SICSLOWPAN_COMPRESSION > SICSLOWPAN_COMPRESSION_IPV6 */
+    if(PACKETBUF_6LO_PTR[PACKETBUF_6LO_DISPATCH] == SICSLOWPAN_DISPATCH_IPV6) {
     LOG_DBG("uncompression: IPV6 dispatch\n");
     packetbuf_hdr_len += SICSLOWPAN_IPV6_HDR_LEN;
 
@@ -1889,7 +1892,7 @@ input(void)
     packetbuf_hdr_len += UIP_IPH_LEN;
     uncomp_hdr_len += UIP_IPH_LEN;
   } else {
-    LOG_ERR("uncompression: unknown dispatch: 0x%02x\n",
+    LOG_ERR("uncompression: unknown dispatch: 0x%02x, or IPHC disabled\n",
              PACKETBUF_6LO_PTR[PACKETBUF_6LO_DISPATCH] & SICSLOWPAN_DISPATCH_IPHC_MASK);
     return;
   }

--- a/os/net/ipv6/sicslowpan.h
+++ b/os/net/ipv6/sicslowpan.h
@@ -66,6 +66,8 @@
 
 /**
  * \name 6lowpan compressions
+ * \note These are assumed to be in order - so that no compression is 0, then more and more
+ *  compressed version follow. E.g. they can be used for comparing: if x > COMPRESSION_IPV6 ...
  * @{
  */
 #define SICSLOWPAN_COMPRESSION_IPV6        0 /* No compression */


### PR DESCRIPTION
Without this fix, setting SICSLOWPAN_CONF_COMPRESSION = SICSLOWPAN_COMPRESSION_IPV6 in a project-conf file leads to compilation failures because uncompress_hdr_iphc() is not defined.