### PR TITLE
Add I2C manipulation module for platform Simplelink

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -56,7 +56,7 @@ CONTIKI_CPU_SOURCEFILES += watchdog-arch.c  dbg-arch.c
 CONTIKI_CPU_SOURCEFILES += uart0-arch.c     slip-arch.c
 CONTIKI_CPU_SOURCEFILES += gpio-hal-arch.c  int-master-arch.c
 CONTIKI_CPU_SOURCEFILES += random.c         trng-arch.c
-CONTIKI_CPU_SOURCEFILES += spi-arch.c
+CONTIKI_CPU_SOURCEFILES += spi-arch.c       i2c-arch.c
 
 # RF source files
 CONTIKI_CPU_SOURCEFILES += sched.c          data-queue.c

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/i2c-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/i2c-arch.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2020, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup cc13xx-cc26xx-i2c
+ * @{
+ *
+ * \file
+ *   Implementation of the I2C HAL driver for CC13xx/CC26xx.
+ *
+ * \author
+ *   Edvard Pettersen <e.pettersen@ti.com>
+ * \author
+ *   George Oikonomou <george@contiki-ng.org>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "i2c-arch.h"
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+bool
+i2c_arch_write_read(I2C_Handle i2c_handle, uint_least8_t slave_addr,
+                    void *wbuf, size_t wcount, void *rbuf,
+                    size_t rcount)
+{
+  I2C_Transaction i2cTransaction = {
+    .writeBuf = wbuf,
+    .writeCount = wcount,
+    .readBuf = rbuf,
+    .readCount = rcount,
+    .slaveAddress = slave_addr,
+  };
+
+  if(i2c_handle) {
+    return false;
+  }
+
+  return I2C_transfer(i2c_handle, &i2cTransaction);
+}
+/*---------------------------------------------------------------------------*/
+/* Releases the I2C Peripheral */
+void
+i2c_arch_release(I2C_Handle i2c_handle)
+{
+  if(!i2c_handle) {
+    return;
+  }
+
+  I2C_close(i2c_handle);
+}
+/*---------------------------------------------------------------------------*/
+I2C_Handle
+i2c_arch_acquire(uint_least8_t index)
+{
+  I2C_Params i2c_params;
+
+  I2C_Params_init(&i2c_params);
+
+  i2c_params.transferMode = I2C_MODE_BLOCKING;
+  i2c_params.bitRate = I2C_400kHz;
+
+  return I2C_open(index, &i2c_params);
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/i2c-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/i2c-arch.c
@@ -62,7 +62,7 @@ i2c_arch_write_read(I2C_Handle i2c_handle, uint_least8_t slave_addr,
     .slaveAddress = slave_addr,
   };
 
-  if(i2c_handle) {
+  if(!i2c_handle) {
     return false;
   }
 

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/i2c-arch.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/i2c-arch.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2020, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup cc13xx-cc26xx-cpu
+ * @{
+ *
+ * \defgroup cc13xx-cc26xx-i2c CC13xx/CC26xx I2C HAL
+ * @{
+ *
+ * \file
+ *   Implementation of the I2C HAL driver for CC13xx/CC26xx.
+ *
+ * \author
+ *   Edvard Pettersen <e.pettersen@ti.com>
+ * \author
+ *   George Oikonomou <george@contiki-ng.org>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef I2C_ARCH_H_
+#define I2C_ARCH_H_
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "board-conf.h"
+/*---------------------------------------------------------------------------*/
+#include <Board.h>
+
+#include <ti/devices/DeviceFamily.h>
+#include DeviceFamily_constructPath(driverlib/cpu.h)
+
+#include <ti/drivers/I2C.h>
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief One-time initialisation of the I2C Driver
+ *
+ * This function must be called before any other I2C driver calls.
+ */
+static inline void
+i2c_arch_init(void)
+{
+  I2C_init();
+}
+
+/**
+ * \brief Open and lock the I2C Peripheral for use
+ * \param index The index of the I2C controller
+ * \return An I2C Handle if successful, or NULL if an error occurs
+ *
+ * Must be called before each I2C transaction.
+ *
+ * When the function returns successfully, i2c_handle will be non-NULL and can
+ * be used in subsequent calls to perform an I2C transaction, for example with
+ * i2c_arch_write_read().
+ *
+ * index can take values among Board_I2Cx e.g. Board_I2C0
+ *
+ * At the end of the transaction, the caller should call i2c_arch_release() in
+ * order to allow other code files to use the I2C module
+ */
+I2C_Handle i2c_arch_acquire(uint_least8_t index);
+
+/**
+ * \brief Release the I2C Peripheral for other modules to use
+ * \param i2c_handle A pointer to an I2C handle
+ *
+ * Must be called after the end of each I2C transaction in order to allow
+ * other modules to use the I2C controller. The i2c_handle is obtained by
+ * an earlier call to i2c_arch_acquire()
+ */
+void i2c_arch_release(I2C_Handle i2c_handle);
+
+/**
+ * \brief              Setup and peform an I2C transaction.
+ * \param  i2c_handle  The I2C handle to use for this transaction
+ * \param  slave_addr  The address of the slave device on the I2C bus
+ * \param  wbuf        Write buffer during the I2C transation.
+ * \param  wcount      How many bytes in the write buffer
+ * \param  rbuf        Input buffer during the I2C transation.
+ * \param  rcount      How many bytes to read into rbuf.
+ * \retval true        The I2C operation was successful
+ * \retval false       The I2C operation failed
+ */
+bool i2c_arch_write_read(I2C_Handle i2c_handle, uint_least8_t slave_addr,
+                         void *wbuf, size_t wcount, void *rbuf, size_t rcount);
+
+/**
+ * \brief             Perform a write-only I2C transaction.
+ * \param  i2c_handle The I2C handle to use for this transaction
+ * \param  slave_addr The address of the slave device on the I2C bus
+ * \param  wbuf       Write buffer during the I2C transaction.
+ * \param  wcount     How many bytes in the write buffer
+ * \retval true       The I2C operation was successful
+ * \retval false      The I2C operation failed
+ */
+static inline bool
+i2c_arch_write(I2C_Handle i2c_handle, uint_least8_t slave_addr,
+               void *wbuf, size_t wcount)
+{
+  return i2c_arch_write_read(i2c_handle, slave_addr, wbuf, wcount, NULL, 0);
+}
+
+/**
+ * \brief             Perform a read-only I2C transaction.
+ * \param  i2c_handle The I2C handle to use for this transaction
+ * \param  slave_addr The address of the slave device on the I2C bus
+ * \param  rbuf       Input buffer during the I2C transaction.
+ * \param  rcount     How many bytes to read into rbuf.
+ * \retval true       The I2C operation was successful
+ * \retval false      The I2C operation failed
+ */
+static inline bool
+i2c_arch_read(I2C_Handle i2c_handle, uint_least8_t slave_addr, void *rbuf,
+              size_t rcount)
+{
+  return i2c_arch_write_read(i2c_handle, slave_addr, NULL, 0, rbuf, rcount);
+}
+/*---------------------------------------------------------------------------*/
+#endif /* I2C_ARCH_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/hdc-1000-sensor.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/hdc-1000-sensor.c
@@ -40,6 +40,7 @@
 #include "contiki.h"
 #include "sys/ctimer.h"
 #include "lib/sensors.h"
+#include "dev/i2c-arch.h"
 /*---------------------------------------------------------------------------*/
 #include "board-conf.h"
 #include "hdc-1000-sensor.h"
@@ -124,84 +125,6 @@ static volatile HDC_1000_SENSOR_STATUS sensor_status = HDC_1000_SENSOR_STATUS_DI
 static struct ctimer startup_timer;
 /*---------------------------------------------------------------------------*/
 /**
- * \brief         Setup and peform an I2C transaction.
- * \param wbuf    Output buffer during the I2C transation.
- * \param wcount  How many bytes in the wbuf.
- * \param rbuf    Input buffer during the I2C transation.
- * \param rcount  How many bytes to read into rbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static bool
-i2c_write_read(void *wbuf, size_t wcount, void *rbuf, size_t rcount)
-{
-  I2C_Transaction i2c_transaction = {
-    .writeBuf = wbuf,
-    .writeCount = wcount,
-    .readBuf = rbuf,
-    .readCount = rcount,
-    .slaveAddress = HDC1000_I2C_ADDRESS,
-  };
-
-  return I2C_transfer(i2c_handle, &i2c_transaction);
-}
-/**
- * \brief         Peform a write only I2C transaction.
- * \param wbuf    Output buffer during the I2C transation.
- * \param wcount  How many bytes in the wbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static inline bool
-i2c_write(void *wbuf, size_t wcount)
-{
-  return i2c_write_read(wbuf, wcount, NULL, 0);
-}
-/**
- * \brief         Peform a read only I2C transaction.
- * \param rbuf    Input buffer during the I2C transation.
- * \param rcount  How many bytes to read into rbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static inline bool
-i2c_read(void *rbuf, size_t rcount)
-{
-  return i2c_write_read(NULL, 0, rbuf, rcount);
-}
-/*---------------------------------------------------------------------------*/
-/* Releases the I2C Peripheral */
-static void
-i2c_release(void)
-{
-  I2C_close(i2c_handle);
-  i2c_handle = NULL;
-}
-/*---------------------------------------------------------------------------*/
-/* Acquires the I2C Peripheral */
-static bool
-i2c_acquire(void)
-{
-  I2C_Params i2c_params;
-
-  if(i2c_handle) {
-    return true;
-  }
-
-  I2C_Params_init(&i2c_params);
-
-  i2c_params.transferMode = I2C_MODE_BLOCKING;
-  i2c_params.bitRate = I2C_400kHz;
-
-  i2c_handle = I2C_open(Board_I2C0, &i2c_params);
-  if(i2c_handle == NULL) {
-    return false;
-  }
-
-  return true;
-}
-/*---------------------------------------------------------------------------*/
-/**
  * \brief   Initialize the HDC-1000 sensor driver.
  * \return  true if I2C operation successful; else, return false.
  */
@@ -210,17 +133,19 @@ sensor_init(void)
 {
   bool rv;
 
-  if(!i2c_acquire()) {
-    i2c_release();
+  i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+  if(!i2c_handle) {
     return false;
   }
 
   /* Enable reading data in one operation */
   uint8_t config_data[] = { HDC1000_REG_CONFIG, LSB16(HDC1000_VAL_CONFIG) };
 
-  rv = i2c_write(config_data, sizeof(config_data));
+  rv = i2c_arch_write(i2c_handle, HDC1000_I2C_ADDRESS, config_data,
+                      sizeof(config_data));
 
-  i2c_release();
+  i2c_arch_release(i2c_handle);
 
   return rv;
 }
@@ -235,13 +160,16 @@ start(void)
   bool rv;
   uint8_t temp_reg[] = { HDC1000_REG_TEMP };
 
-  if(!i2c_acquire()) {
+  i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+  if(!i2c_handle) {
     return false;
   }
 
-  rv = i2c_write(temp_reg, sizeof(temp_reg));
+  rv = i2c_arch_write(i2c_handle, HDC1000_I2C_ADDRESS, temp_reg,
+                      sizeof(temp_reg));
 
-  i2c_release();
+  i2c_arch_release(i2c_handle);
 
   return rv;
 }
@@ -272,19 +200,21 @@ notify_ready(void *unused)
   /* Unused args */
   (void)unused;
 
-  if(!i2c_acquire()) {
-    i2c_release();
+  i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+  if(!i2c_handle) {
     return;
   }
 
   /* Latch readings */
-  if(i2c_read(&sensor_data, sizeof(sensor_data))) {
+  if(i2c_arch_read(i2c_handle, HDC1000_I2C_ADDRESS, &sensor_data,
+                   sizeof(sensor_data))) {
     sensor_status = HDC_1000_SENSOR_STATUS_READINGS_READY;
   } else {
     sensor_status = HDC_1000_SENSOR_STATUS_I2C_ERROR;
   }
 
-  i2c_release();
+  i2c_arch_release(i2c_handle);
 
   sensors_changed(&hdc_1000_sensor);
 }

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/mpu-9250-sensor.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/mpu-9250-sensor.c
@@ -40,6 +40,7 @@
 #include "contiki.h"
 #include "lib/sensors.h"
 #include "sys/rtimer.h"
+#include "dev/i2c-arch.h"
 /*---------------------------------------------------------------------------*/
 #include "board-conf.h"
 #include "mpu-9250-sensor.h"
@@ -235,53 +236,6 @@ static struct ctimer startup_timer;
 #define delay_ms(ms)    CPUdelay((ms) * 1000 * 48 / 7)
 /*---------------------------------------------------------------------------*/
 /**
- * \brief         Setup and peform an I2C transaction.
- * \param wbuf    Output buffer during the I2C transation.
- * \param wcount  How many bytes in the wbuf.
- * \param rbuf    Input buffer during the I2C transation.
- * \param rcount  How many bytes to read into rbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static bool
-i2c_write_read(void *wbuf, size_t wcount, void *rbuf, size_t rcount)
-{
-  I2C_Transaction i2c_transaction = {
-    .writeBuf = wbuf,
-    .writeCount = wcount,
-    .readBuf = rbuf,
-    .readCount = rcount,
-    .slaveAddress = MPU_9250_I2C_ADDRESS,
-  };
-
-  return I2C_transfer(i2c_handle, &i2c_transaction);
-}
-/**
- * \brief         Peform a write only I2C transaction.
- * \param wbuf    Output buffer during the I2C transation.
- * \param wcount  How many bytes in the wbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static inline bool
-i2c_write(void *wbuf, size_t wcount)
-{
-  return i2c_write_read(wbuf, wcount, NULL, 0);
-}
-/**
- * \brief         Peform a read only I2C transaction.
- * \param rbuf    Input buffer during the I2C transation.
- * \param rcount  How many bytes to read into rbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static inline bool
-i2c_read(void *rbuf, size_t rcount)
-{
-  return i2c_write_read(NULL, 0, rbuf, rcount);
-}
-/*---------------------------------------------------------------------------*/
-/**
  * \brief   Initialize the MPU-9250 sensor driver.
  * \return  true if I2C operation successful; else, return false.
  */
@@ -290,17 +244,6 @@ sensor_init(void)
 {
   pin_handle = PIN_open(&pin_state, mpu_9250_pin_table);
   if(pin_handle == NULL) {
-    return false;
-  }
-
-  I2C_Params i2cParams;
-  I2C_Params_init(&i2cParams);
-  i2cParams.transferMode = I2C_MODE_BLOCKING;
-  i2cParams.bitRate = I2C_400kHz;
-
-  i2c_handle = I2C_open(Board_I2C0, &i2cParams);
-  if(i2c_handle == NULL) {
-    PIN_close(&pin_state);
     return false;
   }
 
@@ -319,11 +262,11 @@ sensor_sleep(void)
 {
   {
     uint8_t all_axes_data[] = { REG_PWR_MGMT_2, PWR_MGMT_2_VAL_ALL_AXES };
-    i2c_write(all_axes_data, sizeof(all_axes_data));
+    i2c_arch_write(i2c_handle, MPU_9250_I2C_ADDRESS, all_axes_data, sizeof(all_axes_data));
   }
   {
     uint8_t mpu_sleep_data[] = { REG_PWR_MGMT_1, PWR_MGMT_1_VAL_MPU_SLEEP };
-    i2c_write(mpu_sleep_data, sizeof(mpu_sleep_data));
+    i2c_arch_write(i2c_handle, MPU_9250_I2C_ADDRESS, mpu_sleep_data, sizeof(mpu_sleep_data));
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -335,23 +278,23 @@ sensor_wakeup(void)
 {
   {
     uint8_t mpu_wakeup_data[] = { REG_PWR_MGMT_1, PWR_MGMT_1_VAL_MPU_WAKE_UP };
-    i2c_write(mpu_wakeup_data, sizeof(mpu_wakeup_data));
+    i2c_arch_write(i2c_handle, MPU_9250_I2C_ADDRESS, mpu_wakeup_data, sizeof(mpu_wakeup_data));
   }
   {
     /* All axis initially disabled */
     uint8_t all_axes_data[] = { REG_PWR_MGMT_2, PWR_MGMT_2_VAL_ALL_AXES };
-    i2c_write(all_axes_data, sizeof(all_axes_data));
+    i2c_arch_write(i2c_handle, MPU_9250_I2C_ADDRESS, all_axes_data, sizeof(all_axes_data));
   }
   {
     /* Restore the range */
     uint8_t accel_cfg_data[] = { REG_ACCEL_CONFIG, mpu_9250.acc_range };
-    i2c_write(accel_cfg_data, sizeof(accel_cfg_data));
+    i2c_arch_write(i2c_handle, MPU_9250_I2C_ADDRESS, accel_cfg_data, sizeof(accel_cfg_data));
   }
   {
     /* Clear interrupts */
     uint8_t int_status_data[] = { REG_INT_STATUS };
     uint8_t dummy;
-    i2c_write_read(int_status_data, sizeof(int_status_data), &dummy, 1);
+    i2c_arch_write_read(i2c_handle, MPU_9250_I2C_ADDRESS, int_status_data, sizeof(int_status_data), &dummy, 1);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -360,14 +303,14 @@ sensor_set_acc_range(MPU_9250_SENSOR_ACC_RANGE acc_range)
 {
   /* Apply the range */
   uint8_t accel_cfg_data[] = { REG_ACCEL_CONFIG, acc_range };
-  i2c_write(accel_cfg_data, sizeof(accel_cfg_data));
+  i2c_arch_write(i2c_handle, MPU_9250_I2C_ADDRESS, accel_cfg_data, sizeof(accel_cfg_data));
 }
 /*---------------------------------------------------------------------------*/
 static void
 sensor_set_axes(MPU_9250_SENSOR_TYPE sensor_type)
 {
   uint8_t _data[] = { REG_PWR_MGMT_2, ~(uint8_t)sensor_type };
-  i2c_write(_data, sizeof(_data));
+  i2c_arch_write(i2c_handle, MPU_9250_I2C_ADDRESS, _data, sizeof(_data));
 }
 /*---------------------------------------------------------------------------*/
 static void
@@ -393,7 +336,7 @@ static bool
 sensor_data_ready(uint8_t *int_status)
 {
   uint8_t int_status_data[] = { REG_INT_STATUS };
-  const bool spi_ok = i2c_write_read(int_status_data, sizeof(int_status_data), int_status, 1);
+  const bool spi_ok = i2c_arch_write_read(i2c_handle, MPU_9250_I2C_ADDRESS, int_status_data, sizeof(int_status_data), int_status, 1);
 
   return spi_ok && (*int_status != 0);
 }
@@ -411,7 +354,7 @@ acc_read(uint8_t int_status, uint16_t *data)
 
   /* Burst read of all accelerometer values */
   uint8_t accel_xout_h[] = { REG_ACCEL_XOUT_H };
-  bool spi_ok = i2c_write_read(accel_xout_h, sizeof(accel_xout_h), data, DATA_SIZE);
+  bool spi_ok = i2c_arch_write_read(i2c_handle, MPU_9250_I2C_ADDRESS, accel_xout_h, sizeof(accel_xout_h), data, DATA_SIZE);
   if(!spi_ok) {
     return false;
   }
@@ -434,7 +377,7 @@ gyro_read(uint8_t int_status, uint16_t *data)
 
   /* Burst read of all accelerometer values */
   uint8_t gyro_xout_h[] = { REG_GYRO_XOUT_H };
-  bool spi_ok = i2c_write_read(gyro_xout_h, sizeof(gyro_xout_h), data, DATA_SIZE);
+  bool spi_ok = i2c_arch_write_read(i2c_handle, MPU_9250_I2C_ADDRESS, gyro_xout_h, sizeof(gyro_xout_h), data, DATA_SIZE);
   if(!spi_ok) {
     return false;
   }
@@ -491,6 +434,12 @@ initialise_cb(void *unused)
     return;
   }
 
+  i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+  if(!i2c_handle) {
+    return;
+  }
+
   /* Wake up the sensor */
   sensor_wakeup();
 
@@ -502,6 +451,8 @@ initialise_cb(void *unused)
   /* Enable gyro + accelerometer readout */
   sensor_set_axes(mpu_9250.type);
   delay_ms(10);
+
+  i2c_arch_release(i2c_handle);
 
   ctimer_set(&startup_timer, SENSOR_STARTUP_DELAY, notify_ready_cb, NULL);
 }
@@ -524,10 +475,17 @@ value(int type)
     return MPU_9250_READING_ERROR;
   }
 
+  i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+  if(!i2c_handle) {
+    return MPU_9250_READING_ERROR;
+  }
+
   uint8_t int_status = 0;
   const rtimer_clock_t t0 = RTIMER_NOW();
   while(!sensor_data_ready(&int_status)) {
     if(!(RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + READING_WAIT_TIMEOUT))) {
+      i2c_arch_release(i2c_handle);
       return MPU_9250_READING_ERROR;
     }
   }
@@ -539,8 +497,11 @@ value(int type)
   if((type & MPU_9250_SENSOR_TYPE_ACC) != 0) {
 
     if(!acc_read(int_status, sensor_value)) {
+      i2c_arch_release(i2c_handle);
       return MPU_9250_READING_ERROR;
     }
+
+    i2c_arch_release(i2c_handle);
 
     PRINTF("MPU: ACC = 0x%04x 0x%04x 0x%04x = ",
            sensor_value[0], sensor_value[1], sensor_value[2]);
@@ -557,8 +518,11 @@ value(int type)
   } else if((type & MPU_9250_SENSOR_TYPE_GYRO) != 0) {
 
     if(!gyro_read(int_status, sensor_value)) {
+      i2c_arch_release(i2c_handle);
       return MPU_9250_READING_ERROR;
     }
+
+    i2c_arch_release(i2c_handle);
 
     PRINTF("MPU: Gyro = 0x%04x 0x%04x 0x%04x = ",
            sensor_value[0], sensor_value[1], sensor_value[2]);
@@ -617,9 +581,18 @@ configure(int type, int enable)
       ctimer_stop(&startup_timer);
 
       if(PIN_getOutputValue(Board_MPU_POWER)) {
+        i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+        if(!i2c_handle) {
+          PIN_setOutputValue(pin_handle, Board_MPU_POWER, 0);
+
+          return MPU_9250_SENSOR_STATUS_DISABLED;
+        }
+
         sensor_sleep();
 
-        I2C_cancel(i2c_handle);
+        i2c_arch_release(i2c_handle);
+
         PIN_setOutputValue(pin_handle, Board_MPU_POWER, 0);
       }
 

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/opt-3001-sensor.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/opt-3001-sensor.c
@@ -40,6 +40,7 @@
 #include "contiki.h"
 #include "lib/sensors.h"
 #include "sys/ctimer.h"
+#include "dev/i2c-arch.h"
 /*---------------------------------------------------------------------------*/
 #include "board-conf.h"
 #include "opt-3001-sensor.h"
@@ -148,86 +149,6 @@ static struct ctimer startup_timer;
 static I2C_Handle i2c_handle;
 /*---------------------------------------------------------------------------*/
 /**
- * \brief         Setup and peform an I2C transaction.
- * \param wbuf    Output buffer during the I2C transation.
- * \param wcount  How many bytes in the wbuf.
- * \param rbuf    Input buffer during the I2C transation.
- * \param rcount  How many bytes to read into rbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static bool
-i2c_write_read(void *wbuf, size_t wcount, void *rbuf, size_t rcount)
-{
-  I2C_Transaction i2c_transaction = {
-    .writeBuf = wbuf,
-    .writeCount = wcount,
-    .readBuf = rbuf,
-    .readCount = rcount,
-    .slaveAddress = OPT_3001_I2C_ADDRESS,
-  };
-
-  return I2C_transfer(i2c_handle, &i2c_transaction);
-}
-/**
- * \brief         Peform a write only I2C transaction.
- * \param wbuf    Output buffer during the I2C transation.
- * \param wcount  How many bytes in the wbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static inline bool
-i2c_write(void *wbuf, size_t wcount)
-{
-  return i2c_write_read(wbuf, wcount, NULL, 0);
-}
-/**
- * \brief         Peform a read only I2C transaction.
- * \param rbuf    Input buffer during the I2C transation.
- * \param rcount  How many bytes to read into rbuf.
- * \return        true if the I2C operation was successful;
- *                else, return false.
- */
-static inline bool
-i2c_read(void *rbuf, size_t rcount)
-{
-  return i2c_write_read(NULL, 0, rbuf, rcount);
-}
-/*---------------------------------------------------------------------------*/
-/* Releases the I2C Peripheral */
-static void
-i2c_release(void)
-{
-  I2C_close(i2c_handle);
-  i2c_handle = NULL;
-}
-/*---------------------------------------------------------------------------*/
-/* Acquires the I2C Peripheral */
-static bool
-i2c_acquire(void)
-{
-  I2C_Params i2c_params;
-
-  if(i2c_handle) {
-    return true;
-  }
-
-  I2C_Params_init(&i2c_params);
-
-  i2c_params.transferMode = I2C_MODE_BLOCKING;
-  i2c_params.bitRate = I2C_400kHz;
-
-  i2c_handle = I2C_open(Board_I2C0, &i2c_params);
-  if(i2c_handle == NULL) {
-    return false;
-  }
-
-  opt_3001.status = OPT_3001_STATUS_DISABLED;
-
-  return true;
-}
-/*---------------------------------------------------------------------------*/
-/**
  * \brief         Turn the sensor on/off
  * \param enable  Enable sensor if true; else, disable sensor.
  */
@@ -239,17 +160,20 @@ sensor_enable(bool enable)
     ? CFG_ENABLE_SINGLE_SHOT
     : CFG_DISABLE;
 
-  if(!i2c_acquire()) {
+  i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+  if(!i2c_handle) {
     opt_3001.status = OPT_3001_STATUS_I2C_ERROR;
-    i2c_release();
+    i2c_arch_release(i2c_handle);
     return false;
   }
 
   uint8_t cfg_data[] = { REG_CONFIGURATION, LSB16(data) };
 
-  rv = i2c_write(cfg_data, sizeof(cfg_data));
+  rv = i2c_arch_write(i2c_handle, OPT_3001_I2C_ADDRESS, cfg_data,
+                      sizeof(cfg_data));
 
-  i2c_release();
+  i2c_arch_release(i2c_handle);
 
   return rv;
 }
@@ -262,10 +186,12 @@ notify_ready_cb(void *unused)
 {
   /* Unused args */
   (void)unused;
+  bool rv;
 
-  if(!i2c_acquire()) {
+  i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+  if(!i2c_handle) {
     opt_3001.status = OPT_3001_STATUS_I2C_ERROR;
-    i2c_release();
     return;
   }
 
@@ -278,10 +204,12 @@ notify_ready_cb(void *unused)
   uint8_t cfg_data[] = { REG_CONFIGURATION };
   uint16_t cfg_value = 0;
 
-  bool spi_ok = i2c_write_read(cfg_data, sizeof(cfg_data), &cfg_value, sizeof(cfg_value));
-  if(!spi_ok) {
+  rv = i2c_arch_write_read(i2c_handle, OPT_3001_I2C_ADDRESS, cfg_data,
+                           sizeof(cfg_data), &cfg_value,
+                           sizeof(cfg_value));
+  if(!rv) {
     opt_3001.status = OPT_3001_STATUS_I2C_ERROR;
-    i2c_release();
+    i2c_arch_release(i2c_handle);
     return;
   }
 
@@ -292,7 +220,7 @@ notify_ready_cb(void *unused)
     ctimer_set(&startup_timer, SENSOR_STARTUP_DELAY, notify_ready_cb, NULL);
   }
 
-  i2c_release();
+  i2c_arch_release(i2c_handle);
 }
 /*---------------------------------------------------------------------------*/
 /**
@@ -305,12 +233,15 @@ value(int type)
 {
   /* Unused args */
   (void)type;
+  bool rv;
 
   if(opt_3001.status != OPT_3001_STATUS_DATA_READY) {
     return OPT_3001_READING_ERROR;
   }
 
-  if(!i2c_acquire()) {
+  i2c_handle = i2c_arch_acquire(Board_I2C0);
+
+  if(!i2c_handle) {
     opt_3001.status = OPT_3001_STATUS_I2C_ERROR;
     return OPT_3001_READING_ERROR;
   }
@@ -318,18 +249,22 @@ value(int type)
   uint8_t cfg_data[] = { REG_CONFIGURATION };
   uint16_t cfg_value = 0;
 
-  bool spi_ok = i2c_write_read(cfg_data, sizeof(cfg_data), &cfg_value, sizeof(cfg_value));
-  if(!spi_ok) {
+  rv = i2c_arch_write_read(i2c_handle, OPT_3001_I2C_ADDRESS, cfg_data,
+                           sizeof(cfg_data), &cfg_value, sizeof(cfg_value));
+  if(!rv) {
     opt_3001.status = OPT_3001_STATUS_I2C_ERROR;
+    i2c_arch_release(i2c_handle);
     return OPT_3001_READING_ERROR;
   }
 
   uint8_t result_data[] = { REG_RESULT };
   uint16_t result_value = 0;
 
-  spi_ok = i2c_write_read(result_data, sizeof(result_data), &result_value, sizeof(result_value));
-  i2c_release();
-  if(!spi_ok) {
+  rv = i2c_arch_write_read(i2c_handle, OPT_3001_I2C_ADDRESS, result_data,
+                           sizeof(result_data), &result_value,
+                           sizeof(result_value));
+  i2c_arch_release(i2c_handle);
+  if(!rv) {
     opt_3001.status = OPT_3001_STATUS_I2C_ERROR;
     return OPT_3001_READING_ERROR;
   }


### PR DESCRIPTION
All Simplelink sensortag sensing element drivers implement I2C transactions and bus manipulation internally using static functions. This creates a lot of code duplication.

This work in progress moves all those functions to a new module and makes them re-usable. It also changes all affected drivers to use those new functions.

This will be very handy once we have finalised our I2C HAL (#1242), since the new module implemented here is where we'd put all of the HAL's arch-specific functions.

~Requires #1283~