### PR TITLE
Fixed bug in CC1310 prop RF settings

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x0/prop-settings.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x0/prop-settings.c
@@ -66,6 +66,19 @@
 #include "prop-settings.h"
 /*---------------------------------------------------------------------------*/
 /* TI-RTOS RF Mode Object */
+#if defined(DEVICE_CC1310)
+RF_Mode rf_prop_mode =
+{
+  /*
+   * CC1310 only supports RF_MODE_PROPRIETARY_SUB_1, and hence we need to
+   * separate the rfMode setting between CC1310 and CC1350*.
+   */
+  .rfMode = RF_MODE_PROPRIETARY_SUB_1,
+  .cpePatchFxn = &rf_patch_cpe_genfsk,
+  .mcePatchFxn = 0,
+  .rfePatchFxn = &rf_patch_rfe_genfsk,
+};
+#else
 RF_Mode rf_prop_mode =
 {
   .rfMode = RF_MODE_MULTIPLE,
@@ -73,6 +86,7 @@ RF_Mode rf_prop_mode =
   .mcePatchFxn = 0,
   .rfePatchFxn = &rf_patch_rfe_genfsk,
 };
+#endif
 /*---------------------------------------------------------------------------*/
 /* Overrides for CMD_PROP_RADIO_DIV_SETUP */
 uint32_t rf_prop_overrides[] CC_ALIGN(4) =

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x0/prop-settings.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x0/prop-settings.c
@@ -66,27 +66,24 @@
 #include "prop-settings.h"
 /*---------------------------------------------------------------------------*/
 /* TI-RTOS RF Mode Object */
+
+/*
+ * CC1310 only supports RF_MODE_PROPRIETARY_SUB_1, and hence we need to
+ * separate the rfMode setting between CC1310 and CC1350*.
+ */
 #if defined(DEVICE_CC1310)
-RF_Mode rf_prop_mode =
-{
-  /*
-   * CC1310 only supports RF_MODE_PROPRIETARY_SUB_1, and hence we need to
-   * separate the rfMode setting between CC1310 and CC1350*.
-   */
-  .rfMode = RF_MODE_PROPRIETARY_SUB_1,
-  .cpePatchFxn = &rf_patch_cpe_genfsk,
-  .mcePatchFxn = 0,
-  .rfePatchFxn = &rf_patch_rfe_genfsk,
-};
+#define RF_PROP_MODE  RF_MODE_PROPRIETARY_SUB_1
 #else
+#define RF_PROP_MODE  RF_MODE_MULTIPLE
+#endif
+
 RF_Mode rf_prop_mode =
 {
-  .rfMode = RF_MODE_MULTIPLE,
+  .rfMode = RF_PROP_MODE,
   .cpePatchFxn = &rf_patch_cpe_genfsk,
   .mcePatchFxn = 0,
   .rfePatchFxn = &rf_patch_rfe_genfsk,
 };
-#endif
 /*---------------------------------------------------------------------------*/
 /* Overrides for CMD_PROP_RADIO_DIV_SETUP */
 uint32_t rf_prop_overrides[] CC_ALIGN(4) =


### PR DESCRIPTION
A bug was introduced in the CC1310 prop RF settings when fixing a bug
with BLE beaconing. In short, prop RF settings are shared between CC1310
and CC1350, and rfMode was set to RF_MODE_MULTIPLE which is only
supported on CC1350. This is now split between CC1310 and CC1350.