### PR TITLE
Fixed issues Running Tests Locally

### DIFF
--- a/tests/08-native-runs/02-mqtt-client.sh
+++ b/tests/08-native-runs/02-mqtt-client.sh
@@ -28,7 +28,7 @@ sleep 2
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-make -C $CODE_DIR TARGET=native \
+make -C $CODE_DIR -B TARGET=native \
   DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG \
   > make.log 2> make.err
 sudo $CODE_DIR/$CODE.native > $CLIENT_LOG 2> $CLIENT_ERR &

--- a/tests/14-rpl-lite/02-rpl-root-reboot-2.csc
+++ b/tests/14-rpl-lite/02-rpl-root-reboot-2.csc
@@ -25,7 +25,8 @@
       <identifier>mtype34</identifier>
       <description>mote</description>
       <source>[CONTIKI_DIR]/examples/libs/shell/example.c</source>
-      <commands>make example.cooja TARGET=cooja MAKE_ROUTING=MAKE_ROUTING_RPL_LITE -j</commands>
+      <commands>make TARGET=cooja clean
+make example.cooja TARGET=cooja MAKE_ROUTING=MAKE_ROUTING_RPL_LITE -j</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/15-rpl-classic/02-rpl-root-reboot-2.csc
+++ b/tests/15-rpl-classic/02-rpl-root-reboot-2.csc
@@ -25,7 +25,8 @@
       <identifier>mtype512</identifier>
       <description>mote</description>
       <source>[CONTIKI_DIR]/examples/libs/shell/example.c</source>
-      <commands>make example.cooja TARGET=cooja MAKE_ROUTING=MAKE_ROUTING_RPL_CLASSIC -j</commands>
+      <commands>make TARGET=cooja clean
+make example.cooja TARGET=cooja MAKE_ROUTING=MAKE_ROUTING_RPL_CLASSIC -j</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -30,7 +30,7 @@ sleep 20
 
 # Connect to the simulation
 echo "Starting native border-router"
-nohup make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=native >> $BASENAME.nbr.log 2>&1 &
+nohup make -C $CONTIKI/examples/rpl-border-router/ -B connect-router-cooja TARGET=native >> $BASENAME.nbr.log 2>&1 &
 MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME


### PR DESCRIPTION
This fixes a further issue raised in #897 whereby tests run on a local machine by entering the `tests` directory and running `make` would cause test fails due to unclean build directories. After these changes, local testing works as expected with the exception of out of tree tests, which fail of the out of tree directory is not properly configured.