### PR TITLE
docker: fix an issue on net.ipv6.conf.all.disable_ipv6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
 
 # The test script for each build
 script:
-  - docker run --privileged -v $OUT_OF_TREE_TEST_PATH:/home/user/out-of-tree-tests -v $CNG_HOST_PATH:/home/user/contiki-ng -ti $DOCKER_IMG bash --login -c "make -C tests/??-$TEST_NAME";
+  - docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 -v $OUT_OF_TREE_TEST_PATH:/home/user/out-of-tree-tests -v $CNG_HOST_PATH:/home/user/contiki-ng -ti $DOCKER_IMG bash --login -c "make -C tests/??-$TEST_NAME";
   # Check outcome of the test
   - $CNG_HOST_PATH/tests/check-test.sh $CNG_HOST_PATH/tests/??-$TEST_NAME; exit $?;
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -123,8 +123,5 @@ ENV PATH="${HOME}/renode:${PATH}"
 # Working directory
 WORKDIR ${CONTIKI_NG}
 
-# Enable IPv6 -- must be done at runtime, hence added to .profile
-RUN echo "sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 > /dev/null" >> ${HOME}/.profile
-
 # Start a bash
 CMD bash --login


### PR DESCRIPTION
# Issue
We currently try to change `net.ipv6.conf.all.disable_ipv6` to `0` by `.profile`, but it doesn't work.

```
$ docker run -ti contiker/contiki-ng
sysctl: setting key "net.ipv6.conf.all.disable_ipv6": Read-only file system
user@57f569a70c56:~/contiki-ng$
```

Here is another example:
```
$ docker run -ti contiker/contiki-ng sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 1
```

# Solution

As per [the official documentation of Docker](https://docs.docker.com/engine/reference/commandline/run/), `--sysctl` should be passed to `docker run` for this purpose:

> The --sysctl sets namespaced kernel parameters (sysctls) in the container. For example, to turn on IP forwarding in the containers network namespace, run this command:

# What does this PR do?

This PR proposes to remove the `sysctl` command from `.profile`. The Wiki page will be updated accordingly, adding `--sysctl net.ipv6.conf.all.disable_ipv6=0` to `contiker` aliases.

# Demo

```
$ docker run --sysctl net.ipv6.conf.all.disable_ipv6=0 -ti contiker/contiki-ng sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
```

# Version Info

```
$ docker image ls | grep contiki-ng
contiker/contiki-ng    latest              8307892c9c77        9 months ago        3.32GB

$ docker version
Client: Docker Engine - Community
 Version:           19.03.1
 API version:       1.40
 Go version:        go1.12.5
 Git commit:        74b1e89
 Built:             Thu Jul 25 21:18:17 2019
 OS/Arch:           darwin/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.1
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.5
  Git commit:       74b1e89
  Built:            Thu Jul 25 21:17:52 2019
  OS/Arch:          linux/amd64
  Experimental:     true
 containerd:
  Version:          v1.2.6
  GitCommit:        894b81a4b802e4eb2a91d1ce216b8817763c29fb
 runc:
  Version:          1.0.0-rc8
  GitCommit:        425e105d5a03fabd737a126ad93d62a9eeede87f
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683
```

This issue is confirmed on Docker for Windows as well.