### PR TITLE
Fixed erroneous pointer cast in IEEE CCA request function

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-mode.c
@@ -586,7 +586,7 @@ cca_request(cmd_cca_req_t *cmd_cca_req)
   }
 
   /* Perform the CCA request */
-  stat = RF_runImmediateCmd(ieee_radio.rf_handle, (uint32_t *)&cmd_cca_req);
+  stat = RF_runImmediateCmd(ieee_radio.rf_handle, (uint32_t *)cmd_cca_req);
 
   if(stop_rx) {
     netstack_stop_rx();


### PR DESCRIPTION
`RF_runImmediateCmd()` expects a pointer to the immediate command, but a reference to the pointer of the CCA request command is provided.