### PR TITLE
Add optional support for X in our Vagrant image

### DIFF
--- a/tools/vagrant/bootstrap-vbox-with-x.sh
+++ b/tools/vagrant/bootstrap-vbox-with-x.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+sudo apt update
+
+# Install XFCE4 and VirtualBox Guest Additions
+sudo apt install -y xfce4 \
+  virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
+
+# Permit any user to fire up the desktop environment
+sudo sed -i 's/allowed_users=.*$/allowed_users=anybody/' /etc/X11/Xwrapper.config
+
+sudo VBoxClient --clipboard
+sudo VBoxClient --draganddrop
+sudo VBoxClient --display
+sudo VBoxClient --checkhostversion
+sudo VBoxClient --seamless


### PR DESCRIPTION
This PR provides the ability to optionally add the Xfce desktop environment to our Vagrant image when run with VirtualBox.

In order to make things work the user has to take some additional steps:

* Edit `tools/vagrant/Vagrantfile` and uncomment the following lines:

```
  # config.vm.provider "virtualbox" do |vb|
  #   # Display the VirtualBox GUI when booting the machine
  #   vb.gui = true
[...]
  # end
```
Within the commented block there is also a `  #   vb.memory = "1024"`. Leave that one commented.

* Create/Start/Provision the image as per the normal instructions
* Run `sudo ./contiki-ng/tools/vagrant/bootstrap-vbox-with-x.sh`.

This will install VirtualBox guest additions, X and the Xfce desktop environment.

* Start the image. This will now show the VirtualBox GUI.
* Login using username 'vagrant' and password 'vagrant'
* `sudo startx`

Wiki page will be updated once we have merged this.

ToDo: It should be possible to start Xfce as the vagrant user instead of root, but I have been unable to make this work. One of the required steps is to add the line below to `/etc/X11/Xwrapper.config`
```
allowed_users=anybody
```
The bootstrap script in this PR performs this step anyway.

I have also been unable to make guest desktop resolution to change with auto-resize, but that is not a problem since it can be changed manually. Alternatively, log out from Xfce, resize the VirtualBox GUI window and then startx again. The new session will scale up to fill the VirtualBox window...

Prompted by #781 