### PR TITLE
cooja ContikiClock controling rTimer resolution and CLOCK_SECOND

### DIFF
--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -121,22 +121,13 @@ typedef unsigned long clock_time_t;
 /*  RTIMER_CONF_ARCH_SECOND definition requests cooja to simulate polling
  *      with demanded rtimer step.
  *  This helps achieve RTIMER_BUSYWAIT_UNTIL_ABS accuracy and behaviour close
- *      to real platforms.
- *  This demanded for well TSCH simulation/
+ *      to real platforms. This demanded for precise TSCH simulation
+ * WARN: change default behaviour of COOJA sim was not apropriated, so you should
+ *      provide RTIMER_CONF_ARCH_SECOND explicitly, if need simulate this BUSYWAIT precise
  */
-#ifndef RTIMER_CONF_ARCH_SECOND
+//#define RTIMER_CONF_ARCH_SECOND                     10000
 
-#if defined(MAC_CONF_WITH_TSCH)
-#define RTIMER_CONF_ARCH_SECOND                     10000
-#elif defined(NETSTACK_MAC)
 
-#   if (NETSTACK_MAC == tschmac_driver)
-#define RTIMER_CONF_ARCH_SECOND                     10000
-#   endif
-
-#endif
-
-#endif //RTIMER_CONF_ARCH_SECOND
 
 /* 1 len byte, 2 bytes CRC */
 #define RADIO_PHY_OVERHEAD         3

--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -118,6 +118,24 @@ typedef unsigned long clock_time_t;
 /* Use 64-bit rtimer (default in Contiki-NG is 32) */
 #define RTIMER_CONF_CLOCK_SIZE 8
 
+//  RTIMER_CONF_ARCH_SECOND definition requests cooja to simulate polling
+//      with demanded rtimer step.
+//   This helps achieve RTIMER_BUSYWAIT_UNTIL_ABS accuracy and behaviour close
+//      to real platforms. This demanded for well TSCH simulation
+#ifndef RTIMER_CONF_ARCH_SECOND
+
+#if defined(MAC_CONF_WITH_TSCH)
+#define RTIMER_CONF_ARCH_SECOND                     10000
+#elif defined(NETSTACK_MAC)
+
+#   if (NETSTACK_MAC == tschmac_driver)
+#define RTIMER_CONF_ARCH_SECOND                     10000
+#   endif
+
+#endif
+
+#endif //RTIMER_CONF_ARCH_SECOND
+
 /* 1 len byte, 2 bytes CRC */
 #define RADIO_PHY_OVERHEAD         3
 /* 250kbps data rate. One byte = 32us */

--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -118,10 +118,12 @@ typedef unsigned long clock_time_t;
 /* Use 64-bit rtimer (default in Contiki-NG is 32) */
 #define RTIMER_CONF_CLOCK_SIZE 8
 
-//  RTIMER_CONF_ARCH_SECOND definition requests cooja to simulate polling
-//      with demanded rtimer step.
-//   This helps achieve RTIMER_BUSYWAIT_UNTIL_ABS accuracy and behaviour close
-//      to real platforms. This demanded for well TSCH simulation
+/*  RTIMER_CONF_ARCH_SECOND definition requests cooja to simulate polling
+ *      with demanded rtimer step.
+ *  This helps achieve RTIMER_BUSYWAIT_UNTIL_ABS accuracy and behaviour close
+ *      to real platforms.
+ *  This demanded for well TSCH simulation/
+ */
 #ifndef RTIMER_CONF_ARCH_SECOND
 
 #if defined(MAC_CONF_WITH_TSCH)

--- a/arch/platform/cooja/lib/simEnvChange.h
+++ b/arch/platform/cooja/lib/simEnvChange.h
@@ -32,6 +32,7 @@
 #define SIMENVCHANGE_H_
 
 #include "contiki.h"
