### PR TITLE
keep TSCH timesource state consistent with RPL parent state

### DIFF
--- a/os/net/mac/tsch/tsch-rpl.c
+++ b/os/net/mac/tsch/tsch-rpl.c
@@ -128,9 +128,8 @@ tsch_rpl_callback_new_dio_interval(clock_time_t dio_interval)
 void
 tsch_rpl_callback_parent_switch(rpl_parent_t *old, rpl_parent_t *new)
 {
-  /* Map the TSCH time source on the RPL preferred parent (but stick to the
-   * current time source if there is no preferred aarent) */
-  if(tsch_is_associated == 1 && new != NULL) {
+  /* Map the TSCH time source on the RPL preferred parent */
+  if(tsch_is_associated == 1) {
     tsch_queue_update_time_source(
       (const linkaddr_t *)uip_ds6_nbr_lladdr_from_ipaddr(
         rpl_parent_get_ipaddr(new)));


### PR DESCRIPTION
Fixes #890 and #877

Potentially fixes #608