### PR TITLE
Add support for multiple docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,30 +7,39 @@ notifications:
 
 # Environment setup before test script. Runs for each build
 before_install:
-  # Check if anything has changed within the docker directory
-  - DOCKER_CHANGED=`git diff --name-only $TRAVIS_COMMIT_RANGE -- tools/docker | wc -l`
-  # If Docker directory has not changed, pull image from Dockerhub. Else, build
-  # image from Dockerifle. This needs to be done for each job. Any build error
-  # will count as Travis test failure. In case this updates develop, push new
-  # image to Dockerhub (secure credentials only readable on bulids to
-  # contiki-ng/contiki-ng branches, not forks or PRs)
+  # Construct the correct container image tag corresponding to this branch/pull
+  - CONTIKER_TAG=`git log -1 --oneline -- tools/docker/ | cut -d" " -f1`
+  - DOCKER_IMG=$DOCKER_BASE_IMG:$CONTIKER_TAG
+  # Try to download the image from dockerhub. If it works, use it.
+  #
+  # If however it fails then we are most likely looking at a branch or pull
+  # that touched tools/docker. In this case, build the image.
+  #
+  # Any build error will count as Travis test failure.
+  #
+  # If the test was triggered by a branch update (e.g. a PR merge) then push
+  # the new image to dockerhub. This will only happen for builds against
+  # contiki-ng/contiki-ng, not for builds on forks.
+  - echo $DOCKER_IMG
   - >
-    if [ $DOCKER_CHANGED == 0 ]; then
-      echo "Docker image unchanged, pull from Dockerhub"
-      docker pull $DOCKER_IMG;
-    else
-      echo "Docker image changed, build from Dockerfile"
+    echo "Pulling image $DOCKER_IMG from dockerhub";
+    docker pull $DOCKER_IMG;
+    if [ $? != 0 ]; then
+      echo $CONTIKER_TAG "does not exist or pull failed";
+      echo "This is normal for PR builds and for builds on forks";
+      echo "Building from dockerfile";
       docker build tools/docker -t $DOCKER_IMG;
       if [ $? != 0 ]; then
         echo "Failed to build Docker image"
         exit 1
       fi
-      if [ $TRAVIS_SECURE_ENV_VARS == true ] && [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_BRANCH == 'develop' ]; then
-        echo "This build is for an update of branch develop. Push image to Dockerhub"
+      if [ $TRAVIS_REPO_SLUG == contiki-ng/contiki-ng ] && [ $TRAVIS_PULL_REQUEST == false ]; then
+        echo "This is a branch build that updates the container. Push image to Dockerhub"
         echo $DOCKERHUB_PASSWD | docker login --username contiker --password-stdin
         docker push $DOCKER_IMG;
       fi
     fi
+
   # Build Cooja conditionally
   - if [ ${BUILD_COOJA:-false} = true ] ; then
       ant -q -f $CNG_HOST_PATH/tools/cooja/build.xml jar ;
@@ -58,7 +67,7 @@ script:
 env:
   # Global environment variables, i.e., set for all builds
   global:
-    - DOCKER_IMG='contiker/contiki-ng'
+    - DOCKER_BASE_IMG='contiker/contiki-ng'
     - CNG_HOST_PATH=`pwd`
     - OUT_OF_TREE_TEST_PATH=$HOME/out-of-tree-tests
     - OUT_OF_TREE_TEST_VER=2869ae7

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,12 @@ before_install:
         echo "This is a branch build that updates the container. Push image to Dockerhub"
         echo $DOCKERHUB_PASSWD | docker login --username contiker --password-stdin
         docker push $DOCKER_IMG;
+        if [ $TRAVIS_BRANCH == develop ] || [ $TRAVIS_BRANCH == master ]; then
+          echo "This is a merge in branch $TRAVIS_BRANCH";
+          echo "Push also $DOCKER_BASE_IMG:$TRAVIS_BRANCH";
+          docker tag $DOCKER_IMG $DOCKER_BASE_IMG:$TRAVIS_BRANCH;
+          docker push $DOCKER_BASE_IMG:$TRAVIS_BRANCH;
+        fi
       fi
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   # If the test was triggered by a branch update (e.g. a PR merge) then push
   # the new image to dockerhub. This will only happen for builds against
   # contiki-ng/contiki-ng, not for builds on forks.
-  - echo $DOCKER_IMG
+  - echo "Will use $DOCKER_IMG for this run"
   - >
     echo "Pulling image $DOCKER_IMG from dockerhub";
     docker pull $DOCKER_IMG;


### PR DESCRIPTION
This pull allows us to create and use a separate docker container image each time `tools/docker` gets changed. This means that `tools/docker` changes in one branch will not influence travis tests running against a different branch (potentially causing them to fail, as was the case for #1084 & #1085). Each branch will from now on simply pull and use (or build) the correct docker image.

Each image is tagged with the hash of the most recent commit that changed `tools/docker`. Let's call this `CONTIKER_TAG`. This is retrieved by running:

```
$ git log -1 --oneline -- tools/docker/ | cut -d" " -f1
5310e7ae5
```

Travis tests will attempt to pull `contiker/contiki-ng:$CONTIKER_TAG`.

Then:
* If the pull succeeds then the PR / branch does not change `tools/docker`
* If `tools/docker` changed then the `docker pull` will fail. In this case, or if any other error occurs, we build a new docker image. This new docker image will be tagged `contiker/contiki-ng:$CONTIKER_TAG`

Lastly, if we are running on `contiki-ng/contiki-ng` and if the build was triggered by a branch, push `contiker/contiki-ng:$CONTIKER_TAG` to dockerhub.

To determine whether we are running on `contiki-ng/contiki-ng` (and not on a fork), we change the test to:

```
if [ $TRAVIS_REPO_SLUG == contiki-ng/contiki-ng ]
```

This is because `$TRAVIS_SECURE_ENV_VARS` can be true even outside `contiki-ng/contiki-ng`. It is on `g-oikonomou/contiki-ng` at least.