### PR TITLE
Fix rx problem on cc1310 radio

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/rf-core/prop-mode.c
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/prop-mode.c
@@ -45,7 +45,6 @@
 #include "net/netstack.h"
 #include "sys/energest.h"
 #include "sys/clock.h"
-#include "sys/critical.h"
 #include "sys/rtimer.h"
 #include "sys/cc.h"
 #include "lpm.h"
@@ -129,6 +128,8 @@ static volatile rfc_dataEntry_t *packet_being_received;
 /*---------------------------------------------------------------------------*/
 static int on(void);
 static int off(void);
+
+static bool rf_setup_is_completed = false;
 
 static rfc_propRxOutput_t rx_stats;
 /*---------------------------------------------------------------------------*/
@@ -263,13 +264,23 @@ volatile static uint8_t *rx_read_entry;
 static uint8_t tx_buf[TX_BUF_HDR_LEN + TX_BUF_PAYLOAD_LEN] CC_ALIGN(4);
 /*---------------------------------------------------------------------------*/
 static uint8_t
-rf_is_on(void)
+rx_is_on(void)
 {
   if(!rf_core_is_accessible()) {
     return 0;
   }
 
   return smartrf_settings_cmd_prop_rx_adv.status == RF_CORE_RADIO_OP_STATUS_ACTIVE;
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t
+rf_is_on(void)
+{
+  if (!rf_core_is_accessible()) {
+    return 0;
+  }
+
+  return rf_setup_is_completed;
 }
 /*---------------------------------------------------------------------------*/
 static uint8_t
@@ -502,7 +513,7 @@ rx_on_prop(void)
 {
   int ret;
 
-  if(rf_is_on()) {
+  if(rx_is_on()) {
     PRINTF("rx_on_prop: We were on. PD=%u, RX=0x%04x\n",
            rf_core_is_accessible(), smartrf_settings_cmd_prop_rx_adv.status);
     return RF_CORE_CMD_OK;
@@ -530,7 +541,7 @@ rx_off_prop(void)
 #endif /* MAC_CONF_WITH_TSCH */
 
   /* If we are off, do nothing */
-  if(!rf_is_on()) {
+  if(!rx_is_on()) {
     return RF_CORE_CMD_OK;
   }
 
@@ -543,7 +554,7 @@ rx_off_prop(void)
     /* Continue nonetheless */
   }
 
-  RTIMER_BUSYWAIT_UNTIL(!rf_is_on(), RF_CORE_TURN_OFF_TIMEOUT);
+  RTIMER_BUSYWAIT_UNTIL(!rx_is_on(), RF_CORE_TURN_OFF_TIMEOUT);
 
   if(smartrf_settings_cmd_prop_rx_adv.status == PROP_DONE_STOPPED ||
      smartrf_settings_cmd_prop_rx_adv.status == PROP_DONE_ABORT) {
@@ -816,7 +827,6 @@ release_data_entry(void)
 {
   rfc_dataEntryGeneral_t *entry = (rfc_dataEntryGeneral_t *)rx_read_entry;
   uint8_t *data_ptr = &entry->data;
-  int_master_status_t interrupt_status;
 
   /* Clear the length field (2 bytes) */
   data_ptr[0] = 0;
@@ -826,13 +836,10 @@ release_data_entry(void)
   entry->status = DATA_ENTRY_STATUS_PENDING;
   rx_read_entry = entry->pNextEntry;
 
-  interrupt_status = critical_enter();
-  if(rf_core_rx_is_full) {
-    rf_core_rx_is_full = false;
-    PRINTF("RXQ was full, re-enabling radio!\n");
+  if(!rx_is_on()) {
+    PRINTF("RX was off, re-enabling rx!\n");
     rx_on_prop();
   }
-  critical_exit(interrupt_status);
 
 }
 /*---------------------------------------------------------------------------*/
@@ -1170,7 +1177,7 @@ on(void)
       return RF_CORE_CMD_ERROR;
     }
   }
-
+  rf_setup_is_completed = true;
   return RF_CORE_CMD_OK;
 }
 /*---------------------------------------------------------------------------*/
@@ -1179,6 +1186,12 @@ off(void)
 {
   int i;
   rfc_dataEntry_t *entry;
+
+  if(!rf_is_on()) {
+    PRINTF("off: We were off. PD=%u, RX=0x%04x \n", rf_core_is_accessible(),
+           smartrf_settings_cmd_prop_rx_adv.status);
+    return RF_CORE_CMD_OK;
+  }
 
   /*
    * If we are in the middle of a BLE operation, we got called by ContikiMAC
@@ -1211,6 +1224,8 @@ off(void)
        entry->status = DATA_ENTRY_STATUS_PENDING;
     }
   }
+
+  rf_setup_is_completed = false;
 
   return RF_CORE_CMD_OK;
 }

--- a/arch/cpu/cc26x0-cc13x0/rf-core/rf-core.c
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/rf-core.c
@@ -128,8 +128,6 @@ volatile uint32_t rf_core_last_packet_timestamp = 0;
 /* Are we currently in poll mode? */
 uint8_t rf_core_poll_mode = 0;
 /*---------------------------------------------------------------------------*/
-/* Buffer full flag */
-volatile bool rf_core_rx_is_full = false;
 /* Status of the last command sent */
 volatile uint32_t last_cmd_status;
 /*---------------------------------------------------------------------------*/
@@ -746,8 +744,6 @@ cc26xx_rf_cpe1_isr(void)
 
   if(HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) & IRQ_RX_BUF_FULL) {
     PRINTF("\nRF: BUF_FULL\n\n");
-    /* set a flag that the buffer is full*/
-    rf_core_rx_is_full = true;
     /* make sure read_frame() will be called to make space in RX buffer */
     process_poll(&rf_core_process);
     /* Clear the IRQ_RX_BUF_FULL interrupt flag by writing zero to bit */

--- a/arch/cpu/cc26x0-cc13x0/rf-core/rf-core.h
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/rf-core.h
@@ -320,8 +320,6 @@ typedef struct rf_core_primary_mode_s {
 /* Make the main driver process visible to mode drivers */
 PROCESS_NAME(rf_core_process);
 /*---------------------------------------------------------------------------*/
-/* Buffer full flag */
-extern volatile bool rf_core_rx_is_full;
 /*---------------------------------------------------------------------------*/
 /* RSSI of the last read frame */
 extern volatile int8_t rf_core_last_rssi;


### PR DESCRIPTION
Fixes https://github.com/contiki-ng/contiki-ng/issues/1089

When the radio receives a lot of packes the rx buffer becomes full and the radio stops listening. 

before when handling the rf_core_rx_is_full flag this was logged:
```
RXQ was full, re-enabling radio!
rf_cmd_prop_rx: send_cmd ret=0, CMDSTA=0x00000c23, status=0x0000
```

The current implementation of rf_is_on tested if the status of the rx command is ACTIVE but if an error occurs in the rx command then the radio is still on and just not listening. The different usages of this function indicate that sometimes we want to know if the rx command is in the ACTIVE state and other times we just want to know if the radio is on.

So I decided to hold a flag that is set if the radio is turned on and is cleared when the radio is turned off.

Because of this the radio is no longer turned on or off when the rx command is in an error state like when the rx buffer is full. This solves a lot of issues.

After this work the rf_core_rx_is_full flag is no longer needed, we can just look at the status of the rx command. If the status is not active the rx command is send again.

It might be needed to add a check if the command is not in the PENDING state but rf_cmd_prop_rx waits for the command to reach the ACTIVE state or times out so it does not seem to be required in the current code.