### PR TITLE
Don't build Cooja unless a travis test actually needs it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,6 @@ before_install:
       fi
     fi
 
-  # Build Cooja conditionally
-  - if [ ${BUILD_COOJA:-false} = true ] ; then
-      ant -q -f $CNG_HOST_PATH/tools/cooja/build.xml jar ;
-    fi
-
   # Create a directory for out of tree tests and clone the test repo therein
   # The directory will need created unconditionally so we can always chgrp and
   # mount it, even if empty. Checkout a pre-defined version.

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,18 +80,18 @@ env:
     - TEST_NAME='compile-base'
     - TEST_NAME='compile-arm-ports-01'
     - TEST_NAME='compile-arm-ports-02'
-    - TEST_NAME='rpl-lite' BUILD_COOJA=true
-    - TEST_NAME='rpl-classic' BUILD_COOJA=true
-    - TEST_NAME='tun-rpl-br' BUILD_COOJA=true
+    - TEST_NAME='rpl-lite'
+    - TEST_NAME='rpl-classic'
+    - TEST_NAME='tun-rpl-br'
     - TEST_NAME='coap-lwm2m'
     - TEST_NAME='script-base'
-    - TEST_NAME='simulation-base' BUILD_COOJA=true
-    - TEST_NAME='ieee802154' BUILD_COOJA=true
+    - TEST_NAME='simulation-base'
+    - TEST_NAME='ieee802154'
     - TEST_NAME='compile-nxp-ports'
     - TEST_NAME='documentation'
     - TEST_NAME='compile-tools'
     - TEST_NAME='native-runs'
-    - TEST_NAME='ipv6' BUILD_COOJA=true
-    - TEST_NAME='ipv6-nbr' BUILD_COOJA=true
+    - TEST_NAME='ipv6'
+    - TEST_NAME='ipv6-nbr'
     - TEST_NAME='out-of-tree-build'
     - TEST_NAME='packet-parsing'

--- a/tests/Makefile.script-test
+++ b/tests/Makefile.script-test
@@ -5,7 +5,7 @@ CONTIKI=../..
 
 all: clean summary
 
-summary: $(TESTLOGS)
+summary: cooja $(TESTLOGS)
 	@cat *.testlog > summary
 	@echo "========== Summary =========="
 	@cat summary
@@ -16,3 +16,8 @@ summary: $(TESTLOGS)
 
 clean:
 	@rm -f *.*log report summary
+
+cooja: $(CONTIKI)/tools/cooja/dist/cooja.jar
+
+$(CONTIKI)/tools/cooja/dist/cooja.jar:
+	(cd $(CONTIKI)/tools/cooja; ant jar)

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
   apt-get -qq -y --no-install-recommends install \
     ant \
     build-essential \
-    default-jdk \
     doxygen \
     gdb \
     git \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -100,7 +100,6 @@ RUN export uid=1000 gid=1000 && \
 USER user
 
 # Environment variables
-ENV JAVA_HOME           /usr/lib/jvm/default-java
 ENV HOME                /home/user
 ENV CONTIKI_NG          ${HOME}/contiki-ng
 ENV COOJA               ${CONTIKI_NG}/tools/cooja
@@ -113,6 +112,7 @@ RUN echo "#!/bin/bash\nant -Dbasedir=${COOJA} -f ${COOJA}/build.xml run" > ${HOM
 
 # Make sure we're using Java 8 for Cooja
 RUN sudo update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-i386
+ENV JAVA_HOME           /usr/lib/jvm/java-8-openjdk-i386/
 
 # Download, build and install Renode
 RUN git clone --quiet https://github.com/renode/renode.git \


### PR DESCRIPTION
Our testing system already builds Cooja when needed, so this pull removes the step to build it from `.travis.yml`.

Closes #1088