### PR TITLE
coap-engine,coap-transactions: Fix handling of separate response

### DIFF
--- a/examples/coap/coap-example-server/resources/res-b1-sep-b2.c
+++ b/examples/coap/coap-example-server/resources/res-b1-sep-b2.c
@@ -76,7 +76,9 @@ res_post_handler(coap_message_t *request, coap_message_t *response, uint8_t *buf
 
     /* Send first block */
     coap_transaction_t *transaction = NULL;
-    if((transaction = coap_new_transaction(request_metadata.mid, &request_metadata.endpoint))) {
+    if((transaction = coap_new_transaction(request_metadata.mid,
+                                           request_metadata.token, request_metadata.token_len,
+                                           &request_metadata.endpoint))) {
       coap_message_t resp[1]; /* This way the message can be treated as pointer as usual. */
 
       /* Restore the request information for the response. */

--- a/examples/coap/coap-example-server/resources/res-separate.c
+++ b/examples/coap/coap-example-server/resources/res-separate.c
@@ -97,7 +97,10 @@ res_resume_handler()
 {
   if(separate_active) {
     coap_transaction_t *transaction = NULL;
-    if((transaction = coap_new_transaction(separate_store->request_metadata.mid, &separate_store->request_metadata.endpoint))) {
+    if((transaction = coap_new_transaction(separate_store->request_metadata.mid,
+                                           separate_store->request_metadata.token,
+                                           separate_store->request_metadata.token_len,
+                                           &separate_store->request_metadata.endpoint))) {
       coap_message_t response[1]; /* This way the message can be treated as pointer as usual. */
 
       /* Restore the request information for the response. */

--- a/examples/coap/coap-plugtest-server/resources/res-plugtest-separate.c
+++ b/examples/coap/coap-plugtest-server/resources/res-plugtest-separate.c
@@ -102,6 +102,8 @@ res_resume_handler()
     LOG_DBG("/separate       ");
     coap_transaction_t *transaction = NULL;
     if((transaction = coap_new_transaction(separate_store->request_metadata.mid,
+                                           separate_store->request_metadata.token,
+                                           separate_store->request_metadata.token_len,
                                            &separate_store->request_metadata.endpoint))) {
       LOG_DBG_(
         "RESPONSE (%s %u)\n", separate_store->request_metadata.type == COAP_TYPE_CON ? "CON" : "NON", separate_store->request_metadata.mid);

--- a/os/net/app-layer/coap/coap-blocking-api.c
+++ b/os/net/app-layer/coap/coap-blocking-api.c
@@ -87,7 +87,9 @@ PT_THREAD(coap_blocking_request
 
   do {
     request->mid = coap_get_mid();
-    if((state->transaction = coap_new_transaction(request->mid, remote_ep))) {
+    if((state->transaction = coap_new_transaction(request->mid,
+                                                  request->token, request->token_len,
+                                                  remote_ep))) {
       state->transaction->callback = coap_blocking_request_callback;
       state->transaction->callback_data = blocking_state;
 

--- a/os/net/app-layer/coap/coap-callback-api.c
+++ b/os/net/app-layer/coap/coap-callback-api.c
@@ -65,7 +65,9 @@ progress_request(coap_callback_request_state_t *callback_state) {
   coap_message_t *request = state->request;
   request->mid = coap_get_mid();
   if((state->transaction =
-      coap_new_transaction(request->mid, state->remote_endpoint))) {
+      coap_new_transaction(request->mid,
+                           request->token, request->token_len,
+                           state->remote_endpoint))) {
     state->transaction->callback = coap_request_callback;
     state->transaction->callback_data = state;
 

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -170,7 +170,7 @@ coap_receive(const coap_endpoint_t *src,
     if(message->code >= COAP_GET && message->code <= COAP_DELETE) {
 
       /* use transaction buffer for response to confirmable request */
-      if((transaction = coap_new_transaction(message->mid, src))) {
+      if((transaction = coap_new_transaction(message->mid, message->token, message->token_len, src))) {
         uint32_t block_num = 0;
         uint16_t block_size = COAP_MAX_BLOCK_SIZE;
         uint32_t block_offset = 0;
@@ -307,17 +307,39 @@ coap_receive(const coap_endpoint_t *src,
         coap_remove_observer_by_mid(src, message->mid);
       }
 
-      if((transaction = coap_get_transaction_by_mid(message->mid))) {
-        /* free transaction memory before callback, as it may create a new transaction */
-        coap_resource_response_handler_t callback = transaction->callback;
-        void *callback_data = transaction->callback_data;
-
-        coap_clear_transaction(transaction);
-
-        /* check if someone registered for the response */
-        if(callback) {
-          callback(callback_data, message);
+      const coap_endpoint_t *ep;
+      if(message->type == COAP_TYPE_ACK && message->code == 0) {
+        /* Handles regular (empty message) ACKs. */
+        /* ACKs carrying a piggyback response is handled below in the same way as any normal response */
+        LOG_DBG("Got empty ACK. Waiting for separate response\n");
+        if((transaction = coap_get_transaction_by_mid(message->mid))) {
+          transaction->acked = true;
         }
+      } else if((ep = coap_get_src_endpoint(message))) {
+        if((transaction = coap_get_transaction_by_token_and_endpoint(message->token, message->token_len, ep))) {
+          /* free transaction memory before callback, as it may create a new transaction */
+          coap_resource_response_handler_t callback = transaction->callback;
+          void *callback_data = transaction->callback_data;
+
+          coap_clear_transaction(transaction);
+
+          if(message->type == COAP_TYPE_CON) {
+            LOG_DBG("Got CON response. Need to ACK\n");
+
+            coap_message_t ack[1];
+            /* ACK with empty code (0) */
+            coap_init_message(ack, COAP_TYPE_ACK, 0, message->mid);
+            /* serializing into IPBUF: Only overwrites header parts that are already parsed into the response struct */
+            coap_sendto(ep, coap_databuf(), coap_serialize_message(ack, coap_databuf()));
+          }
+
+          /* check if someone registered for the response */
+          if(callback) {
+            callback(callback_data, message);
+          }
+        }
+      } else {
+        LOG_ERR("ERROR: no endpoint in response\n");
       }
       /* if(ACKed transaction) */
       transaction = NULL;

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -166,6 +166,15 @@ coap_receive(const coap_endpoint_t *src,
     LOG_DBG_COAP_STRING((const char *)message->payload, message->payload_len);
     LOG_DBG_("\n");
 
+#ifdef WITH_DTLS
+    /* when using DTLS the payload can be overwritten by the respose */
+    static uint8_t payload_buffer[COAP_MAX_CHUNK_SIZE];
+    if(message->payload != NULL) {
+      memcpy(payload_buffer, message->payload, message->payload_len);
+      message->payload = payload_buffer;
+    }
+#endif /* WITH_DTLS */
+
     /* handle requests */
     if(message->code >= COAP_GET && message->code <= COAP_DELETE) {
 
@@ -329,7 +338,7 @@ coap_receive(const coap_endpoint_t *src,
             coap_message_t ack[1];
             /* ACK with empty code (0) */
             coap_init_message(ack, COAP_TYPE_ACK, 0, message->mid);
-            /* serializing into IPBUF: Only overwrites header parts that are already parsed into the response struct */
+            /* serializing into IPBUF: Overwrites parts that are already parsed into the response struct */
             coap_sendto(ep, coap_databuf(), coap_serialize_message(ack, coap_databuf()));
           }
 

--- a/os/net/app-layer/coap/coap-observe-client.c
+++ b/os/net/app-layer/coap/coap-observe-client.c
@@ -297,7 +297,7 @@ coap_obs_request_registration(const coap_endpoint_t *endpoint, char *uri,
   coap_set_header_observe(request, 0);
   token_len = coap_generate_token(&token);
   set_token(request, token, token_len);
-  t = coap_new_transaction(request->mid, endpoint);
+  t = coap_new_transaction(request->mid, request->token, request->token_len, endpoint);
   if(t) {
     obs = coap_obs_add_observee(endpoint, (uint8_t *)token, token_len, uri,
                                 notification_callback, data);

--- a/os/net/app-layer/coap/coap-observe.c
+++ b/os/net/app-layer/coap/coap-observe.c
@@ -243,7 +243,7 @@ coap_notify_observers_sub(coap_resource_t *resource, const char *subpath)
 
       /*TODO implement special transaction for CON, sharing the same buffer to allow for more observers */
 
-      if((transaction = coap_new_transaction(coap_get_mid(), &obs->endpoint))) {
+      if((transaction = coap_new_transaction(coap_get_mid(), obs->token, obs->token_len, &obs->endpoint))) {
         /* if COAP_OBSERVE_REFRESH_INTERVAL is zero, never send observations as confirmable messages */
         if(COAP_OBSERVE_REFRESH_INTERVAL != 0
             && (obs->obs_counter % COAP_OBSERVE_REFRESH_INTERVAL == 0)) {

--- a/os/net/app-layer/coap/coap-transactions.c
+++ b/os/net/app-layer/coap/coap-transactions.c
@@ -44,9 +44,12 @@
 #include "coap-transactions.h"
 #include "coap-observe.h"
 #include "coap-timer.h"
+#include "coap-endpoint.h"
 #include "lib/memb.h"
 #include "lib/list.h"
 #include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
 
 /* Log configuration */
 #include "coap-log.h"
@@ -61,13 +64,22 @@ LIST(transactions_list);
 static void
 coap_retransmit_transaction(coap_timer_t *nt)
 {
+  uint8_t i;
   coap_transaction_t *t = coap_timer_get_user_data(nt);
+
   if(t == NULL) {
     LOG_DBG("No retransmission data in coap_timer!\n");
     return;
   }
   ++(t->retrans_counter);
-  LOG_DBG("Retransmitting %u (%u)\n", t->mid, t->retrans_counter);
+  if (t->acked) {
+    LOG_DBG("Waiting on response ");
+    for(i = 0; i < t->token_len; ++i)
+      LOG_DBG_("%"PRIx8, t->token[i]);
+    LOG_DBG_(" (%u)\n", t->retrans_counter);
+  } else {
+    LOG_DBG("Retransmitting %u (%u)\n", t->mid, t->retrans_counter);
+  }
   coap_send_transaction(t);
 }
 /*---------------------------------------------------------------------------*/
@@ -76,13 +88,16 @@ coap_retransmit_transaction(coap_timer_t *nt)
 /*- Internal API ------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 coap_transaction_t *
-coap_new_transaction(uint16_t mid, const coap_endpoint_t *endpoint)
+coap_new_transaction(uint16_t mid, const uint8_t *token, uint8_t token_len, const coap_endpoint_t *endpoint)
 {
   coap_transaction_t *t = memb_alloc(&transactions_memb);
 
   if(t) {
     t->mid = mid;
+    memcpy(t->token, token, MIN(COAP_TOKEN_LEN, token_len));
+    t->token_len = token_len;
     t->retrans_counter = 0;
+    t->acked = false;
 
     /* save client address */
     coap_endpoint_copy(&t->endpoint, endpoint);
@@ -102,7 +117,9 @@ coap_send_transaction(coap_transaction_t *t)
      ((COAP_HEADER_TYPE_MASK & t->message[0]) >> COAP_HEADER_TYPE_POSITION)) {
     if(t->retrans_counter <= COAP_MAX_RETRANSMIT) {
       /* not timed out yet */
-      coap_sendto(&t->endpoint, t->message, t->message_len);
+      if(!t->acked) {
+        coap_sendto(&t->endpoint, t->message, t->message_len);
+      }
       LOG_DBG("Keeping transaction %u\n", t->mid);
 
       if(t->retrans_counter == 0) {
@@ -162,6 +179,29 @@ coap_get_transaction_by_mid(uint16_t mid)
   for(t = (coap_transaction_t *)list_head(transactions_list); t; t = t->next) {
     if(t->mid == mid) {
       LOG_DBG("Found transaction for MID %u: %p\n", t->mid, t);
+      return t;
+    }
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+coap_transaction_t *
+coap_get_transaction_by_token_and_endpoint(const uint8_t *token, uint8_t token_len,
+                                           const coap_endpoint_t *endpoint)
+{
+  uint8_t i;
+  coap_transaction_t *t = NULL;
+
+  for(t = (coap_transaction_t *)list_head(transactions_list); t; t = t->next) {
+    if(t->token_len == token_len &&
+       0 == memcmp(t->token, token, MIN(COAP_TOKEN_LEN, token_len)) &&
+       coap_endpoint_cmp(&t->endpoint, endpoint)) {
+      LOG_DBG("Found transaction for Token ");
+      for(i = 0; i < token_len; ++i)
+        LOG_DBG_("%"PRIx8, token[i]);
+      LOG_DBG_(", Endpoint ");
+      LOG_DBG_COAP_EP(endpoint);
+      LOG_DBG_(": %p\n", t);
       return t;
     }
   }

--- a/os/net/app-layer/coap/coap-transactions.h
+++ b/os/net/app-layer/coap/coap-transactions.h
@@ -47,6 +47,9 @@
 #include "coap.h"
 #include "coap-engine.h"
 #include "coap-timer.h"
+#include "coap-constants.h"
+#include <stdbool.h>
+#include <stdint.h>
 
 /*
  * Modulo mask (thus +1) for a random number to get the tick number for the random
@@ -60,9 +63,12 @@ typedef struct coap_transaction {
   struct coap_transaction *next;        /* for LIST */
 
   uint16_t mid;
+  uint8_t token[COAP_TOKEN_LEN];
+  uint8_t token_len;
   coap_timer_t retrans_timer;
   uint32_t retrans_interval;
   uint8_t retrans_counter;
+  bool acked;
 
   coap_endpoint_t endpoint;
 
@@ -74,10 +80,11 @@ typedef struct coap_transaction {
                                                  * Use snprintf(buf, len+1, "", ...) to completely fill payload */
 } coap_transaction_t;
 
-coap_transaction_t *coap_new_transaction(uint16_t mid, const coap_endpoint_t *ep);
+coap_transaction_t *coap_new_transaction(uint16_t mid, const uint8_t *token, uint8_t token_len, const coap_endpoint_t *ep);
 void coap_send_transaction(coap_transaction_t *t);
 void coap_clear_transaction(coap_transaction_t *t);
 coap_transaction_t *coap_get_transaction_by_mid(uint16_t mid);
-
+coap_transaction_t *coap_get_transaction_by_token_and_endpoint(const uint8_t *token, uint8_t token_len,
+                                                               const coap_endpoint_t *endpoint);
 #endif /* COAP_TRANSACTIONS_H_ */
 /** @} */


### PR DESCRIPTION
A response from a server might come as a "separate response" where first an
empty message ACK is sent to tell the client there is no need to retransmit, and
that it should expect a response message soon. (RFC 7252 §5.2.2)

To stop the client from retransmitting when our message has already been ACKed,
a field was added to coap_transaction_t that blocks the coap_sendto call in
coap_send_transaction, with the retrans_timer continuing to fire like normal so
that we can still time out if the response from the server never shows up.

The response message is sent with a new Message ID chosen by the server, and if
its type is CON it should be ACK:ed by the client to inform the server that the
response has been successfully received.

To be able to handle all of the above we also need to fix how transactions are
managed and matched; the response from the server won't be using the same
Message ID as in the request. According to RFC, request/response should be
matched using the token and endpoint information only (RFC 7252 §5.3), so
transactions were refactored to match on this information instead of matching on
Message ID (except in the case of an empty message ACK).