### PR TITLE
travis: specify Trusty explicitly to avoid Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Setup environment for Docker
 language: generic
 services: docker
+dist: trusty
 notifications:
   email: false
 


### PR DESCRIPTION
This introduces the workaround for Issue #1084. This workaround should have the minimal impact to our test environment on Travis-CI.