### PR TITLE
sixtop: add missing methods of test_mac_driver (tests/13-ieee802154)

### DIFF
--- a/tests/13-ieee802154/code-6tisch/common.c
+++ b/tests/13-ieee802154/code-6tisch/common.c
@@ -38,6 +38,8 @@
 #include "lib/simEnvChange.h"
 #include "sys/cooja_mt.h"
 
+#define TEST_MAC_MAX_PAYLOAD_LEN 100
+
 static uint8_t send_is_called;
 
 void
@@ -73,11 +75,36 @@ send(mac_callback_t sent_callback, void *ptr)
   send_is_called = 1;
 }
 
+static void
+input(void)
+{
+  /* do nothing */
+}
+
+static int
+on(void)
+{
+  return 1; /* always on */
+}
+
+static int
+off(void)
+{
+  return 0; /* never be turned off */
+}
+
+static int
+max_payload(void)
+{
+  return TEST_MAC_MAX_PAYLOAD_LEN;
+}
+
 const struct mac_driver test_mac_driver = {
   "Test MAC",
   init,
   send,
-  NULL,
-  NULL,
-  NULL
+  input,
+  on,
+  off,
+  max_payload,
 };


### PR DESCRIPTION
This PR replaces `NULL` methods of `test_mac_driver` with dummy ones. This change prevents a test failure observed in https://github.com/contiki-ng/contiki-ng/pull/858#issuecomment-467176105.

I had the same test failure on my machine. Here is the output:
```
$ contiker '(ulimit -c unlimited; make -C tests/13-ieee802154)'
make: Entering directory '/home/user/contiki-ng/tests/13-ieee802154'
Running test 01-panid-handling with random Seed 1............ OK
Running test 02-tsch-flush-nbr-queue with random Seed 1............. OK
Running test 03-cooja-test-sixtop with random Seed 1................... OK
Running test 04-cooja-test-sixp-pkt with random Seed 1......................./../tests/simexec.sh: line 67:  1499 Aborted                 (core dumped) java -Xshare:on -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$CSC -contiki=$CONTIKI
 -random-seed=$SEED > $BASENAME.$SEED.coojalog
 FAIL
==== 04-cooja-test-sixp-pkt.1.coojalog ====
...
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00000000, pid=1499, tid=0xc35c4b40
#
# JRE version: OpenJDK Runtime Environment (8.0_171-b11) (build 1.8.0_171-8u171-b11-0ubuntu0.16.04.1-b11)
# Java VM: OpenJDK Server VM (25.171-b11 mixed mode, sharing linux-x86 )
# Problematic frame:
# C  0x00000000
#
# Core dump written. Default location: /home/user/contiki-ng/tests/13-ieee802154/core or core.1499
#
 INFO [Thread-1] (LogScriptEngine.java:309) - Test script finished
# An error report file with more information is saved as:
# /home/user/contiki-ng/tests/13-ieee802154/hs_err_pid1499.log
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
==== 04-cooja-test-sixp-pkt.1.scriptlog ====
...
679000 node-1 =check-me= DONE
TEST OK
Running test 05-cooja-test-sixp-trans with random Seed 1................... OK
Running test 06-cooja-test-sixp-nbr with random Seed 1................... OK
Running test 07-cooja-test-sixp with random Seed 1..................... OK
Running test 08-cooja-test-sixtop-sf-error-handler with random Seed 1................... OK
========== Summary ==========
01-panid-handling                        TEST OK      1/1
02-tsch-flush-nbr-queue                  TEST OK      1/1
03-cooja-test-sixtop                     TEST OK      1/1
04-cooja-test-sixp-pkt                   TEST FAIL    0/1 -- failed seeds: 1
05-cooja-test-sixp-trans                 TEST OK      1/1
06-cooja-test-sixp-nbr                   TEST OK      1/1
07-cooja-test-sixp                       TEST OK      1/1
08-cooja-test-sixtop-sf-error-handler    TEST OK      1/1
make: Leaving directory '/home/user/contiki-ng/tests/13-ieee802154'
```

This is the backtrace I got.
```
#0  0xf7754b49 in __kernel_vsyscall ()
#1  0xf75aeea9 in raise () from /lib/i386-linux-gnu/libc.so.6
#2  0xf75b0407 in abort () from /lib/i386-linux-gnu/libc.so.6
#3  0xf6d346f3 in ?? () from /usr/lib/jvm/java-8-openjdk-i386/jre/lib/i386/server/libjvm.so
#4  0xf6ecc49d in ?? () from /usr/lib/jvm/java-8-openjdk-i386/jre/lib/i386/server/libjvm.so
#5  0xf6d3f336 in JVM_handle_linux_signal () from /usr/lib/jvm/java-8-openjdk-i386/jre/lib/i386/server/libjvm.so
#6  0xf6d314cd in ?? () from /usr/lib/jvm/java-8-openjdk-i386/jre/lib/i386/server/libjvm.so
#7  <signal handler called>
#8  0x00000000 in ?? ()
#9  0xc2e7c387 in output (localdest=0x0) at ../../../os/net/ipv6/sicslowpan.c:1577
#10 0xc2e77b0e in tcpip_output (a=0x0) at ../../../os/net/ipv6/tcpip.c:124
#11 0xc2e7807c in tcpip_ipv6_output () at ../../../os/net/ipv6/tcpip.c:736
#12 0xc2e7fedd in uip_icmp6_send (dest=0xc2eae1e8 <rpl_multicast_addr>, type=155, code=0, payload_len=2) at ../../../os/net/ipv6/uip-icmp6.c:257
#13 0xc2e80a06 in rpl_icmp6_dis_output (addr=0xc2eae1e8 <rpl_multicast_addr>) at ../../../os/net/routing/rpl-lite/rpl-icmp6.c:168
#14 0xc2e82539 in handle_dis_timer (ptr=0x0) at ../../../os/net/routing/rpl-lite/rpl-timers.c:109
#15 0xc2e74f96 in process_thread_ctimer_process (process_pt=0xc2e9e130 <ctimer_process+12>, ev=136 '\210', data=0xc2ea9724 <dis_timer+4>) at ../../../os/sys/ctimer.c:80
#16 0xc2e75b9f in call_process (p=0xc2e9e124 <ctimer_process>, ev=136 '\210', data=0xc2ea9724 <dis_timer+4>) at ../../../os/sys/process.c:190
#17 0xc2e75d83 in do_event () at ../../../os/sys/process.c:296
#18 0xc2e75da4 in process_run () at ../../../os/sys/process.c:310
#19 0xc2e70ac3 in platform_main_loop () at ../../../arch/platform/cooja/./platform.c:192
#20 0xc2e74e06 in main () at ../../../os/contiki-main.c:164
#21 0xc2e70b28 in process_run_thread_loop (data=0x0) at ../../../arch/platform/cooja/./platform.c:217
#22 0x00000000 in ?? ()
```

I conclude, having `NULL` for `test_mac_driver.max_payload()` causes this `SIGSEGV`. I implemented `mac_payload` as well as other missing methods just in case.