### PR TITLE
fix temperature sensor reading in nrf52dk platform, which was stuck a…

### DIFF
--- a/arch/platform/nrf52dk/dev/temperature-sensor.c
+++ b/arch/platform/nrf52dk/dev/temperature-sensor.c
@@ -64,7 +64,15 @@ static int
 value(int type)
 {
 #ifndef SOFTDEVICE_PRESENT
-  return nrf_temp_read();
+  int32_t volatile temp;
+
+  NRF_TEMP->TASKS_START = 1;
+  while(NRF_TEMP->EVENTS_DATARDY == 0);
+  NRF_TEMP->EVENTS_DATARDY = 0;
+  temp = nrf_temp_read();
+  NRF_TEMP->TASKS_STOP = 1;
+
+  return temp;
 #else
   int32_t temp;
   sd_temp_get(&temp);

--- a/arch/platform/nrf52dk/dev/temperature-sensor.c
+++ b/arch/platform/nrf52dk/dev/temperature-sensor.c
@@ -67,7 +67,8 @@ value(int type)
   int32_t volatile temp;
 
   NRF_TEMP->TASKS_START = 1;
-  while(NRF_TEMP->EVENTS_DATARDY == 0);
+  /* nRF52832 datasheet: one temperature measurement takes typically 36 us */
+  RTIMER_BUSYWAIT_UNTIL(NRF_TEMP->EVENTS_DATARDY, RTIMER_SECOND * 72 / 1000000);
   NRF_TEMP->EVENTS_DATARDY = 0;
   temp = nrf_temp_read();
   NRF_TEMP->TASKS_STOP = 1;


### PR DESCRIPTION
The blink-hello example for the nrf52dk platform display temperature samples stuck at zero:
...
temp: 0.00
temp: 0.00
temp: 0.00
...

After fixing the temperature sensor driver's value() function by adding a proper sequence of HAL statements from the NRF SDK, the blink-hello example shows correct temperature values in degree Celsius:
...
temp: 22.50
temp: 22.25
temp: 22.75
...