### PR TITLE
Allow MPL Reactive Forwarding to be Disabled

### DIFF
--- a/os/net/ipv6/multicast/mpl.h
+++ b/os/net/ipv6/multicast/mpl.h
@@ -59,7 +59,7 @@
 /*---------------------------------------------------------------------------*/
 /* Protocol Constants */
 /*---------------------------------------------------------------------------*/
-#define ALL_MPL_FORWARDERS(a, r)   uip_ip6addr(a, 0xFF00 + r,0x00,0x00,0x00,0x00,0x00,0x00,0xFC)
+#define ALL_MPL_FORWARDERS(a, r)   uip_ip6addr(a, 0xFF00 + r, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFC)
 #define HBHO_OPT_TYPE_MPL          0x6D
 #define MPL_IP_HOP_LIMIT           0xFF   /**< Hop limit for ICMP messages */
 #define HBHO_BASE_LEN              8
@@ -145,7 +145,7 @@
 #endif
 /*---------------------------------------------------------------------------*/
 /**
-* Seed ID Low Bits
+ * Seed ID Low Bits
  * If the Seed ID Length setting is 1 or 2, this setting defines the seed
  * id for this seed. If the seed id setting is 3, then this defines the lower
  * 64 bits of the seed id.
@@ -157,7 +157,7 @@
 #endif
 /*---------------------------------------------------------------------------*/
 /**
-* Seed ID High Bits
+ * Seed ID High Bits
  * If the Seed ID Length setting is 3, this setting defines the upper 64 bits
  * for the seed id. Else it's ignored.
  */
@@ -217,20 +217,31 @@
 #endif
 /*---------------------------------------------------------------------------*/
 /**
- * MPL Forwarding Strategy
- * Two forwarding strategies are defined for MPL. With Proactive forwarding
- * enabled, the forwarder will schedule transmissions of new messages
- * before any control messages are received to indicate that neighbouring nodes
- * have yet to receive the messages. With Reactive forwarding enabled, MPL
- * forwarders will only schedule transmissions of new MPL messages once control
- * messages have been received indicating that they are missing those messages.
- * 1 - Indicates that proactive forwarding be enabled
- * 0 - Indicates that proactive forwarding be disabled
+ * MPL Forwarding Strategies
+ * Two forwarding strategies are defined for MPL, Proactive Forwarding and
+ * Reactive Forwarding. Both may be used simultaneously, or either one may be
+ * used on it's own. At least one strategy must be enabled.
+ *
+ * With Proactive forwarding enabled, the forwarder will schedule
+ * messages to be forwarded using a trickle timer as soon as the message is
+ * received. This works like traditional multicast does.
+ *
+ * With Reactive forwarding enabled, MPL forwarders will cache messages and
+ * communicate the contents of their caches using MPL Control messages. Any
+ * forwarders missing messages then have the messages transmitted or
+ * retransmitted by a neighbour once it's known that the message is missing
+ * from the neighbours cache.
  */
 #ifndef MPL_CONF_PROACTIVE_FORWARDING
 #define MPL_PROACTIVE_FORWARDING            0
 #else
 #define MPL_PROACTIVE_FORWARDING MPL_CONF_PROACTIVE_FORWARDING
+#endif
+
+#ifndef MPL_CONF_REACTIVE_FORWARDING
+#define MPL_REACTIVE_FORWARDING            1
+#else
+#define MPL_REACTIVE_FORWARDING MPL_CONF_REACTIVE_FORWARDING
 #endif
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
This PR adds a config switch that allows for the reactive forwarding strategy
in MPL to be disabled, something that was overlooked in my original implementation. With reactive forwarding disabled *most* of the caching of messages is disabled, and no MPL Control messages are exchanged. Instead only proactive forwarding is used where received messages are immediately scheduled for transmission by a trickle timer, so are forwarded after a small random delay. Some inconsistencies in the domain can also be detected by the 'M' flag within the data message which will trigger a retransmission. Messages are removed from the cache after the trickle timer has expired `DATA_MESSAGE_TIMER_EXPIRATIONS` times. Disabling reactive forwarding allows for smaller caches to be used, and also for the code relating to MPL Control messages to also be omitted at compile time. 