### PR TITLE
Do a full clone in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 notifications:
   email: false
 
+git:
+  depth: false
+
 # Environment setup before test script. Runs for each build
 before_install:
   # Construct the correct container image tag corresponding to this branch/pull


### PR DESCRIPTION
Currently travis does a shallow clone. This is likely to cause issues with the conditional docker image build logic. This commit removes the --depth argument altogether.