### PR TITLE
Update rpl-dag.c

### DIFF
--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -1029,6 +1029,9 @@ rpl_get_any_dag_with_parent(bool requires_parent)
 int
 rpl_has_joined(void)
 {
+  if(rpl_dag_root_is_root()) {
+    return 1;
+  }
   return rpl_get_any_dag_with_parent(true) != NULL;
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
I noticed that the function `int rpl_has_joined(void)` in rpl-classic returns 0 if it is called by the root of the dodag. Because of that issue the root dodag will never send a tsch beacon since the condition
`TSCH_RPL_CHECK_DODAG_JOINED()`  inside the process `tsch_send_eb_process` always fails.
The fix is straightforward: if I am the root of rpl dag I am joined to the dag by definition.
I tried this code with with Zolertia zoul RE-Mote revision B.
