### PR TITLE
Replace process_post with process_poll in tsch.c

### DIFF
--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -535,7 +535,7 @@ tsch_disassociate(void)
 {
   if(tsch_is_associated == 1) {
     tsch_is_associated = 0;
-    process_post(&tsch_process, PROCESS_EVENT_POLL, NULL);
+    process_poll(&tsch_process);
   }
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The former is not safe in interrupt context. It may be fixed later in `process.c` fix by @debug-ito , but there is just no need for `process_post()` in that specific place.