### PR TITLE
Switch between zoul radios with a single define

### DIFF
--- a/arch/platform/zoul/contiki-conf.h
+++ b/arch/platform/zoul/contiki-conf.h
@@ -113,18 +113,22 @@ uint16_t *radio_tsch_timeslot_timing(void);
  *
  * @{
  */
-/* Configure CSMA for when it's selected */
+#ifndef ZOUL_CONF_USE_CC1200_RADIO
+#define ZOUL_CONF_USE_CC1200_RADIO 0
+#endif
 
-#if CC1200_CONF_SUBGHZ_50KBPS_MODE
-#define NETSTACK_CONF_RADIO                                 cc1200_driver
-#define CC1200_CONF_RF_CFG                                  cc1200_802154g_863_870_fsk_50kbps
-#define ANTENNA_SW_SELECT_DEF_CONF                          ANTENNA_SW_SELECT_SUBGHZ
-#define CC1200_CONF_USE_GPIO2                               0
-#define CC1200_CONF_USE_RX_WATCHDOG                         0
+#if ZOUL_CONF_USE_CC1200_RADIO
+#define NETSTACK_CONF_RADIO                           cc1200_driver
+#define ANTENNA_SW_SELECT_DEF_CONF                    ANTENNA_SW_SELECT_SUBGHZ
+#define CC1200_CONF_USE_GPIO2                         0
+#define CC1200_CONF_USE_RX_WATCHDOG                   0
 
-#define CSMA_CONF_ACK_WAIT_TIME                          (RTIMER_SECOND / 200)
-#define CSMA_CONF_AFTER_ACK_DETECTED_WAIT_TIME           (RTIMER_SECOND / 1500)
+#define CSMA_CONF_ACK_WAIT_TIME                       (RTIMER_SECOND / 200)
+#define CSMA_CONF_AFTER_ACK_DETECTED_WAIT_TIME        (RTIMER_SECOND / 1500)
 
+#ifndef CC1200_CONF_RF_CFG
+#define CC1200_CONF_RF_CFG                   cc1200_802154g_863_870_fsk_50kbps
+#endif
 #endif
 
 /* This can be overriden to use the cc1200_driver instead */

--- a/tests/03-compile-arm-ports-02/Makefile
+++ b/tests/03-compile-arm-ports-02/Makefile
@@ -22,7 +22,7 @@ lwm2m-ipso-objects/zoul:DEFINES=LWM2M_Q_MODE_CONF_ENABLED=1,LWM2M_Q_MODE_CONF_IN
 hello-world/zoul \
 hello-world/zoul:DEFINES=ZOUL_CONF_USE_CC1200_RADIO=1 \
 sensniff/zoul \
-sensniff/zoul:ZOUL_CONF_SUB_GHZ_SNIFFER=1 \
+sensniff/zoul:DEFINES=ZOUL_CONF_SUB_GHZ_SNIFFER=1 \
 storage/cfs-coffee/zoul \
 storage/antelope-shell/zoul \
 6tisch/simple-node/zoul \

--- a/tests/03-compile-arm-ports-02/Makefile
+++ b/tests/03-compile-arm-ports-02/Makefile
@@ -20,6 +20,7 @@ lwm2m-ipso-objects/zoul:MAKE_WITH_DTLS=1 \
 lwm2m-ipso-objects/zoul:DEFINES=LWM2M_Q_MODE_CONF_ENABLED=1 \
 lwm2m-ipso-objects/zoul:DEFINES=LWM2M_Q_MODE_CONF_ENABLED=1,LWM2M_Q_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1\
 hello-world/zoul \
+hello-world/zoul:DEFINES=ZOUL_CONF_USE_CC1200_RADIO=1 \
 sensniff/zoul \
 sensniff/zoul:ZOUL_CONF_SUB_GHZ_SNIFFER=1 \
 storage/cfs-coffee/zoul \


### PR DESCRIPTION
This pull:

* Makes it easy to switch between zoul radios (cc2538/cc1200) through the `ZOUL_CONF_USE_CC1200_RADIO` macro. When defined as non-zero, the configuration system selects sane default values for sub-ghz operation with the cc1200. Users can leave this macro defined as zero and configure sub-ghz operation manually
* Adds a new compile test for platform zoul / sub-ghz configuration
* Fixes the zoul sub-ghz sensniff compile test

Requires #974 