### PR TITLE
MQTT: Provide the message id for subscribe, unsubscribe and publish

### DIFF
--- a/os/net/app-layer/mqtt/mqtt.c
+++ b/os/net/app-layer/mqtt/mqtt.c
@@ -1495,6 +1495,10 @@ mqtt_subscribe(struct mqtt_connection *conn, uint16_t *mid, char *topic,
   conn->out_packet.qos = qos_level;
   conn->out_packet.qos_state = MQTT_QOS_STATE_NO_ACK;
 
+  if(mid) {
+    *mid = conn->out_packet.mid;
+  }
+
   process_post(&mqtt_process, mqtt_do_subscribe_event, conn);
   return MQTT_STATUS_OK;
 }
@@ -1519,6 +1523,10 @@ mqtt_unsubscribe(struct mqtt_connection *conn, uint16_t *mid, char *topic)
   conn->out_packet.topic = topic;
   conn->out_packet.topic_length = strlen(topic);
   conn->out_packet.qos_state = MQTT_QOS_STATE_NO_ACK;
+
+  if(mid) {
+    *mid = conn->out_packet.mid;
+  }
 
   process_post(&mqtt_process, mqtt_do_unsubscribe_event, conn);
   return MQTT_STATUS_OK;
@@ -1551,6 +1559,10 @@ mqtt_publish(struct mqtt_connection *conn, uint16_t *mid, char *topic,
   conn->out_packet.payload_size = payload_size;
   conn->out_packet.qos = qos_level;
   conn->out_packet.qos_state = MQTT_QOS_STATE_NO_ACK;
+
+  if(mid) {
+    *mid = conn->out_packet.mid;
+  }
 
   process_post(&mqtt_process, mqtt_do_publish_event, conn);
   return MQTT_STATUS_OK;


### PR DESCRIPTION
The MQTT functions mqtt_subscribe, mqtt_unsubscribe and mqtt_publish all have a parameter `uint16_t *mid` to provide the caller of these functions with the message id created for the event. However, these functions do not set this variable which is addressed by this PR.