### PR TITLE
lc-addrlabels: remove statement expression (fixes #986)

### DIFF
--- a/os/sys/lc-addrlabels.h
+++ b/os/sys/lc-addrlabels.h
@@ -73,7 +73,11 @@ typedef void * lc_t;
   } while(0)
 
 #define LC_SET(s)                               \
-  do { ({ __label__ resume; resume: (s) = &&resume; }); }while(0)
+  do {                                          \
+    __label__ resume;                           \
+  resume:                                       \
+    (s) = &&resume;                             \
+  } while(0)
 
 #define LC_END(s)
 


### PR DESCRIPTION
According to GCC documentation, jumping into a statement expression with
a computed goto (using labels as values) has undefined behavior and
should be avoided.  However, this is exactly what is happening in the
current `LC_SET` implementation.

Fortunately, the statement expression which contains the label in `LC_SET`
can safely be removed since the operand is only evaluated once, and
multi-statement operations of the macro are already handled by a
`do-while(0)` construct.

For more information, see issue #986 