### PR TITLE
add multiple channel option to Orchestra unicast slotframe

### DIFF
--- a/os/net/mac/tsch/tsch-schedule.c
+++ b/os/net/mac/tsch/tsch-schedule.c
@@ -224,9 +224,6 @@ tsch_schedule_add_link(struct tsch_slotframe *slotframe,
     if(timeslot > (slotframe->size.val - 1)) {
       LOG_ERR("! add_link invalid timeslot: %u\n", timeslot);
       return NULL;
-    } else if(channel_offset > 15) {
-      LOG_ERR("! add_link invalid channel_offset: %u\n", channel_offset);
-      return NULL;
     }
 
     /* Start with removing the link currently installed at this timeslot (needed

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -238,10 +238,20 @@ tsch_release_lock(void)
 
 /* Return channel from ASN and channel offset */
 uint8_t
-tsch_calculate_channel(struct tsch_asn_t *asn, uint8_t channel_offset)
+tsch_calculate_channel(struct tsch_asn_t *asn, uint16_t channel_offset, struct tsch_packet *p)
 {
-  uint16_t index_of_0 = TSCH_ASN_MOD(*asn, tsch_hopping_sequence_length);
-  uint16_t index_of_offset = (index_of_0 + channel_offset) % tsch_hopping_sequence_length.val;
+  uint16_t index_of_0, index_of_offset;
+#if TSCH_WITH_LINK_SELECTOR
+  if(p != NULL) {
+    uint16_t packet_channel_offset = queuebuf_attr(p->qb, PACKETBUF_ATTR_TSCH_CHANNEL_OFFSET);
+    if(packet_channel_offset != 0xffff) {
+      /* The schedule specifies a channel offset for this one; use it */
+      channel_offset = packet_channel_offset;
+    }
+  }
+#endif
+  index_of_0 = TSCH_ASN_MOD(*asn, tsch_hopping_sequence_length);
+  index_of_offset = (index_of_0 + channel_offset) % tsch_hopping_sequence_length.val;
   return tsch_hopping_sequence[index_of_offset];
 }
 
@@ -1014,7 +1024,8 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
           burst_link_scheduled = 0;
         } else {
           /* Hop channel */
-          tsch_current_channel = tsch_calculate_channel(&tsch_current_asn, current_link->channel_offset);
+          tsch_current_channel = tsch_calculate_channel(&tsch_current_asn,
+              current_link->channel_offset, current_packet);
         }
         NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, tsch_current_channel);
         /* Turn the radio on already here if configured so; necessary for radios with slow startup */

--- a/os/net/mac/tsch/tsch-slot-operation.h
+++ b/os/net/mac/tsch/tsch-slot-operation.h
@@ -67,10 +67,11 @@ extern int tsch_current_burst_count;
  * The offset to the ASN and performs a hopping sequence lookup.
  *
  * \param asn A given ASN
- * \param channel_offset A given channel offset
+ * \param channel_offset Link's channel offset
+ * \param p Packet that can override the link's channel offset
  * \return The resulting channel
  */
-uint8_t tsch_calculate_channel(struct tsch_asn_t *asn, uint8_t channel_offset);
+uint8_t tsch_calculate_channel(struct tsch_asn_t *asn, uint16_t channel_offset, struct tsch_packet *p);
 /**
  * Checks if the TSCH lock is set. Accesses to global structures outside of
  * interrupts must be done through the lock, unless the sturcutre has

--- a/os/net/packetbuf.h
+++ b/os/net/packetbuf.h
@@ -227,6 +227,7 @@ enum {
 #if TSCH_WITH_LINK_SELECTOR
   PACKETBUF_ATTR_TSCH_SLOTFRAME,
   PACKETBUF_ATTR_TSCH_TIMESLOT,
+  PACKETBUF_ATTR_TSCH_CHANNEL_OFFSET,
 #endif /* TSCH_WITH_LINK_SELECTOR */
 
   /* Scope 1 attributes: used between two neighbors only. */

--- a/os/services/orchestra/orchestra-conf.h
+++ b/os/services/orchestra/orchestra-conf.h
@@ -81,7 +81,8 @@
 #define ORCHESTRA_UNICAST_SENDER_BASED            0
 #endif /* ORCHESTRA_CONF_UNICAST_SENDER_BASED */
 
