### PR TITLE
Add LGTM config for native C extraction

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,19 @@
+extraction:
+  cpp:
+    index:
+      build_command:
+      - "make -B TARGET=native -C examples/websocket/"
+      - "make -B TARGET=native -C examples/mqtt-client/"
+      - "make -B TARGET=native -C examples/mqtt-client/ DEFINES=MQTT_CONF_VERSION=MQTT_PROTOCOL_VERSION_5"
+      - "make -B TARGET=native -C examples/coap/coap-example-server/"
+      - "make -B TARGET=native -C examples/coap/coap-example-client/"
+      - "make -B TARGET=native -C examples/lwm2m-ipso-objects/"
+      - "make -B TARGET=native -C examples/multicast/"
+      - "make -B TARGET=native -C examples/rpl-border-router/"
+      - "make -B TARGET=native -C examples/snmp-server/"
+      - "make -B TARGET=native -C examples/libs/data-structures/"
+      - "make -B TARGET=native -C examples/libs/shell/"
+      - "make -B TARGET=native -C examples/libs/deployment/"
+      - "make -B TARGET=native -C examples/libs/trickle-library/"
+      - "make -B TARGET=native -C examples/libs/logging/"
+


### PR DESCRIPTION
[LGTM](https://lgtm.com/) (now owned by GitHub) is a "code analysis platform for finding zero-days and preventing critical vulnerabilities". It is free for open source project and it can be configured to [run automatically on each PR](https://lgtm.com/help/lgtm/managing-automated-code-review) by installing the GitHub App to the repository. It can then leave comments indicating if a PR fixes or introduces alerts. In addition, queries can be run post-analysis using their CodeQL semantic engine.

This PR adds a simple config file necessary for LGTM to correctly build several examples for the native platform. An aggregate report will be produced. You can see an example analysis [here](https://lgtm.com/projects/g/alexandruioanp/ctk-copy/?mode=list&lang=cpp&severity=error%2Cwarning) (I had to create a copy of the repo for testing as LGTM doesn't run on forks).
