### PR TITLE
Do not refresh watchdog in rtimer busy-wait macros

### DIFF
--- a/os/sys/rtimer.h
+++ b/os/sys/rtimer.h
@@ -57,11 +57,6 @@
 #include "dev/watchdog.h"
 #include <stdbool.h>
 
-#if CONTIKI_TARGET_COOJA
-#include "lib/simEnvChange.h"
-#include "sys/cooja_mt.h"
-#endif
-
 /** \brief The rtimer size (in bytes) */
 #ifdef RTIMER_CONF_CLOCK_SIZE
 #define RTIMER_CLOCK_SIZE RTIMER_CONF_CLOCK_SIZE
@@ -194,24 +189,14 @@ void rtimer_arch_schedule(rtimer_clock_t t);
 #endif /* RTIMER_CONF_GUARD_TIME */
 
 /** \brief Busy-wait until a condition. Start time is t0, max wait time is max_time */
-#if CONTIKI_TARGET_COOJA
-#define RTIMER_BUSYWAIT_UNTIL_ABS(cond, t0, max_time) \
-  ({                                                                \
-    bool c;                                                         \
-    while(!(c = cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), (t0) + (max_time))) { \
-      simProcessRunValue = 1;                                       \
-      cooja_mt_yield();                                             \
-    }                                                               \
-    c;                                                              \
-  })
-#else /* CONTIKI_TARGET_COOJA */
+#ifndef RTIMER_BUSYWAIT_UNTIL_ABS
 #define RTIMER_BUSYWAIT_UNTIL_ABS(cond, t0, max_time) \
   ({                                                                \
     bool c;                                                         \
     while(!(c = cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), (t0) + (max_time))); \
     c;                                                              \
   })
-#endif /* CONTIKI_TARGET_COOJA */
+#endif /* RTIMER_BUSYWAIT_UNTIL_ABS */
 
 /** \brief Busy-wait until a condition for at most max_time */
 #define RTIMER_BUSYWAIT_UNTIL(cond, max_time)       \


### PR DESCRIPTION
This removes the watchdog refresh from the rtimer busy-wait macros. Partially addresses https://github.com/contiki-ng/contiki-ng/issues/835

I think removing the refresh should not break anything here. Before these macros, the only busy-wait done with watchdog refresh was in `cc1200.c` and this was meant to handle busy waiting during `transmit` at very low data rates. No data rate low enough to result in 1s airtime is supported in NG though, so this shouldn't be an issue.