### PR TITLE
uip-ds6-route: add a missing 'const' qualifier

### DIFF
--- a/os/net/ipv6/uip-ds6-route.c
+++ b/os/net/ipv6/uip-ds6-route.c
@@ -516,7 +516,7 @@ uip_ds6_route_rm(uip_ds6_route_t *route)
       /* If this was the only route using this neighbor, remove the
          neighbor from the table - this implicitly unlocks nexthop */
 #if LOG_WITH_ANNOTATE
-      uip_ipaddr_t *nexthop = uip_ds6_route_nexthop(route);
+      const uip_ipaddr_t *nexthop = uip_ds6_route_nexthop(route);
       if(nexthop != NULL) {
         LOG_ANNOTATE("#L %u 0\n", nexthop->u8[sizeof(uip_ipaddr_t) - 1]);
       }


### PR DESCRIPTION
Fix Issue #1177. More precisely, this fix is for https://github.com/contiki-ng/contiki-ng/issues/1177#issuecomment-576017558.

You can reproduce the issue using `examples/rpl-udp` with the following changes:

* add `MAKE_ROUTING = MAKE_ROUTING_RPL_CLASSIC` to `Makefile`
* create `project-conf.h` having `#define LOG_CONF_WITH_ANNOTATE 1`