### PR TITLE
Choose correct CoAP response block size if request has no Block2 option

### DIFF
--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -266,14 +266,18 @@ coap_receive(const coap_endpoint_t *src,
 
                 /* Resource requested Block2 transfer */
               } else if(new_offset != 0) {
+                uint16_t block_size = COAP_MAX_BLOCK_SIZE;
+                if (new_offset > 0 && new_offset < COAP_MAX_BLOCK_SIZE) {
+                    block_size = (uint16_t) new_offset;
+                }
                 LOG_DBG("Blockwise: no block option for blockwise resource, using block size %u\n",
-                        COAP_MAX_BLOCK_SIZE);
+                        block_size);
 
                 coap_set_header_block2(response, 0, new_offset != -1,
-                                       COAP_MAX_BLOCK_SIZE);
+                                       block_size);
                 coap_set_payload(response, response->payload,
                                  MIN(response->payload_len,
-                                     COAP_MAX_BLOCK_SIZE));
+                                     block_size));
               } /* blockwise transfer handling */
             } /* no errors/hooks */
             /* successful service callback */


### PR DESCRIPTION
If a CoAP request has no Block2 option, the response may still contain a Block2 option, in which case a blockwise transfer of the response is initiated. See the first example of Section 3.1 of RFC 7959 (https://tools.ietf.org/html/rfc7959#section-3.1) for an example.

This pull request changes the way that Contiki chooses the block size for the response in this case. Before, it would always use the maximum supported block size, even if it is larger than the actual response. This behavior causes some clients (e.g., Californium) to behave incorrectly.

Instead, I propose choosing it according to the offset chosen by the application's resource handler, which should accurately reflect the block size.