### PR TITLE
Do not allow to 'trick' the platform and board exclude checks

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -478,6 +478,8 @@ ifeq ($(PLATFORM_ACTION),skip)
 # Skip this target.
 $(CONTIKI_PROJECT):
 	@echo "Skipping $@: not for the '$(TARGET)/$(BOARD)' platform!"
+%.$(TARGET):
+	@echo "Skipping $@: not for the '$(TARGET)/$(BOARD)' platform!"
 else
 # Build this target.
 # Match-anything pattern rule to allow the project makefiles to


### PR DESCRIPTION
Aims to avoid the reported inconsistency (#696)

As as side note, output of `Skipping $@: not for the '$(TARGET)/$(BOARD)' platform!` looks strange for platforms with no boards, especially if the BOARD is e.g set from a shell. But I don't have a good idea how to improve it.