### PR TITLE
TSCH: remove an unused macro in tsch.c

### DIFF
--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -71,15 +71,6 @@
 #define LOG_MODULE "TSCH"
 #define LOG_LEVEL LOG_LEVEL_MAC
 
-/* Use to collect link statistics even on Keep-Alive, even though they were
- * not sent from an upper layer and don't have a valid packet_sent callback */
-#ifndef TSCH_LINK_NEIGHBOR_CALLBACK
-#if NETSTACK_CONF_WITH_IPV6
-void uip_ds6_link_neighbor_callback(int status, int numtx);
-#define TSCH_LINK_NEIGHBOR_CALLBACK(dest, status, num) uip_ds6_link_neighbor_callback(status, num)
-#endif /* NETSTACK_CONF_WITH_IPV6 */
-#endif /* TSCH_LINK_NEIGHBOR_CALLBACK */
-
 /* The address of the last node we received an EB from (other than our time source).
  * Used for recovery */
 static linkaddr_t last_eb_nbr_addr;


### PR DESCRIPTION
Although `TSCH_LINK_NEIGHBOR_CALLBACK` is conditionally defined in `tsch.c`, this macro is not referred from anywhere.

```
$ pwd
/Users/yatch/Work/contiki-ng
$ find . -name \*.\[ch\] | xargs grep TSCH_LINK_NEIGHBOR_CALLBACK
./os/net/mac/tsch/tsch.c:#ifndef TSCH_LINK_NEIGHBOR_CALLBACK
./os/net/mac/tsch/tsch.c:#define TSCH_LINK_NEIGHBOR_CALLBACK(dest, status, num) uip_ds6_link_neighbor_callback(status, num)
./os/net/mac/tsch/tsch.c:#endif /* TSCH_LINK_NEIGHBOR_CALLBACK */
```

It seems this is a leftover from the refactoring work by https://github.com/contiki-ng/contiki-ng/pull/47.