### PR TITLE
add option to disable router solicitation

### DIFF
--- a/os/contiki-default-conf.h
+++ b/os/contiki-default-conf.h
@@ -130,6 +130,16 @@
 #endif /* UIP_CONF_TCP */
 #endif /* UIP_CONF_TCP_CONNS */
 
+/* UIP_CONF_ND6_SEND_RS enables standard IPv6 Router Solicitating.
+ * We enable it by default when IPv6 is used without RPL. */
+#ifndef UIP_CONF_ND6_SEND_RS
+#if (NETSTACK_CONF_WITH_IPV6 && !UIP_CONF_IPV6_RPL)
+#define UIP_CONF_ND6_SEND_RS 1
+#else /* NETSTACK_CONF_WITH_IPV6 && !UIP_CONF_IPV6_RPL */
+#define UIP_CONF_ND6_SEND_RS 0
+#endif /* NETSTACK_CONF_WITH_IPV6 && !UIP_CONF_IPV6_RPL */
+#endif /* UIP_CONF_ND6_SEND_RS */
+
 /* UIP_CONF_ND6_SEND_RA enables standard IPv6 Router Advertisement.
  * We enable it by default when IPv6 is used without RPL. */
 #ifndef UIP_CONF_ND6_SEND_RA

--- a/os/net/ipv6/tcpip.c
+++ b/os/net/ipv6/tcpip.c
@@ -401,7 +401,7 @@ eventhandler(process_event_t ev, process_data_t data)
           uip_ds6_periodic();
           tcpip_ipv6_output();
         }*/
-#if !UIP_CONF_ROUTER
+#if !UIP_CONF_ROUTER && UIP_ND6_SEND_RS
     if(data == &uip_ds6_timer_rs &&
         etimer_expired(&uip_ds6_timer_rs)) {
       uip_ds6_send_rs();

--- a/os/net/ipv6/uip-ds6.c
+++ b/os/net/ipv6/uip-ds6.c
@@ -66,8 +66,10 @@ static uint8_t racount;                                         /**< number of R
 static uint16_t rand_time;                                      /**< random time value for timers */
 #endif
 #else /* UIP_CONF_ROUTER */
+#if UIP_ND6_SEND_RS
 struct etimer uip_ds6_timer_rs;                                 /**< RS timer, to schedule RS sending */
 static uint8_t rscount;                                         /**< number of rs already sent */
+#endif /* UIP_ND6_SEND_RS */
 #endif /* UIP_CONF_ROUTER */
 
 /** \name "DS6" Data structures */
@@ -162,9 +164,11 @@ uip_ds6_init(void)
   stimer_set(&uip_ds6_timer_ra, 2);     /* wait to have a link local IP address */
 #endif /* UIP_ND6_SEND_RA */
 #else /* UIP_CONF_ROUTER */
+#if UIP_ND6_SEND_RS
   etimer_set(&uip_ds6_timer_rs,
              random_rand() % (UIP_ND6_MAX_RTR_SOLICITATION_DELAY *
                               CLOCK_SECOND));
+#endif /* UIP_ND6_SEND_RS */ 
 #endif /* UIP_CONF_ROUTER */
   etimer_set(&uip_ds6_timer_periodic, UIP_DS6_PERIOD);
 
@@ -728,6 +732,7 @@ uip_ds6_send_ra_periodic(void)
 
 #endif /* UIP_ND6_SEND_RA */
 #else /* UIP_CONF_ROUTER */
+#if UIP_ND6_SEND_RS
 /*---------------------------------------------------------------------------*/
 void
 uip_ds6_send_rs(void)
@@ -747,6 +752,7 @@ uip_ds6_send_rs(void)
   return;
 }
 
+#endif /* UIP_ND6_SEND_RS */
 #endif /* UIP_CONF_ROUTER */
 /*---------------------------------------------------------------------------*/
 uint32_t

--- a/os/net/ipv6/uip-ds6.h
+++ b/os/net/ipv6/uip-ds6.h
@@ -259,7 +259,9 @@ extern struct etimer uip_ds6_timer_periodic;
 #if UIP_CONF_ROUTER
 extern uip_ds6_prefix_t uip_ds6_prefix_list[UIP_DS6_PREFIX_NB];
 #else /* UIP_CONF_ROUTER */
+#if UIP_ND6_SEND_RS
 extern struct etimer uip_ds6_timer_rs;
+#endif /* UIP_ND6_SEND_RS */
 #endif /* UIP_CONF_ROUTER */
 
 
@@ -372,8 +374,10 @@ void uip_ds6_send_ra_sollicited(void);
 void uip_ds6_send_ra_periodic(void);
 #endif /* UIP_ND6_SEND_RA */
 #else /* UIP_CONF_ROUTER */
+#if UIP_ND6_SEND_RS
 /** \brief Send periodic RS to find router */
 void uip_ds6_send_rs(void);
+#endif /* UIP_ND6_SEND_RS */
 #endif /* UIP_CONF_ROUTER */
 
 /** \brief Compute the reachable time based on base reachable time, see RFC 4861*/

--- a/os/net/ipv6/uip-nd6.c
+++ b/os/net/ipv6/uip-nd6.c
@@ -801,7 +801,7 @@ uip_nd6_ra_output(uip_ipaddr_t * dest)
 #endif /* UIP_ND6_SEND_RA */
 #endif /* UIP_CONF_ROUTER */
 
-#if !UIP_CONF_ROUTER
+#if !UIP_CONF_ROUTER && UIP_ND6_SEND_RS
 /*---------------------------------------------------------------------------*/
 void
 uip_nd6_rs_output(void)
