### PR TITLE
Multicast Tests Fix

### DIFF
--- a/tests/07-simulation-base/15-cooja-multicast-11-hops-rollt-tm.csc
+++ b/tests/07-simulation-base/15-cooja-multicast-11-hops-rollt-tm.csc
@@ -24,7 +24,8 @@
       <identifier>mtype612</identifier>
       <description>Root/sender</description>
       <source>[CONTIKI_DIR]/examples/multicast/root.c</source>
-      <commands>make -j root.cooja TARGET=cooja DEFINES=UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_ROLL_TM</commands>
+      <commands>make TARGET=cooja clean
+make -j root.cooja TARGET=cooja DEFINES=UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_ROLL_TM</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/07-simulation-base/16-cooja-multicast-11-hops-smrf.csc
+++ b/tests/07-simulation-base/16-cooja-multicast-11-hops-smrf.csc
@@ -24,7 +24,8 @@
       <identifier>mtype612</identifier>
       <description>Root/sender</description>
       <source>[CONTIKI_DIR]/examples/multicast/root.c</source>
-      <commands>make -j root.cooja TARGET=cooja DEFINES=UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_SMRF</commands>
+      <commands>make TARGET=cooja clean
+make -j root.cooja TARGET=cooja DEFINES=UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_SMRF</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/07-simulation-base/17-cooja-multicast-11-hops-esmrf.csc
+++ b/tests/07-simulation-base/17-cooja-multicast-11-hops-esmrf.csc
@@ -24,7 +24,8 @@
       <identifier>mtype612</identifier>
       <description>Root/sender</description>
       <source>[CONTIKI_DIR]/examples/multicast/root.c</source>
-      <commands>make -j root.cooja TARGET=cooja DEFINES=UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_ESMRF</commands>
+      <commands>make TARGET=cooja clean
+make -j root.cooja TARGET=cooja DEFINES=UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_ESMRF</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/07-simulation-base/18-cooja-multicast-31-hops.csc
+++ b/tests/07-simulation-base/18-cooja-multicast-31-hops.csc
@@ -24,7 +24,8 @@
       <identifier>mtype816</identifier>
       <description>Root/sender</description>
       <source>[CONTIKI_DIR]/examples/multicast/root.c</source>
-      <commands>make -j root.cooja TARGET=cooja</commands>
+      <commands>make TARGET=cooja clean
+make -j root.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>


### PR DESCRIPTION
This fixes issue #897. It adds commands to the cooja mote types in the simulation file to ensure the tests are run on a clean build of contiki-ng, rather than using old build files from previous tests which can cause the wrong multicast driver to be tested.