### PR TITLE
TSCH EB timer and documentation fix

### DIFF
--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -128,15 +128,6 @@ typedef unsigned long clock_time_t;
 
 #define UIP_ARCH_IPCHKSUM        1
 
-#if MAC_CONF_WITH_TSCH
-/* A bug in cooja causes many EBs to be missed at scan. Increase EB
-   frequency to shorten the join process */
-#undef TSCH_CONF_EB_PERIOD
-#define TSCH_CONF_EB_PERIOD (4 * CLOCK_SECOND)
-#undef TSCH_CONF_MAX_EB_PERIOD
-#define TSCH_CONF_MAX_EB_PERIOD (4 * CLOCK_SECOND)
-#endif /* MAC_CONF_WITH_TSCH */
-
 #define CFS_CONF_OFFSET_TYPE	long
 
 #define PLATFORM_CONF_SUPPORTS_STACK_CHECK  0

--- a/os/net/mac/tsch/tsch-conf.h
+++ b/os/net/mac/tsch/tsch-conf.h
@@ -71,14 +71,20 @@
 #define TSCH_DESYNC_THRESHOLD (2 * TSCH_MAX_KEEPALIVE_TIMEOUT)
 #endif
 
-/* Period between two consecutive EBs */
+/* The default period between two consecutive EBs (not taking into account any randomization).
+ * When TSCH_CONF_EB_PERIOD is set to 0, sending EBs is disabled completely; the EB process is not started.
+ * Otherwise, if RPL is used, TSCH_CONF_EB_PERIOD used only before joining the RPL network;
+ * afterwards, the EB period is set dynamically based on RPL DIO period, updated whenever
+ * the DIO period changes, and is upper bounded by TSCH_MAX_EB_PERIOD.
+ */
 #ifdef TSCH_CONF_EB_PERIOD
 #define TSCH_EB_PERIOD TSCH_CONF_EB_PERIOD
 #else
 #define TSCH_EB_PERIOD (16 * CLOCK_SECOND)
 #endif
 
-/* Max Period between two consecutive EBs */
+/* Max Period between two consecutive EBs.
+ * Has no effect when TSCH_EB_PERIOD is zero. */
 #ifdef TSCH_CONF_MAX_EB_PERIOD
 #define TSCH_MAX_EB_PERIOD TSCH_CONF_MAX_EB_PERIOD
 #else

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -1181,8 +1181,10 @@ turn_on(void)
     tsch_is_started = 1;
     /* Process tx/rx callback and log messages whenever polled */
     process_start(&tsch_pending_events_process, NULL);
-    /* periodically send TSCH EBs */
-    process_start(&tsch_send_eb_process, NULL);
+    if(TSCH_EB_PERIOD > 0) {
+      /* periodically send TSCH EBs */
+      process_start(&tsch_send_eb_process, NULL);
+    }
     /* try to associate to a network or start one if setup as coordinator */
     process_start(&tsch_process, NULL);
     LOG_INFO("starting as %s\n", tsch_is_coordinator ? "coordinator": "node");

--- a/os/net/mac/tsch/tsch.h
+++ b/os/net/mac/tsch/tsch.h
@@ -198,6 +198,11 @@ void tsch_set_join_priority(uint8_t jp);
  * not be set to exceed TSCH_MAX_EB_PERIOD. Set to 0 to stop sending EBs.
  * Actual transmissions are jittered, spaced by a random number within
  * [period*0.75, period[
+ * If RPL is used, the period will be automatically reset by RPL
+ * equal to the DIO period whenever the DIO period changes.
+ * Hence, calling `tsch_set_eb_period(0)` is NOT sufficient to disable sending EB!
+ * To do that, either configure the node in RPL leaf mode, or
+ * use static config for TSCH (`define TSCH_CONF_EB_PERIOD 0`).
  *
  * \param period The period in Clock ticks.
  */

--- a/tests/17-tun-rpl-br/02-border-router-cooja-tsch.csc
+++ b/tests/17-tun-rpl-br/02-border-router-cooja-tsch.csc
@@ -26,7 +26,7 @@
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/examples/rpl-border-router/border-router.c</source>
       <commands>make TARGET=cooja clean
-make -j border-router.cooja TARGET=cooja MAKE_MAC=MAKE_MAC_TSCH</commands>
+make -j border-router.cooja TARGET=cooja MAKE_MAC=MAKE_MAC_TSCH DEFINES=TSCH_CONF_DEFAULT_HOPPING_SEQUENCE=TSCH_HOPPING_SEQUENCE_1_1</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
@@ -52,7 +52,7 @@ make -j border-router.cooja TARGET=cooja MAKE_MAC=MAKE_MAC_TSCH</commands>
       <description>Cooja Mote Type #2</description>
       <source>[CONTIKI_DIR]/examples/hello-world/hello-world.c</source>
       <commands>make TARGET=cooja clean
-make -j hello-world.cooja TARGET=cooja MAKE_MAC=MAKE_MAC_TSCH</commands>
+make -j hello-world.cooja TARGET=cooja MAKE_MAC=MAKE_MAC_TSCH DEFINES=TSCH_CONF_DEFAULT_HOPPING_SEQUENCE=TSCH_HOPPING_SEQUENCE_1_1</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>


### PR DESCRIPTION
Two things:
1. Do not start TSCH EB sending process when the TSCH_EB_PERIOD is set to zero. Otherwise, the timer runs every tick and wastes CPU resources.
2. Document that `tsch_set_eb_period(0)` is not sufficient to turn off EB sending if RPL is used.