### PR TITLE
Improve ENERGEST support for platform Simplelink

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/platform.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/platform.c
@@ -44,6 +44,7 @@
 #include "sys/rtimer.h"
 #include "sys/node-id.h"
 #include "sys/platform.h"
+#include "sys/energest.h"
 #include "dev/button-hal.h"
 #include "dev/gpio-hal.h"
 #include "dev/serial-line.h"
@@ -276,6 +277,7 @@ platform_idle(void)
    */
   if(clock_arch_enter_idle()) {
     /* Drop to some low power mode */
+    ENERGEST_SWITCH(ENERGEST_TYPE_CPU, ENERGEST_TYPE_LPM);
     Power_idleFunc();
     /*
      * Clear the Watchdog immediately after wakeup, as the wakeup reason could
@@ -283,6 +285,7 @@ platform_idle(void)
      * clock_arch_set_wakeup() for why this might be the case.
      */
     watchdog_periodic();
+    ENERGEST_SWITCH(ENERGEST_TYPE_LPM, ENERGEST_TYPE_CPU);
     clock_arch_exit_idle();
   }
 }


### PR DESCRIPTION
As reported in #1292, platform simplelink does not currently toggle ENERGEST sleep/deep sleep states correctly. Unfortunately, we have no way to distinguish between LPM and DEEP_LPM without messing around with CoreSDK, which is something we should not do. But we can at least mark every entry to a low power state as entering `ENERGEST_TYPE_DEEP_LPM`.

Fixes #1292