### PR TITLE
Implemented bug fix to trickle timer

### DIFF
--- a/os/lib/trickle-timer.c
+++ b/os/lib/trickle-timer.c
@@ -81,7 +81,7 @@ static void double_interval(void *ptr);
 static uint32_t
 wide_rand(void)
 {
-  return ((uint32_t)random_rand() << 16 | random_rand());
+  return (uint32_t)random_rand() << 16 | random_rand();
 }
 #endif
 /*---------------------------------------------------------------------------*/
@@ -98,7 +98,7 @@ static uint8_t
 max_imax(clock_time_t value)
 {
   uint8_t zeros = 0;
-#if (TRICKLE_TIMER_MAX_IMAX_WIDTH==TRICKLE_TIMER_MAX_IMAX_GENERIC)
+#if (TRICKLE_TIMER_MAX_IMAX_WIDTH == TRICKLE_TIMER_MAX_IMAX_GENERIC)
   uint8_t i;
   clock_time_t mask = 0xFFFF;
 
@@ -111,7 +111,7 @@ max_imax(clock_time_t value)
     }
   }
 
-#elif (TRICKLE_TIMER_MAX_IMAX_WIDTH==TRICKLE_TIMER_MAX_IMAX_16_BIT)
+#elif (TRICKLE_TIMER_MAX_IMAX_WIDTH == TRICKLE_TIMER_MAX_IMAX_16_BIT)
   if((value & 0xFF00) == 0) {
     zeros += 8;
     value <<= 8;
@@ -127,7 +127,7 @@ max_imax(clock_time_t value)
   if((value & 0x8000) == 0) {
     zeros++;
   }
-#elif (TRICKLE_TIMER_MAX_IMAX_WIDTH==TRICKLE_TIMER_MAX_IMAX_32_BIT)
+#elif (TRICKLE_TIMER_MAX_IMAX_WIDTH == TRICKLE_TIMER_MAX_IMAX_32_BIT)
   if((value & 0xFFFF0000) == 0) {
     zeros += 16;
     value <<= 16;
@@ -307,7 +307,7 @@ new_interval(struct trickle_timer *tt)
 void
 trickle_timer_consistency(struct trickle_timer *tt)
 {
-  if (tt->i_cur == TRICKLE_TIMER_IS_STOPPED) {
+  if(tt->i_cur == TRICKLE_TIMER_IS_STOPPED) {
     return;
   }
   if(tt->c < 0xFF) {
@@ -319,7 +319,7 @@ trickle_timer_consistency(struct trickle_timer *tt)
 void
 trickle_timer_inconsistency(struct trickle_timer *tt)
 {
-  if (tt->i_cur == TRICKLE_TIMER_IS_STOPPED) {
+  if(tt->i_cur == TRICKLE_TIMER_IS_STOPPED) {
     return;
   }
   /* "If I is equal to Imin when Trickle hears an "inconsistent" transmission,

--- a/os/lib/trickle-timer.c
+++ b/os/lib/trickle-timer.c
@@ -307,6 +307,9 @@ new_interval(struct trickle_timer *tt)
 void
 trickle_timer_consistency(struct trickle_timer *tt)
 {
+  if (tt->i_cur == TRICKLE_TIMER_IS_STOPPED) {
+    return;
+  }
   if(tt->c < 0xFF) {
     tt->c++;
   }
@@ -316,6 +319,9 @@ trickle_timer_consistency(struct trickle_timer *tt)
 void
 trickle_timer_inconsistency(struct trickle_timer *tt)
 {
+  if (tt->i_cur == TRICKLE_TIMER_IS_STOPPED) {
+    return;
+  }
   /* "If I is equal to Imin when Trickle hears an "inconsistent" transmission,
    * Trickle does nothing." */
   if(tt->i_cur != tt->i_min) {
@@ -366,6 +372,8 @@ trickle_timer_config(struct trickle_timer *tt, clock_time_t i_min,
   tt->i_max = i_max;
   tt->i_max_abs = i_min << i_max;
   tt->k = k;
+  tt->i_cur = TRICKLE_TIMER_IS_STOPPED;
+  tt->cb = NULL;
 
   PRINTF("trickle_timer config: Imin=%lu, Imax=%u, k=%u\n",
          (unsigned long)tt->i_min, tt->i_max, tt->k);


### PR DESCRIPTION
Fix for issue #887.

This modifies the trickle timer library to guard some functions to prevent undesirable behaviour with the library. It also adds a couple of lines to timer configurations to ensure a consistent state of a timer is maintained throughout it's lifetime.

There are four main changes:

- Guard the `trickle_timer_consistency()` function so it returns and does nothing if a timer is stopped

- Guard the `trickle_timer_inconsistency()` function so it returns and does nothing if a timer is stopped

- Explicitly set `tt->i_cur` to `TRICKLE_TIMER_IS_STOPPED` in `trickle_timer_config()` to ensure that a timer created by that function is in the 'stopped' state before it's started.

- Explicitly set `tt->cb` to `NULL` in `trickle_timer_config()` so an undefined function can never be used as a callback.