### PR TITLE
Fix Contiki-NG example building with TSCH adaptive timesync is disabled

### DIFF
--- a/os/net/mac/tsch/tsch-adaptive-timesync.c
+++ b/os/net/mac/tsch/tsch-adaptive-timesync.c
@@ -219,5 +219,11 @@ tsch_adaptive_timesync_reset(void)
 {
 }
 /*---------------------------------------------------------------------------*/
+long int
+tsch_adaptive_timesync_get_drift_ppm(void)
+{
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
 #endif /* TSCH_ADAPTIVE_TIMESYNC */
 /** @} */


### PR DESCRIPTION
Add dummy implementation of `tsch_adaptive_timesync_get_drift_ppm` when adaptive timesync is disabled, otherwise examples that use the shell module do not link.