### PR TITLE
Fix indentation and code style

### DIFF
--- a/os/sys/ctimer.c
+++ b/os/sys/ctimer.c
@@ -74,13 +74,13 @@ PROCESS_THREAD(ctimer_process, ev, data)
     PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_TIMER);
     for(c = list_head(ctimer_list); c != NULL; c = c->next) {
       if(&c->etimer == data) {
-	list_remove(ctimer_list, c);
-	PROCESS_CONTEXT_BEGIN(c->p);
-	if(c->f != NULL) {
-	  c->f(c->ptr);
-	}
-	PROCESS_CONTEXT_END(c->p);
-	break;
+        list_remove(ctimer_list, c);
+        PROCESS_CONTEXT_BEGIN(c->p);
+        if(c->f != NULL) {
+          c->f(c->ptr);
+        }
+        PROCESS_CONTEXT_END(c->p);
+        break;
       }
     }
   }
@@ -97,14 +97,14 @@ ctimer_init(void)
 /*---------------------------------------------------------------------------*/
 void
 ctimer_set(struct ctimer *c, clock_time_t t,
-	   void (*f)(void *), void *ptr)
+           void (*f)(void *), void *ptr)
 {
   ctimer_set_with_process(c, t, f, ptr, PROCESS_CURRENT());
 }
 /*---------------------------------------------------------------------------*/
 void
 ctimer_set_with_process(struct ctimer *c, clock_time_t t,
-	   void (*f)(void *), void *ptr, struct process *p)
+                        void (*f)(void *), void *ptr, struct process *p)
 {
   PRINTF("ctimer_set %p %lu\n", c, (unsigned long)t);
   c->p = p;

--- a/os/sys/ctimer.h
+++ b/os/sys/ctimer.h
@@ -116,7 +116,7 @@ void ctimer_restart(struct ctimer *c);
  *
  */
 void ctimer_set(struct ctimer *c, clock_time_t t,
-		void (*f)(void *), void *ptr);
+                void (*f)(void *), void *ptr);
 
 /**
  * \brief      Set a callback timer.
@@ -132,7 +132,7 @@ void ctimer_set(struct ctimer *c, clock_time_t t,
  *
  */
 void ctimer_set_with_process(struct ctimer *c, clock_time_t t,
-		void (*f)(void *), void *ptr, struct process *p);
+                             void (*f)(void *), void *ptr, struct process *p);
 
 /**
  * \brief      Stop a pending callback timer.

--- a/os/sys/etimer.c
+++ b/os/sys/etimer.c
@@ -61,7 +61,7 @@ update_time(void)
   clock_time_t now;
   struct etimer *t;
 
-  if (timerlist == NULL) {
+  if(timerlist == NULL) {
     next_expiration = 0;
   } else {
     now = clock_time();
@@ -70,7 +70,7 @@ update_time(void)
     tdist = t->timer.start + t->timer.interval - now;
     for(t = t->next; t != NULL; t = t->next) {
       if(t->timer.start + t->timer.interval - now < tdist) {
-	tdist = t->timer.start + t->timer.interval - now;
+        tdist = t->timer.start + t->timer.interval - now;
       }
     }
     next_expiration = now + tdist;
@@ -80,11 +80,11 @@ update_time(void)
 PROCESS_THREAD(etimer_process, ev, data)
 {
   struct etimer *t, *u;
-	
+
   PROCESS_BEGIN();
 
   timerlist = NULL;
-  
+
   while(1) {
     PROCESS_YIELD();
 
@@ -92,52 +92,52 @@ PROCESS_THREAD(etimer_process, ev, data)
       struct process *p = data;
 
       while(timerlist != NULL && timerlist->p == p) {
-	timerlist = timerlist->next;
+        timerlist = timerlist->next;
       }
 
       if(timerlist != NULL) {
-	t = timerlist;
-	while(t->next != NULL) {
-	  if(t->next->p == p) {
-	    t->next = t->next->next;
-	  } else
-	    t = t->next;
-	}
+        t = timerlist;
+        while(t->next != NULL) {
+          if(t->next->p == p) {
+            t->next = t->next->next;
+          } else {
+            t = t->next;
+          }
+        }
       }
       continue;
     } else if(ev != PROCESS_EVENT_POLL) {
       continue;
     }
 
-  again:
-    
+again:
+
     u = NULL;
-    
+
     for(t = timerlist; t != NULL; t = t->next) {
       if(timer_expired(&t->timer)) {
-	if(process_post(t->p, PROCESS_EVENT_TIMER, t) == PROCESS_ERR_OK) {
-	  
-	  /* Reset the process ID of the event timer, to signal that the
-	     etimer has expired. This is later checked in the
-	     etimer_expired() function. */
-	  t->p = PROCESS_NONE;
-	  if(u != NULL) {
-	    u->next = t->next;
-	  } else {
-	    timerlist = t->next;
-	  }
-	  t->next = NULL;
-	  update_time();
-	  goto again;
-	} else {
-	  etimer_request_poll();
-	}
+        if(process_post(t->p, PROCESS_EVENT_TIMER, t) == PROCESS_ERR_OK) {
+
+          /* Reset the process ID of the event timer, to signal that the
+             etimer has expired. This is later checked in the
+             etimer_expired() function. */
+          t->p = PROCESS_NONE;
+          if(u != NULL) {
+            u->next = t->next;
+          } else {
+            timerlist = t->next;
+          }
+          t->next = NULL;
+          update_time();
+          goto again;
+        } else {
+          etimer_request_poll();
+        }
       }
       u = t;
     }
