### PR TITLE
cc26x0-cc13x0 CPU: make LPM_MODE_MAX_SUPPORTED a configurable flag

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/lpm.h
+++ b/arch/cpu/cc26x0-cc13x0/lpm.h
@@ -54,7 +54,11 @@
 #define LPM_MODE_DEEP_SLEEP    2
 #define LPM_MODE_SHUTDOWN      3
 
+#ifndef LPM_MODE_MAX_SUPPORTED_CONF
 #define LPM_MODE_MAX_SUPPORTED LPM_MODE_DEEP_SLEEP
+#else
+#define LPM_MODE_MAX_SUPPORTED LPM_MODE_MAX_SUPPORTED_CONF
+#endif
 /*---------------------------------------------------------------------------*/
 #define LPM_DOMAIN_NONE        0
 #define LPM_DOMAIN_SERIAL      PRCM_DOMAIN_SERIAL


### PR DESCRIPTION
Working on the CC1310 I needed to change the LPM mode from the project_conf.h file. I hope this is not against the coding guidelines, I could not find any mention of configuration flags there, but since it is platform specific I am not completely sure. 

Maybe the configuration flag name should be something like `CC26XX_CC13XX_LPM_MODE_MAX_SUPPORTED_CONF` ?