### PR TITLE
Fix sensortag reed relay logic

### DIFF
--- a/arch/platform/cc26x0-cc13x0/sensortag/board-buttons.c
+++ b/arch/platform/cc26x0-cc13x0/sensortag/board-buttons.c
@@ -47,7 +47,7 @@
 /*---------------------------------------------------------------------------*/
 BUTTON_HAL_BUTTON(reed_relay, "Reed Relay", BOARD_IOID_REED_RELAY, \
                   GPIO_HAL_PIN_CFG_PULL_DOWN, \
-                  BOARD_BUTTON_HAL_INDEX_REED_RELAY, true);
+                  BOARD_BUTTON_HAL_INDEX_REED_RELAY, false);
 
 BUTTON_HAL_BUTTON(key_left, "Key Left", BOARD_IOID_KEY_LEFT, \
                   GPIO_HAL_PIN_CFG_PULL_UP, BOARD_BUTTON_HAL_INDEX_KEY_LEFT, \

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/button-sensor-arch.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/button-sensor-arch.c
@@ -71,7 +71,7 @@ BUTTON_HAL_BUTTON(
   GPIO_HAL_PIN_CFG_PULL_DOWN |
   GPIO_HAL_PIN_CFG_HYSTERESIS,  /**< Pull configuration */
   BUTTON_HAL_ID_REED_RELAY,     /**< Unique ID */
-  true);                        /**< Negative logic */
+  false);                       /**< Negative logic */
 /*---------------------------------------------------------------------------*/
 BUTTON_HAL_BUTTONS(&key_left, &key_right, &reed_relay);
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The button HAL is configured to use negative logic (active: low) for the sensortag's reed relay. This is incorrect, the reed is actually active high. This commit fixes the behaviour for both platforms that support sensortags.