### PR TITLE
Explicitly document libraries that are unsafe to use within interrupts

### DIFF
--- a/os/dev/watchdog.h
+++ b/os/dev/watchdog.h
@@ -34,6 +34,8 @@
 
 void watchdog_init(void);
 void watchdog_start(void);
+
+/* Do not use this function from within an interrupt context */
 void watchdog_periodic(void);
 void watchdog_stop(void);
 

--- a/os/lib/circular-list.h
+++ b/os/lib/circular-list.h
@@ -48,6 +48,8 @@
  * update the list's head and item order. If you call one of these functions
  * as part of a list traversal, it is advised to stop / restart traversing
  * after the respective function returns.
+ *
+ * This library is not safe to be used within an interrupt context.
  * @{
  */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbl-circ-list.h
+++ b/os/lib/dbl-circ-list.h
@@ -49,6 +49,8 @@
  * update the list's head and item order. If you call one of these functions
  * as part of a list traversal, it is advised to stop / restart traversing
  * after the respective function returns.
+ *
+ * This library is not safe to be used within an interrupt context.
  * @{
  */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbl-list.h
+++ b/os/lib/dbl-list.h
@@ -49,6 +49,8 @@
  * update the list's head and item order. If you call one of these functions
  * as part of a list traversal, it is advised to stop / restart traversing
  * after the respective function returns.
+ *
+ * This library is not safe to be used within an interrupt context.
  * @{
  */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/list.h
+++ b/os/lib/list.h
@@ -60,6 +60,7 @@
  * list with list_remove(). The head and tail of a list can be
  * extracted using list_head() and list_tail(), respectively.
  *
+ * This library is not safe to be used within an interrupt context.
  * @{
  */
 

--- a/os/lib/queue.h
+++ b/os/lib/queue.h
@@ -44,6 +44,8 @@
  * struct, the first field must be a pointer called \e next. This field will
  * be used by the library to maintain the queue. Application code must not
  * modify this field directly.
+ *
+ * This library is not safe to be used within an interrupt context.
  * @{
  */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/stack.h
+++ b/os/lib/stack.h
@@ -44,6 +44,8 @@
  * struct, the first field must be a pointer called \e next. This field will
  * be used by the library to maintain the stack. Application code must not
  * modify this field directly.
+ *
+ * This library is not safe to be used within an interrupt context.
  * @{
  */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/trickle-timer.h
+++ b/os/lib/trickle-timer.h
@@ -65,6 +65,7 @@
  * 'consistent' or 'inconsistent' message and when an 'external event' occurs
  * (in this context, those terms have the exact same meaning as in the RFC).
  *
+ * It is \e not safe to manipulate trickle timers within an interrupt context.
  * @{
  */
 

--- a/os/sys/ctimer.h
+++ b/os/sys/ctimer.h
@@ -49,6 +49,7 @@
  * The ctimer module provides a timer mechanism that calls a specified
  * C function when a ctimer expires.
  *
+ * It is \e not safe to manipulate callback timers within an interrupt context.
  */
 
 #ifndef CTIMER_H_

--- a/os/sys/etimer.h
+++ b/os/sys/etimer.h
@@ -56,6 +56,7 @@
  * \sa \ref timer "Simple timer library"
  * \sa \ref clock "Clock library" (used by the timer library)
  *
+ * It is \e not safe to manipulate event timers within an interrupt context.
  * @{
  */
 


### PR DESCRIPTION
This pull explicitly documents in the API docs some functions/libraries that are unsafe to use inside an interrupt context.

These changes to API documentation complement [this new wiki page](https://github.com/contiki-ng/contiki-ng/wiki/Documentation:-Multitasking-and-scheduling)

Resolves #841