### PR TITLE
Provide non-returning assert() implementation

### DIFF
--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -48,6 +48,8 @@
 
 #define COOJA 1
 
+#define ASSERT_CONF_RETURNS  1
+
 #define LEDS_CONF_LEGACY_API 1
 
 #ifndef EEPROM_CONF_SIZE

--- a/os/lib/assert.c
+++ b/os/lib/assert.c
@@ -27,6 +27,7 @@
  * SUCH DAMAGE. 
  *
  */
+#include "lib/assert.h"
 
 #include <stdio.h>
 
@@ -34,8 +35,8 @@ void
 _xassert(const char *file, int lineno)
 {
   printf("Assertion failed: file %s, line %d.\n", file, lineno);
-  /*
-   * loop for a while;
-   * call _reset_vector__();
-   */
+
+#if !ASSERT_RETURNS
+  while(1);
+#endif
 }

--- a/os/lib/assert.c
+++ b/os/lib/assert.c
@@ -37,6 +37,8 @@ _xassert(const char *file, int lineno)
   printf("Assertion failed: file %s, line %d.\n", file, lineno);
 
 #if !ASSERT_RETURNS
+  printf("The firmware will stop running\n");
+  printf("A watchdog timer may restart this device\n");
   while(1);
 #endif
 }

--- a/os/lib/assert.h
+++ b/os/lib/assert.h
@@ -31,13 +31,25 @@
 #ifndef ASSERT_H_
 #define ASSERT_H_
 
+#include "sys/cc.h"
+
+#ifdef ASSERT_CONF_RETURNS
+#define ASSERT_RETURNS ASSERT_CONF_RETURNS
+#else
+#define ASSERT_RETURNS 0
+#endif
+
 #undef assert
 #ifdef NDEBUG
 #define assert(e) ((void)0)
 #else
 #define assert(e) ((e) ? (void)0 : _xassert(__FILE__, __LINE__))
+#if ASSERT_RETURNS
 void _xassert(const char *, int);
-#endif
+#else
+void _xassert(const char *, int) CC_NORETURN;
+#endif /* ASSERT_RETURNS */
+#endif /* NDEBUG */
 
 #ifndef CTASSERT                /* Allow lint to override */
 #define CTASSERT(x)             _CTASSERT(x, __LINE__)

--- a/os/sys/cc-gcc.h
+++ b/os/sys/cc-gcc.h
@@ -39,5 +39,7 @@
 
 #define CC_CONF_ALIGN(n) __attribute__((__aligned__(n)))
 
+#define CC_CONF_NORETURN __attribute__((__noreturn__))
+
 #endif /* __GNUC__ */
 #endif /* _CC_GCC_H_ */

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -106,6 +106,16 @@
 #endif /* CC_CONF_INLINE */
 
 /**
+ * Configure if the C compiler supports functions that are not meant to return
+ * e.g. with __attribute__((__noreturn__))
+ */
+#ifdef CC_CONF_NORETURN
+#define CC_NORETURN CC_CONF_NORETURN
+#else
+#define CC_NORETURN
+#endif /* CC_CONF_NORETURN */
+
+/**
  * Configure if the C compiler supports the assignment of struct value.
  */
 #ifdef CC_CONF_ASSIGN_AGGREGATE


### PR DESCRIPTION
As reported in #959, our `os/lib/assert.h` will always get included instead of an `assert.h` that may be shipping with the toolchain. In some cases this is very undesirable and breaks builds, while I cannot immediately think of any use-cases where we may actually want to be doing this.

Currently, `assert.h` is provided by all relevant toolchains except our recommended msp430-gcc v4.7.0.

This pull recommends moving our own `assert.[ch]` to their own `os/lib/assert/` directory. This allows us to explicitly select them by adding them as a `MODULE` if required. In doing so:

* We can enable the respective functionality where the system does not provide it. We do so for all msp430 builds
* We can overwrite the system-provided header if there is reason to do so

@yatch I see you are using `assert()` in various places in the 6tisch/6top code and tests. Do you need non-default behaviour anywhere? Any other comments here or in #959 ?

Fixes #959 