### PR TITLE
Remove watchdog_periodic() calls that may happen inside an interrupt context

### DIFF
--- a/arch/cpu/cc2538/usb/usb-arch.c
+++ b/arch/cpu/cc2538/usb/usb-arch.c
@@ -1114,13 +1114,8 @@ ep_tx(uint8_t ep_hw)
     len -= copy;
     ep->buffer->left -= copy;
 
-    /*
-     * Delay somewhat if the previous packet has not yet left the IN FIFO,
-     * making sure the dog doesn't bark while we're waiting
-     */
-    while(REG(USB_CSIL) & USB_CSIL_INPKT_RDY) {
-      watchdog_periodic();
-    }
+    /* Delay somewhat if the previous packet has not yet left the IN FIFO */
+    while(REG(USB_CSIL) & USB_CSIL_INPKT_RDY);
 
     write_hw_buffer(EP_INDEX(ep_hw), ep->buffer->data, copy);
     ep->buffer->data += copy;

--- a/arch/cpu/cc26x0-cc13x0/rf-core/prop-mode.c
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/prop-mode.c
@@ -728,8 +728,6 @@ transmit(unsigned short transmit_len)
     /* If we enter here, TX actually started */
     ENERGEST_SWITCH(ENERGEST_TYPE_LISTEN, ENERGEST_TYPE_TRANSMIT);
 
-    watchdog_periodic();
-
     /* Idle away while the command is running */
     while((cmd_tx_adv->status & RF_CORE_RADIO_OP_MASKED_STATUS)
           == RF_CORE_RADIO_OP_MASKED_STATUS_RUNNING) {

--- a/arch/cpu/nrf52832/ble/ble-mac.c
+++ b/arch/cpu/nrf52832/ble/ble-mac.c
@@ -314,7 +314,6 @@ send_packet(mac_callback_t sent, void *ptr)
     for(i = 0; i < BLE_MAC_MAX_INTERFACE_NUM; i++) {
       if(interfaces[i].handle.cid != 0 && interfaces[i].handle.conn_handle != 0) {
         ret = send_to_peer(&interfaces[i].handle);
-        watchdog_periodic();
       }
     }
   } else if((handle = find_handle(dest)) != NULL) {
@@ -326,7 +325,6 @@ send_packet(mac_callback_t sent, void *ptr)
   if(ret) {
     busy_tx = 1;
     while(busy_tx) {
-      watchdog_periodic();
       sd_app_evt_wait();
     }
     mac_call_sent_callback(sent, ptr, MAC_TX_OK, 1);


### PR DESCRIPTION
This pull removes calls to `watchdog_periodic()` from parts of the code that may get called inside an interrupt context.

There are two more calls that I identified as suspicious:

* `tsch-slot-operation::tsch_get_lock()`

https://github.com/contiki-ng/contiki-ng/blob/develop/os/net/mac/tsch/tsch-slot-operation.c#L207

I am not so sure about this one, but I think this also happens inside an interrupt so I've removed it. Happy to put it back if it's safe.

* `sicslowpan.c::send_packet()`

https://github.com/contiki-ng/contiki-ng/blob/develop/os/net/ipv6/sicslowpan.c#L1472

I think that one should be OK and I've left it there.

Fixes #835 