### PR TITLE
COOJA: Split DbgIO from serial

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/g-oikonomou/sensniff.git
 [submodule "tools/cooja"]
 	path = tools/cooja
-	url = https://github.com/contiki-ng/cooja.git
+	url = https://github.com/alexrayne/cooja.git
 [submodule "os/net/security/tinydtls"]
 	path = os/net/security/tinydtls
 	url = https://github.com/contiki-ng/tinydtls.git

--- a/arch/platform/cooja/dev/rs232.c
+++ b/arch/platform/cooja/dev/rs232.c
@@ -57,7 +57,7 @@ char simSerialReceivingData[SERIAL_BUF_SIZE];
  * */
 #define SERIAL_BUF_STOP 0x10000
 int simSerialReceivingLength = SERIAL_BUF_SIZE | SERIAL_BUF_STOP;
-char simSerialReceivingFlag;
+char simSerialReceivingFlag  = 0;
 
 char simSerialSendData[SERIAL_BUF_SIZE];
 int simSerialSendLength;
@@ -112,6 +112,10 @@ doInterfaceActionsBeforeTick(void)
   if (!simSerialReceivingFlag) {
     return;
   }
+
+  //wait for rs232_init
+  if (simSerialReceivingLength > SERIAL_BUF_STOP)
+      return;
 
   if (simSerialReceivingLength == 0) {
     /* Error, should not be zero */

--- a/arch/platform/cooja/dev/rs232.c
+++ b/arch/platform/cooja/dev/rs232.c
@@ -113,7 +113,8 @@ doInterfaceActionsBeforeTick(void)
     for (i=0; i < simSerialReceivingLength; i++) {
       serial_line_input_byte(simSerialReceivingData[i]);
     }
-    serial_line_input_byte(0x0a);
+    // intrude \n,  why this is here?
+    //serial_line_input_byte(0x0a);
   }
 
   simSerialReceivingLength = 0;

--- a/arch/platform/cooja/dev/rs232.c
+++ b/arch/platform/cooja/dev/rs232.c
@@ -88,12 +88,6 @@ rs232_print(char *message)
     simSerialSendFlag = 1;
 }
 /*-----------------------------------------------------------------------------------*/
-void
-slip_arch_writeb(unsigned char c)
-{
-    rs232_send(c);
-}
-/*-----------------------------------------------------------------------------------*/
 static void
 doInterfaceActionsBeforeTick(void)
 {

--- a/arch/platform/cooja/platform.c
+++ b/arch/platform/cooja/platform.c
@@ -59,6 +59,7 @@
 #include "net/queuebuf.h"
 
 #include "dev/eeprom.h"
+#include "dev/rs232.h"
 #include "dev/serial-line.h"
 #include "dev/cooja-radio.h"
 #include "dev/button-sensor.h"
@@ -189,6 +190,7 @@ platform_init_stage_three()
   eeprom_init();
   /* Start serial process */
   serial_line_init();
+  rs232_init();
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/platform/cooja/slip-arch.c
+++ b/arch/platform/cooja/slip-arch.c
@@ -37,3 +37,9 @@ slip_arch_init()
   rs232_set_input(slip_input_byte);
 }
 
+/*-----------------------------------------------------------------------------------*/
+void
+slip_arch_writeb(unsigned char c)
+{
+    rs232_send(c);
+}

--- a/arch/platform/cooja/slip-arch.c
+++ b/arch/platform/cooja/slip-arch.c
@@ -34,7 +34,6 @@
 void
 slip_arch_init()
 {
-  rs232_init();
   rs232_set_input(slip_input_byte);
 }
 

--- a/arch/platform/cooja/slip-arch.c
+++ b/arch/platform/cooja/slip-arch.c
@@ -34,6 +34,7 @@
 void
 slip_arch_init()
 {
+  rs232_init();
   rs232_set_input(slip_input_byte);
 }
 

--- a/arch/platform/cooja/sys/cooja-log.c
+++ b/arch/platform/cooja/sys/cooja-log.c
@@ -91,45 +91,12 @@ doInterfaceActionsAfterTick(void)
 {
 }
 /*-----------------------------------------------------------------------------------*/
-static int log_putchar_with_slip;
-void
-log_set_putchar_with_slip(int with)
-{
-  log_putchar_with_slip = with;
-}
-/*-----------------------------------------------------------------------------------*/
 #if IMPLEMENT_PRINTF
 int
 putchar(int c)
 {
-#define SLIP_END 0300
-  static char debug_frame = 0;
-
-  if(log_putchar_with_slip) {
-    simlog_char(SLIP_END);
-
-    if(!debug_frame) {		/* Start of debug output */
-      simlog_char(SLIP_END);
-      simlog_char('\r');	/* Type debug line == '\r' */
-      debug_frame = 1;
-    }
-
-    simlog_char((char)c);
-
-    /*
-     * Line buffered output, a newline marks the end of debug output and
-     * implicitly flushes debug output.
-     */
-    if(c == '\n') {
-      simlog_char(SLIP_END);
-      debug_frame = 0;
-    }
-
-    return c;
-  } else {
     simlog_char(c);
     return c;
-  }
 }
 /*-----------------------------------------------------------------------------------*/
 int


### PR DESCRIPTION
for COOJA: Splited DbgIO output via simlog_interface from serial via rs232_interface.
   This allow to separate serial data from debug print, and therefore we have pure
   serial connection with host.

* Initialy it was motivated by problems with tunslip6, like (issue #1261)[https://github.com/contiki-ng/contiki-ng/issues/1264], and that later has fixed by PR #1400 . If your app have problems to separate debug printing from communication data, this PR have sence.

+ have append receiver buffer protecting vs fill in not initialised state  (at start before init), 
and from overload by cooja interface - passing to cooja mote buffer size.

* this patch relay on split-cooja-dbg_serial patch ( look cooja PR#27), that provide SerialRS232  interface separated from DebugLog.
  Since it is triky to push patch to aside repo, look for it an github/alexrayne/cooja

* since cooja looks not maintained, it still in not buildabe state, so i migrate to cooja branch [PR #27](https://github.com/contiki-ng/cooja/pull/27) that supports this PR in buildable state.