### PR TITLE
Fix native-border-router with TSCH

### DIFF
--- a/examples/slip-radio/Makefile
+++ b/examples/slip-radio/Makefile
@@ -1,7 +1,6 @@
 CONTIKI_PROJECT=slip-radio
 all: $(CONTIKI_PROJECT)
 MODULES += os/services/slip-cmd
-CFLAGS += -DSLIP_ARCH_CONF_ENABLE=1
 
 # slip-radio is only intended for platforms with SLIP support
 PLATFORMS_EXCLUDE = native nrf52dk

--- a/examples/slip-radio/Makefile
+++ b/examples/slip-radio/Makefile
@@ -1,5 +1,7 @@
 CONTIKI_PROJECT=slip-radio
 all: $(CONTIKI_PROJECT)
+MODULES += os/services/slip-cmd
+CFLAGS += -DSLIP_ARCH_CONF_ENABLE=1
 
 # slip-radio is only intended for platforms with SLIP support
 PLATFORMS_EXCLUDE = native nrf52dk

--- a/examples/slip-radio/README.md
+++ b/examples/slip-radio/README.md
@@ -1,5 +1,5 @@
 This example is intended to run on a mode that is connected to a native host
-system by SLIP. Full IEEE 802.15.4 packets are transmitted over slip, turning
-the mote into a simple radio, with the RPL and 6LoWPAN stack running on the
-host. This is typically used with the native border router (example
-`rpl-border-router` on target native).
+system by SLIP. Full IP packets are transmitted over slip, and a mote adds
+IEEE 802.15.4 frame header. The mote has fully functional MAC and radio driver,
+and the RPL and 6LoWPAN stack running on the host. This is typically used
+with the native border router (example `rpl-border-router` on target native).

--- a/examples/slip-radio/project-conf.h
+++ b/examples/slip-radio/project-conf.h
@@ -43,6 +43,6 @@
 /* Configuration for the slipradio/network driver. */
 #define NETSTACK_CONF_NETWORK slipnet_driver
 
-#define NETSTACK_CONF_FRAMER no_framer
+#define NETSTACK_CONF_FRAMER framer_802154
 /*---------------------------------------------------------------------------*/
 #endif /* PROJECT_CONF_H_ */

--- a/os/services/rpl-border-router/native/README.md
+++ b/os/services/rpl-border-router/native/README.md
@@ -1,15 +1,14 @@
-This code connects a 802.15.4 radio over TTY with the full uIPv6 stack of
-Contiki-NG including 6LoWPAN and 802.15.4 framing / parsing. The native border
-router also acts as a RPL Root and handles the routing and maintains the RPL
-network. Finally the native border router connects the full 6LoWPAN/RPL
-network to the host (linux/os-x) network stack making it possible for
+This code connects a 802.15.4 radio over TTY with the full uIPv6 stack
+of Contiki-NG including 6LoWPAN. The native border router also acts as
+a RPL Root and handles the routing and maintains the RPL network.
+Finally the native border router connects the full 6LoWPAN/RPL network
+to the host (linux/os-x) network stack making it possible for
 applications on the host to transparently reach all the nodes in the
 6LoWPAN/RPL network.
 
-This is designed to interact with the a ../slip-radio example running on a
-mote that is either directly USB/TTY connected, or is remote via a TCP
-connect.  What's on the SLIP interface is really not Serial Line IP, but SLIP
-framed 15.4 packets.
+This is designed to interact with the a examples/slip-radio running on
+a mote that is either directly USB/TTY connected, or is remote via a
+TCP connect.
 
 The native border router supports a number of commands on its stdin.
 Each are prefixed by !:
@@ -20,8 +19,14 @@ Each are prefixed by !:
 * !Q - exit
 
 Queries are prefixed by ?:
-* ?M is used for requesting the MAC address from the radio in order to use it for uIP6 and its stateless address auto configuration of its IPv6 address. This will make the native border router have the address that correspond to the MAC address of the slip-radio. (response is !M from the slip-radio)
+* ?M is used for requesting the MAC address from the radio in order to
+use it for uIP6 and its stateless address auto configuration of its IPv6
+address. This will make the native border router have the address that
+correspond to the MAC address of the slip-radio. (response is !M from
+the slip-radio)
 
