### PR TITLE
Octet delay for native border router

### DIFF
--- a/examples/rpl-border-router/project-conf.h
+++ b/examples/rpl-border-router/project-conf.h
@@ -45,9 +45,10 @@
 
 /*  This will fix the packet drop problem of Native Border Router.
  *  Packet drop exist between native and slip-radio because of high
- *  writing speed of two devices. OCTET_DELAY will reduce the writing
- *  speed using usleep(). The result will reduce the packet drop
- *  between native and slip-radio.
+ *  writing speed of native device. SLIP_DEV_CONF_OCTET_DELAY in
+ *  microsecond will reduce the writing speed of native device using 
+ *  usleep(). The result will reduce the packet drop between native 
+ *  and slip-radio.
  */
 #if CONTIKI_TARGET_NATIVE
 #define SLIP_DEV_CONF_OCTET_DELAY 0

--- a/examples/rpl-border-router/project-conf.h
+++ b/examples/rpl-border-router/project-conf.h
@@ -43,13 +43,7 @@
 #define UIP_CONF_TCP 1
 #endif
 
-/*  This will fix the packet drop problem of Native Border Router.
- *  Packet drop exist between native and slip-radio because of high
- *  writing speed of native device. SLIP_DEV_CONF_OCTET_DELAY in
- *  microsecond will reduce the writing speed of native device using 
- *  usleep(). The result will reduce the packet drop between native 
- *  and slip-radio.
- */
+/* octet delay setting of SLIP in microsecond */
 #if CONTIKI_TARGET_NATIVE
 #define SLIP_DEV_CONF_OCTET_DELAY 0
 #endif

--- a/examples/rpl-border-router/project-conf.h
+++ b/examples/rpl-border-router/project-conf.h
@@ -43,4 +43,14 @@
 #define UIP_CONF_TCP 1
 #endif
 
+/*  This will fix the packet drop problem of Native Border Router.
+ *  Packet drop exist between native and slip-radio because of high
+ *  writing speed of two devices. OCTET_DELAY will reduce the writing
+ *  speed using usleep(). The result will reduce the packet drop
+ *  between native and slip-radio.
+ */
+#if CONTIKI_TARGET_NATIVE
+#define SLIP_DEV_CONF_OCTET_DELAY 0
+#endif
+
 #endif /* PROJECT_CONF_H_ */

--- a/os/services/rpl-border-router/native/module-macros.h
+++ b/os/services/rpl-border-router/native/module-macros.h
@@ -35,8 +35,6 @@
 
 #define SLIP_DEV_CONF_SEND_DELAY (CLOCK_SECOND / 32)
 
-/* octet delay setting of SLIP in microsecond */
-#define SLIP_DEV_CONF_OCTET_DELAY 1000
 
 #define SERIALIZE_ATTRIBUTES 1
 

--- a/os/services/rpl-border-router/native/module-macros.h
+++ b/os/services/rpl-border-router/native/module-macros.h
@@ -35,6 +35,9 @@
 
 #define SLIP_DEV_CONF_SEND_DELAY (CLOCK_SECOND / 32)
 
+/* octet delay setting of SLIP in microsecond */
+#define SLIP_DEV_CONF_OCTET_DELAY 1000
+
 #define SERIALIZE_ATTRIBUTES 1
 
 #define CMD_CONF_OUTPUT border_router_cmd_output

--- a/os/services/rpl-border-router/native/module-macros.h
+++ b/os/services/rpl-border-router/native/module-macros.h
@@ -35,7 +35,6 @@
 
 #define SLIP_DEV_CONF_SEND_DELAY (CLOCK_SECOND / 32)
 
-
 #define SERIALIZE_ATTRIBUTES 1
 
 #define CMD_CONF_OUTPUT border_router_cmd_output

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -70,6 +70,12 @@ extern speed_t slip_config_b_rate;
 #define SEND_DELAY 0
 #endif
 
+#ifdef SLIP_DEV_CONF_OCTET_DELAY
+#define OCTET_DELAY SLIP_DEV_CONF_OCTET_DELAY
+#else
+#define OCTET_DELAY 0
+#endif
+
 int devopen(const char *dev, int flags);
 
 static FILE *inslip;
@@ -316,7 +322,29 @@ slip_empty()
   return slip_packet_end == 0;
 }
 /*---------------------------------------------------------------------------*/
+<<<<<<< HEAD
 void
