### PR TITLE
[WIP] Proposed docker container refactor

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -5,7 +5,6 @@ FROM i386/ubuntu:18.04 as minimal
 ENV DEBIAN_FRONTEND noninteractive
 ARG USER=user
 ARG UID=1000
-ARG GID=100
 
 # Update path with toolchains
 ENV PATH=${PATH}:/opt/bin
@@ -44,7 +43,7 @@ RUN apt-get -qq update && \
 
 # Create user, enable X forwarding, add to group dialout
 # -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix
-RUN useradd -m -s /bin/bash -N -u $UID $USER && \
+RUN useradd -m -s /bin/bash -u $UID $USER && \
     echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers && \
     chmod 0440 /etc/sudoers && \
     usermod -aG dialout $USER

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,53 +1,131 @@
-FROM i386/ubuntu:18.04
+# The minimal image should be enough to build contiki for native
+# targets
+FROM i386/ubuntu:18.04 as minimal
 
 ENV DEBIAN_FRONTEND noninteractive
+ARG USER=user
+ARG UID=1000
+ARG GID=100
+
+# Update path with toolchains
+ENV PATH=${PATH}:/opt/bin
+
+# Base Tools
+RUN apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install \
+        gcc \
+        libc6-dev \
+        gdb \
+        make \
+        sudo \
+        git \
+        curl wget \
+        python-pip \
+        python-serial \
+        mosquitto \
+        mosquitto-clients \
+        netcat-openbsd \
+        rlwrap \
+        srecord \
+        valgrind \
+        snmp \
+        snmp-mibs-downloader \
+        net-tools iproute2 iputils-ping iputils-tracepath \
+        nodejs npm \
+        gnupg \
+        > /dev/null \
+        && \
+    # Install coap-cli
+    npm -q install coap-cli@0.5.1 -g \
+    npm cache clean && \
+    apt-get -qq -y autoremove --purge npm && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create user, enable X forwarding, add to group dialout
+# -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix
+RUN useradd -m -s /bin/bash -N -u $UID $USER && \
+    echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers && \
+    chmod 0440 /etc/sudoers && \
+    usermod -aG dialout $USER
 
 # Set user for what comes next
+USER ${UID}
+
+# Environment variables
+ENV HOME                /home/user
+ENV USER                ${USER}
+ENV CONTIKI_NG          ${HOME}/contiki-ng
+
+WORKDIR                 ${HOME}
+
+# By default, we use a Docker bind mount to share the repo with the host,
+# with Docker run option:
+# -v <HOST_CONTIKI_NG_ABS_PATH>:/home/user/contiki-ng
+# Alternatively, uncomment the next line to download Contiki-NG
+#RUN git clone --recursive https://github.com/contiki-ng/contiki-ng.git ${CONTIKI_NG}
+
+# Working directory
+WORKDIR ${CONTIKI_NG}
+
+# Start a bash
+CMD bash --login
+
+
+# COOJA build target
+# Includes tools to build msp430 targets and run
+# simulations with cooja
+FROM minimal as cooja
 USER root
 
-# Tools
+# Base Tools
 RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg > /dev/null