-* ?C is used for requesting the currently used channel for the slip-radio. The response is !C with a channel number (from the slip-radio).
+* ?C is used for requesting the currently used channel for the slip-radio.
+The response is !C with a channel number (from the slip-radio).
 
-* !C is used for setting the channel of the slip-radio (useful if the motes are using another channel than the one used in the slip-radio).
+* !C is used for setting the channel of the slip-radio (useful if the
+motes are using another channel than the one used in the slip-radio).

--- a/os/services/rpl-border-router/native/border-router-mac.c
+++ b/os/services/rpl-border-router/native/border-router-mac.c
@@ -180,7 +180,7 @@ static int
 max_payload()
 {
   init_sec();
-  return 127 - NETSTACK_FRAMER.length();
+  return RPL_BORDER_ROUTER_MAC_LEN - NETSTACK_FRAMER.length();
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/services/rpl-border-router/native/border-router-mac.c
+++ b/os/services/rpl-border-router/native/border-router-mac.c
@@ -179,26 +179,8 @@ off()
 static int
 max_payload()
 {
-  int framer_hdrlen;
-  radio_value_t max_radio_payload_len;
-  radio_result_t res;
-
   init_sec();
-  
-  res = NETSTACK_RADIO.get_value(RADIO_CONST_MAX_PAYLOAD_LEN,
-                                 &max_radio_payload_len);
-
-  if(res == RADIO_RESULT_NOT_SUPPORTED) {
-    LOG_ERR("Failed to retrieve max radio driver payload length\n");
-    return 0;
-  }
-
-  framer_hdrlen = NETSTACK_FRAMER.length();
-  if(framer_hdrlen < 0) {
-    return 0;
-  }
-
-  return MIN(max_radio_payload_len, PACKETBUF_SIZE) - framer_hdrlen;
+  return RPL_BORDER_ROUTER_MAC_LEN - NETSTACK_FRAMER.length();
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/services/rpl-border-router/native/border-router-mac.c
+++ b/os/services/rpl-border-router/native/border-router-mac.c
@@ -179,8 +179,26 @@ off()
 static int
 max_payload()
 {
+  int framer_hdrlen;
+  radio_value_t max_radio_payload_len;
+  radio_result_t res;
+
   init_sec();
-  return RPL_BORDER_ROUTER_MAC_LEN - NETSTACK_FRAMER.length();
+  
+  res = NETSTACK_RADIO.get_value(RADIO_CONST_MAX_PAYLOAD_LEN,
+                                 &max_radio_payload_len);
+
+  if(res == RADIO_RESULT_NOT_SUPPORTED) {
+    LOG_ERR("Failed to retrieve max radio driver payload length\n");
+    return 0;
+  }
+
+  framer_hdrlen = NETSTACK_FRAMER.length();
+  if(framer_hdrlen < 0) {
+    return 0;
+  }
+
+  return MIN(max_radio_payload_len, PACKETBUF_SIZE) - framer_hdrlen;
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/services/rpl-border-router/native/module-macros.h
+++ b/os/services/rpl-border-router/native/module-macros.h
@@ -41,3 +41,9 @@
 
 /* used by wpcap (see /cpu/native/net/wpcap-drv.c) */
 #define SELECT_CALLBACK 1
+
+#ifdef RPL_BORDER_ROUTER_CONF_MAC_LEN
+#define RPL_BORDER_ROUTER_MAC_LEN RPL_BORDER_ROUTER_CONF_MAC_LEN
+#else
+#define RPL_BORDER_ROUTER_MAC_LEN 127
+#endif

--- a/os/services/rpl-border-router/native/module-macros.h
+++ b/os/services/rpl-border-router/native/module-macros.h
@@ -41,3 +41,10 @@
 
 /* used by wpcap (see /cpu/native/net/wpcap-drv.c) */
 #define SELECT_CALLBACK 1
+
+/* Default MAC len for 802.15.4 classic */
+#ifdef  RPL_BORDER_ROUTER_MAC_CONF_LEN
+#define RPL_BORDER_ROUTER_MAC_LEN RPL_BORDER_ROUTER_MAC_CONF_LEN
+#else
+#define RPL_BORDER_ROUTER_MAC_LEN MIN(NETSTACK_RADIO_MAX_PAYLOAD_LEN, PACKETBUF_SIZE)
+#endif

--- a/os/services/rpl-border-router/native/module-macros.h
+++ b/os/services/rpl-border-router/native/module-macros.h
@@ -41,10 +41,3 @@
 
 /* used by wpcap (see /cpu/native/net/wpcap-drv.c) */
 #define SELECT_CALLBACK 1
-
-/* Default MAC len for 802.15.4 classic */
-#ifdef  RPL_BORDER_ROUTER_MAC_CONF_LEN
-#define RPL_BORDER_ROUTER_MAC_LEN RPL_BORDER_ROUTER_MAC_CONF_LEN
-#else
-#define RPL_BORDER_ROUTER_MAC_LEN MIN(NETSTACK_RADIO_MAX_PAYLOAD_LEN, PACKETBUF_SIZE)
-#endif

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -55,6 +55,7 @@
 #include "net/packetbuf.h"
 #include "cmd.h"
 #include "border-router-cmds.h"
+#include "os/services/slip-cmd/packetutils.h"
 
 extern int slip_config_verbose;
 extern int slip_config_flowcontrol;
@@ -161,10 +162,25 @@ is_sensible_string(const unsigned char *s, int len)
 void
 slip_packet_input(unsigned char *data, int len)
 {
-  packetbuf_copyfrom(data, len);
-  if(slip_config_verbose > 0) {
-    printf("Packet input over SLIP: %d\n", len);
+  int pos;
+  packetbuf_clear();
+  pos = packetutils_deserialize_atts(data, len);
+  if(pos < 0) {
+    err(1, "slip-dev: illegal packetbuf_attrs\n");
+    return;
   }
+  pos += packetutils_deserialize_addrs(&data[pos], len - pos);
+  if(pos < 0) {
+    err(1, "slip-dev: illegal packetbuf_addrs\n");
+    return;
+  }
+  len -= pos;
+  if(len > PACKETBUF_SIZE) {
+    len = PACKETBUF_SIZE;
+  }
+  packetbuf_set_datalen(len);
+  memcpy(packetbuf_dataptr(), &data[pos], len);
+
   NETSTACK_MAC.input();
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/slip-cmd/packetutils.c
+++ b/os/services/slip-cmd/packetutils.c
@@ -59,7 +59,7 @@ packetutils_serialize_atts(uint8_t *data, int size)
   int cnt = 0;
   /* assume that values are 16-bit */
   uint16_t val;
-  PRINTF("packetutils: serializing packet atts");
+  LOG_INFO("packetutils: serializing packet atts");
   for(i = 0; i < PACKETBUF_NUM_ATTRS; i++) {
     val = packetbuf_attr(i);
     if(val != 0) {

--- a/os/services/slip-cmd/packetutils.c
+++ b/os/services/slip-cmd/packetutils.c
@@ -59,7 +59,7 @@ packetutils_serialize_atts(uint8_t *data, int size)
   int cnt = 0;
   /* assume that values are 16-bit */
   uint16_t val;
-  LOG_INFO("packetutils: serializing packet atts");
+  LOG_INFO("packetutils: serializing packet atts\n");
   for(i = 0; i < PACKETBUF_NUM_ATTRS; i++) {
     val = packetbuf_attr(i);
     if(val != 0) {

--- a/os/services/slip-cmd/packetutils.h
+++ b/os/services/slip-cmd/packetutils.h
@@ -30,8 +30,73 @@
 #ifndef PACKETUTILS_H_
 #define PACKETUTILS_H_
 
-int packetutils_serialize_atts(uint8_t *data, int size);
+#include "os/sys/log.h"
 
+/* Log level for packetutil module */
+#ifdef LOG_CONF_LEVEL_PACKETUTILS
+#define LOG_LEVEL_PACKETUTILS LOG_CONF_LEVEL_PACKETUTILS
+#else /* PACKET_UTILS_CONF_LOG_LEVEL */
+#define LOG_LEVEL_PACKETUTILS LOG_LEVEL_NONE
+#endif /* LOG_CONF_LEVEL_PACKETUTILS */
+
+/**
+ * Package the all packetbuf_attr data.
+ *
+ * Caveat,
+ *   This function reads global variable `packetbuf`
+ *
+ * For examples,
+ *   If already set packetbuf_attr(PACKETBUF_ATTR_RSSI, -80),
+ *   data buffer is following.
+ *   +------+------+-------------+
+ *   | 0x01 | 0x04 | 0xff | 0xb0 |
+ *   +------+------+-------------+
+ *
+ *   The 1st octet shows number of attributes.
+ *   After the 2nd octet, 3 octets group shows 1 attribute.
+ *   The 1st octet of group shows attribute type, see packetbuf.h
+ *   The 2nd and 3rd octets of group show attribute value,
+ *   2nd shows upper 8bits, and 3rd shows lower 8bits.
+ *
+ *   If packetbuf had more attribute, 3 octets group continues.
+ *
+ * \param data The buffer stores packaged packetbuf_attr data.
+ * \param size Length of the `data` buffer.
+ * \return The length of packaged data if success, -1 if falure.
+ */
+int packetutils_serialize_atts(uint8_t *data, int size);
+/**
+ * Unpackage the all packetbuf_attr data.
+ *
+ * Caveat,
+ *   This function overwrites global variable `packetbuf`
+ *
+ * \param data The buffer stores unpackaged packetbuf_attr data.
+ * \param size Length of the `data` buffer.
+ * \return The length of unpackaged data if success, -1 if falure.
+ */
 int packetutils_deserialize_atts(const uint8_t *data, int size);
+/**
+ * Package the all packetbuf_addr data.
+ *
+ * Caveat,
+ *   This function reads global variable `packetbuf`
+ *
+ * \param data The buffer stores packaged packetbuf_addr data.
+ * \param size Length of the `data` buffer.
+ * \return The length of packaged data if success, -1 if falure.
+ */
+int packetutils_serialize_addrs(uint8_t *data, int size);
+/**
+ * Package the all packetbuf_addr data.
+ *
+ * Caveat,
+ *   This function overwrites global variable `packetbuf`
+ *
+ * \param data The buffer stores unpackaged packetbuf_addr data.
+ * \param size Length of the `data` buffer.
+ * \return The length of unpackaged data if success, -1 if falure.
+ */
+int packetutils_deserialize_addrs(const uint8_t *data, int size);
 
 #endif /* PACKETUTILS_H_ */

--- a/os/services/slip-cmd/packetutils.h
+++ b/os/services/slip-cmd/packetutils.h
@@ -88,7 +88,7 @@ int packetutils_deserialize_atts(const uint8_t *data, int size);
  */
 int packetutils_serialize_addrs(uint8_t *data, int size);
 /**
- * Package the all packetbuf_addr data.
+ * Unpackage the all packetbuf_addr data.
  *
  * Caveat,
  *   This function overwrites global variable `packetbuf`


### PR DESCRIPTION
# Problem

I tried to use `examples/rpl-border-router` and `examples/slip-radio` on Cooja with TSCH, but it could not form a TSCH network.
I also checked radio message logs, and confirmed that they didn't send Enhanced Beacons.

# Why does it happen?

This problem happens because `slip-radio` doesn't have header generation function (i.e. the framer) of IEEE 802.15.4. The framer is executed by native `rpl-border-router`, not by MAC layer of slip-radio.

When the border router sends an IPv6 packet, there is no problem. The native rpl-border-router creates a complete frame, passes it to slip-radio and slip-radio transmits it. However, when slip-radio tries to send an Enhanced Beacon, it cannot make the frame it because it doesn't have the framer.

# Changes

In this p-r, followings are changed.

- The framer of IEEE 802.15.4 is moved from native `rpl-border-router` to `slip-radio`. As a result, MAC payloads without MAC header are now exchanged over the SLIP link.
- Now packetbuf attributes (including the sender and receiver addresses) are serialized and exchanged over the SLIP link. This is necessary because the MAC header is not exchanged anymore.