### PR TITLE
build system: warn if using compiler versions known to be problematic

### DIFF
--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -1,0 +1,27 @@
+# -*- makefile -*-
+#
+# GCC specific definitions and actions
+#
+
+GCC_MAJOR_VERSION := $(shell $(CC) -v 2>&1 | grep "gcc version" | cut -b 13)
+GCC_MINOR_VERSION := $(shell $(CC) -v 2>&1 | grep "gcc version" | cut -b 15)
+
+# Warn if using version 6.3.x of arm-none-eabi-gcc
+ifeq ("$(CC)","arm-none-eabi-gcc")
+  ifeq (6,$(GCC_MAJOR_VERSION))
+    ifeq (3,$(GCC_MINOR_VERSION))
+      $(warning Warning: you're using a version of $(CC) that may create broken Contiki-NG executables.)
+      $(warning We recommend to upgrade or downgrade your toolchain.)
+    endif
+  endif
+endif
+
+# Warn if using 4.6.x or older msp430-gcc
+ifeq ("$(CC)","msp430-gcc")
+  ifeq ($(shell test $(GCC_MAJOR_VERSION) -lt 5; echo $$?),0)
+    ifeq ($(shell test $(GCC_MINOR_VERSION) -lt 7; echo $$?),0)
+      $(warning Warning: you're using an old version of $(CC).)
+      $(warning Upgrade to 4.7.x is recommended for extended memory support and bugfixes.)
+    endif
+  endif
+endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -469,6 +469,9 @@ ifeq ($(findstring $(TARGET),native cooja),)
   include $(CONTIKI)/Makefile.embedded
 endif
 
+### Include Makefile.gcc for GCC specific definitions and actions
+include $(CONTIKI)/Makefile.gcc
+
 # Don't treat $(BUILD_DIR_BOARD)/%.$(TARGET) and $(TARGET) as intermediate
 # files because for many platforms they are in fact the primary target.
 .PRECIOUS: $(BUILD_DIR_BOARD)/%.$(TARGET) %.$(TARGET)


### PR DESCRIPTION
This hopefully will make Contiki-NG more user friendly. The idea is to nudge users to upgrade / downgrade their toolchains when their currently installed version is one of those that don't work well with Contiki-NG.