### PR TITLE
Allow the MQTT client example for platform Cooja

### DIFF
--- a/examples/mqtt-client/Makefile
+++ b/examples/mqtt-client/Makefile
@@ -10,6 +10,6 @@ MODULES += $(CONTIKI_NG_APP_LAYER_DIR)/mqtt
 
 MODULES_REL += arch/platform/$(TARGET)
 
-PLATFORMS_ONLY = cc26x0-cc13x0 cc2538dk openmote zoul native simplelink
+PLATFORMS_ONLY = cc26x0-cc13x0 cc2538dk openmote zoul native simplelink cooja
 
 include $(CONTIKI)/Makefile.include


### PR DESCRIPTION
There is no reason to disallow the cross-platform MQTT Client example for platform Cooja, but the platform is not listed under `PLATFORMS_ONLY`.

This pull fixes this.

Tested end-to-end inside docker, with:

* MQTT Client native cooja node
* Sky simulated BR inside Cooja
* tunslip6 outside Cooja talking to the simulated BR
* Mosquitto outside

Closes #1216

