### PR TITLE
Add support for the .upload make target for platform simplelink

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -142,3 +142,29 @@ $(OBJECTDIR)/ccfg-conf.o: ccfg-conf.c FORCE | $(OBJECTDIR)
 
 # Include the Sub-family Makefile specific for the specified device
 include $(CONTIKI_CPU)/$(SUBFAMILY)/Makefile.$(SUBFAMILY)
+
+################################################################################
+### For the .upload make target
+PYTHON = python
+BSL_FLAGS += -e -w -v
+
+ifdef PORT
+  BSL_FLAGS += -p $(PORT)
+endif
+
+BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
+
+ifeq ($(BOARD_SUPPORTS_BSL),1)
+%.upload: $(OUT_BIN)
+ifeq ($(wildcard $(BSL)), )
+	@echo "ERROR: Could not find the cc2538-bsl script. Did you run 'git submodule update --init' ?"
+else
+	$(PYTHON) $(BSL) $(BSL_FLAGS) $<
+endif
+else
+%.upload:
+	@echo "This board cannot be programmed through the ROM bootloader and therefore does not support the .upload target."
+endif
+
+### For the login etc targets
+BAUDRATE ?= 115200


### PR DESCRIPTION
This commit allows users of platform simplelink to program their devices using the .upload make target. This will only work for those simplelink boards that can actually be programmed using the cc2538-bsl script. As of the time of writing this commit, this can only be done with the old `x0` devices (cc13x0 and cc26x0), but not the newer `x2` devices. Changes to the BSL script itself likely required before these platforms can be supported.

Closes #1036