+=======
+static ssize_t
+write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
+{
+  int n=0;
+  int i;
+
+  if(inter_octet_delay == 0) {
+    return write(fd, buf, count);
+  }
+  else{
+    for(i=0; i<count; i++){
+      n+= write(fd, buf + i, 1);
+      usleep(inter_octet_delay);
+    }
+    return n;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+>>>>>>> f99626ba0... test-slip: write slowly function added
 slip_flushbuf(int fd)
 {
   int n;
@@ -325,7 +353,7 @@ slip_flushbuf(int fd)
     return;
   }
 
-  n = write(fd, slip_buf + slip_begin, slip_packet_end - slip_begin);
+  n = write_slowly(fd, slip_buf + slip_begin, slip_packet_end - slip_begin, OCTET_DELAY);
 
   if(n == -1 && errno != EAGAIN) {
     err(1, "slip_flushbuf write failed");

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -70,7 +70,12 @@ extern speed_t slip_config_b_rate;
 #define SEND_DELAY 0
 #endif
 
-/* octet delay setting of SLIP in microsecond */
+/*  Depending on the slip radio device, sometimes packet drop exist 
+ *  between native and slip-radio because of high writing speed of 
+ *  native device. SLIP_DEV_CONF_OCTET_DELAY in microsecond will 
+ *  reduce the writing speed of native device using usleep(). The 
+ *  result will reduce the packet drop between native and slip-radio.
+ */
 #ifdef SLIP_DEV_CONF_OCTET_DELAY
 #define OCTET_DELAY SLIP_DEV_CONF_OCTET_DELAY
 #else

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -357,7 +357,7 @@ slip_flushbuf(int fd)
 
   if(n == -1 && errno != EAGAIN) {
     err(1, "slip_flushbuf write failed");
-  } else if(n == -1) {
+  } else if((n == -1 && errno==EAGAIN)||n==0) {
     PROGRESS("Q");		/* Outqueue is full! */
   } else {
     slip_begin += n;

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -328,22 +328,22 @@ void
 static ssize_t
 write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
 {
-  int n=0;
+  int n = 0;
   int i;
   int write_status;
 
   if(inter_octet_delay == 0) {
     return write(fd, buf, count);
-  } else{
-    for(i=0; i<count; i++){
+  } else {
+    for(i = 0; i < count; i++) {
       write_status = write(fd, buf + i, 1);
       if(write_status == -1 && errno != EAGAIN) {
         return write_status;
-      } else if ((write_status == -1 && errno==EAGAIN)||write_status==0){
+      } else if((write_status == -1 && errno == EAGAIN) || write_status == 0) {
         PROGRESS("Q");		/* Outqueue is full! */
         return n;
       } else {
-        n+= write_status;
+        n += write_status;
         usleep(inter_octet_delay);
       } 
     }
@@ -365,7 +365,7 @@ slip_flushbuf(int fd)
 
   if(n == -1 && errno != EAGAIN) {
     err(1, "slip_flushbuf write failed");
-  } else if((n == -1 && errno==EAGAIN)||n==0) {
+  } else if((n == -1 && errno == EAGAIN) || n == 0) {
     PROGRESS("Q");		/* Outqueue is full! */
   } else {
     slip_begin += n;

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -322,9 +322,6 @@ slip_empty()
   return slip_packet_end == 0;
 }
 /*---------------------------------------------------------------------------*/
-<<<<<<< HEAD
-void
-=======
 static ssize_t
 write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
 {
@@ -349,7 +346,6 @@ write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
 }
 /*---------------------------------------------------------------------------*/
 static void
->>>>>>> f99626ba0... test-slip: write slowly function added
 slip_flushbuf(int fd)
 {
   int n;

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -328,20 +328,18 @@ void
 static ssize_t
 write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
 {
-  int n = 0;
-  int i;
-  int write_status;
-
   if(inter_octet_delay == 0) {
     return write(fd, buf, count);
   } else {
-    for(i = 0; i < count; i++) {
-      write_status = write(fd, buf + i, 1);
+    int n = 0;
+    int write_status;
+    while(n < count) {
+      write_status = write(fd, buf + n, 1);
       if(write_status == -1 && errno != EAGAIN) {
         return write_status;
       } else if((write_status == -1 && errno == EAGAIN) || write_status == 0) {
-        PROGRESS("Q");		/* Outqueue is full! */
-        return n;
+        usleep(10000);
+        continue;
       } else {
         n += write_status;
         usleep(inter_octet_delay);

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -330,14 +330,21 @@ write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
 {
   int n=0;
   int i;
+  int write_status;
 
   if(inter_octet_delay == 0) {
     return write(fd, buf, count);
-  }
-  else{
+  } else{
     for(i=0; i<count; i++){
-      n+= write(fd, buf + i, 1);
-      usleep(inter_octet_delay);
+      write_status = write(fd, buf + i, 1);
+      if(write_status == -1 && errno != EAGAIN) {
+        err(1, "slip_flushbuf write failed");
+      } else if ((write_status == -1 && errno==EAGAIN)||write_status==0){
+        return 0;
+      } else {
+        n+= write_status;
+        usleep(inter_octet_delay);
+      } 
     }
     return n;
   }

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -338,8 +338,7 @@ write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
       if(write_status == -1 && errno != EAGAIN) {
         return write_status;
       } else if((write_status == -1 && errno == EAGAIN) || write_status == 0) {
-        usleep(10000);
-        continue;
+        return n;
       } else {
         n += write_status;
         usleep(inter_octet_delay);

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -338,7 +338,7 @@ write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
     for(i=0; i<count; i++){
       write_status = write(fd, buf + i, 1);
       if(write_status == -1 && errno != EAGAIN) {
-        err(1, "slip_flushbuf write failed");
+        return write_status;
       } else if ((write_status == -1 && errno==EAGAIN)||write_status==0){
         PROGRESS("Q");		/* Outqueue is full! */
         return n;

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -70,10 +70,10 @@ extern speed_t slip_config_b_rate;
 #define SEND_DELAY 0
 #endif
 
-/*  Depending on the slip radio device, sometimes packet drop exist 
- *  between native and slip-radio because of high writing speed of 
- *  native device. SLIP_DEV_CONF_OCTET_DELAY in microsecond will 
- *  reduce the writing speed of native device using usleep(). The 
+/*  Depending on the slip radio device, sometimes packet drop exist
+ *  between native and slip-radio because of high writing speed of
+ *  native device. SLIP_DEV_CONF_OCTET_DELAY in microsecond will
+ *  reduce the writing speed of native device using usleep(). The
  *  result will reduce the packet drop between native and slip-radio.
  */
 #ifdef SLIP_DEV_CONF_OCTET_DELAY
@@ -345,7 +345,7 @@ write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
       } else {
         n += write_status;
         usleep(inter_octet_delay);
-      } 
+      }
     }
     return n;
   }

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -70,6 +70,7 @@ extern speed_t slip_config_b_rate;
 #define SEND_DELAY 0
 #endif
 
+/* octet delay setting of SLIP in microsecond */
 #ifdef SLIP_DEV_CONF_OCTET_DELAY
 #define OCTET_DELAY SLIP_DEV_CONF_OCTET_DELAY
 #else

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -70,7 +70,8 @@ extern speed_t slip_config_b_rate;
 #define SEND_DELAY 0
 #endif
 
-/*  Depending on the slip radio device, sometimes packet drop exist
+/*
+ *  Depending on the slip radio device, sometimes packet drop exist
  *  between native and slip-radio because of high writing speed of
  *  native device. SLIP_DEV_CONF_OCTET_DELAY in microsecond will
  *  reduce the writing speed of native device using usleep(). The
@@ -337,13 +338,14 @@ write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
     int n = 0;
     int write_status;
     while(n < count) {
+      /* writing data one byte at a time */
       write_status = write(fd, buf + n, 1);
       if(write_status == -1 && errno != EAGAIN) {
         return write_status;
       } else if((write_status == -1 && errno == EAGAIN) || write_status == 0) {
         return n;
       } else {
-        n += write_status;
+        n += 1;
         usleep(inter_octet_delay);
       }
     }

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -340,7 +340,8 @@ write_slowly(int fd, const void *buf, size_t count, int inter_octet_delay)
       if(write_status == -1 && errno != EAGAIN) {
         err(1, "slip_flushbuf write failed");
       } else if ((write_status == -1 && errno==EAGAIN)||write_status==0){
-        return 0;
+        PROGRESS("Q");		/* Outqueue is full! */
+        return n;
       } else {
         n+= write_status;
         usleep(inter_octet_delay);


### PR DESCRIPTION
# Problem

Depending on the slip radio device, sometimes packet drops exist between native and slip-radio of native border router.

# Why does it happen?

This happen because of high writing speed of native device to the constraint slip radio device.

# Solution

We introduce an octet delay in every write by the native device to the slip radio device. `SLIP_DEV_CONF_OCTET_DELAY` in microsecond will reduce the writing speed of native device using `usleep()`. The result will reduce the packet drop between native and slip-radio. The default is `OCTET_DELAY = 0` for back compatibility.


