### PR TITLE
reduce the IPv6 data structure (DS) maintenance timer frequency

### DIFF
--- a/examples/platform-specific/cc26x0-cc13x0/very-sleepy-demo/project-conf.h
+++ b/examples/platform-specific/cc26x0-cc13x0/very-sleepy-demo/project-conf.h
@@ -40,7 +40,6 @@
 /*---------------------------------------------------------------------------*/
 /* For very sleepy operation */
 #define RF_BLE_CONF_ENABLED                   0
-#define UIP_DS6_CONF_PERIOD        CLOCK_SECOND
 #define UIP_CONF_TCP                          0
 #define RPL_CONF_LEAF_ONLY                    1
 

--- a/os/net/ipv6/uip-ds6.h
+++ b/os/net/ipv6/uip-ds6.h
@@ -165,7 +165,7 @@
 /** \brief General DS6 definitions */
 /** Period for uip-ds6 periodic task*/
 #ifndef UIP_DS6_CONF_PERIOD
-#define UIP_DS6_PERIOD   (CLOCK_SECOND/10)
+#define UIP_DS6_PERIOD   (60 * CLOCK_SECOND)
 #else
 #define UIP_DS6_PERIOD UIP_DS6_CONF_PERIOD
 #endif


### PR DESCRIPTION
Reduces frequency of the timer to save energy.
We don't really need the data structure maintenance 10 times per second, at least not by default.