### PR TITLE
DIO after the rank changed

### DIFF
--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -853,7 +853,7 @@ rpl_select_dag(rpl_instance_t *instance, rpl_parent_t *p)
   } else if(best_dag->rank != old_rank) {
     LOG_DBG("RPL: Preferred parent update, rank changed from %u to %u\n",
            (unsigned)old_rank, best_dag->rank);
-	   rpl_reset_dio_timer(instance);
+	   	rpl_reset_dio_timer(instance);
   }
   return best_dag;
 }

--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -89,6 +89,7 @@ NBR_TABLE_GLOBAL(rpl_parent_t, rpl_parents);
 /* Allocate instance table. */
 rpl_instance_t instance_table[RPL_MAX_INSTANCES];
 rpl_instance_t *default_instance;
+int diff_rank=0;
 
 /*---------------------------------------------------------------------------*/
 void
@@ -853,7 +854,10 @@ rpl_select_dag(rpl_instance_t *instance, rpl_parent_t *p)
   } else if(best_dag->rank != old_rank) {
     LOG_DBG("RPL: Preferred parent update, rank changed from %u to %u\n",
            (unsigned)old_rank, best_dag->rank);
-	   	rpl_reset_dio_timer(instance);
+	   diff_rank=best_dag->rank - old_rank;
+           if(diff_rank>instance->min_hoprankinc-1 || (diff_rank<0 && diff_rank<(-1*instance->min_hoprankinc)+1)){
+              rpl_reset_dio_timer(instance);
+              }
   }
   return best_dag;
 }

--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -853,6 +853,7 @@ rpl_select_dag(rpl_instance_t *instance, rpl_parent_t *p)
   } else if(best_dag->rank != old_rank) {
     LOG_DBG("RPL: Preferred parent update, rank changed from %u to %u\n",
            (unsigned)old_rank, best_dag->rank);
+	   rpl_reset_dio_timer(instance);
   }
   return best_dag;
 }


### PR DESCRIPTION
I think maybe better to a node after changed own rank that awareness other nodes by sending multicast DIO message. If you are considering this modification arises unnecessary DIO traffic, we can add a threshold to prevent this. For example, if change been more than (minhop-1) thus, the DIO will send.

*in the current implementation, some time node rank change but other nodes don't get awareness about this change for several minutes