-/* The hash function used to assign timeslot to a given node (based on its link-layer address) */
+/* The hash function used to assign timeslot to a given node (based on its link-layer address).
+ * For rules with multiple channel offsets, it is also used to select the channel offset. */
 #ifdef ORCHESTRA_CONF_LINKADDR_HASH
 #define ORCHESTRA_LINKADDR_HASH                   ORCHESTRA_CONF_LINKADDR_HASH
 #else /* ORCHESTRA_CONF_LINKADDR_HASH */
@@ -101,5 +102,33 @@
 #else /* ORCHESTRA_CONF_COLLISION_FREE_HASH */
 #define ORCHESTRA_COLLISION_FREE_HASH             0 /* Set to 1 if ORCHESTRA_LINKADDR_HASH returns unique hashes */
 #endif /* ORCHESTRA_CONF_COLLISION_FREE_HASH */
+
+/* Channel offset for the EB rule, default 0 */
+#ifdef ORCHESTRA_CONF_EB_CHANNEL_OFFSET
+#define ORCHESTRA_EB_CHANNEL_OFFSET               ORCHESTRA_CONF_EB_CHANNEL_OFFSET
+#else
+#define ORCHESTRA_EB_CHANNEL_OFFSET               0
+#endif
+
+/* Channel offset for the default common rule, default 1 */
+#ifdef ORCHESTRA_CONF_DEFAULT_COMMON_CHANNEL_OFFSET
+#define ORCHESTRA_DEFAULT_COMMON_CHANNEL_OFFSET   ORCHESTRA_CONF_DEFAULT_COMMON_CHANNEL_OFFSET
+#else
+#define ORCHESTRA_DEFAULT_COMMON_CHANNEL_OFFSET   1
+#endif
+
+/* Min channel offset for the unicast rules; the default min/max range is [2, 255] */
+#ifdef ORCHESTRA_CONF_UNICAST_MIN_CHANNEL_OFFSET
+#define ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET       ORCHESTRA_CONF_UNICAST_MIN_CHANNEL_OFFSET
+#else
+#define ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET       2
+#endif
+
+/* Max channel offset for the unicast rules */
+#ifdef ORCHESTRA_CONF_UNICAST_MAX_CHANNEL_OFFSET
+#define ORCHESTRA_UNICAST_MAX_CHANNEL_OFFSET       ORCHESTRA_CONF_UNICAST_MAX_CHANNEL_OFFSET
+#else
+#define ORCHESTRA_UNICAST_MAX_CHANNEL_OFFSET       255
+#endif
 
 #endif /* __ORCHESTRA_CONF_H__ */

--- a/os/services/orchestra/orchestra-rule-default-common.c
+++ b/os/services/orchestra/orchestra-rule-default-common.c
@@ -39,7 +39,6 @@
 #include "orchestra.h"
 
 static uint16_t slotframe_handle = 0;
-static uint16_t channel_offset = 0;
 
 #if ORCHESTRA_EBSF_PERIOD > 0
 /* There is a slotframe for EBs, use this slotframe for non-EB traffic only */
@@ -51,7 +50,7 @@ static uint16_t channel_offset = 0;
 
 /*---------------------------------------------------------------------------*/
 static int
