### PR TITLE
Replace memcpy in tcp-socket

### DIFF
--- a/os/net/ipv6/tcp-socket.c
+++ b/os/net/ipv6/tcp-socket.c
@@ -76,9 +76,9 @@ acked(struct tcp_socket *s)
        outputbuf_lastsent */
 
     if(s->output_data_send_nxt > 0) {
-      memcpy(&s->output_data_ptr[0],
-             &s->output_data_ptr[s->output_data_send_nxt],
-             s->output_data_maxlen - s->output_data_send_nxt);
+      memmove(&s->output_data_ptr[0],
+              &s->output_data_ptr[s->output_data_send_nxt],
+              s->output_data_maxlen - s->output_data_send_nxt);
     }
     if(s->output_data_len < s->output_data_send_nxt) {
       PRINTF("tcp: acked assertion failed s->output_data_len (%d) < s->output_data_send_nxt (%d)\n",
@@ -350,7 +350,7 @@ tcp_socket_send(struct tcp_socket *s,
 
   len = MIN(datalen, s->output_data_maxlen - s->output_data_len);
 
-  memcpy(&s->output_data_ptr[s->output_data_len], data, len);
+  memmove(&s->output_data_ptr[s->output_data_len], data, len);
   s->output_data_len += len;
 
   if(s->output_senddata_len == 0) {


### PR DESCRIPTION
This commit fixes #1061.

`memcpy()` should not be used if the source and destination memory locations alias.

In `acked()` the expectation is clearly that the two buffers overlap.

In `tcp_socket_send()` it's a bit trickier. This issue was discovered because the MQTT library was using a single memory location for 2 things: the buffer that it uses to construct its output packet and the buffer that it passes to the TCP socket for the output data. The TCP API does not require that the 2 buffers that are passed to `tcp_socket_send()` are non-overlapping and I think this change is preferable to adding that constraint and fixing all potential occurrences of this issue, as:
- this allows for some memory to be saved
- while `memcpy()` is supposed to be faster than `memmove()`, I don't believe this is a performance-critical area and I don't think embedded systems can heavily optimise `memcpy()` compared to `memmove()`
- I've seen some implementations of `memmove()` that perform a check and branch to `memcpy()` if the locations don't alias so the performance penalty is reduced