### PR TITLE
Upgrade and improve our vagrant image

### DIFF
--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -7,6 +7,7 @@ sudo apt install -y --no-install-recommends \
   libc6:i386 libstdc++6:i386 libncurses5:i386 libz1:i386 \
   build-essential doxygen git wget unzip python-serial rlwrap npm \
   default-jdk ant srecord python-pip iputils-tracepath uncrustify \
+  mosquitto mosquitto-clients valgrind \
   python-magic linux-image-extra-virtual openjdk-8-jdk
 
 sudo apt-get clean

--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -7,7 +7,7 @@ sudo apt install -y --no-install-recommends \
   libc6:i386 libstdc++6:i386 libncurses5:i386 libz1:i386 \
   build-essential doxygen git wget unzip python-serial rlwrap npm \
   default-jdk ant srecord python-pip iputils-tracepath uncrustify \
-  python-magic linux-image-extra-virtual
+  python-magic linux-image-extra-virtual openjdk-8-jdk
 
 sudo apt-get clean
 sudo python2 -m pip install intelhex sphinx_rtd_theme sphinx
@@ -48,8 +48,11 @@ echo "export NRF52_SDK_ROOT=/usr/nrf52-sdk" >> ${HOME}/.bashrc
 
 sudo usermod -aG dialout vagrant
 
+# Make sure we're using Java 8 for Cooja
+sudo update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
 # Environment variables
-echo "export JAVA_HOME=/usr/lib/jvm/default-java" >> ${HOME}/.bashrc
+echo "export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64" >> ${HOME}/.bashrc
 echo "export CONTIKI_NG=${HOME}/contiki-ng" >> ${HOME}/.bashrc
 echo "export COOJA=${CONTIKI_NG}/tools/cooja" >> ${HOME}/.bashrc
 echo "export PATH=${HOME}:${PATH}" >> ${HOME}/.bashrc

--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -8,6 +8,7 @@ sudo apt install -y --no-install-recommends \
   build-essential doxygen git wget unzip python-serial rlwrap npm \
   default-jdk ant srecord python-pip iputils-tracepath uncrustify \
   mosquitto mosquitto-clients valgrind \
+  smitools snmp snmp-mibs-downloader \
   python-magic linux-image-extra-virtual openjdk-8-jdk
 
 sudo apt-get clean

--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -10,7 +10,7 @@ sudo apt install -y --no-install-recommends \
   python-magic linux-image-extra-virtual
 
 sudo apt-get clean
-sudo python2 -m pip install intelhex
+sudo python2 -m pip install intelhex sphinx_rtd_theme sphinx
 
 # Install ARM toolchain
 wget https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2


### PR DESCRIPTION
This PR upgrades our vagrant image to Ubuntu 18.04

We also apply some improvements:

* We force Java to version 8
* We install various packages required in order for some tests to pass locally

The vagrant image is affected by #1069. This will be fixed separately