-select_packet(uint16_t *slotframe, uint16_t *timeslot)
+select_packet(uint16_t *slotframe, uint16_t *timeslot, uint16_t *channel_offset)
 {
   /* We are the default slotframe, select anything */
   if(slotframe != NULL) {
@@ -67,14 +66,13 @@ static void
 init(uint16_t sf_handle)
 {
   slotframe_handle = sf_handle;
-  channel_offset = slotframe_handle;
   /* Default slotframe: for broadcast or unicast to neighbors we
    * do not have a link to */
   struct tsch_slotframe *sf_common = tsch_schedule_add_slotframe(slotframe_handle, ORCHESTRA_COMMON_SHARED_PERIOD);
   tsch_schedule_add_link(sf_common,
       LINK_OPTION_RX | LINK_OPTION_TX | LINK_OPTION_SHARED,
       ORCHESTRA_COMMON_SHARED_TYPE, &tsch_broadcast_address,
-      0, channel_offset);
+      0, ORCHESTRA_DEFAULT_COMMON_CHANNEL_OFFSET);
 }
 /*---------------------------------------------------------------------------*/
 struct orchestra_rule default_common = {

--- a/os/services/orchestra/orchestra-rule-eb-per-time-source.c
+++ b/os/services/orchestra/orchestra-rule-eb-per-time-source.c
@@ -56,7 +56,7 @@ get_node_timeslot(const linkaddr_t *addr)
 }
 /*---------------------------------------------------------------------------*/
 static int
-select_packet(uint16_t *slotframe, uint16_t *timeslot)
+select_packet(uint16_t *slotframe, uint16_t *timeslot, uint16_t *channel_offset)
 {
   /* Select EBs only */
   if(packetbuf_attr(PACKETBUF_ATTR_FRAME_TYPE) == FRAME802154_BEACONFRAME) {
@@ -86,7 +86,7 @@ new_time_source(const struct tsch_neighbor *old, const struct tsch_neighbor *new
     if(old_ts == get_node_timeslot(&linkaddr_node_addr)) {
       /* This was the same timeslot as slot. Reset original link options */
       tsch_schedule_add_link(sf_eb, LINK_OPTION_TX, LINK_TYPE_ADVERTISING_ONLY,
-        &tsch_broadcast_address, old_ts, 0);
+        &tsch_broadcast_address, old_ts, ORCHESTRA_EB_CHANNEL_OFFSET);
     } else {
       /* Remove slot */
       tsch_schedule_remove_link_by_timeslot(sf_eb, old_ts);
@@ -100,7 +100,7 @@ new_time_source(const struct tsch_neighbor *old, const struct tsch_neighbor *new
     }
     /* Listen to the time source's EBs */
     tsch_schedule_add_link(sf_eb, link_options, LINK_TYPE_ADVERTISING_ONLY,
-      &tsch_broadcast_address, new_ts, 0);
+      &tsch_broadcast_address, new_ts, ORCHESTRA_EB_CHANNEL_OFFSET);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -114,7 +114,7 @@ init(uint16_t sf_handle)
   tsch_schedule_add_link(sf_eb,
                          LINK_OPTION_TX,
                          LINK_TYPE_ADVERTISING_ONLY, &tsch_broadcast_address,
-                         get_node_timeslot(&linkaddr_node_addr), 0);
+                         get_node_timeslot(&linkaddr_node_addr), ORCHESTRA_EB_CHANNEL_OFFSET);
 }
 /*---------------------------------------------------------------------------*/
 struct orchestra_rule eb_per_time_source = {

--- a/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
+++ b/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
@@ -60,7 +60,7 @@
 #endif
 
 static uint16_t slotframe_handle = 0;
-static uint16_t channel_offset = 0;
+static uint16_t local_channnel_offset;
 static struct tsch_slotframe *sf_unicast;
 
 /*---------------------------------------------------------------------------*/
@@ -69,6 +69,17 @@ get_node_timeslot(const linkaddr_t *addr)
 {
   if(addr != NULL && ORCHESTRA_UNICAST_PERIOD > 0) {
     return ORCHESTRA_LINKADDR_HASH(addr) % ORCHESTRA_UNICAST_PERIOD;
+  } else {
+    return 0xffff;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static uint16_t
+get_node_channel_offset(const linkaddr_t *addr)
+{
+  if(addr != NULL && ORCHESTRA_UNICAST_MAX_CHANNEL_OFFSET >= ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET) {
+    return ORCHESTRA_LINKADDR_HASH(addr) % (ORCHESTRA_UNICAST_MAX_CHANNEL_OFFSET - ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET + 1)
+        + ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET;
   } else {
     return 0xffff;
   }
@@ -101,9 +112,13 @@ add_uc_link(const linkaddr_t *linkaddr)
       link_options |= ORCHESTRA_UNICAST_SENDER_BASED ? LINK_OPTION_TX | UNICAST_SLOT_SHARED_FLAG: LINK_OPTION_RX;
     }
 
-    /* Add/update link */
+    /* Add/update link.
+     * Always configure the link with the local node's channel offset.
+     * If this is an Rx link, that is what the node needs to use.
+     * If this is a Tx link, packet's channel offset will override the link's channel offset.
+     */
     tsch_schedule_add_link(sf_unicast, link_options, LINK_TYPE_NORMAL, &tsch_broadcast_address,
-          timeslot, channel_offset);
+          timeslot, local_channel_offset);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -144,7 +159,7 @@ remove_uc_link(const linkaddr_t *linkaddr)
     /* This is our link, keep it but update the link options */
     uint8_t link_options = ORCHESTRA_UNICAST_SENDER_BASED ? LINK_OPTION_TX | UNICAST_SLOT_SHARED_FLAG: LINK_OPTION_RX;
     tsch_schedule_add_link(sf_unicast, link_options, LINK_TYPE_NORMAL, &tsch_broadcast_address,
-              timeslot, channel_offset);
+              timeslot, local_channnel_offset);
   } else {
     /* Remove link */
     tsch_schedule_remove_link(sf_unicast, l);
@@ -164,7 +179,7 @@ child_removed(const linkaddr_t *linkaddr)
 }
 /*---------------------------------------------------------------------------*/
 static int
-select_packet(uint16_t *slotframe, uint16_t *timeslot)
+select_packet(uint16_t *slotframe, uint16_t *timeslot, uint16_t *channel_offset)
 {
   /* Select data packets we have a unicast link to */
   const linkaddr_t *dest = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
@@ -175,6 +190,10 @@ select_packet(uint16_t *slotframe, uint16_t *timeslot)
     }
     if(timeslot != NULL) {
       *timeslot = ORCHESTRA_UNICAST_SENDER_BASED ? get_node_timeslot(&linkaddr_node_addr) : get_node_timeslot(dest);
+    }
+    /* set per-packet channel offset */
+    if(channel_offset != NULL) {
+      *channel_offset = get_node_channel_offset(dest);
     }
     return 1;
   }
