### PR TITLE
TSCH: fix channel_offset in the logs if taken from a packet, and refactor TSCH channel / channel_offset selection inside a slot

### DIFF
--- a/os/net/mac/tsch/tsch-log.c
+++ b/os/net/mac/tsch/tsch-log.c
@@ -85,7 +85,7 @@ tsch_log_process_pending(void)
       printf("[INFO: TSCH-LOG  ] {asn %02x.%08lx link %2u %3u %3u %2u %2u ch %2u} ",
              log->asn.ms1b, log->asn.ls4b,
              log->link->slotframe_handle, sf ? sf->size.val : 0,
-             log->burst_count, log->link->timeslot + log->burst_count, log->link->channel_offset,
+             log->burst_count, log->link->timeslot + log->burst_count, log->channel_offset,
              log->channel);
     }
     switch(log->type) {
@@ -138,6 +138,7 @@ tsch_log_prepare_add(void)
     log->link = current_link;
     log->burst_count = tsch_current_burst_count;
     log->channel = tsch_current_channel;
+    log->channel_offset = tsch_current_channel_offset;
     return log;
   } else {
     log_dropped++;

--- a/os/net/mac/tsch/tsch-log.h
+++ b/os/net/mac/tsch/tsch-log.h
@@ -82,6 +82,7 @@ struct tsch_log_t {
   struct tsch_link *link;
   uint8_t burst_count;
   uint8_t channel;
+  uint8_t channel_offset;
   union {
     char message[48];
     struct {

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -149,8 +149,9 @@ static rtimer_clock_t volatile current_slot_start;
 /* Are we currently inside a slot? */
 static volatile int tsch_in_slot_operation = 0;
 
-/* If we are inside a slot, this tells the current channel */
+/* If we are inside a slot, these tell the current channel and channel offset */
 uint8_t tsch_current_channel;
+uint8_t tsch_current_channel_offset;
 
 /* Info about the link, packet and neighbor of
  * the current (or next) slot */
@@ -236,20 +237,34 @@ tsch_release_lock(void)
 /*---------------------------------------------------------------------------*/
 /* Channel hopping utility functions */
 
-/* Return channel from ASN and channel offset */
-uint8_t
-tsch_calculate_channel(struct tsch_asn_t *asn, uint16_t channel_offset, struct tsch_packet *p)
+/* Return the channel offset to use for the current slot */
+static uint8_t
+tsch_get_channel_offset(struct tsch_link *link, struct tsch_packet *p)
 {
-  uint16_t index_of_0, index_of_offset;
 #if TSCH_WITH_LINK_SELECTOR
   if(p != NULL) {
     uint16_t packet_channel_offset = queuebuf_attr(p->qb, PACKETBUF_ATTR_TSCH_CHANNEL_OFFSET);
     if(packet_channel_offset != 0xffff) {
       /* The schedule specifies a channel offset for this one; use it */
-      channel_offset = packet_channel_offset;
+      return packet_channel_offset;
     }
   }
 #endif
+  return link->channel_offset;
+}
+
+/**
+ * Returns a 802.15.4 channel from an ASN and channel offset. Basically adds
+ * The offset to the ASN and performs a hopping sequence lookup.
+ *
+ * \param asn A given ASN
+ * \param channel_offset Given channel offset
+ * \return The resulting channel
+ */
+static uint8_t
+tsch_calculate_channel(struct tsch_asn_t *asn, uint16_t channel_offset)
+{
+  uint16_t index_of_0, index_of_offset;
   index_of_0 = TSCH_ASN_MOD(*asn, tsch_hopping_sequence_length);
   index_of_offset = (index_of_0 + channel_offset) % tsch_hopping_sequence_length.val;
   return tsch_hopping_sequence[index_of_offset];
@@ -1024,8 +1039,8 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
           burst_link_scheduled = 0;
         } else {
           /* Hop channel */
-          tsch_current_channel = tsch_calculate_channel(&tsch_current_asn,
-              current_link->channel_offset, current_packet);
+          tsch_current_channel_offset = tsch_get_channel_offset(current_link, current_packet);
+          tsch_current_channel = tsch_calculate_channel(&tsch_current_asn, tsch_current_channel_offset);
         }
         NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, tsch_current_channel);
         /* Turn the radio on already here if configured so; necessary for radios with slow startup */

--- a/os/net/mac/tsch/tsch-slot-operation.h
+++ b/os/net/mac/tsch/tsch-slot-operation.h
@@ -63,16 +63,6 @@ extern int tsch_current_burst_count;
 /********** Functions *********/
 
 /**
- * Returns a 802.15.4 channel from an ASN and channel offset. Basically adds
- * The offset to the ASN and performs a hopping sequence lookup.
- *
- * \param asn A given ASN
- * \param channel_offset Link's channel offset
- * \param p Packet that can override the link's channel offset
- * \return The resulting channel
- */
-uint8_t tsch_calculate_channel(struct tsch_asn_t *asn, uint16_t channel_offset, struct tsch_packet *p);
-/**
  * Checks if the TSCH lock is set. Accesses to global structures outside of
  * interrupts must be done through the lock, unless the sturcutre has
  * atomic read/write

--- a/os/net/mac/tsch/tsch.h
+++ b/os/net/mac/tsch/tsch.h
@@ -161,8 +161,9 @@ extern const linkaddr_t tsch_eb_address;
 extern struct tsch_asn_t tsch_current_asn;
 extern uint8_t tsch_join_priority;
 extern struct tsch_link *current_link;
-/* If we are inside a slot, this tells the current channel */
+/* If we are inside a slot, these tell the current channel and channel offset */
 extern uint8_t tsch_current_channel;
+extern uint8_t tsch_current_channel_offset;
 /* TSCH channel hopping sequence */
 extern uint8_t tsch_hopping_sequence[TSCH_HOPPING_SEQUENCE_MAX_LEN];
 extern struct tsch_asn_divisor_t tsch_hopping_sequence_length;


### PR DESCRIPTION
Fixes #1181