### PR TITLE
Add missing include

### DIFF
--- a/os/net/ipv6/uip-ds6.h
+++ b/os/net/ipv6/uip-ds6.h
@@ -43,6 +43,7 @@
 #define UIP_DS6_H_
 
 #include "net/ipv6/uip.h"
+#include "net/ipv6/multicast/uip-mcast6.h"
 #include "sys/stimer.h"
 /* The size of uip_ds6_addr_t depends on UIP_ND6_DEF_MAXDADNS. Include uip-nd6.h to define it. */
 #include "net/ipv6/uip-nd6.h"


### PR DESCRIPTION
MPL requires more space for interface multicast addresses. This is done by setting `UIP_CONF_DS6_MADDR_NBU` in `mpl.h`. For whatever reason, this configuration macro was getting picked up when building with RPL Classic but not with Lite, resulting in the table of interface multicast addresses being smaller than what we need.

This pull fixes this.

Fixes #1147

@RCfesk 