### PR TITLE
Change default tunslip6 verbosity

### DIFF
--- a/tools/serial-io/tunslip6.c
+++ b/tools/serial-io/tunslip6.c
@@ -64,7 +64,7 @@
 #endif
 speed_t b_rate = BAUDRATE;
 
-int verbose = 1;
+int verbose = 2;
 const char *ipaddr;
 const char *netmask;
 int slipfd = 0;
@@ -862,8 +862,8 @@ fprintf(stderr," -v level       Verbosity level\n");
 fprintf(stderr," -v[level]      Verbosity level\n");
 #endif
 fprintf(stderr,"    -v0         No messages\n");
-fprintf(stderr,"    -v1         Encapsulated SLIP debug messages (default)\n");
-fprintf(stderr,"    -v2         Printable strings after they are received\n");
+fprintf(stderr,"    -v1         Encapsulated SLIP debug messages\n");
+fprintf(stderr,"    -v2         Printable strings after they are received (default)\n");
 fprintf(stderr,"    -v3         Printable strings and SLIP packet notifications\n");
 fprintf(stderr,"    -v4         All printable characters as they are received\n");
 fprintf(stderr,"    -v5         All SLIP packets in hex\n");

--- a/tools/serial-io/tunslip6.c
+++ b/tools/serial-io/tunslip6.c
@@ -868,7 +868,7 @@ fprintf(stderr,"    -v3         Printable strings and SLIP packet notifications\
 fprintf(stderr,"    -v4         All printable characters as they are received\n");
 fprintf(stderr,"    -v5         All SLIP packets in hex\n");
 #ifndef __APPLE__
-fprintf(stderr,"    -v          Equivalent to -v3\n");
+fprintf(stderr,"    -v          Equivalent to -v2\n");
 #endif
 fprintf(stderr," -d[basedelay]  Minimum delay between outgoing SLIP packets.\n");
 fprintf(stderr,"                Actual delay is basedelay*(#6LowPAN fragments) milliseconds.\n");


### PR DESCRIPTION
Unless we specify `-v[level]`, tunslip6 will default to `-v1`. This causes undesirable behaviour: The following embedded BR output lines will not get printed to console immediately (but they will if e.g. the BR resets):

```
[INFO: BR        ] Waiting for prefix
[INFO: BR        ] Server IPv6 addresses:
[INFO: BR        ]   fd00::212:4b00:7b5:a183
[INFO: BR        ]   fe80::212:4b00:7b5:a183
```
These lines will in fact get printed if we run `tunslip6` with `-v2`.

Now in the BR-related wiki page we describe that the `connect-router` make target will result in these lines getting printed, but it does not since it invokes `tunslip6` without specifying the verbosity level (so the call results in the default `-v1`). This causes user confusion.

These lines are IMHO very useful to see anyway, so instead of changing the wiki this PR proposes changing the default tunslip6 verbosity to `-v2`.

This PR also fixes an error in the `tunslip6` help message: `-v` is equivalent to `-v2` not `-v3`

Closes #1037 