### PR TITLE
MQTT: increase size of variable i to avoid potential infinite loop

### DIFF
--- a/os/net/app-layer/mqtt/mqtt.c
+++ b/os/net/app-layer/mqtt/mqtt.c
@@ -1111,12 +1111,14 @@ tcp_input(struct tcp_socket *s,
     conn->in_packet.payload_pos += copy_bytes;
     pos += copy_bytes;
 
+#if DEBUG_MQTT == 1
     uint32_t i;
     DBG("MQTT - Copied bytes: \n");
     for(i = 0; i < copy_bytes; i++) {
       DBG("%02X ", conn->in_packet.payload[i]);
     }
     DBG("\n");
+#endif
 
     /* Full buffer, shall only happen to PUBLISH messages. */
     if(MQTT_INPUT_BUFF_SIZE - conn->in_packet.payload_pos == 0) {

--- a/os/net/app-layer/mqtt/mqtt.c
+++ b/os/net/app-layer/mqtt/mqtt.c
@@ -1111,7 +1111,7 @@ tcp_input(struct tcp_socket *s,
     conn->in_packet.payload_pos += copy_bytes;
     pos += copy_bytes;
 
-    uint8_t i;
+    uint32_t i;
     DBG("MQTT - Copied bytes: \n");
     for(i = 0; i < copy_bytes; i++) {
       DBG("%02X ", conn->in_packet.payload[i]);


### PR DESCRIPTION
If compiled without any optimization, this debug loop can result in an infinite loop.

Special thanks to H2020 Vessedia (https://vessedia.eu/) the vulnerability report.