### PR TITLE
RPL CLassic: only allow DAGs with a parent in rpl_has_joined

### DIFF
--- a/os/net/routing/rpl-classic/rpl-conf.h
+++ b/os/net/routing/rpl-classic/rpl-conf.h
@@ -91,17 +91,6 @@
 #define RPL_CONF_STATS 0
 #endif /* RPL_CONF_STATS */
 
-/* Set to 1 to drop packets when a forwarding loop is detected
- * on a packet that already had an error signaled, as per RFC6550 - 11.2.2.2.
- * Disabled by default for more reliability: even in the event of a loop,
- * packets get a chance to eventually find their way to the destination. */
-#ifdef RPL_CONF_LOOP_ERROR_DROP
-#define RPL_LOOP_ERROR_DROP RPL_CONF_LOOP_ERROR_DROP
-#else /* RPL_CONF_LOOP_ERROR_DROP */
-#define RPL_LOOP_ERROR_DROP 0
-#endif /* RPL_CONF_LOOP_ERROR_DROP */
-
-
 /*
  * The objective function (OF) used by a RPL root is configurable through
  * the RPL_CONF_OF_OCP parameter. This is defined as the objective code

--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -1011,10 +1011,25 @@ rpl_move_parent(rpl_dag_t *dag_src, rpl_dag_t *dag_dst, rpl_parent_t *parent)
   parent->dag = dag_dst;
 }
 /*---------------------------------------------------------------------------*/
+static rpl_dag_t *
+rpl_get_any_dag_with_parent(bool requires_parent)
+{
+  int i;
+
+  for(i = 0; i < RPL_MAX_INSTANCES; ++i) {
+    if(instance_table[i].used
+         && instance_table[i].current_dag->joined
+         && (!requires_parent || instance_table[i].current_dag->preferred_parent != NULL)) {
+      return instance_table[i].current_dag;
+    }
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
 int
 rpl_has_joined(void)
 {
-  return rpl_get_any_dag() != NULL;
+  return rpl_get_any_dag_with_parent(true) != NULL;
 }
 /*---------------------------------------------------------------------------*/
 int
@@ -1054,14 +1069,7 @@ rpl_get_dag(const uip_ipaddr_t *addr)
 rpl_dag_t *
 rpl_get_any_dag(void)
 {
-  int i;
-
-  for(i = 0; i < RPL_MAX_INSTANCES; ++i) {
-    if(instance_table[i].used && instance_table[i].current_dag->joined) {
-      return instance_table[i].current_dag;
-    }
-  }
-  return NULL;
+  return rpl_get_any_dag_with_parent(false);
 }
 /*---------------------------------------------------------------------------*/
 rpl_instance_t *

--- a/os/net/routing/rpl-lite/rpl-conf.h
+++ b/os/net/routing/rpl-lite/rpl-conf.h
@@ -396,6 +396,16 @@
 
 #endif /* MAC_CONF_WITH_TSCH */
 
+/* Set to 1 to drop packets when a forwarding loop is detected
+ * on a packet that already had an error signaled, as per RFC6550 - 11.2.2.2.
+ * Disabled by default for more reliability: even in the event of a loop,
+ * packets get a chance to eventually find their way to the destination. */
+#ifdef RPL_CONF_LOOP_ERROR_DROP
+#define RPL_LOOP_ERROR_DROP RPL_CONF_LOOP_ERROR_DROP
+#else /* RPL_CONF_LOOP_ERROR_DROP */
+#define RPL_LOOP_ERROR_DROP 0
+#endif /* RPL_CONF_LOOP_ERROR_DROP */
+
 /** @} */
 
 #endif /* RPL_CONF_H */


### PR DESCRIPTION
Fixes #933
Fixes #1105