### PR TITLE
uip-icmp6: in echo_reply_input, pass the correct icmp payload pointer

### DIFF
--- a/os/net/ipv6/uip-icmp6.c
+++ b/os/net/ipv6/uip-icmp6.c
@@ -283,7 +283,7 @@ echo_reply_input(void)
         n = list_item_next(n)) {
       if(n->callback != NULL) {
         n->callback(&sender, ttl,
-                    (uint8_t *)&UIP_ICMP_BUF[sizeof(struct uip_icmp_hdr)],
+                    (uint8_t *)UIP_ICMP_PAYLOAD,
                     uip_len - sizeof(struct uip_icmp_hdr) - UIP_IPH_LEN);
       }
     }


### PR DESCRIPTION
The old code seems to have assumed that the type of UIP_ICMP_BUF was
char* (or equivalent) while in fact it was struct uip_icmp_hdr*.

Thus when computing the address to UIP_ICMP_BUF[sizeof(struct
uip_icmp_hdr)], where sizeof(struct uip_icmp_hdr) = 4, it would
increment the pointer by 4*4 = 16 bytes, and not 4 bytes as would be
expected.