### PR TITLE
Correct base drift for CC13XX SubGhz, Compensate base drift at association

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-def.h
+++ b/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-def.h
@@ -111,7 +111,7 @@
  * PPM -8.544922 / 40000 = -0.000214
  */
 #define TSCH_CONF_BASE_DRIFT_PPM -214
-#else
+#else /* CPU_FAMILY_CC13XX */
 /* The drift compared to "true" 10ms slots.
  * Enable adaptive sync to enable compensation for this.
  * Slot length 10000 usec
@@ -122,8 +122,8 @@
  * TSCH_CONF_BASE_DRIFT_PPM -977
  */
 #define TSCH_CONF_BASE_DRIFT_PPM -977
-#endif
-#endif
+#endif /* CPU_FAMILY_CC13XX */
+#endif /* TSCH_CONF_BASE_DRIFT_PPM */
 
 /* 10 times per second */
 #ifndef TSCH_CONF_CHANNEL_SCAN_DURATION

--- a/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-def.h
+++ b/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-def.h
@@ -100,6 +100,18 @@
 #endif
 
 #ifndef TSCH_CONF_BASE_DRIFT_PPM
+#if CPU_FAMILY_CC13XX
+/* The drift compared to "true" 40ms slots.
+ * Enable adaptive sync to enable compensation for this.
+ * Slot length 40000 usec
+ *             1311 ticks
+ * Tick duration 30.517578125 usec
+ * Real slot duration 40008.544922 usec
+ * Target - real duration = -8.544922 usec
+ * PPM -8.544922 / 40000 = -0.000214
+ */
+#define TSCH_CONF_BASE_DRIFT_PPM -214
+#else
 /* The drift compared to "true" 10ms slots.
  * Enable adaptive sync to enable compensation for this.
  * Slot length 10000 usec
@@ -110,6 +122,7 @@
  * TSCH_CONF_BASE_DRIFT_PPM -977
  */
 #define TSCH_CONF_BASE_DRIFT_PPM -977
+#endif
 #endif
 
 /* 10 times per second */

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -1151,6 +1151,8 @@ tsch_slot_operation_start(void)
     TSCH_ASN_INC(tsch_current_asn, timeslot_diff);
     /* Time to next wake up */
     time_to_next_active_slot = timeslot_diff * tsch_timing[tsch_ts_timeslot_length];
+    /* Compensate for the base drift */
+    time_to_next_active_slot += tsch_timesync_adaptive_compensate(time_to_next_active_slot);
     /* Update current slot start */
     prev_slot_start = current_slot_start;
     current_slot_start += time_to_next_active_slot;


### PR DESCRIPTION
This addresses issue #1145 .

CC1310 uses slot length of 40000 usec instead of 10000 usec.
The base drift rate is different from 2.4 Ghz.

When the first EB is received, the next time to wake up calculation needs to include the base drift compensation.