### PR TITLE
Add mpmc-ring, a multi-producer multi-consumer lock-free ring buffer

### DIFF
--- a/examples/libs/mpmc-ring-interrupt/Makefile
+++ b/examples/libs/mpmc-ring-interrupt/Makefile
@@ -1,0 +1,8 @@
+CONTIKI_PROJECT = mpmc-ring-interrupt
+all: $(CONTIKI_PROJECT)
+
+MAKE_MAC=MAKE_MAC_NULLMAC
+MAKE_NET=MAKE_NET_NULLNET
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/examples/libs/mpmc-ring-interrupt/README.md
+++ b/examples/libs/mpmc-ring-interrupt/README.md
@@ -1,0 +1,45 @@
+# mpmc-ring-interrupt example
+
+This example demonstrates and tests interrupt-safety of
+lib/mpmc-ring.
+
+## What it does
+
+It prepares a message queue managed by mpmc-ring. Two producers put
+some messages into the queue. One producer runs in normal context,
+and the other in interrupt context (using rtimer). At the same time,
+two consumers (in normal and interrupt contexts, respectively) get
+messages from the queue and stores them in dedicated memory regions.
+
+                          put             get
+       NORMAL (Producer) --+               +--> (Consumer) --> [store]
+                           |               |
+                           +-> --------- >-+
+                               | queue |
+                           +-> --------- >-+
+                           |               |
+    INTERRUPT (Producer) --+               +--> (Consumer) --> [store]
+
+After all activities are finished, it checks the content of the two
+message stores. If the stores do not contain the exact messages put
+by the producers, it prints error messages.
+
+If the check succeeds, it re-initializes the producers, consumers
+and queue, and run the same test again. If the check fails, it
+resets.
+
+## Configuration
+
+In project-conf, you can configure number of messages two produers
+put to the queue and two consumers get from the queue. You can also
+configure speed of the producers and consumers relative to each
+other.
+
+## Expectations
+
+This example should run without any error logs even though there are
+multiple producers and consumers.
+
+## Author
+
+Toshio Ito <toshio9.ito@toshiba.co.jp>