@@ -200,15 +219,18 @@ new_time_source(const struct tsch_neighbor *old, const struct tsch_neighbor *new
 static void
 init(uint16_t sf_handle)
 {
+  uint16_t timeslot;
+  linkaddr_t *local_addr = &linkaddr_node_addr;
+
   slotframe_handle = sf_handle;
-  channel_offset = sf_handle;
+  local_channnel_offset = get_node_channel_offset(local_addr);
   /* Slotframe for unicast transmissions */
   sf_unicast = tsch_schedule_add_slotframe(slotframe_handle, ORCHESTRA_UNICAST_PERIOD);
-  uint16_t timeslot = get_node_timeslot(&linkaddr_node_addr);
+  timeslot = get_node_timeslot(local_addr);
   tsch_schedule_add_link(sf_unicast,
             ORCHESTRA_UNICAST_SENDER_BASED ? LINK_OPTION_TX | UNICAST_SLOT_SHARED_FLAG: LINK_OPTION_RX,
             LINK_TYPE_NORMAL, &tsch_broadcast_address,
-            timeslot, channel_offset);
+            timeslot, local_channnel_offset);
 }
 /*---------------------------------------------------------------------------*/
 struct orchestra_rule unicast_per_neighbor_rpl_storing = {

--- a/os/services/orchestra/orchestra.c
+++ b/os/services/orchestra/orchestra.c
@@ -117,12 +117,16 @@ orchestra_callback_packet_ready(void)
   /* By default, use any slotframe, any timeslot */
   uint16_t slotframe = 0xffff;
   uint16_t timeslot = 0xffff;
+  /* The default channel offset 0xffff means that the channel offset in the scheduled
+   * tsch_link structure is used instead. Any other value specified in the packetbuf
+   * overrides per-link value, allowing to implement multi-channel Orchestra. */
+  uint16_t channel_offset = 0xffff;
   int matched_rule = -1;
 
   /* Loop over all rules until finding one able to handle the packet */
   for(i = 0; i < NUM_RULES; i++) {
     if(all_rules[i]->select_packet != NULL) {
-      if(all_rules[i]->select_packet(&slotframe, &timeslot)) {
+      if(all_rules[i]->select_packet(&slotframe, &timeslot, &channel_offset)) {
         matched_rule = i;
         break;
       }
@@ -132,6 +136,7 @@ orchestra_callback_packet_ready(void)
 #if TSCH_WITH_LINK_SELECTOR
   packetbuf_set_attr(PACKETBUF_ATTR_TSCH_SLOTFRAME, slotframe);
   packetbuf_set_attr(PACKETBUF_ATTR_TSCH_TIMESLOT, timeslot);
+  packetbuf_set_attr(PACKETBUF_ATTR_TSCH_CHANNEL_OFFSET, channel_offset);
 #endif
 
   return matched_rule;

--- a/os/services/orchestra/orchestra.h
+++ b/os/services/orchestra/orchestra.h
@@ -45,7 +45,7 @@
 struct orchestra_rule {
   void (* init)(uint16_t slotframe_handle);
   void (* new_time_source)(const struct tsch_neighbor *old, const struct tsch_neighbor *new);
-  int  (* select_packet)(uint16_t *slotframe, uint16_t *timeslot);
+  int  (* select_packet)(uint16_t *slotframe, uint16_t *timeslot, uint16_t *channel_offset);
   void (* child_added)(const linkaddr_t *addr);
   void (* child_removed)(const linkaddr_t *addr);
   const char *name;


### PR DESCRIPTION
This increases the performance of Orchestra by reducing the number of collisions, especially helpful in dense networks.