### PR TITLE
make connect-router for rpl-border-router can now use PORT variable

### DIFF
--- a/os/services/rpl-border-router/embedded/Makefile.embedded
+++ b/os/services/rpl-border-router/embedded/Makefile.embedded
@@ -1,7 +1,13 @@
 PREFIX ?= fd00::1/64
 
+ifdef PORT
+	TUNSLIP6_ARGS = -s $(PORT) $(PREFIX)
+else
+	TUNSLIP6_ARGS = $(PREFIX)
+endif
+
 connect-router: $(TUNSLIP6)
-	sudo $(TUNSLIP6) $(PREFIX)
+	sudo $(TUNSLIP6) $(TUNSLIP6_ARGS)
 
 connect-router-cooja: $(TUNSLIP6)
 	sudo $(TUNSLIP6) -a 127.0.0.1 $(PREFIX)


### PR DESCRIPTION
When running `make connect-router` tunslip6 was unable to create a tunnel as the cc1350/launchpads or cc2650/launchpads, possibly several others, enmuerates as `ttyACM0`. For a tunnel to be created tunslip6 has to be ran manually as `tunslip6 -s /dev/ttyACM0 fd00::1`. PORT already can be specified as a variable when flashing the device `make PORT=/dev/ttyACM0 project.upload` or by adding it to the project's `Makefile`. This change makes it so that by specifying a PORT variable, it will be added to the tunslip6 options. This will let you specify whichever tty device you'd like when using `connect-router`, such as `make PORT=/dev/ttyACM0 connect-router`.
If PORT isn't specified it behaves as earlier.

I also found a typo in viewconf.c which makes it so the value of `TSCH_CONF_DEFAULT_HOPPING_SEQUENCE` appears incorrectly as the text `TTSCH_CONF_DEFAULT_HOPPING_SEQUENCE` instead of whatever value(s) it is set to.