### PR TITLE
TSCH: do not send EB packets when in leaf mode

### DIFF
--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -859,6 +859,8 @@ PROCESS_THREAD(tsch_send_eb_process, ev, data)
       /* Implementation section 6.3 of RFC 8180 */
       && TSCH_RPL_CHECK_DODAG_JOINED()
 #endif /* TSCH_RPL_CHECK_DODAG_JOINED */
+      /* don't send when in leaf mode */
+      && !NETSTACK_ROUTING.is_in_leaf_mode()
         ) {
       /* Enqueue EB only if there isn't already one in queue */
       if(tsch_queue_packet_count(&tsch_eb_address) == 0) {

--- a/os/net/routing/nullrouting/nullrouting.c
+++ b/os/net/routing/nullrouting/nullrouting.c
@@ -152,6 +152,12 @@ drop_route(uip_ds6_route_t *route)
 {
 }
 /*---------------------------------------------------------------------------*/
+static uint8_t
+is_in_leaf_mode(void)
+{
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
 const struct routing_driver nullrouting_driver = {
   "nullrouting",
   init,
@@ -173,6 +179,7 @@ const struct routing_driver nullrouting_driver = {
   link_callback,
   neighbor_state_changed,
   drop_route,
+  is_in_leaf_mode,
 };
 /*---------------------------------------------------------------------------*/
 

--- a/os/net/routing/routing.h
+++ b/os/net/routing/routing.h
@@ -182,6 +182,12 @@ struct routing_driver {
    * \param route The route that will be dropped after this function returns
    */
   void (* drop_route)(uip_ds6_route_t *route);
+  /**
+   * Tells whether the protocol is in leaf mode
+   *
+   * \retval 1 if the protocol is in leaf mode, 0 if not.
+   */
+  uint8_t (* is_in_leaf_mode)(void);
 };
 
 #endif /* ROUTING_H_ */

--- a/os/net/routing/rpl-classic/rpl.c
+++ b/os/net/routing/rpl-classic/rpl.c
@@ -423,6 +423,18 @@ get_root_ipaddr(uip_ipaddr_t *ipaddr)
   return 0;
 }
 /*---------------------------------------------------------------------------*/
+uint8_t
+rpl_is_in_leaf_mode(void)
+{
+  /*
+   * Confusingly, most of the RPL code uses the `rpl_mode` variable
+   * ony to check whether the node is in mesh or feather mode,
+   * and makes decision about the leaf status based on the preprocessor flag.
+   * For consistency, do the same here.
+   */
+  return RPL_LEAF_ONLY ? 1 : 0;
+}
+/*---------------------------------------------------------------------------*/
 const struct routing_driver rpl_classic_driver = {
   "RPL Classic",
   init,
@@ -444,6 +456,7 @@ const struct routing_driver rpl_classic_driver = {
   rpl_link_callback,
   rpl_ipv6_neighbor_callback,
   drop_route,
+  rpl_is_in_leaf_mode,
 };
 /*---------------------------------------------------------------------------*/
 

--- a/os/net/routing/rpl-classic/rpl.h
+++ b/os/net/routing/rpl-classic/rpl.h
@@ -341,5 +341,12 @@ int rpl_has_joined(void);
  */
 int rpl_has_downward_route(void);
 
+/**
+ * Tells whether the protocol is in leaf mode
+ *
+ * \retval 1 if the protocol is in leaf mode, 0 if not.
+ */
+uint8_t rpl_is_in_leaf_mode(void);
+
 /*---------------------------------------------------------------------------*/
 #endif /* RPL_H */

--- a/os/net/routing/rpl-lite/rpl.c
+++ b/os/net/routing/rpl-lite/rpl.c
@@ -264,6 +264,7 @@ const struct routing_driver rpl_lite_driver = {
   rpl_link_callback,
   neighbor_state_changed,
   drop_route,
+  rpl_get_leaf_only,
 };
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Should the network allowing to join new nodes through leaf nodes? I don't think so. There are a few potential problems created by the current approach.
- additional EB collisions especially in dense networks with many leafs or mobile leafs
- the leafs send EBs by default and therefore are less energy efficient

This PR disables joining through leaf nodes.