### PR TITLE
cooja native exception hook for jni

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -74,3 +74,22 @@ ifeq ($(WERROR),1)
 CFLAGSNO += -Werror
 endif
 CFLAGS   += $(CFLAGSNO)
+
+
+# coffeecatch link with project, allow crash trace in JNI
+ifneq ("${WITH_COFFEE}",) 
+
+CONTIKI_TARGET_DIRS += lib/coffeecatch
+COOJA_BASE	+= coffeecatch.c coffeejni.c
+
+CFLAGS   += -funwind-tables
+CFLAGS   += -DUSE_UNWIND -DSIG_ABORT_SIGSEGV=1
+
+ifeq ("${WITH_COFFEE}",2)
+# use NDK_DEBUG=2 for debug coffeecatch internals
+CFLAGS   += -DNDK_DEBUG=2
+else
+CFLAGS   += -DNDK_DEBUG=0
+endif
+
+endif 


### PR DESCRIPTION
present any signal in native code aborts JNI machine, without any info. Therefore here
appends coffeecatch to cooja platform - it is signal/exception handler, that allow  transfer signals to JNI exception, and retrieve stacktrace.

* to include coffeecatch provide make command with  WITH_COFFEE=?
* WITH_COFFEE=2 - coffee use debuging mode - that logs all coffee mesages to
      moteN.coffee.log files

* this patch intended to use with support of stackdump in cooja. this provided by
   alexrayne/cooja:feature/fni-exception-handle

* at present coffecatch not very stable. i`ve frequently got abort signal on some internals of coffecacht hooks. debuging it - misterious quest. But, anyway, sometimes it provides helpful stackdump on contikimote code crash.