### PR TITLE
Fix simplelink gpio hysteresis bitmask

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.c
@@ -96,7 +96,7 @@ to_hal_cfg(PIN_Config pin_cfg, gpio_hal_pin_cfg_t *cfg)
   /* Input config */
   if(pin_cfg & PIN_BM_INPUT_MODE) {
     /* Hysteresis config */
-    if((pin_cfg & PIN_BM_HYSTERESIS) == PIN_HYSTERESIS) {
+    if((pin_cfg & PIN_BM_HYSTERESIS) == PIN_BM_HYSTERESIS) {
       *cfg |= GPIO_HAL_PIN_CFG_HYSTERESIS;
     }
 


### PR DESCRIPTION
For TI Simplelink platforms:

My fancy new GCC 8 compiler said the expression always evaluates false and halted compilation on this warning.

Fixed.