### PR TITLE
lib: memb: simplify handling of allocation status

### DIFF
--- a/os/lib/memb.h
+++ b/os/lib/memb.h
@@ -63,6 +63,7 @@
 #ifndef MEMB_H_
 #define MEMB_H_
 
+#include <stdbool.h>
 #include "sys/cc.h"
 
 /**
@@ -87,16 +88,16 @@ MEMB(connections, struct connection, 16);
  *
  */
 #define MEMB(name, structure, num) \
-        static char CC_CONCAT(name,_memb_count)[num]; \
+        static bool CC_CONCAT(name,_memb_used)[num]; \
         static structure CC_CONCAT(name,_memb_mem)[num]; \
         static struct memb name = {sizeof(structure), num, \
-                                          CC_CONCAT(name,_memb_count), \
+                                          CC_CONCAT(name,_memb_used), \
                                           (void *)CC_CONCAT(name,_memb_mem)}
 
 struct memb {
   unsigned short size;
   unsigned short num;
-  char *count;
+  bool *used;
   void *mem;
 };
 
@@ -122,11 +123,10 @@ void *memb_alloc(struct memb *m);
  *
  * \param ptr A pointer to the memory block that is to be deallocated.
  *
- * \return The new reference count for the memory block (should be 0
- * if successfully deallocated) or -1 if the pointer "ptr" did not
- * point to a legal memory block.
+ * \return error code, should be 0 if successfully deallocated or -1 if the
+ * pointer "ptr" did not point to a legal memory block.
  */
-char  memb_free(struct memb *m, void *ptr);
+int  memb_free(struct memb *m, void *ptr);
 
 int memb_inmemb(struct memb *m, void *ptr);
 


### PR DESCRIPTION
During formal verification of memb* functions it was discovered that
reference counting in the functions could be significantly simplified.

Here is the citation from the work:
"This verification case study also allowed to detect a potentially
harmful situation. The memb_free function used to decrement the count
associated to the given block, instead of setting it to 0. An awkward
consequence of this is that calling memb_free on a block with an unusual
count (e.g., greater than 2) would not actually free it. While this
should not happen under normal circumstances, we have decided to replace
that decrement operation by a set to 0. This choice makes memb_free both
simpler and more robust, easing the verification process..."

"Formal Verification of a Memory Allocation Module of Contiki with
Frama-C: a Case Study" Frédéric Mangano, Simon Duquennoy, Nikolai Kosmatov

This commit adopts the verification results from the work.

Signed-off-by: Denis Efremov <efremov@linux.com>
Signed-off-by: Nikolay Kosmatov <nikolaikosmatov@gmail.com>
Signed-off-by: Allan Blanchard <allan.blanchard@inria.fr>
Signed-off-by: Frederic Loulergue <frederic.loulergue@nau.edu>

Cc: @simonduq, @AllanBlanchard, @fredericloulergue