### PR TITLE
[bugfix] Disable SysTick interrupt when dropping to some low-power mode

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/clock-arch.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/clock-arch.h
@@ -56,6 +56,11 @@ bool clock_arch_enter_idle(void);
  */
 void clock_arch_exit_idle(void);
 /*---------------------------------------------------------------------------*/
+/**
+ * \brief   Called by the Power driver when dropping to some low-power state.
+ */
+void clock_arch_standby_policy(void);
+/*---------------------------------------------------------------------------*/
 #endif /* CLOCK_ARCH_H_ */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1310/CC1310_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1310/CC1310_LAUNCHXL.c
@@ -708,10 +708,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include "clock-arch.h"
 
 const PowerCC26XX_Config PowerCC26XX_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/CC1312R1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/CC1312R1_LAUNCHXL.c
@@ -779,10 +779,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
+#include "clock-arch.h"
 
 const PowerCC26X2_Config PowerCC26X2_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1350-4/CC1350_LAUNCHXL_433.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1350-4/CC1350_LAUNCHXL_433.c
@@ -704,10 +704,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include "clock-arch.h"
 
 const PowerCC26XX_Config PowerCC26XX_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1350/CC1350_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1350/CC1350_LAUNCHXL.c
@@ -708,10 +708,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include "clock-arch.h"
 
 const PowerCC26XX_Config PowerCC26XX_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p-2/CC1352P_2_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p-2/CC1352P_2_LAUNCHXL.c
@@ -746,10 +746,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
+#include "clock-arch.h"
 
 const PowerCC26X2_Config PowerCC26X2_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p-4/CC1352P_4_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p-4/CC1352P_4_LAUNCHXL.c
@@ -746,10 +746,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
+#include "clock-arch.h"
 
 const PowerCC26X2_Config PowerCC26X2_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p1/CC1352P1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352p1/CC1352P1_LAUNCHXL.c
@@ -755,10 +755,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
+#include "clock-arch.h"
 
 const PowerCC26X2_Config PowerCC26X2_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352r1/CC1352R1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1352r1/CC1352R1_LAUNCHXL.c
@@ -765,10 +765,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
+#include "clock-arch.h"
 
 const PowerCC26X2_Config PowerCC26X2_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc2650/CC2650_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc2650/CC2650_LAUNCHXL.c
@@ -707,10 +707,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include "clock-arch.h"
 
 const PowerCC26XX_Config PowerCC26XX_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc26x2r1/CC26X2R1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc26x2r1/CC26X2R1_LAUNCHXL.c
@@ -777,10 +777,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26X2.h>
+#include "clock-arch.h"
 
 const PowerCC26X2_Config PowerCC26X2_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/CC1350STK.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/CC1350STK.c
@@ -705,10 +705,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include "clock-arch.h"
 
 const PowerCC26XX_Config PowerCC26XX_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/CC2650STK.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/CC2650STK.c
@@ -706,10 +706,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include "clock-arch.h"
 
 const PowerCC26XX_Config PowerCC26XX_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/srf06/cc13x0/CC1350DK_7XD.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/srf06/cc13x0/CC1350DK_7XD.c
@@ -604,10 +604,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include "clock-arch.h"
 
 const PowerCC26XX_Config PowerCC26XX_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,

--- a/arch/platform/simplelink/cc13xx-cc26xx/srf06/cc26x0/CC2650DK_7ID.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/srf06/cc26x0/CC2650DK_7ID.c
@@ -605,10 +605,11 @@ const PINCC26XX_HWAttrs PINCC26XX_hwAttrs = {
  */
 #include <ti/drivers/Power.h>
 #include <ti/drivers/power/PowerCC26XX.h>
+#include "clock-arch.h"
 
 const PowerCC26XX_Config PowerCC26XX_config = {
     .policyInitFxn      = NULL,
-    .policyFxn          = &PowerCC26XX_standbyPolicy,
+    .policyFxn          = &clock_arch_standby_policy,
     .calibrateFxn       = &PowerCC26XX_calibrate,
     .enablePolicy       = true,
     .calibrateRCOSC_LF  = true,


### PR DESCRIPTION
It was discovered that the SysTick interrupt must be disabled before
dropping to some low-power mode. If not, then in some rare occasions a
race condition of the device entering/leaving the low-power mode and the
SysTick interrupt triggering may clobber the CPU context and put it in an
invalid state, and will in most cases crash the CPU.

A "proxy" standby policy is implemented which wraps the actual Power
driver standby policy with disabling and enabling the SysTick interrupt,
before and after. This ensure the SysTick is always disabled when
entering some low-power mode, regardless of which context that triggers
the standby policy.