### PR TITLE
tsch: introduce TSCH_CONF_PENDING_BIT_ENABLED

### DIFF
--- a/os/net/mac/tsch/tsch-conf.h
+++ b/os/net/mac/tsch/tsch-conf.h
@@ -362,6 +362,15 @@
 #define TSCH_WITH_LINK_SELECTOR (BUILD_WITH_ORCHESTRA)
 #endif /* TSCH_CONF_WITH_LINK_SELECTOR */
 
+/* Having the pending bit on in frame, following frames to the same
+ * destination can be transmitted consecutively over unscheduled
+ * links. This enables bursty TX. (default enabled) */
+#ifdef TSCH_CONF_PENDING_BIT_ENABLED
+#define TSCH_PENDING_BIT_ENABLED TSCH_CONF_PENDING_BIT_ENABLED
+#else
+#define TSCH_PENDING_BIT_ENABLED 1
+#endif
+
 /******** Configuration: CSMA *******/
 
 /* TSCH CSMA-CA parameters, see IEEE 802.15.4e-2012 */

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -497,12 +497,14 @@ PT_THREAD(tsch_tx_slot(struct pt *pt, struct rtimer *t))
       is_broadcast = current_neighbor->is_broadcast;
       /* Unicast. More packets in queue for the neighbor? */
       burst_link_requested = 0;
+#if TSCH_PENDING_BIT_ENABLED
       if(!is_broadcast
              && tsch_current_burst_count + 1 < TSCH_BURST_MAX_LEN
              && tsch_queue_packet_count(&current_neighbor->addr) > 1) {
         burst_link_requested = 1;
         tsch_packet_set_frame_pending(packet, packet_len);
       }
+#endif /* TSCH_PENDING_BIT_ENABLED */
       /* read seqno from payload */
       seqno = ((uint8_t *)(packet))[2];
       /* if this is an EB, then update its Sync-IE */
@@ -904,8 +906,10 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
                 NETSTACK_RADIO.transmit(ack_len);
                 tsch_radio_off(TSCH_RADIO_CMD_OFF_WITHIN_TIMESLOT);
 
+#if TSCH_PENDING_BIT_ENABLED
                 /* Schedule a burst link iff the frame pending bit was set */
                 burst_link_scheduled = tsch_packet_get_frame_pending(current_input->payload, current_input->len);
+#endif /* TSCH_PENDING_BIT_ENABLED */
               }
             }
 


### PR DESCRIPTION
This PR introduces `TSCH_CONF_PENDING_BIT_ENABLED` which gives a choice, whether to enable the pending bit, defined in Section 7.2.1.3 of IEEE 802.15.4-2015, or not. Having the pending bit enabled, a transmitter can perform the bursty TX.

See discussion in Issue #994.