### PR TITLE
Fix a possible bug in TSCH communication

### DIFF
--- a/arch/platform/cooja/dev/cooja-radio.c
+++ b/arch/platform/cooja/dev/cooja-radio.c
@@ -197,8 +197,6 @@ channel_clear(void)
 static int
 radio_send(const void *payload, unsigned short payload_len)
 {
-  int radiostate = simRadioHWOn;
-
   /* Simulate turnaround time of 2ms for packets, 1ms for acks*/
 #if COOJA_SIMULATE_TURNAROUND
   simProcessRunValue = 1;
@@ -210,8 +208,7 @@ radio_send(const void *payload, unsigned short payload_len)
 #endif /* COOJA_SIMULATE_TURNAROUND */
 
   if(!simRadioHWOn) {
-    /* Turn on radio temporarily */
-    simRadioHWOn = 1;
+    return RADIO_TX_ERR;
   }
   if(payload_len > COOJA_RADIO_BUFSIZE) {
     return RADIO_TX_ERR;
@@ -239,7 +236,6 @@ radio_send(const void *payload, unsigned short payload_len)
     cooja_mt_yield();
   }
 
-  simRadioHWOn = radiostate;
   return RADIO_TX_OK;
 }
 /*---------------------------------------------------------------------------*/

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -905,6 +905,7 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
                 TSCH_SCHEDULE_AND_YIELD(pt, t, rx_start_time,
                                         packet_duration + tsch_timing[tsch_ts_tx_ack_delay] - RADIO_DELAY_BEFORE_TX, "RxBeforeAck");
                 TSCH_DEBUG_RX_EVENT();
+                tsch_radio_on(TSCH_RADIO_CMD_ON_WITHIN_TIMESLOT);
                 NETSTACK_RADIO.transmit(ack_len);
                 tsch_radio_off(TSCH_RADIO_CMD_OFF_WITHIN_TIMESLOT);
 

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -566,7 +566,7 @@ PT_THREAD(tsch_tx_slot(struct pt *pt, struct rtimer *t))
           tx_duration = TSCH_PACKET_DURATION(packet_len);
           /* limit tx_time to its max value */
           tx_duration = MIN(tx_duration, tsch_timing[tsch_ts_max_tx]);
-          /* turn tadio off -- will turn on again to wait for ACK if needed */
+          /* turn radio off -- will turn on again to wait for ACK if needed */
           tsch_radio_off(TSCH_RADIO_CMD_OFF_WITHIN_TIMESLOT);
 
           if(mac_tx_status == RADIO_TX_OK) {

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -549,6 +549,14 @@ PT_THREAD(tsch_tx_slot(struct pt *pt, struct rtimer *t))
           /* delay before TX */
           TSCH_SCHEDULE_AND_YIELD(pt, t, current_slot_start, tsch_timing[tsch_ts_tx_offset] - RADIO_DELAY_BEFORE_TX, "TxBeforeTx");
           TSCH_DEBUG_TX_EVENT();
+#if !TSCH_CCA_ENABLED
+          /*
+           * turn radio on -- the radio has not been turned on when
+           * both of TSCH_RADIO_ON_DURING_TIMESLOT and CCA are
+           * disabled.
+           */
+          tsch_radio_on(TSCH_RADIO_CMD_ON_WITHIN_TIMESLOT);
+#endif /* TSCH_CCA_ENABLED */
           /* send packet already in radio tx buffer */
           mac_tx_status = NETSTACK_RADIO.transmit(packet_len);
           tx_count++;


### PR DESCRIPTION
If CCA is disabled, a node having `TSCH_RADIO_ON_DURING_TIMESLOT` set with `0` cannot transmit a frame during a TSCH TX slot because the radio is off when transmission is triggered. In addition, such a node cannot send back an ACK frame in a TSCH RX slot.

The fix is a by-product of Issue #833, that is closed by this PR.