### PR TITLE
UDP example code cleanup

### DIFF
--- a/examples/libs/ipv6-uipbuf/udp-client.c
+++ b/examples/libs/ipv6-uipbuf/udp-client.c
@@ -12,9 +12,6 @@
 #define UDP_CLIENT_PORT	8765
 #define UDP_SERVER_PORT	5678
 
-static struct simple_udp_connection udp_conn;
-
-#define START_INTERVAL		(15 * CLOCK_SECOND)
 #define SEND_INTERVAL		  (60 * CLOCK_SECOND)
 
 static struct simple_udp_connection udp_conn;

--- a/examples/rpl-udp/udp-client.c
+++ b/examples/rpl-udp/udp-client.c
@@ -12,9 +12,6 @@
 #define UDP_CLIENT_PORT	8765
 #define UDP_SERVER_PORT	5678
 
-static struct simple_udp_connection udp_conn;
-
-#define START_INTERVAL		(15 * CLOCK_SECOND)
 #define SEND_INTERVAL		  (60 * CLOCK_SECOND)
 
 static struct simple_udp_connection udp_conn;


### PR DESCRIPTION
This PR removes some duplicate declaration and unused `#define`s.