### PR TITLE
fix PROCESS_EVENT_EXIT not called

### DIFF
--- a/os/sys/process.c
+++ b/os/sys/process.c
@@ -175,6 +175,7 @@ static void
 call_process(struct process *p, process_event_t ev, process_data_t data)
 {
   int ret;
+  struct process *old_current = process_current;
 
 #if DEBUG
   if(p->state == PROCESS_STATE_CALLED) {
@@ -196,6 +197,8 @@ call_process(struct process *p, process_event_t ev, process_data_t data)
       p->state = PROCESS_STATE_RUNNING;
     }
   }
+
+  process_current = old_current;
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -361,10 +364,7 @@ process_post(struct process *p, process_event_t ev, process_data_t data)
 void
 process_post_synch(struct process *p, process_event_t ev, process_data_t data)
 {
-  struct process *caller = process_current;
-
   call_process(p, ev, data);
-  process_current = caller;
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
 # Bug description

```
process_init();
process_start(&TestProcess, 0);
process_poll(&TestProcess);
process_run();
process_exit(&TestProcess);   // this line will NOT call PROCESS_EVENT_EXIT event in TestProcess
```


- process_current state remains 'dirty'
   after process poll or event
 - if process_exit is called for last polled
   process, that process will NOT receive
   PROCESS_EVENT_EXIT event

`process_exit` will call `exit_process(p, PROCESS_CURRENT());`.
https://github.com/contiki-ng/contiki-ng/blob/86934a16dc44fe0f90af5f151d1478d6658f4a27/os/sys/process.c#L204

exit_process function will call PROCESS_EVENT_EXIT event only if current process is not exiting process.
https://github.com/contiki-ng/contiki-ng/blob/86934a16dc44fe0f90af5f151d1478d6658f4a27/os/sys/process.c#L153

process_current status will (wrongly) point to last polled (do_poll) or event sent (do_event) process.

# After this fix is applied

`process_current` state is saved and restored inside function call_process.

# How to reproduce

```
PROCESS(TestProcess, "");
int num_of_received_exit_events = 0;
int num_of_exit_commands = 0;
PROCESS_THREAD(TestProcess, ev, data)
{
    if (ev == PROCESS_EVENT_EXIT)
    {
        num_of_received_exit_events ++;
    }

    PROCESS_BEGIN();
    while(1)
    {
        PROCESS_YIELD();
    }
    PROCESS_END();
}

void main()
{
    process_init();
    while (1)
    {
        process_start(&TestProcess, 0);
        process_poll(&TestProcess);  // after this process_current will point to TestProcess
        process_run();
        num_of_exit_commands ++;
        process_exit(&TestProcess);  // this will not fire PROCESS_EVENT_EXIT because of 'dirty' process_current
     }
}
```