+    apt-get -qq -y --no-install-recommends install \
+        openjdk-8-jdk \
+        ant \
+        bzip2 \
+        > /dev/null \
+        && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-  echo "deb http://download.mono-project.com/repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/mono-xamarin.list && \
-  apt-get -qq update && \
-  apt-get -qq -y --no-install-recommends install \
-    ant \
-    build-essential \
-    default-jdk \
-    doxygen \
-    gdb \
-    git \
-    gtk-sharp2 \
-    iputils-tracepath \
-    iputils-ping \
-    libcanberra-gtk-module:i386 \
-    libgtk2.0-0 \
-    mono-complete \
-    mosquitto \
-    mosquitto-clients \
-    net-tools \
-    npm \
-    openjdk-8-jdk \
-    python-pip \
-    python-serial \
-    rlwrap \
-    sudo \
-    screen \
-    srecord \
-    uml-utilities \
-    unzip \
-    valgrind \
-    wget \
-    smitools \
-    snmp \
-    snmp-mibs-downloader \
-    > /dev/null \
-  && apt-get -qq clean
+# Install msp430 toolchain
+RUN wget -nv http://simonduq.github.io/resources/mspgcc-4.7.2-compiled.tar.bz2 && \
+  tar xjf mspgcc*.tar.bz2 -C /tmp/ && \
+  cp -f -r /tmp/msp430/* /usr/local/ && \
+  rm -rf /tmp/msp430 mspgcc*.tar.bz2
 
-# Install coap-cli
-RUN npm -q install coap-cli@0.5.1 -g
+# Make sure we're using Java 8 for Cooja
+RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-i386
+
+# Set user for what comes next
+USER ${USER}
+
+# Environment variables
+ENV JAVA_HOME           /usr/lib/jvm/java-8-openjdk-i386
+ENV COOJA               ${CONTIKI_NG}/tools/cooja
+ENV                     PATH="${HOME}:${PATH}"
+
+WORKDIR ${HOME}
+
+# Create Cooja shortcut
+RUN echo "#!/bin/bash\nant -Dbasedir=${COOJA} -f ${COOJA}/build.xml run" > ${HOME}/cooja && \
+  chmod +x ${HOME}/cooja
+
+# By default, we use a Docker bind mount to share the repo with the host,
+# with Docker run option:
+# -v <HOST_CONTIKI_NG_ABS_PATH>:/home/user/contiki-ng
+# Alternatively, uncomment the next two lines to download Contiki-NG and pre-compile Cooja.
+#RUN git clone --recursive https://github.com/contiki-ng/contiki-ng.git ${CONTIKI_NG}
+#RUN ant -q -f ${CONTIKI_NG}/tools/cooja/build.xml jar
+
+# Working directory
+WORKDIR ${CONTIKI_NG}
+
+# ARM build target
+# includes dependencies to build arm targets
+FROM cooja as arm
+USER root
 
 # Install ARM toolchain
 RUN wget -nv https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2 && \
@@ -55,11 +133,57 @@ RUN wget -nv https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+downloa
   cp -f -r /tmp/gcc-arm-none-eabi-5_2-2015q4/* /usr/local/ && \
   rm -rf /tmp/gcc-arm-none-eabi-* gcc-arm-none-eabi-*-linux.tar.bz2
 
-# Install msp430 toolchain
-RUN wget -nv http://simonduq.github.io/resources/mspgcc-4.7.2-compiled.tar.bz2 && \
-  tar xjf mspgcc*.tar.bz2 -C /tmp/ && \
-  cp -f -r /tmp/msp430/* /usr/local/ && \
-  rm -rf /tmp/msp430 mspgcc*.tar.bz2
+# Set user and workdir
+USER ${USER}
+WORKDIR ${CONTIKI_NG}
+
+
+# nRF52 build target
+# includes dependencies to build arm targets
+# as well as the nRF52 toolkit
+FROM arm as nrf52
+USER root
+
+# Base Tools
+RUN apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install \
+        unzip \
+        > /dev/null \
+        && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
+
+## Install nRF52 SDK
+RUN wget -nv https://developer.nordicsemi.com/nRF5_IoT_SDK/nRF5_IoT_SDK_v0.9.x/nrf5_iot_sdk_3288530.zip && \
+    mkdir /usr/nrf52-sdk && \
+    unzip -q nrf5_iot_sdk_3288530.zip -d /usr/nrf52-sdk && \
+    rm nrf5_iot_sdk_3288530.zip
+
+ENV NRF52_SDK_ROOT /usr/nrf52-sdk
+
+USER ${USER}
+WORKDIR ${CONTIKI_NG}
+
+# NXP build target
+# includes dependencies to build arm targets
+FROM nrf52 as nxp
+USER root
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+  echo "deb http://download.mono-project.com/repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/mono-xamarin.list && \
+    apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install \
+        gtk-sharp2 \
+        libcanberra-gtk-module:i386 \
+        libgtk2.0-0 \
+        mono-complete \
+        screen \
+        uml-utilities \
+        smitools \
+        > /dev/null \
+        && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install NXP toolchain (partial, with binaries excluded. Download from nxp.com)
 RUN wget -nv http://simonduq.github.io/resources/ba-elf-gcc-4.7.4-part1.tar.bz2 && \
@@ -75,47 +199,9 @@ RUN wget -nv http://simonduq.github.io/resources/ba-elf-gcc-4.7.4-part1.tar.bz2 
 
 ENV PATH="/usr/ba-elf-gcc/bin:${PATH}"
 
-## Install nRF52 SDK
-RUN wget -nv https://developer.nordicsemi.com/nRF5_IoT_SDK/nRF5_IoT_SDK_v0.9.x/nrf5_iot_sdk_3288530.zip && \
-    mkdir /usr/nrf52-sdk && \
-    unzip -q nrf5_iot_sdk_3288530.zip -d /usr/nrf52-sdk && \
-    rm nrf5_iot_sdk_3288530.zip
-
-ENV NRF52_SDK_ROOT /usr/nrf52-sdk
-
-# Install sphinx and sphinx_rtd_theme, required for building and testing the
-# readthedocs API documentation
-RUN pip -q install --upgrade pip
-RUN pip -q install setuptools && pip -q install sphinx_rtd_theme sphinx
-
-# Create user, enable X forwarding, add to group dialout
-# -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix
-RUN export uid=1000 gid=1000 && \
-    mkdir -p /home/user && \
-    echo "user:x:${uid}:${gid}:user,,,:/home/user:/bin/bash" >> /etc/passwd && \
-    echo "user:x:${uid}:" >> /etc/group && \
-    echo "user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers && \
-    chmod 0440 /etc/sudoers && \
-    chown ${uid}:${gid} -R /home/user && \
-    usermod -aG dialout user
-
 # Set user for what comes next
-USER user
-
-# Environment variables
-ENV JAVA_HOME           /usr/lib/jvm/default-java
-ENV HOME                /home/user
-ENV CONTIKI_NG          ${HOME}/contiki-ng
-ENV COOJA               ${CONTIKI_NG}/tools/cooja
-ENV                     PATH="${HOME}:${PATH}"
-WORKDIR                 ${HOME}
-
-# Create Cooja shortcut
-RUN echo "#!/bin/bash\nant -Dbasedir=${COOJA} -f ${COOJA}/build.xml run" > ${HOME}/cooja && \
-  chmod +x ${HOME}/cooja
-
-# Make sure we're using Java 8 for Cooja
-RUN sudo update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-i386
+USER ${USER}
+WORKDIR ${HOME}
 
 # Download, build and install Renode
 RUN git clone --quiet https://github.com/renode/renode.git \
@@ -124,15 +210,26 @@ RUN git clone --quiet https://github.com/renode/renode.git \
   && ./build.sh
 ENV PATH="${HOME}/renode:${PATH}"
 
-# By default, we use a Docker bind mount to share the repo with the host,
-# with Docker run option:
-# -v <HOST_CONTIKI_NG_ABS_PATH>:/home/user/contiki-ng
-# Alternatively, uncomment the next two lines to download Contiki-NG and pre-compile Cooja.
-#RUN git clone --recursive https://github.com/contiki-ng/contiki-ng.git ${CONTIKI_NG}
-#RUN ant -q -f ${CONTIKI_NG}/tools/cooja/build.xml jar
-
-# Working directory
 WORKDIR ${CONTIKI_NG}
 
-# Start a bash
-CMD bash --login
+# Documentation build target
+# includes doxygen and sphinx packages to build
+# documentation
+FROM nxp as docs
+USER root
+
+# Base Tools
+RUN apt-get -qq update && \
+    apt-get -qq -y --no-install-recommends install \
+        doxygen \
+        > /dev/null \
+        && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install sphinx and sphinx_rtd_theme, required for building and testing the
+# readthedocs API documentation
+RUN pip -q install --upgrade pip
+RUN pip -q install setuptools && pip -q install sphinx_rtd_theme sphinx
+
+USER ${USER}


### PR DESCRIPTION
The current contiker docker image although is very useful, it is quite
large in size (1.2GB compressed, 3.5 uncompressed). I propose a refactor
of the Dockerfile that allows to produce smaller intermediate images for
different targets, making it faster to get started with Contiki-NG

I divided the dockerfile into 5 targets, each one extending the one
above with additional functionality

- minimal, containing build packages and tools to build contiki examples
  in native (~450MB uncompressed)
- cooja, including the packages in minimal, plus the msp430 toochain and java packages to test
  simulations in cooja (~1GB uncompressed)
- arm, to build arm-based projects (~1.5GB uncompressed)
- nrf52, which adds nrf52 sdk (~1.6GB uncompressed)
- nxp, adding nxp build tools plus the renode tool and its dependencies
  (~3GB uncompressed)
- docs, which adds additional packages to build the documentation
  (~3.4GB uncompressed)

Each target can be built using the following command
```
docker build contiker/contiki-ng:$TARGET --target $TARGET .
```

To compensate a little for the space added by the additional layers, I
also removed some packages that I think should be unnecessary (e.g. g++,
dpkg-dev in the build-essential package, or java-11 in the default-jdk
package, amonst others).

The full docker image *should* be fully backwards compatible with the
old image, although I would appreciate if someone could review it.

What is left to do in the PR

- [x] Refactor dockerfile
- [ ] Review new containers and run tests
- [ ] Define new target image names in refactor
- [ ] Update Travis to create new targets
- [ ] Update documentation

Let me know if this appears interesting to you and I can keep working on it