+#include <stdint.h>
 
 /* Simulation interface structure */
 struct simInterface {
@@ -44,6 +45,20 @@ extern int simProcessRunValue;
 extern int simEtimerPending;
 extern clock_time_t simEtimerNextExpirationTime;
 extern clock_time_t simCurrentTime;
+
+// ContikiClock API extention
+
+// @brief inform about mote eTimer clock rate
+// @value <= 0 - ignore it, use cooja old behaviour
+extern int          simCLOCK_SECOND;
+
+// @brief requests cooja for poll resolution with specified Hz
+// @value <= 0 - ignore it, use cooja old behaviour
+extern int          simRtimerResolution_hz;
+
+// @brief provide timeout for RTIMER_BUSYWAIT_UNTIL_ABS
+extern int64_t      simRtimerWaitTime;
+
 
 // Variable that when set to != 0, stops the mote from falling asleep next tick
 extern char simDontFallAsleep;

--- a/arch/platform/cooja/lib/simEnvChange.h
+++ b/arch/platform/cooja/lib/simEnvChange.h
@@ -28,6 +28,11 @@
  *
  */
 
+/**
+ * \addtogroup cooja_platform COOJA platform
+ * @{
+ */
+
 #ifndef SIMENVCHANGE_H_
 #define SIMENVCHANGE_H_
 
@@ -46,18 +51,29 @@ extern int simEtimerPending;
 extern clock_time_t simEtimerNextExpirationTime;
 extern clock_time_t simCurrentTime;
 
-// ContikiClock API extention
+/**
+ * \defgroup ContikiClock_ext ContikiClock API extention
+ * @{
+ *
+ * extention for an ContikiClock interface for rtimer resolution control
+ */
 
-// @brief inform about mote eTimer clock rate
-// @value <= 0 - ignore it, use cooja old behaviour
+/* inform about mote eTimer clock rate
+ * @value <= 0 - ignore it, use cooja old behaviour
+ */
 extern int          simCLOCK_SECOND;
 
-// @brief requests cooja for poll resolution with specified Hz
-// @value <= 0 - ignore it, use cooja old behaviour
+/* requests cooja for poll resolution with specified Hz
+ * @value <= 0 - ignore it, use cooja old behaviour
+ */
 extern int          simRtimerResolution_hz;
 
-// @brief provide timeout for RTIMER_BUSYWAIT_UNTIL_ABS
+// provide timeout for RTIMER_BUSYWAIT_UNTIL_ABS
 extern int64_t      simRtimerWaitTime;
+
+/**
+ * @}
+ */
 
 
 // Variable that when set to != 0, stops the mote from falling asleep next tick
@@ -80,3 +96,6 @@ void doActionsBeforeTick();
 void doActionsAfterTick();
 
 #endif /* SIMENVCHANGE_H_ */
+/**
+ * @}
+ */

--- a/arch/platform/cooja/rtimer-arch.c
+++ b/arch/platform/cooja/rtimer-arch.c
@@ -53,12 +53,24 @@ int simRtimerPending;
 rtimer_clock_t simRtimerNextExpirationTime;
 rtimer_clock_t simRtimerCurrentTicks;
 
+int64_t        simRtimerWaitTime = 0;
+
+#ifdef RTIMER_CONF_ARCH_SECOND
+int            simRtimerResolution_hz = RTIMER_CONF_ARCH_SECOND;
+#else
+#error "no RTIMER_CONF_ARCH_SECOND"
+int            simRtimerResolution_hz = 0;
+#endif
+
 /*---------------------------------------------------------------------------*/
 void
 rtimer_arch_init(void)
 {
   simRtimerNextExpirationTime = 0;
   simRtimerPending = 0;
+
+  (void) simRtimerResolution_hz;
+  (void) simRtimerWaitTime;
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/platform/cooja/rtimer-arch.c
+++ b/arch/platform/cooja/rtimer-arch.c
@@ -58,7 +58,6 @@ int64_t        simRtimerWaitTime = 0;
 #ifdef RTIMER_CONF_ARCH_SECOND
 int            simRtimerResolution_hz = RTIMER_CONF_ARCH_SECOND;
 #else
-#error "no RTIMER_CONF_ARCH_SECOND"
 int            simRtimerResolution_hz = 0;
 #endif
 

--- a/arch/platform/cooja/rtimer-arch.h
+++ b/arch/platform/cooja/rtimer-arch.h
@@ -52,9 +52,11 @@ rtimer_clock_t rtimer_arch_next(void);
 /** \brief A platform-specific implementation that calls cooja_mt_yield()
  * periodically. Without this, Cooja will get stuck in the busy-loop
  * without ever updating the current rtimer time. */
+extern int64_t      simRtimerWaitTime;
 #define RTIMER_BUSYWAIT_UNTIL_ABS(cond, t0, max_time) \
   ({                                                                \
     bool c;                                                         \
+    simRtimerWaitTime = (t0) + (max_time)+1;                        \
     while(!(c = cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), (t0) + (max_time))) { \
       simProcessRunValue = 1;                                       \
       cooja_mt_yield();                                             \

--- a/arch/platform/cooja/sys/clock.c
+++ b/arch/platform/cooja/sys/clock.c
@@ -31,7 +31,6 @@
 #include "contiki.h"
 #include "sys/clock.h"
 #include "lib/simEnvChange.h"
-#include <stdint.h>
 
 const struct simInterface clock_interface;
 

--- a/arch/platform/cooja/sys/clock.c
+++ b/arch/platform/cooja/sys/clock.c
@@ -31,11 +31,13 @@
 #include "contiki.h"
 #include "sys/clock.h"
 #include "lib/simEnvChange.h"
+#include <stdint.h>
 
 const struct simInterface clock_interface;
 
 // COOJA variables
 clock_time_t simCurrentTime;
+int         simCLOCK_SECOND = CLOCK_SECOND;
 
 /*-----------------------------------------------------------------------------------*/
 void
@@ -68,6 +70,7 @@ doInterfaceActionsBeforeTick(void)
 static void
 doInterfaceActionsAfterTick(void)
 {
+    (void)simCLOCK_SECOND;  //just to prevent garbage clenup
 }
 /*-----------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
this patch provide mote control of cooja ContikiClock controling rTimer resolution and CLOCK_SECOND. It works in cooperate with cooja PR#39 , that prvide cooja simulator support for resolution control.

Since resolution of mote polling was hard-fixed on 1ms, this accuracy not enough for TSCH stack simulate. A bit changes on slot-operation timing algorithm crushes abylity to syncheonise TSCH motes with each other, since this accuracy can`t be less then 1ms. (Present stack surprisingly takes into sync, buy with the cost of not accurate sync of transmition slot start - it is adjust transmition to 1ms granularity. Looks that sync achieves only with RTIMER_GUARD=0 ).

To provide cooja with accurate syncronise need allow RTIMER_BUSY_WAIT work with accuracy of rtmer, that demanded by TSCH stack about 32kHz. (but even 8kHz pretty enough).

This patch setup resolution by RTIMER_CONF_ARCH_SECOND config. TSCH stack by default setup this to 10khz. No any cooja sim project changes need to do - If cooja have PR#39, it takes RTIMER_CONF_ARCH_SECOND into account. 

So there:
+ resolution of system clock was fixed i cooja on 1kHz, now mote provide it by simCLOCK_SECOND

+ resolution for rTimer mote can provide by simRtimerResolution_hz. This affects cooja polling period of mote.
   By default, cooja polls mote by 1ms. But for accurate process better time precision
   need polling with less then 1ms. and rTimer ordinary much more precise.
   RTIMER_CONF_ARCH_SECOND config uses for this resolution declare.

+ RTIMER_BUSY_WAIT resolution was downgrade by cooja to 1ms. Now mote can provide time for precise wait via simRtimerWaitTime