### PR TITLE
Fixes contiki-ng/contiki-ng#774 Won't compile asm files

### DIFF
--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -10,6 +10,7 @@ CC       = arm-none-eabi-gcc
 CPP      = arm-none-eabi-cpp
 LD       = arm-none-eabi-gcc
 AR       = arm-none-eabi-ar
+AS       = arm-none-eabi-gcc
 OBJCOPY  = arm-none-eabi-objcopy
 OBJDUMP  = arm-none-eabi-objdump
 NM       = arm-none-eabi-nm
@@ -24,6 +25,11 @@ CFLAGS += -fshort-enums -fomit-frame-pointer -fno-builtin
 ifeq ($(WERROR),1)
   CFLAGS += -Werror
 endif
+
+### Pass CFLAGS along to assembly files in the build
+ASFLAGS += $(CFLAGS)
+### Specify '-c' option to assemble only and not link
+ASFLAGS += -c 
 
 LDFLAGS += -mthumb -mlittle-endian
 


### PR DESCRIPTION
Reference issue #774.

This fix takes care of compiling both .s and .S for me.

Using `gcc` rather than `as` in `arch/cpu/arm/Makefile.arm`  to compile asm files offers all of the available preprocessor goodies, so that's what I've chosen to implement.