-    
   }
-  
+
   PROCESS_END();
 }
 /*---------------------------------------------------------------------------*/
@@ -157,10 +157,10 @@ add_timer(struct etimer *timer)
   if(timer->p != PROCESS_NONE) {
     for(t = timerlist; t != NULL; t = t->next) {
       if(t == timer) {
-	/* Timer already on list, bail out. */
+        /* Timer already on list, bail out. */
         timer->p = PROCESS_CURRENT();
-	update_time();
-	return;
+        update_time();
+        return;
       }
     }
   }
@@ -251,12 +251,13 @@ etimer_stop(struct etimer *et)
   } else {
     /* Else walk through the list and try to find the item before the
        et timer. */
-    for(t = timerlist; t != NULL && t->next != et; t = t->next);
+    for(t = timerlist; t != NULL && t->next != et; t = t->next) {
+    }
 
     if(t != NULL) {
       /* We've found the item before the event timer that we are about
-	 to remove. We point the items next pointer to the event after
-	 the removed item. */
+         to remove. We point the items next pointer to the event after
+         the removed item. */
       t->next = et->next;
 
       update_time();

--- a/os/sys/process.c
+++ b/os/sys/process.c
@@ -146,7 +146,7 @@ exit_process(struct process *p, struct process *fromprocess)
      */
     for(q = process_list; q != NULL; q = q->next) {
       if(p != q) {
-	call_process(q, PROCESS_EVENT_EXITED, (process_data_t)p);
+        call_process(q, PROCESS_EVENT_EXITED, (process_data_t)p);
       }
     }
 
@@ -162,8 +162,8 @@ exit_process(struct process *p, struct process *fromprocess)
   } else {
     for(q = process_list; q != NULL; q = q->next) {
       if(q->next == p) {
-	q->next = p->next;
-	break;
+        q->next = p->next;
+        break;
       }
     }
   }
@@ -276,20 +276,20 @@ do_event(void)
     if(receiver == PROCESS_BROADCAST) {
       for(p = process_list; p != NULL; p = p->next) {
 
-	/* If we have been requested to poll a process, we do this in
-	   between processing the broadcast event. */
-	if(poll_requested) {
-	  do_poll();
-	}
-	call_process(p, ev, data);
+        /* If we have been requested to poll a process, we do this in
+           between processing the broadcast event. */
+        if(poll_requested) {
+          do_poll();
+        }
+        call_process(p, ev, data);
       }
     } else {
       /* This is not a broadcast event, so we deliver it to the
-	 specified process. */
+         specified process. */
       /* If the event was an INIT event, we should also update the
-	 state of the process. */
+         state of the process. */
       if(ev == PROCESS_EVENT_INIT) {
-	receiver->state = PROCESS_STATE_RUNNING;
+        receiver->state = PROCESS_STATE_RUNNING;
       }
 
       /* Make sure that the process actually is running. */
@@ -325,11 +325,11 @@ process_post(struct process *p, process_event_t ev, process_data_t data)
 
   if(PROCESS_CURRENT() == NULL) {
     PRINTF("process_post: NULL process posts event %d to process '%s', nevents %d\n",
-	   ev,PROCESS_NAME_STRING(p), nevents);
+           ev, PROCESS_NAME_STRING(p), nevents);
   } else {
     PRINTF("process_post: Process '%s' posts event %d to process '%s', nevents %d\n",
-	   PROCESS_NAME_STRING(PROCESS_CURRENT()), ev,
-	   p == PROCESS_BROADCAST? "<broadcast>": PROCESS_NAME_STRING(p), nevents);
+           PROCESS_NAME_STRING(PROCESS_CURRENT()), ev,
+           p == PROCESS_BROADCAST ? "<broadcast>" : PROCESS_NAME_STRING(p), nevents);
   }
 
   if(nevents == PROCESS_CONF_NUMEVENTS) {


### PR DESCRIPTION
Some old files under `os/sys` use tabs instead of spaces here and there. This looks funny in my editor and annoys me every time I open them to take a look...

This PR fixes indentation and opportunistically applies some other code style improvements