### PR TITLE
Fix a couple of simplelink platform bugs

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/opt-3001-sensor.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/opt-3001-sensor.c
@@ -303,9 +303,13 @@ value(int type)
 
   result_value = SWAP16(result_value);
 
-  uint32_t e = (result_value & 0x0FFF) >> 0;
-  uint32_t m = (result_value & 0xF000) >> 12;
-  uint32_t converted = m * 100 * (1 << e);
+  /* formula for computing lux: lux = 0.01 * 2^e * m
+   * scale up by 100 to avoid floating point, then require
+   * users to scale down by same.
+   */
+  uint32_t m = (result_value & 0x0FFF) >> 0;
+  uint32_t e = (result_value & 0xF000) >> 12;
+  uint32_t converted = m * (1 << e);
 
   PRINTF("OPT: %04X            r=%d (centilux)\n", result_value,
          (int)(converted));

--- a/examples/platform-specific/cc26x0-cc13x0/Makefile
+++ b/examples/platform-specific/cc26x0-cc13x0/Makefile
@@ -1,4 +1,4 @@
-CONTIKI_PROJECT = cc26xx-demo
+CONTIKI_PROJECT = cc26x0-demo
 
 PLATFORMS_ONLY = cc26x0-cc13x0
 


### PR DESCRIPTION
Fixes the opt3001 sensor in the simplelink sensortag package to return the correct value. #768  
Also makes the platform-specific/cc26x0-cc13x0 example build.