--- a/examples/libs/mpmc-ring-interrupt/mpmc-ring-interrupt.c
+++ b/examples/libs/mpmc-ring-interrupt/mpmc-ring-interrupt.c
@@ -1,0 +1,593 @@
+/*
+ * Copyright (C) 2020, Toshiba Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "contiki.h"
+#include "dev/watchdog.h"
+#include "lib/mpmc-ring.h"
+#include "lib/ringbufindex.h"
+#include "lib/random.h"
+#include "sys/timer.h"
+#include "sys/rtimer.h"
+#include "sys/etimer.h"
+#include "sys/clock.h"
+#include "sys/critical.h"
+#include "sys/node-id.h"
+
+#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_MODULE "mpmc"
+#include "sys/log.h"
+
+/*---------------------------------------------------------------------------*/
+
+#if ENABLE_LOG_IN_RTIMER
+#define RLOG_DBG(...) LOG_DBG(__VA_ARGS__)
+#define RLOG_INFO(...) LOG_INFO(__VA_ARGS__)
+#else /* ENABLE_LOG_IN_RTIMER */
+#define RLOG_DBG(...)
+#define RLOG_INFO(...)
+#endif /* ENABLE_LOG_IN_RTIMER */
+
+
+/*---------------------------------------------------------------------------*/
+/*
+ * Abstraction of the queue
+ */
+
+#if USE_RINGBUFINDEX
+typedef struct ringbufindex the_queue_t;
+typedef uint8_t the_index_t;
+#else /* USE_RINGBUFINDEX */
+typedef mpmc_ring_t the_queue_t;
+typedef mpmc_ring_index_t the_index_t;
+#endif /* USE_RINGBUFINDEX */
+
+static inline void the_queue_init(the_queue_t *q, int s);
+static inline int the_queue_put_begin(the_queue_t *q, the_index_t *got);
+static inline int the_queue_put_commit(the_queue_t *q, const the_index_t *i);
+static inline int the_queue_get_begin(the_queue_t *q, the_index_t *got);
+static inline int the_queue_get_commit(the_queue_t *q, const the_index_t *i);
+static inline int the_queue_index_get(const the_index_t *i);
+static inline int the_queue_elements(the_queue_t *q);
+
+#if USE_RINGBUFINDEX
+static inline void the_queue_init(the_queue_t *q, int s) { ringbufindex_init(q,(uint8_t)s); }
+static inline int the_queue_put_begin(the_queue_t *q, the_index_t *got)
+{
+  int ret = ringbufindex_peek_put(q);
+  if(ret < 0) {
+    return 0;
+  } else {
+    *got = ret;
+    return 1;
+  }
+}
+static inline int the_queue_put_commit(the_queue_t *q, const the_index_t *i) { return ringbufindex_put(q); }
+static inline int the_queue_get_begin(the_queue_t *q, the_index_t *got)
+{
+  int ret = ringbufindex_peek_get(q);
+  if(ret < 0) {
+    return 0;
+  } else {
+    *got = ret;
+    return 1;
+  }
+}
+static inline int the_queue_get_commit(the_queue_t *q, const the_index_t *i) { return (ringbufindex_get(q) >= 0); }
+static inline int the_queue_index_get(const the_index_t *i) { return *i; }
+static inline int the_queue_elements(the_queue_t *q) { return ringbufindex_elements(q); }
+#else /* USE_RINGBUFINDEX */
+static inline void the_queue_init(the_queue_t *q, int s) { mpmc_ring_init(q); }
+static inline int the_queue_put_begin(the_queue_t *q, the_index_t *got) { return mpmc_ring_put_begin(q,got); }
+static inline int the_queue_put_commit(the_queue_t *q, const the_index_t *i) { mpmc_ring_put_commit(q,i); return 1; }
+static inline int the_queue_get_begin(the_queue_t *q, the_index_t *got) { return mpmc_ring_get_begin(q,got); }
+static inline int the_queue_get_commit(the_queue_t *q, const the_index_t *i) { mpmc_ring_get_commit(q,i); return 1; }
+static inline int the_queue_index_get(const the_index_t *i) { return i->i; }
+static inline int the_queue_elements(the_queue_t *q) { return mpmc_ring_elements(q); }
+#endif /* USE_RINGBUFINDEX */
+
+
+/*---------------------------------------------------------------------------*/
+typedef uint16_t msg_t;
+
+/**
+ * Deliberately take time to move a message from source to dest. It
+ * copies the message one bit at a time.
+ */
+static inline
+void msg_move(msg_t *dest, const msg_t *source)
+{
+  int bit_index;
+  int wait_max = MOVE_WAIT_COUNT + (MOVE_WAIT_COUNT * random_rand() / RANDOM_RAND_MAX);
+  *dest = 0;
+  for(bit_index = 0 ; bit_index < sizeof(msg_t) * 8 ; bit_index++) {
+    msg_t mask = 1 << bit_index;
+    int wait;
+    *dest = (*dest & (~mask)) | (*source & mask);
+    for(wait = 0 ; wait < wait_max ; wait++) {
+      /* emulate long access time... */
+      ;
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/**
+ * A producer of the queue. It generates messages sequentially.
+ */
+struct message_gen {
+  msg_t next;
+  uint32_t generated_num;
+  uint32_t count_queue_full;
+};
+
+static void
+message_gen_init(struct message_gen *gen, msg_t init_msg)
+{
+  gen->next = init_msg;
+  gen->generated_num = 0;
+  gen->count_queue_full = 0;
+}
+
+static msg_t
+message_gen_next(struct message_gen *gen)
+{
+  msg_t n = gen->next;
+  gen->next++;
+  gen->generated_num++;
+  return n;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * A consumer of the queue. It stores messages obtained from the
+ * queue.
+ */
+struct message_store {
+  msg_t *storage;
+  uint32_t current_num;
+  uint32_t count_queue_drain;
+};
+
+static void
+message_store_init(struct message_store *store, msg_t *storage_impl)
+{
+  store->storage = storage_impl;
+  store->current_num = 0;
+  store->count_queue_drain = 0;
+}
+
+static void
+message_store_input(struct message_store *store, const msg_t *val)
+{
+  msg_move(&store->storage[store->current_num], val);
+  store->current_num++;
+}
+
+/*---------------------------------------------------------------------------*/
+/**
+ * Controller of a producer or consumer. it regulates the speed of
+ * the message stream, and keeps track of the time when the stream
+ * started and finished.
+ */
+struct stream_control {
+  int finished;
+  int try_counter;
+  int try_interval;
+  clock_time_t start_time;
+  clock_time_t finish_time;
+};
+
+static void
+stream_control_init(volatile struct stream_control *sc, int finished, int try_interval)
+{
+  sc->finished = finished;
+  sc->try_counter = 0;
+  sc->try_interval = try_interval;
+  sc->start_time = clock_time();
+  sc->finish_time = 0;
+}
+
+/**
+ * \return Non-zero if a producer or consumer can process a
+ * message. Zero otherwise.
+ */
+static int
+stream_control_try(volatile struct stream_control *sc)
+{
+  sc->try_counter++;
+  return (sc->try_counter % sc->try_interval == 0);
+}
+
+static void
+stream_control_finish(volatile struct stream_control *sc)
+{
+  sc->finished = 1;
+  sc->finish_time = clock_time();
+}
+
+static inline int
+stream_control_is_finished(volatile struct stream_control *sc)
+{
+  return sc->finished;
+}
+
+static inline clock_time_t
+stream_control_duration(volatile struct stream_control *sc)
+{
+  return sc->finish_time - sc->start_time;
+}
+
+/*---------------------------------------------------------------------------*/
+/**
+ * The memory region for messages in the queue.
+ */
+static msg_t queue[QUEUE_LEN];
+#if USE_RINGBUFINDEX
+static struct ringbufindex queue_r;
+#else /* USE_RINGBUFINDEX */
+MPMC_RING(queue_r, QUEUE_LEN);
+#endif /* USE_RINGBUFINDEX */
+
+#define MESSAGE_POOL_SIZE (NORMAL_GET_NUM + INTERRUPT_GET_NUM)
+
+/**
+ * The memory region to store messages obtained from the queue. It's
+ * divided into two, and assigned to nornal_store and
+ * interrupt_store.
+ */
+static msg_t message_pool[MESSAGE_POOL_SIZE];
+
+/**
+ * The consumer in normal context.
+ */
+static struct message_store normal_store;
+
+/**
+ * The consumer in interrupt context.
+ */
+static struct message_store interrupt_store;
+
+/**
+ * The producer in normal context.
+ */
+static struct message_gen normal_put_gen;
+
+/**
+ * The producer in interrupt context.
+ */
+static struct message_gen interrupt_put_gen;
+
+/**
+ * Controls the role of task_rtimer. If non-zero, task_rtimer puts
+ * a message. Otherwise it gets a message.
+ */
+static int do_put_in_rtimer;
+
+/**
+ * Controls the start time of the consumers. If non-zero, the
+ * consumers work.
+ */
+static int enable_get;
+
+/* stream controllers for the producers and consumers */
+static volatile struct stream_control sc_normal_put;
+static volatile struct stream_control sc_normal_get;
+static volatile struct stream_control sc_interrupt_put;
+static volatile struct stream_control sc_interrupt_get;
+
+/*---------------------------------------------------------------------------*/
+/**
+ * Put a message from the producer to the queue. If the queue is
+ * full, it does nothing.
+ *
+ * \return Non-zero if it successfully puts a message. Zero
+ * otherwise.
+ */
+static inline
+int do_put(struct message_gen *gen)
+{
+  the_index_t i;
+  msg_t next;
+  if(!the_queue_put_begin(&queue_r, &i)) {
+    gen->count_queue_full++;
+    return 0;
+  }
+  next = message_gen_next(gen);
+  msg_move(&queue[the_queue_index_get(&i)], &next);
+  return the_queue_put_commit(&queue_r, &i);
+}
+
+/**
+ * Get a message from the queue to the consumer. If the queue is
+ * empty, it does nothing.
+ *
+ * \return Non-zero if it successfully gets a message. Zero
+ * otherwise.
+ */
+static inline
+int do_get(struct message_store *store)
+{
+  the_index_t i;
+  if(!the_queue_get_begin(&queue_r, &i)) {
+    store->count_queue_drain++;
+    return 0;
+  }
+  message_store_input(store, &queue[the_queue_index_get(&i)]);
+  return the_queue_get_commit(&queue_r, &i);
+}
+/*---------------------------------------------------------------------------*/
+
+static void task_rtimer(struct rtimer *rt, void *data);
+
+static void
+init_states(void)
+{
+  message_store_init(&normal_store, message_pool);
+  message_store_init(&interrupt_store, message_pool + NORMAL_GET_NUM);
+  message_gen_init(&normal_put_gen, 0);
+  message_gen_init(&interrupt_put_gen, NORMAL_PUT_NUM);
+  do_put_in_rtimer = 0;
+  enable_get = (START_GET_NUM == 0);
+  stream_control_init(&sc_normal_put, (NORMAL_PUT_NUM == 0), PUT_INTERVAL);
+  stream_control_init(&sc_normal_get, (NORMAL_GET_NUM == 0), GET_INTERVAL);
+  stream_control_init(&sc_interrupt_put, (INTERRUPT_PUT_NUM == 0), PUT_INTERVAL);
+  stream_control_init(&sc_interrupt_get, (INTERRUPT_GET_NUM == 0), GET_INTERVAL);
+  memset(message_pool, 0xFF, sizeof(message_pool));
+  memset(queue, 0, sizeof(queue));
+  the_queue_init(&queue_r, QUEUE_LEN);
+}
+
+static void
+schedule_rtimer(void)
+{
+  static struct rtimer rt;
+  rtimer_set(&rt, RTIMER_NOW() + INTERRUPT_RTIMER_INTERVAL, 0, &task_rtimer, NULL);
+}
+
+static void
+task_rtimer(struct rtimer *rt, void *data)
+{
+  /*
+   * Run the producer or consumer alternately.
+   */
+  int try_i;
+  for(try_i = 0 ; try_i < TRY_PER_INTERRUPT ; try_i++) {
+    if(do_put_in_rtimer) {
+      if(interrupt_put_gen.generated_num < INTERRUPT_PUT_NUM) {
+        if(stream_control_try(&sc_interrupt_put) && do_put(&interrupt_put_gen)) {
+          RLOG_DBG("Interrupt put\n");
+        }
+        if(interrupt_put_gen.generated_num == INTERRUPT_PUT_NUM) {
+          stream_control_finish(&sc_interrupt_put);
+          RLOG_INFO("Interrupt put done\n");
+        }
+      }
+    } else if(enable_get) {
+      if(interrupt_store.current_num < INTERRUPT_GET_NUM) {
+        if(stream_control_try(&sc_interrupt_get) && do_get(&interrupt_store)) {
+          RLOG_DBG("Interrupt get\n");
+        }
+        if(interrupt_store.current_num == INTERRUPT_GET_NUM) {
+          stream_control_finish(&sc_interrupt_get);
+          RLOG_INFO("Interrupt get done\n");
+        }
+      }
+    }
+    do_put_in_rtimer = !do_put_in_rtimer;
+    if(stream_control_is_finished(&sc_interrupt_put)
+       && stream_control_is_finished(&sc_interrupt_get)) {
+      RLOG_INFO("Finished rtimer\n");
+      return;
+    }
+  }
+  schedule_rtimer();
+}
+/*---------------------------------------------------------------------------*/
+static int
+message_comparator(const void *a, const void *b)
+{
+  const msg_t *msg_a = (const msg_t *)a;
+  const msg_t *msg_b = (const msg_t *)b;
+  return
+    (*msg_a < *msg_b) ? -1
+    : (*msg_a > *msg_b) ? 1
+    : 0;
+}
+
+/**
+ * Verify the test result.
+ *
+ * \return Non-zero if it's ok. Zero otherwise.
+ */
+static int
+check_result(void)
+{
+  int index = 0;
+  int is_ok = 1;
+  int expected_diff = 0;
+  qsort(message_pool, MESSAGE_POOL_SIZE, sizeof(msg_t), message_comparator);
+  for(index = 0 ; index < NORMAL_GET_NUM + INTERRUPT_GET_NUM ; index++) {
+    int got = (int)message_pool[index];
+    if(got != index) {
+      int got_diff = got - index;
+      is_ok = 0;
+      if(got_diff != expected_diff) {
+        /* If it finds one element misplaced, basically the
+         * following elements are also misplaced. To suppress logs,
+         * we show an error message only when the difference
+         * changes.
+         */
+        LOG_ERR("message_pool[%d] = %d (should be %d, difference is %d)\n", index, got, index, got_diff);
+        expected_diff = got_diff;
+      }
+    }
+    watchdog_periodic();
+  }
+  for( ; index < MESSAGE_POOL_SIZE ; index++) {
+    if(message_pool[index] != 0xFFFF) {
+      is_ok = 0;
+      LOG_ERR("message_pool[%d] = %u (should be %u)\n", index, message_pool[index], 0xFFFF);
+    }
+    watchdog_periodic();
+  }
+  if(the_queue_elements(&queue_r) != 0) {
+    is_ok = 0;
+    LOG_ERR("%d elements still in the queue (should be 0)\n", the_queue_elements(&queue_r));
+  }
+  LOG_INFO("Check result: %s\n", is_ok ? "OK" : "NG");
+  LOG_INFO("Get num: normal:%lu interrupt:%lu\n", normal_store.current_num, interrupt_store.current_num);
+  LOG_INFO("Put num: normal:%lu interrupt:%lu\n", normal_put_gen.generated_num, interrupt_put_gen.generated_num);
+  LOG_INFO("Queue full:  normal:%lu interrupt:%lu\n", normal_put_gen.count_queue_full, interrupt_put_gen.count_queue_full);
+  LOG_INFO("Queue drain: normal:%lu interrupt:%lu\n", normal_store.count_queue_drain, interrupt_store.count_queue_drain);
+  LOG_INFO("Get duration: normal:%ld interrupt:%ld\n", (int32_t)stream_control_duration(&sc_normal_get), (int32_t)stream_control_duration(&sc_interrupt_get));
+  LOG_INFO("Put duration: normal:%ld interrupt:%ld\n", (int32_t)stream_control_duration(&sc_normal_put), (int32_t)stream_control_duration(&sc_interrupt_put));
+  return is_ok;
+}
+/*---------------------------------------------------------------------------*/
+PROCESS(normal_put, "normal PUT process");
+PROCESS_THREAD(normal_put, ev, data)
+{
+  PROCESS_BEGIN();
+  while(!stream_control_is_finished(&sc_normal_put)) {
+    PROCESS_PAUSE();
+    if(normal_put_gen.generated_num < NORMAL_PUT_NUM) {
+      if(stream_control_try(&sc_normal_put) && do_put(&normal_put_gen)) {
+        LOG_DBG("Normal put\n");
+        // check_intermediate_integrity();
+      }
+      if(normal_put_gen.generated_num == NORMAL_PUT_NUM) {
+        stream_control_finish(&sc_normal_put);
+        LOG_INFO("Normal put done\n");
+      }
+    }
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS(normal_get, "normal GET process");
+PROCESS_THREAD(normal_get, ev, data)
+{
+  PROCESS_BEGIN();
+  while(!stream_control_is_finished(&sc_normal_get)) {
+    PROCESS_PAUSE();
+    if(!enable_get) {
+      continue;
+    }
+    if(normal_store.current_num < NORMAL_GET_NUM) {
+      if(stream_control_try(&sc_normal_get) && do_get(&normal_store)) {
+        LOG_DBG("Normal get\n");
+        // check_intermediate_integrity();
+      }
+      if(normal_store.current_num == NORMAL_GET_NUM) {
+        stream_control_finish(&sc_normal_get);
+        LOG_INFO("Normal get done\n");
+      }
+    }
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS(main_process, "the main process");
+AUTOSTART_PROCESSES(&main_process);
+PROCESS_THREAD(main_process, ev, data)
+{
+  static struct etimer et_clean_up;
+  static struct timer test_timeout;
+  static uint16_t run_count = 0;
+  static int break_with_fail;
+
+  PROCESS_BEGIN();
+  random_init(node_id);
+  LOG_INFO("mpmc-ring-interrupt started.\n");
+
+  while(1) {
+    LOG_INFO("run_count = %u\n", run_count);
+    LOG_INFO("START_GET_NUM = %d\n", START_GET_NUM);
+    LOG_INFO("PUT_INTERVAL = %d\n", PUT_INTERVAL);
+    LOG_INFO("GET_INTERVAL = %d\n", GET_INTERVAL);
+    LOG_INFO("QUEUE_LEN = %d\n", QUEUE_LEN);
+    LOG_INFO("TRY_PER_INTERRUPT = %d\n", TRY_PER_INTERRUPT);
+    LOG_INFO("NORMAL_PUT_NUM = %d\n", NORMAL_PUT_NUM);
+    LOG_INFO("INTERRUPT_PUT_NUM = %d\n", INTERRUPT_PUT_NUM);
+    LOG_INFO("NORMAL_GET_NUM = %d\n", NORMAL_GET_NUM);
+    LOG_INFO("INTERRUPT_GET_NUM = %d\n", INTERRUPT_GET_NUM);
+    LOG_INFO("INTERRUPT_RTIMER_INTERVAL = %ld\n", INTERRUPT_RTIMER_INTERVAL);
+    LOG_INFO("USE_RINGBUFINDEX = %d\n", USE_RINGBUFINDEX);
+    LOG_INFO("TEST_TIMEOUT = %d\n", TEST_TIMEOUT);
+    break_with_fail = 0;
+    timer_set(&test_timeout, TEST_TIMEOUT * CLOCK_SECOND);
+    init_states();
+    schedule_rtimer();
+    process_start(&normal_get, NULL);
+    process_start(&normal_put, NULL);
+    PROCESS_PAUSE();
+  
+    while(1) {
+      PROCESS_PAUSE();
+      if(timer_expired(&test_timeout)) {
+        break_with_fail = 1;
+        LOG_ERR("Test timeout.\n");
+        break;
+      }
+      if(!enable_get && the_queue_elements(&queue_r) >= START_GET_NUM) {
+        enable_get = 1;
+      }
+      if(stream_control_is_finished(&sc_interrupt_put) && stream_control_is_finished(&sc_normal_put)) {
+        if(stream_control_is_finished(&sc_interrupt_get) && stream_control_is_finished(&sc_normal_get)) {
+          /* PUT and GET all finished. This is the normal end condition. */
+          break;
+        }
+      } else if(stream_control_is_finished(&sc_interrupt_get) && stream_control_is_finished(&sc_normal_get)) {
+        break_with_fail = 1;
+        LOG_ERR("Consumers finished, but producers are not finished yet.\n");
+        break;
+      }
+    }
+    if(!check_result() || break_with_fail) {
+      LOG_INFO("Now resetting..\n");
+      watchdog_reboot();
+    }
+    LOG_INFO("Stopping the test.\n");
+    stream_control_finish(&sc_normal_put);
+    stream_control_finish(&sc_normal_get);
+    stream_control_finish(&sc_interrupt_put);
+    stream_control_finish(&sc_interrupt_get);
+    etimer_set(&et_clean_up, CLOCK_SECOND * 5);
+    PROCESS_WAIT_UNTIL(etimer_expired(&et_clean_up));
+    PROCESS_WAIT_UNTIL(!process_is_running(&normal_get));
+    PROCESS_WAIT_UNTIL(!process_is_running(&normal_put));
+    LOG_INFO("The test stopped.\n");
+    run_count++;
+  }
+  PROCESS_END();
+}

--- a/examples/libs/mpmc-ring-interrupt/project-conf.h
+++ b/examples/libs/mpmc-ring-interrupt/project-conf.h
@@ -1,0 +1,105 @@
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+/*---------------------------------------------------------------------------*/
+
+/*
+ * The consumers start when the number of elements in the queue
+ * reaches this value.
+ */
+#define START_GET_NUM 0
+
+/*
+ * A producer puts one item per `PUT_INTERVAL` attempts. That is, if
+ * you set it to a big value, the producer becomes slow to produce a
+ * new value. This parameter, together with `GET_INTERVAL`, can be
+ * useful to test the cases where the traffic volume is unbalanced
+ * between producers and consumers.
+ */
+#define PUT_INTERVAL 1
+
+/*
+ * Same as `PUT_INTERVAL` but for consumers.
+ */
+#define GET_INTERVAL 1
+
+/*
+ * Length of the message queue.
+ */
+#define QUEUE_LEN 64
+
+/*
+ * Number of get or put trials done in a single call to the
+ * interrupt handler.
+ */
+#define TRY_PER_INTERRUPT 5
+
+/*---------------------------------------------------------------------------*/
+
+/*
+ * Number of messages that the normal producer puts.
+ */
+#define NORMAL_PUT_NUM 2500
+
+/*
+ * Number of messages that the interrupt producer puts.
+ */
+#define INTERRUPT_PUT_NUM 1500
+
+/*
+ * Number of messages that the normal consumer gets.
+ */
+#define NORMAL_GET_NUM 2500
+
+/*
+ * Number of messages that the interrupt consumer gets.
+ */
+#define INTERRUPT_GET_NUM 1500
+
+#if NORMAL_PUT_NUM + INTERRUPT_PUT_NUM != NORMAL_GET_NUM + INTERRUPT_GET_NUM
+#error Total of PUT_NUM must be equal to the total of GET_NUM
+#endif /* NORMAL_PUT_NUM + INTERRUPT_PUT_NUM != NORMAL_GET_NUM + INTERRUPT_GET_NUM */
+
+/*---------------------------------------------------------------------------*/
+
+/*
+ * Time interval of interrupts
+ */
+#define INTERRUPT_RTIMER_INTERVAL (US_TO_RTIMERTICKS(53))
+
+/*
+ * Extra delay for moving one message.
+ *
+ * The higher this value is, the more often that preemption between
+ * queue operations happens.
+ */
+#define MOVE_WAIT_COUNT 100
+
+/*
+ * If non-zero, use ringbufindex instead of mpmc-ring for queue
+ * implementation. This is to demonstrate danger of using
+ * ringbufindex in multi-producer multi-consumer scenarios.
+ */
+#define USE_RINGBUFINDEX 0
+
+/*
+ * Timeout interval in seconds. If the test doesn't finish in this
+ * interval, it's considered as a failure.
+ */
+#define TEST_TIMEOUT 120
+
+/*
+ * If non-zero, it prints log messages in the callback for rtimer,
+ * that is, in an interrupt context.
+ */
+#define ENABLE_LOG_IN_RTIMER 0
+
+
+/*
+ * Increase the watchdog timeout for testing.
+ */
+#if CONTIKI_TARGET_SIMPLELINK && CONTIKI_BOARD_LAUNCHPAD_CC1310
+#define WATCHDOG_CONF_TIMEOUT_MS 100000
+#endif /* CONTIKI_TARGET_SIMPLELINK && CONTIKI_BOARD_LAUNCHPAD_CC1310 */
+
+#endif /* PROJECT_CONF_H_ */

--- a/os/lib/mpmc-ring.c
+++ b/os/lib/mpmc-ring.c
@@ -1,0 +1,251 @@
+#include <string.h>
+#include "lib/assert.h"
+#include "sys/memory-barrier.h"
+#include "sys/critical.h"
+
+#include "mpmc-ring.h"
+
+/*----------------------------------------------------------------------------------------*/
+
+/*
+ * Implementation note: The implementation of this bounded mpmc queue
+ * is borrowed from the `heapless::mpmc` from Rust's `heapless` crate,
+ * https://docs.rs/heapless/. The Rust implementation is also based on
+ * a C++ implementation by Dmitry Vyukov,
+ * http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue.
+ *
+ * The mpmc queue maintains "sequence number" for each cell in the
+ * queue. The sequence number is maintained in such a way as:
+ *
+ * - cell[i] is empty    <=> seq[i] % size == i
+ * - cell[i] is occupied <=> seq[i] % size == i + 1
+ *
+ * The queue also maintains `get_pos` and `put_pos`. They runs in the
+ * whole domain of `uint8_t`. `(get_pos % size)` is the index of the
+ * cell to get an element from. `(put_pos % size)` is the index of the
+ * cell to put an element to. Those two position variables follow the
+ * rules below.
+ *
+ * - cell[get_pos % size] is empty    ==> seq[get_pos % size] == get_pos
+ * - cell[get_pos % size] is occupied ==> seq[get_pos % size] == get_pos + 1
+ * - cell[put_pos % size] is empty    ==> seq[put_pos % suze] == put_pos
+ * - cell[put_pos % size] is occupied ==> seq[put_pos % suze] == put_pos + 1 - size
+ *
+ * Example (1): The queue size == 8. "g(2)" means `get_pos == 2`,
+ * "p(6)" means `put_pos == 6`. Cells [2,3,4,5] are occupied, other
+ * cells are empty.
+ *
+ *     index    0   1   2   3   4   5   6   7
+ *           +---+---+---+---+---+---+---+---+
+ *     seq.  |  8|  9|  3|  4|  5|  6|  6|  7|
+ *           +---+---+---+---+---+---+---+---+
+ *                    ^               ^
+ *                    g(2)            p(6)
+ *
+ * Example (2): Cells [5,6,7,0,1] are occupied (wrapped at the
+ * boundary of 8), other cells are empty. The sequence number is used
+ * to tell if the cell is in a wrapped region or not. That is why the
+ * queue size must be <= 128.
+ *
+ *     index    0   1   2   3   4   5   6   7
+ *           +---+---+---+---+---+---+---+---+
+ *     seq.  | 41| 42| 42| 43| 44| 38| 39| 40|
+ *           +---+---+---+---+---+---+---+---+
+ *                    ^           ^
+ *                    p(42)       g(37)
+ *
+ * Example (3): All cells are occupied. The sequence number is wrapped
+ * at 256 boundary. Difference of sequence numbers is at most the size
+ * of the queue. So, if the queue size < 128, we can easily detect the
+ * wrapping at 256 boundary.
+ *
+ *     index    0   1   2   3   4   5   6   7
+ *           +---+---+---+---+---+---+---+---+
+ *     seq.  |  1|  2|  3|252|253|254|255|  0|
+ *           +---+---+---+---+---+---+---+---+
+ *                        ^
+ *                        g(251)
+ *                        p(3)
+ * 
+ *
+ * CAVEAT: In very limited scenarios, internal of mpmc-ring can get
+ * broken. For example,
+ *
+ * 1. Start `put_begin` on a non-full queue, such as the following.
+ *
+ *     index    0   1   2   3   4   5   6   7
+ *           +---+---+---+---+---+---+---+---+
+ *     seq.  | 48| 49| 43| 44| 45| 45| 46| 47|
+ *           +---+---+---+---+---+---+---+---+
+ *                      ^           ^
+ *                      g(42)       p(45)
+ *
+ * 2. An interrupt occurs during processing the `put_begin`, just
+ * after it calculates the `dif` (which is 0) but before executing
+ * `atomic_cas_uint8`.
+ *
+ * 3. In the interrupt, it executes (256 * N) put operations and
+ * some get operations (N is a natural number). In the end, the
+ * queue becomes full with the same `put_pos` as it had before the
+ * interrupt.
+ *
+ *     index    0   1   2   3   4   5   6   7
+ *           +---+---+---+---+---+---+---+---+
+ *     seq.  | 41| 42| 43| 44| 45| 38| 39| 40|
+ *           +---+---+---+---+---+---+---+---+
+ *                                  ^
+ *                                  g(37)
+ *                                  p(45)
+ *
+ * 4. The original `put_begin` resumes. Because `dif == 0`, it runs
+ * `atomic_cas_uint8`. Because the `put_pos` remains the same, it
+ * increments `put_pos`. However, because the queue is actually
+ * full, this is incorrect. This leads to loss of data stored in
+ * cell[5] in the above example.
+ *
+ *
+ * The above problem occurs when (1) an interrupt occurs inside
+ * `put_begin`, before executing `atomic_cas_uint8`, and (2) the
+ * interrupt changes the queue state from non-full to full, and (3)
+ * the interrupt runs (256 * N) put operations so that `put_pos`
+ * remains the same. The dual is also true for `get_begin` and
+ * non-empty queue. Anyway, I think the above condition is so rare.
+ *
+ */
+
+void
+mpmc_ring_init(mpmc_ring_t *ring)
+{
+  uint8_t i;
+
+  assert(ring->mask < 64);
+  assert(ring->mask > 0);
+  assert((ring->mask & (ring->mask + 1)) == 0);
+  
+  ring->put_pos = 0;
+  ring->get_pos = 0;
+  for(i = 0 ; i <= ring->mask ; i++) {
+    ring->sequences[i] = i;
+  }
+}
+
+int
+mpmc_ring_put_begin(mpmc_ring_t *ring, mpmc_ring_index_t *got_index)
+{
+  uint8_t pos;
+  uint8_t index;
+
+  assert(ring != NULL);
+  assert(got_index != NULL);
+  
+  pos = ring->put_pos;
+  memory_barrier();
+  while(1) {
+    int8_t dif;
+    index = pos & ring->mask;
+    dif = (int8_t)(ring->sequences[index]) - (int8_t)pos;
+    memory_barrier();
+    if(dif == 0) {
+      if(atomic_cas_uint8(&ring->put_pos, pos, pos + 1)) {
+        break;
+      }
+    } else if(dif < 0) {
+      return 0;
+    } else {
+      pos = ring->put_pos;
+      memory_barrier();
+    }
+  }
+  got_index->i = index;
+  got_index->_pos = pos;
+  return 1;
+}
+
+void
+mpmc_ring_put_commit(mpmc_ring_t *ring, const mpmc_ring_index_t *index)
+{
+  assert(ring != NULL);
+  assert(index != NULL);
+
+  ring->sequences[index->i] = index->_pos + 1;
+}
+
+int
+mpmc_ring_get_begin(mpmc_ring_t *ring, mpmc_ring_index_t *got_index)
+{
+  /* Basically the dual of put_begin */
+  uint8_t pos;
+  uint8_t index;
+
+  assert(ring != NULL);
+  assert(got_index != NULL);
+  
+  pos = ring->get_pos;
+  memory_barrier();
+  while(1) {
+    int8_t dif;
+    index = pos & ring->mask;
+    dif = (int8_t)(ring->sequences[index]) - (int8_t)(pos + 1);
+    memory_barrier();
+    if(dif == 0) {
+      if(atomic_cas_uint8(&ring->get_pos, pos, pos + 1)) {
+        break;
+      }
+    } else if(dif < 0) {
+      return 0;
+    } else {
+      pos = ring->get_pos;
+      memory_barrier();
+    }
+  }
+  got_index->i = index;
+  got_index->_pos = pos;
+  return 1;
+}
+
+void
+mpmc_ring_get_commit(mpmc_ring_t *ring, const mpmc_ring_index_t *index)
+{
+  assert(ring != NULL);
+  assert(index != NULL);
+
+  ring->sequences[index->i] = index->_pos + ring->mask + 1;
+}
+
+int
+mpmc_ring_elements(const mpmc_ring_t *ring)
+{
+  assert(ring != NULL);
+  int8_t dif = ((int8_t)ring->put_pos - (int8_t)ring->get_pos);
+  return dif;
+
+  /*
+   * The code below is necessary if we allow mpmc_ring of size
+   * 128. The else clause is especially for the case where size == 128
+   * && elements = 128.
+   *
+   * if(dif >= 0) {
+   *   return (int)dif;
+   * } else {
+   *   int ret = (int)dif;
+   *   while(ret <= 0) {
+   *     ret += ring->mask + 1;
+   *   }
+   *   return ret;
+   * }
+   */
+}
+
+int
+mpmc_ring_empty(const mpmc_ring_t *ring)
+{
+  return mpmc_ring_elements(ring) == 0;
+}
+
+uint8_t
+mpmc_ring_size(const mpmc_ring_t *ring)
+{
+  assert(ring != NULL);
+  return ring->mask + 1;
+}
+

--- a/os/lib/mpmc-ring.h
+++ b/os/lib/mpmc-ring.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2020, Toshiba Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \file
+ *         Multi-Producer Multi-Consumer lock-free ring buffer
+ * \author
+ *         Toshio Ito <toshio9.ito@toshiba.co.jp>
+ *
+ * mpmc-ring is analogous to ringbufindex, but it supports
+ * multi-producer, multi-consumer scenarios. To do that, mpmc-ring
+ * requires extra memory.
+ *
+ * mpmc-ring uses sys/atomic to arbitrate parallel accesses to the
+ * queue. If your platform implements sys/atomic by deferring
+ * interrupts, mpmc-queue also defers interrupts.
+ *
+ * To define and allocate a mpmc-ring object, use MPMC_RING macro. For
+ * basic usage, see tests/07-simulation-base/code-mpmc-ring and
+ * examples/libs/mpmc-ring-interrupt/mpmc-ring-interrupt.c, especially
+ * do_get and do_put functions.
+ */
+
+#ifndef _MPMC_RING_H_
+#define _MPMC_RING_H_
+
+#include "contiki.h"
+#include "sys/atomic.h"
+#include "sys/cc.h"
+
+/*----------------------------------------------------------------------------------------*/
+
+/**
+ * The multi-producer multi-consumer ring buffer.
+ *
+ * Do not declare and define struct mpmc_ring directly. Use
+ * MPMC_RING macro instead.
+ *
+ * All fields are private. Users should not read or write them.
+ */
+typedef struct mpmc_ring {
+  uint8_t put_pos;
+  uint8_t get_pos;
+  uint8_t * const sequences;
+  const uint8_t mask;
+} mpmc_ring_t;
+
+/**
+ * The array index managed by mpmc_ring.
+ */
+typedef struct mpmc_ring_index {
+  /**
+   * The index for the user-defined array that keeps the actual data
+   * structures. Users can read this field.
+   */
+  uint8_t i;
+
+  /**
+   * This field is private. Users should not read or write it.
+   */
+  uint8_t _pos;
+} mpmc_ring_index_t;
+
+/*----------------------------------------------------------------------------------------*/
+
+/**
+ * Declare and define a mpmc_ring.
+ *
+ * \param name Variable name of the mpmc_ring_t.
+ *
+ * \param size Size of the array that keeps the queue elements. Must
+ * be power of 2, and 0 < size <= 64.
+ */
+#define MPMC_RING(name, size)                                           \
+  static uint8_t CC_CONCAT(name,_sequences)[size];                      \
+  static mpmc_ring_t name = { 0, 0, CC_CONCAT(name,_sequences), (size) - 1 };
+
+/**
+ * Initialize the mpmc_ring.
+ */
+void mpmc_ring_init(mpmc_ring_t *ring);
+
+/**
+ * Start putting an element to the queue. Every call to
+ * mpmc_ring_put_begin must be finished by one and only call to
+ * mpmc_ring_put_commit.
+ *
+ * \param ring The mpmc_ring object
+ *
+ * \param got_index (output) The index that the caller should use to
+ * put an element.
+ *
+ * \retval 0 Failure. The queue is full. got_index is not modified.
+ * \retval 1 Success. got_index is modified.
+ */
+int mpmc_ring_put_begin(mpmc_ring_t *ring, mpmc_ring_index_t *got_index);
+
+/**
+ * Finish putting an element to the queue.
+ *
+ * \param ring The mpmc_ring object.
+ *
+ * \param index The index obtained by the matching call to
+ * mpmc_ring_put_begin.
+ *
+ */
+void mpmc_ring_put_commit(mpmc_ring_t *ring, const mpmc_ring_index_t *index);
+
+/**
+ * Start getting an element from the queue. Every call to
+ * mpmc_ring_get_begin must be finished by one and only call to
+ * mpmc_ring_get_commit.
+ *
+ * \param ring The mpmc_ring object
+ *
+ * \param got_index (output) The index that the caller should use to
+ * get an element.
+ *
+ * \retval 0 Failure. The queue is empty. got_index is not modified.
+ * \retval 1 Success. got_index is modified.
+ */
+int mpmc_ring_get_begin(mpmc_ring_t *ring, mpmc_ring_index_t *got_index);
+
+/**
+ * Finish getting an element to the queue.
+ *
+ * \param ring The mpmc_ring object.
+ *
+ * \param index The index obtained by the matching call to
+ * mpmc_ring_get_begin.
+ *
+ */
+void mpmc_ring_get_commit(mpmc_ring_t *ring, const mpmc_ring_index_t *index);
+
+/**
+ * \return Number of elements currently in the queue.
+ */
+int mpmc_ring_elements(const mpmc_ring_t *ring);
+
+/**
+ * \return Non-zero if the queue is empty. Zero otherwise.
+ */
+int mpmc_ring_empty(const mpmc_ring_t *ring);
+
+/**
+ * \return Number of elements that the queue can keep.
+ */
+uint8_t mpmc_ring_size(const mpmc_ring_t *ring);
+
+#endif /* _MPMC_RING_H_ */

--- a/tests/07-simulation-base/08-mpmc-ring.csc
+++ b/tests/07-simulation-base/08-mpmc-ring.csc
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>Test mpmc-ring</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype297</identifier>
+      <description>mpmc-ring testee</description>
+      <source>[CONFIG_DIR]/code-mpmc-ring/test-mpmc-ring.c</source>
+      <commands>make test-mpmc-ring.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiEEPROM
+        <eeprom>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</eeprom>
+      </interface_config>
+      <motetype_identifier>mtype297</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>1</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.TrafficVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <viewport>0.9090909090909091 0.0 0.0 0.9090909090909091 194.0 173.0</viewport>
+    </plugin_config>
+    <width>400</width>
+    <z>4</z>
+    <height>400</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1320</width>
+    <z>3</z>
+    <height>240</height>
+    <location_x>400</location_x>
+    <location_y>160</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.TimeLine
+    <plugin_config>
+      <mote>0</mote>
+      <showRadioRXTX />
+      <showRadioHW />
+      <showLEDs />
+      <zoomfactor>500.0</zoomfactor>
+    </plugin_config>
+    <width>1720</width>
+    <z>2</z>
+    <height>166</height>
+    <location_x>0</location_x>
+    <location_y>957</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Notes
+    <plugin_config>
+      <notes>Enter notes here</notes>
+      <decorations>true</decorations>
+    </plugin_config>
+    <width>1040</width>
+    <z>5</z>
+    <height>160</height>
+    <location_x>680</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <scriptfile>[CONFIG_DIR]/js/08-mpmc-ring.js</scriptfile>
+      <active>true</active>
+    </plugin_config>
+    <width>495</width>
+    <z>0</z>
+    <height>525</height>
+    <location_x>663</location_x>
+    <location_y>105</location_y>
+  </plugin>
+</simconf>

--- a/tests/07-simulation-base/code-mpmc-ring/Makefile
+++ b/tests/07-simulation-base/code-mpmc-ring/Makefile
@@ -1,0 +1,6 @@
+all: test-mpmc-ring
+
+MODULES += os/services/unit-test
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/tests/07-simulation-base/code-mpmc-ring/project-conf.h
+++ b/tests/07-simulation-base/code-mpmc-ring/project-conf.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, Toshio Ito
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#define UNIT_TEST_PRINT_FUNCTION test_print_report
+
+#endif /* !PROJECT_CONF_H_ */

--- a/tests/07-simulation-base/code-mpmc-ring/test-mpmc-ring.c
+++ b/tests/07-simulation-base/code-mpmc-ring/test-mpmc-ring.c
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2020, Toshio Ito
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "contiki.h"
+#include "sys/cc.h"
+#include "unit-test/unit-test.h"
+
+#include "lib/mpmc-ring.h"
+
+#define UTEST_RINGS(name,desc)                             \
+  UNIT_TEST_REGISTER(name##_2, desc ": size 2");           \
+  UNIT_TEST(name##_2) { name(utp, &ring2); }               \
+  UNIT_TEST_REGISTER(name##_32, desc ": size 32");         \
+  UNIT_TEST(name##_32) { name(utp, &ring32); }             \
+  UNIT_TEST_REGISTER(name##_64, desc ": size 64");       \
+  UNIT_TEST(name##_64) { name(utp, &ring64); }           \
+
+#define UTEST_RING_RUN(name)                    \
+  UNIT_TEST_RUN(name##_2);                      \
+  UNIT_TEST_RUN(name##_32);                     \
+  UNIT_TEST_RUN(name##_64);
+
+/*****************************************************************/
+
+PROCESS(test_process, "mpmc-ring test");
+AUTOSTART_PROCESSES(&test_process);
+
+static void
+init_index(mpmc_ring_index_t *i)
+{
+  i->i = 0;
+  i->_pos = 0;
+}
+
+void
+test_print_report(const unit_test_t *utp)
+{
+  printf("=check-me= ");
+  if(utp->result == unit_test_failure) {
+    printf("FAILED   - %s: exit at L%u\n", utp->descr, utp->exit_line);
+  } else {
+    printf("SUCCEEDED - %s\n", utp->descr);
+  }
+}
+
+static void
+test_init_get(unit_test_t *utp, mpmc_ring_t *ring)
+{
+  mpmc_ring_index_t index;
+  int is_success;
+  
+  UNIT_TEST_BEGIN();
+
+  mpmc_ring_init(ring);
+  UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == 0);
+  UNIT_TEST_ASSERT(mpmc_ring_empty(ring));
+  is_success = mpmc_ring_get_begin(ring, &index);
+  UNIT_TEST_ASSERT(!is_success);
+
+  UNIT_TEST_END();
+}
+
+static void
+test_put_get(unit_test_t *utp, mpmc_ring_t *ring)
+{
+  const int GET_COUNT = mpmc_ring_size(ring) / 2;
+  const int LOOP_NUM = 300;
+  mpmc_ring_index_t index;
+  int vals[128];
+  int put_val = 100;
+  int exp_val = put_val;
+  int got_val;
+  int i;
+  int is_success;
+
+  UNIT_TEST_BEGIN();
+
+  mpmc_ring_init(ring);
+
+  /* Put to full */
+  for(i = 0 ; i < mpmc_ring_size(ring) ; i++) {
+    init_index(&index);
+    is_success = mpmc_ring_put_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    vals[index.i] = put_val;
+    mpmc_ring_put_commit(ring, &index);
+    put_val++;
+
+    // if(i > 100) {
+    //   printf("Loop = %d, elems = %d, get_pos = %u, put_pos = %u\n",
+    //          i, mpmc_ring_elements(ring), ring->get_pos, ring->put_pos);
+    // }
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == i + 1);
+  }
+  init_index(&index);
+  is_success = mpmc_ring_put_begin(ring, &index);
+  UNIT_TEST_ASSERT(!is_success);
+
+  /* Get half-way */
+  for(i = 0 ; i < GET_COUNT ; i++) {
+    init_index(&index);
+    is_success = mpmc_ring_get_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    got_val = vals[index.i];
+    mpmc_ring_get_commit(ring, &index);
+    UNIT_TEST_ASSERT(got_val == exp_val);
+    exp_val++;
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == mpmc_ring_size(ring) - i - 1);
+  }
+
+  /* Put and get for a while */
+  for(i = 0 ; i < LOOP_NUM ; i++) {
+    init_index(&index);
+    is_success = mpmc_ring_put_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    vals[index.i] = put_val;
+    mpmc_ring_put_commit(ring, &index);
+    put_val++;
+
+    // printf("Loop = %d, elems = %d, get_pos = %u, put_pos = %u\n",
+    //        i, mpmc_ring_elements(ring), ring->get_pos, ring->put_pos);
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == mpmc_ring_size(ring) - GET_COUNT + 1);
+
+    init_index(&index);
+    is_success = mpmc_ring_get_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    got_val = vals[index.i];
+    mpmc_ring_get_commit(ring, &index);
+    UNIT_TEST_ASSERT(got_val == exp_val);
+    exp_val++;
+    
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == mpmc_ring_size(ring) - GET_COUNT);
+  }
+
+  /* Get to empty */
+  for(i = 0 ; i < mpmc_ring_size(ring) - GET_COUNT ; i++ ) {
+    init_index(&index);
+    is_success = mpmc_ring_get_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    got_val = vals[index.i];
+    mpmc_ring_get_commit(ring, &index);
+    UNIT_TEST_ASSERT(got_val == exp_val);
+    exp_val++;
+
+    // printf("Loop = %d, elems = %d, get_pos = %u, put_pos = %u\n",
+    //        i, mpmc_ring_elements(ring), ring->get_pos, ring->put_pos);
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == mpmc_ring_size(ring) - GET_COUNT - i - 1);
+  }
+  is_success = mpmc_ring_get_begin(ring, &index);
+  UNIT_TEST_ASSERT(!is_success);
+  
+  UNIT_TEST_END();
+}
+
+static void
+test_drain255(unit_test_t *utp, mpmc_ring_t *ring)
+{
+  mpmc_ring_index_t index;
+  int i;
+  int is_success;
+  int vals[128];
+  int got;
+  
+  UNIT_TEST_BEGIN();
+
+  mpmc_ring_init(ring);
+
+  for(i = 0 ; i < 255 ; i++) {
+    is_success = mpmc_ring_put_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    vals[index.i] = 77 + i;
+    mpmc_ring_put_commit(ring, &index);
+
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == 1);
+
+    is_success = mpmc_ring_get_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    got = vals[index.i];
+    mpmc_ring_get_commit(ring, &index);
+    UNIT_TEST_ASSERT(got == 77 + i);
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == 0);
+  }
+
+  // this should return failure immediately (without blocking)
+  is_success = mpmc_ring_get_begin(ring, &index);
+  UNIT_TEST_ASSERT(!is_success);
+  
+  UNIT_TEST_END();
+}
+
+static void
+test_full_at_wrapped0(unit_test_t *utp, mpmc_ring_t *ring)
+{
+  mpmc_ring_index_t index;
+  int i;
+  int is_success;
+  int vals[128];
+  int got;
+  
+  UNIT_TEST_BEGIN();
+
+  mpmc_ring_init(ring);
+
+  for(i = 0 ; i < 256 - (int)(mpmc_ring_size(ring)) ; i++) {
+    is_success = mpmc_ring_put_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    vals[index.i] = 77 + i;
+    mpmc_ring_put_commit(ring, &index);
+
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == 1);
+
+    is_success = mpmc_ring_get_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    got = vals[index.i];
+    mpmc_ring_get_commit(ring, &index);
+    UNIT_TEST_ASSERT(got == 77 + i);
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == 0);
+  }
+
+  for(i = 0 ; i < (int)(mpmc_ring_size(ring)) ; i++) {
+    is_success = mpmc_ring_put_begin(ring, &index);
+    UNIT_TEST_ASSERT(is_success);
+    vals[index.i] = 888;
+    mpmc_ring_put_commit(ring, &index);
+    UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == i + 1);
+  }
+
+  // this should return failure immediately (without blocking)
+  is_success = mpmc_ring_put_begin(ring, &index);
+  UNIT_TEST_ASSERT(!is_success);
+
+  UNIT_TEST_ASSERT(mpmc_ring_elements(ring) == mpmc_ring_size(ring));
+  
+  UNIT_TEST_END();
+}
+
+/*****************************************************************/
+
+MPMC_RING(ring2, 2);
+MPMC_RING(ring32, 32);
+MPMC_RING(ring64, 64);
+
+UTEST_RINGS(test_init_get, "Init and get");
+UTEST_RINGS(test_put_get, "Put and get");
+UTEST_RINGS(test_drain255, "Drain at pos 255");
+UTEST_RINGS(test_full_at_wrapped0, "Full at wrapped pos 0");
+
+PROCESS_THREAD(test_process, ev, data)
+{
+  PROCESS_BEGIN();
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UTEST_RING_RUN(test_init_get);
+  UTEST_RING_RUN(test_put_get);
+  UTEST_RING_RUN(test_drain255);
+  UTEST_RING_RUN(test_full_at_wrapped0);
+
+  printf("=check-me= DONE\n");
+  PROCESS_END();
+}

--- a/tests/07-simulation-base/js/08-mpmc-ring.js
+++ b/tests/07-simulation-base/js/08-mpmc-ring.js
@@ -1,0 +1,30 @@
+TIMEOUT(1000000, log.testFailed());
+
+var failed = false;
+
+while(true) {
+    YIELD();
+
+    log.log(time + " " + "node-" + id + " "+ msg + "\n");
+
+    if(msg.contains("Assertion failed")) {
+        failed = true;
+        break;
+    }
+
+    if(msg.contains("=check-me=") == false) {
+        continue;
+    }
+
+    if(msg.contains("FAILED")) {
+        failed = true;
+    }
+
+    if(msg.contains("DONE")) {
+        break;
+    }
+}
+if(failed) {
+    log.testFailed();
+}
+log.testOK();


### PR DESCRIPTION
An alternative solution to #883. Instead of modifying ringbufindex, I made a new data structure.

This pull-request adds a new data structure, os/lib/mpmc-ring, and its test program, examples/libs/mpmc-ring-interrupt. mpmc-ring is like ringbufindex, but it supports multi-producer multi-consumer scenarios. To do that, mpmc-ring requires extra memory to keep track of parallel transactions. I also added comments to ringbufindex's document that it's for the single-producer single-consumer scenario only.


## Test

I tested mpmc-ring with the example mpmc-ring-interrupt. The example program sets up two producers and two consumers in normal and interrupt contexts, streams messages through the queue and checks the output. See [README of the example](https://github.com/debug-ito/contiki-ng/blob/pr-mpmc-ring/examples/libs/mpmc-ring-interrupt/README.md) for detail.

Test environment:

- code: https://github.com/contiki-ng/contiki-ng/commit/c51a1998dc503ee6983a2180f587f42ccb191644
- hardware: CC1310 LaunchPad
- TARGET: simplelink
- BOARD: launchpad/cc1310
- compiler: the one in the Contiker

I ran the example with the following six configurations.

| Case | `START_GET_NUM` | `PUT_INTERVAL` | `GET_INTERVAL` | `QUEUE_LEN` | Note  |
| ---- | --------------- | -------------- | -------------- | ----------- | ----- |
| 1.   | 0               | 1              | 1              | 64          | The queue is always nearly empty. |
| 2.   | 32              | 1              | 1              | 64          | The queue is almost always half-occupied. |
| 3.   | 63              | 1              | 1              | 64          | The queue is almost always nearly full. |
| 4.   | 0               | 1              | 2              | 64          | The producer is faster.   |
| 5.   | 63              | 2              | 1              | 64          | The consumer is faster.   |
| 6.   | 0               | 1              | 2              | 256         | The producer is faster and the queue size is the maximum.  |

Using six different LaunchPads, I ran the above six cases in parallel for about 115 hours. Each LaunchPad ran about 70,000 trials with no errors.
