### PR TITLE
Simplelink radio fixes

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-conf.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-conf.h
@@ -161,7 +161,7 @@
 
 /* Size of each RX buffer in bytes. */
 #ifndef RF_CONF_RX_BUF_SIZE
-#define RF_CONF_RX_BUF_SIZE          144
+#define RF_CONF_RX_BUF_SIZE          146
 #endif
 
 /* Enable/disable BLE beacon. */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-mode.c
@@ -611,7 +611,7 @@ cca_request(cmd_cca_req_t *cmd_cca_req)
     }
 
     /* Make sure RX is running before we continue, unless we timeout and fail */
-    RTIMER_BUSYWAIT_UNTIL(!rx_is_active(), TIMEOUT_ENTER_RX_WAIT);
+    RTIMER_BUSYWAIT_UNTIL(rx_is_active(), TIMEOUT_ENTER_RX_WAIT);
 
     if(!rx_is_active()) {
       LOG_ERR("CCA request failed to turn on RX, RX status=0x%04X\n", v_cmd_rx.status);

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
@@ -259,7 +259,7 @@ get_rssi(void)
     }
 
     /* Make sure RX is running before we continue, unless we timeout and fail */
-    RTIMER_BUSYWAIT_UNTIL(!rx_is_active(), TIMEOUT_ENTER_RX_WAIT);
+    RTIMER_BUSYWAIT_UNTIL(rx_is_active(), TIMEOUT_ENTER_RX_WAIT);
 
     if(!rx_is_active()) {
       LOG_ERR("RSSI measurement failed to turn on RX, RX status=0x%04X\n", v_cmd_rx.status);

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/sched.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/sched.c
@@ -261,12 +261,12 @@ netstack_sched_fs(void)
    *
    * For Prop-mode, the synth is always manually calibrated with CMD_FS.
    */
-#if (RF_MODE == RF_CORE_MODE_2_4_GHZ)
+#if (RF_MODE == RF_MODE_2_4_GHZ)
   if(rx_key) {
     cmd_rx_restore(rx_key);
     return RF_RESULT_OK;
   }
-#endif /* RF_MODE == RF_CORE_MODE_2_4_GHZ */
+#endif /* RF_MODE == RF_MODE_2_4_GHZ */
 
   RF_EventMask events;
   bool synth_error = false;


### PR DESCRIPTION
Before the TSCH driver can be developed, there are some fixes needed in the Simplelink platform. Discovered based on IEEE mode testing.