### PR TITLE
coap-blocking-api: Signal timeout to the callback function

### DIFF
--- a/examples/coap/coap-example-client/coap-example-client.c
+++ b/examples/coap/coap-example-client/coap-example-client.c
@@ -79,6 +79,11 @@ client_chunk_handler(coap_message_t *response)
 {
   const uint8_t *chunk;
 
+  if(response == NULL) {
+    puts("Request timed out");
+    return;
+  }
+
   int len = coap_get_payload(response, &chunk);
 
   printf("|%.*s", len, (char *)chunk);

--- a/examples/lwm2m-ipso-objects/example-server.c
+++ b/examples/lwm2m-ipso-objects/example-server.c
@@ -172,6 +172,12 @@ client_chunk_handler(coap_message_t *response)
 {
   const uint8_t *chunk;
   unsigned int format;
+
+  if(response == NULL) {
+    PRINTF("\nRequest timed out\n");
+    return;
+  }
+
   int len = coap_get_payload(response, &chunk);
   coap_get_header_content_format(response, &format);
 

--- a/os/net/app-layer/coap/coap-blocking-api.c
+++ b/os/net/app-layer/coap/coap-blocking-api.c
@@ -108,6 +108,7 @@ PT_THREAD(coap_blocking_request
       if(!state->response) {
         LOG_WARN("Server not responding\n");
         state->status = COAP_REQUEST_STATUS_TIMEOUT;
+        request_callback(NULL); /* Call the callback with NULL to signal timeout */
         PT_EXIT(&blocking_state->pt);
       }
 


### PR DESCRIPTION
Currently there is no convenient way for the caller of COAP_BLOCKING_REQUEST
to tell if the request timed out.

This change calls the request_callback with a NULL pointer as the argument
on timeout. Thus the caller will be able to handle a timeout by checking
for NULL in the callback function.