### PR TITLE
Fix RPL Lite compilation when probing is disabled

### DIFF
--- a/os/net/routing/rpl-lite/rpl-neighbor.c
+++ b/os/net/routing/rpl-lite/rpl-neighbor.c
@@ -196,9 +196,12 @@ remove_neighbor(rpl_nbr_t *nbr)
   /* Make sure we don't point to a removed neighbor. Note that we do not need
   to worry about preferred_parent here, as it is locked in the the table
   and will never be removed by external modules. */
+#if RPL_WITH_PROBING
   if(nbr == curr_instance.dag.urgent_probing_target) {
     curr_instance.dag.urgent_probing_target = NULL;
   }
+#endif
+
   if(nbr == curr_instance.dag.unicast_dio_target) {
     curr_instance.dag.unicast_dio_target = NULL;
   }

--- a/os/net/routing/rpl-lite/rpl.c
+++ b/os/net/routing/rpl-lite/rpl.c
@@ -101,9 +101,11 @@ rpl_link_callback(const linkaddr_t *addr, int status, int numtx)
     if(nbr != NULL) {
       /* If this is the neighbor we were probing urgently, mark urgent
       probing as done */
+#if RPL_WITH_PROBING
       if(curr_instance.dag.urgent_probing_target == nbr) {
         curr_instance.dag.urgent_probing_target = NULL;
       }
+#endif
       /* Link stats were updated, and we need to update our internal state.
       Updating from here is unsafe; postpone */
       LOG_INFO("packet sent to ");


### PR DESCRIPTION
RPL-Lite fails to compile when `RPL_CONF_WITH_PROBING` is defined as 0.

```
$ git diff -- os/net/routing/rpl-lite/rpl-conf.h
diff --git a/os/net/routing/rpl-lite/rpl-conf.h b/os/net/routing/rpl-lite/rpl-conf.h
index 5d674fa96..5d37205b3 100644
--- a/os/net/routing/rpl-lite/rpl-conf.h
+++ b/os/net/routing/rpl-lite/rpl-conf.h
@@ -155,7 +155,7 @@
 #ifdef RPL_CONF_WITH_PROBING
 #define RPL_WITH_PROBING RPL_CONF_WITH_PROBING
 #else
-#define RPL_WITH_PROBING 1
+#define RPL_WITH_PROBING 0
 #endif
 
 /*
```

```
  CC        ../../os/net/routing/rpl-lite/rpl-neighbor.c
../../os/net/routing/rpl-lite/rpl-neighbor.c: In function 'remove_neighbor':
../../os/net/routing/rpl-lite/rpl-neighbor.c:199:30: error: 'rpl_dag_t {aka struct rpl_dag}' has no member named 'urgent_probing_target'
   if(nbr == curr_instance.dag.urgent_probing_target) {
                              ^
../../os/net/routing/rpl-lite/rpl-neighbor.c:200:22: error: 'rpl_dag_t {aka struct rpl_dag}' has no member named 'urgent_probing_target'
     curr_instance.dag.urgent_probing_target = NULL;
                      ^
make: *** [build/cc2538dk/obj/rpl-neighbor.o] Error 1
```

```
  CC        ../../os/net/routing/rpl-lite/rpl.c
../../os/net/routing/rpl-lite/rpl.c: In function 'rpl_link_callback':
../../os/net/routing/rpl-lite/rpl.c:104:27: error: 'rpl_dag_t {aka struct rpl_dag}' has no member named 'urgent_probing_target'
       if(curr_instance.dag.urgent_probing_target == nbr) {
                           ^
../../os/net/routing/rpl-lite/rpl.c:105:26: error: 'rpl_dag_t {aka struct rpl_dag}' has no member named 'urgent_probing_target'
         curr_instance.dag.urgent_probing_target = NULL;
                          ^
make: *** [build/cc2538dk/obj/rpl.o] Error 1
```

Fixes #891