### PR TITLE
minor improvements and cleanups in TSCH

### DIFF
--- a/os/net/mac/tsch/tsch-adaptive-timesync.h
+++ b/os/net/mac/tsch/tsch-adaptive-timesync.h
@@ -44,11 +44,6 @@
 
 #include "contiki.h"
 
-/***** External Variables *****/
-
-/** \brief The neighbor last used as our time source */
-extern struct tsch_neighbor *last_timesource_neighbor;
-
 /********** Functions *********/
 
 /**
@@ -71,6 +66,12 @@ int32_t tsch_timesync_adaptive_compensate(rtimer_clock_t delta_ticks);
  * \return The time drift in PPM
  */
 long int tsch_adaptive_timesync_get_drift_ppm(void);
+
+/**
+ * \brief Reset the status of the module
+ */
+void tsch_adaptive_timesync_reset(void);
+
 
 #endif /* __TSCH_ADAPTIVE_TIMESYNC_H__ */
 /** @} */

--- a/os/net/mac/tsch/tsch-queue.c
+++ b/os/net/mac/tsch/tsch-queue.c
@@ -265,7 +265,7 @@ tsch_queue_add_packet(const linkaddr_t *addr, uint8_t max_transmissions,
     }
   }
   LOG_ERR("! add packet failed: %u %p %d %p %p\n", tsch_is_locked(), n, put_index, p, p ? p->qb : NULL);
-  return 0;
+  return NULL;
 }
 /*---------------------------------------------------------------------------*/
 /* Returns the number of packets currently in any TSCH queue */

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -526,6 +526,7 @@ tsch_disassociate(void)
 {
   if(tsch_is_associated == 1) {
     tsch_is_associated = 0;
+    tsch_adaptive_timesync_reset();
     process_poll(&tsch_process);
   }
 }
@@ -847,7 +848,7 @@ PROCESS_THREAD(tsch_send_eb_process, ev, data)
 
   /* Set an initial delay except for coordinator, which should send an EB asap */
   if(!tsch_is_coordinator) {
-    etimer_set(&eb_timer, random_rand() % TSCH_EB_PERIOD);
+    etimer_set(&eb_timer, TSCH_EB_PERIOD ? random_rand() % TSCH_EB_PERIOD : 0);
     PROCESS_WAIT_UNTIL(etimer_expired(&eb_timer));
   }
 


### PR DESCRIPTION
* Add `tsch_adaptive_timesync_reset()` function
* Rename `is_broadcast` to `do_wait_for_ack` to better reflect how it is used in code (and there can be non-ACK'able unicast messages, after all)
* Return `NULL` instead of `0` from `tsch_queue_add_packet`
* Allow to compile the code when `TSCH_EB_PERIOD` is set to 0