@@ -1096,7 +1096,7 @@ UIP_ICMP6_HANDLER(rs_input_handler, ICMP6_RS, UIP_ICMP6_HANDLER_CODE_ANY,
                   rs_input);
 #endif
 
-#if !UIP_CONF_ROUTER
+#if !UIP_CONF_ROUTER && UIP_ND6_SEND_RS
 UIP_ICMP6_HANDLER(ra_input_handler, ICMP6_RA, UIP_ICMP6_HANDLER_CODE_ANY,
                   ra_input);
 #endif
@@ -1120,8 +1120,8 @@ uip_nd6_init()
   uip_icmp6_register_input_handler(&rs_input_handler);
 #endif
 
-#if !UIP_CONF_ROUTER
-  /* Only process RAs if we are not a router */
+#if !UIP_CONF_ROUTER && UIP_ND6_SEND_RS
+  /* Only process RAs if we are not a router and happy to send out RSs */
   uip_icmp6_register_input_handler(&ra_input_handler);
 #endif
 }

--- a/os/net/ipv6/uip-nd6.c
+++ b/os/net/ipv6/uip-nd6.c
@@ -100,26 +100,26 @@
 #define ND6_OPT_RDNSS_BUF(opt)             ((uip_nd6_opt_dns *)ND6_OPT(opt))
 /** @} */
 
-#if UIP_ND6_SEND_NS || UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER
+#if UIP_ND6_SEND_NS || UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || (!UIP_CONF_ROUTER && UIP_ND6_SEND_RS)
 static uint8_t nd6_opt_offset;                     /** Offset from the end of the icmpv6 header to the option in uip_buf*/
 static uint8_t *nd6_opt_llao;   /**  Pointer to llao option in uip_buf */
 static uip_ds6_nbr_t *nbr; /**  Pointer to a nbr cache entry*/
 static uip_ds6_addr_t *addr; /**  Pointer to an interface address */
-#endif /* UIP_ND6_SEND_NS || UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER */
+#endif /* UIP_ND6_SEND_NS || UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || (!UIP_CONF_ROUTER && UIP_ND6_SEND_RS) */
 
-#if UIP_ND6_SEND_NS || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER
+#if UIP_ND6_SEND_NS || UIP_ND6_SEND_RA || (!UIP_CONF_ROUTER && UIP_ND6_SEND_RS)
 static uip_ds6_defrt_t *defrt; /**  Pointer to a router list entry */
-#endif /* UIP_ND6_SEND_NS || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER */
+#endif /* UIP_ND6_SEND_NS || UIP_ND6_SEND_RA || (!UIP_CONF_ROUTER && UIP_ND6_SEND_RS) */
 
-#if !UIP_CONF_ROUTER            // TBD see if we move it to ra_input
+#if (!UIP_CONF_ROUTER && UIP_ND6_SEND_RS)       // TBD see if we move it to ra_input
 static uip_nd6_opt_prefix_info *nd6_opt_prefix_info; /**  Pointer to prefix information option in uip_buf */
 static uip_ipaddr_t ipaddr;
 #endif
-#if (!UIP_CONF_ROUTER || UIP_ND6_SEND_RA)
+#if ((!UIP_CONF_ROUTER && UIP_ND6_SEND_RS) || UIP_ND6_SEND_RA)
 static uip_ds6_prefix_t *prefix; /**  Pointer to a prefix list entry */
 #endif
 
-#if UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER
+#if UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || (!UIP_CONF_ROUTER && UIP_ND6_SEND_RS)
 /*------------------------------------------------------------------*/
 /* Copy link-layer address from LLAO option to a word-aligned uip_lladdr_t */
 static int
@@ -130,7 +130,7 @@ extract_lladdr_from_llao_aligned(uip_lladdr_t *dest) {
   }
   return 0;
 }
-#endif /* UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER */
+#endif /* UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || (!UIP_CONF_ROUTER && UIP_ND6_SEND_RS) */
 /*------------------------------------------------------------------*/
 #if UIP_ND6_SEND_NA /* UIP_ND6_SEND_NA */
 /* create a llao */

--- a/os/net/ipv6/uip-nd6.h
+++ b/os/net/ipv6/uip-nd6.h
@@ -81,6 +81,11 @@
 
 /** \name RFC 4861 Router constants */
 /** @{ */
+#ifndef UIP_CONF_ND6_SEND_RS
+#define UIP_ND6_SEND_RS                     1   /* enable/disable RS sending */
+#else
+#define UIP_ND6_SEND_RS UIP_CONF_ND6_SEND_RS
+#endif
 #ifndef UIP_CONF_ND6_SEND_RA
 #define UIP_ND6_SEND_RA                     1   /* enable/disable RA sending */
 #else
@@ -401,6 +406,8 @@ void uip_nd6_ra_output(uip_ipaddr_t *dest);
 #endif /* UIP_ND6_SEND_RA */
 #endif /*UIP_CONF_ROUTER*/
 
+#if !UIP_CONF_ROUTER
+#if UIP_ND6_SEND_RS
 /**
  * \brief Send a Router Solicitation
  *
@@ -413,6 +420,8 @@ void uip_nd6_ra_output(uip_ipaddr_t *dest);
  * SHOULD be included otherwise
  */
 void uip_nd6_rs_output(void);
+#endif /* UIP_ND6_SEND_RS */
+#endif /*!UIP_CONF_ROUTER*/
 
 /**
  * \brief Initialise the uIP ND core


### PR DESCRIPTION
right now when rpl is used router advertisements are disabled, but router solicitation is enabled. Giving the weird behavior that leaf nodes send out router solicitations but never receive a response (router advertisement). So when using rpl I suggest that the sending of router solicitations is disabled.