### PR TITLE
allow to configure maximal URI length for CoAP observables

### DIFF
--- a/os/net/app-layer/coap/coap-conf.h
+++ b/os/net/app-layer/coap/coap-conf.h
@@ -105,5 +105,12 @@
 #define COAP_OBSERVE_REFRESH_INTERVAL  20
 #endif /* COAP_OBSERVE_REFRESH_INTERVAL */
 
+/* Maximal length of observable URL */
+#ifdef COAP_CONF_OBSERVER_URL_LEN
+#define COAP_OBSERVER_URL_LEN COAP_CONF_OBSERVER_URL_LEN
+#else
+#define COAP_OBSERVER_URL_LEN 20
+#endif
+
 #endif /* COAP_CONF_H_ */
 /** @} */

--- a/os/net/app-layer/coap/coap-observe.h
+++ b/os/net/app-layer/coap/coap-observe.h
@@ -48,8 +48,6 @@
 #include "coap-transactions.h"
 #include "coap-engine.h"
 
-#define COAP_OBSERVER_URL_LEN 20
-
 typedef struct coap_observer {
   struct coap_observer *next;   /* for LIST */
 


### PR DESCRIPTION
This is just a very minor thing, but it has annoyed me several times already.