### PR TITLE
Improve quality of logging output in various files

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
@@ -447,7 +447,7 @@ read(void *buf, unsigned short buf_len)
 
   /* Sanity check that Frame is at least Frame Shave bytes long */
   if(frame_len < FRAME_SHAVE) {
-    LOG_ERR("Received rame is too short, len=%d\n", frame_len);
+    LOG_ERR("Received frame is too short, len=%d\n", frame_len);
 
     data_queue_release_entry();
     return 0;

--- a/examples/6tisch/simple-node/project-conf.h
+++ b/examples/6tisch/simple-node/project-conf.h
@@ -70,12 +70,12 @@
 /*******************************************************/
 
 /* Logging */
-#define LOG_CONF_LEVEL_RPL                         LOG_LEVEL_INFO
+#define LOG_CONF_LEVEL_RPL                         LOG_LEVEL_WARN
 #define LOG_CONF_LEVEL_TCPIP                       LOG_LEVEL_WARN
 #define LOG_CONF_LEVEL_IPV6                        LOG_LEVEL_WARN
 #define LOG_CONF_LEVEL_6LOWPAN                     LOG_LEVEL_WARN
 #define LOG_CONF_LEVEL_MAC                         LOG_LEVEL_INFO
-#define LOG_CONF_LEVEL_FRAMER                      LOG_LEVEL_DBG
+#define LOG_CONF_LEVEL_FRAMER                      LOG_LEVEL_WARN
 #define TSCH_LOG_CONF_PER_SLOT                     1
 
 #endif /* PROJECT_CONF_H_ */

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -1213,6 +1213,11 @@ max_payload(void)
   radio_value_t max_radio_payload_len;
   radio_result_t res;
 
+  if(!tsch_is_associated) {
+    LOG_WARN("Cannot compute max payload size: not associated\n");
+    return 0;
+  }
+
   res = NETSTACK_RADIO.get_value(RADIO_CONST_MAX_PAYLOAD_LEN,
                                  &max_radio_payload_len);
 


### PR DESCRIPTION
Explanation of the changes:
* the `max_payload` function currently returns 0 when TSCH is not associated because the framer fails to create a frame in that case. This PR explicitly looks at whether that's the case and prints and  informative warning if so.
* `simple-node` example: the logs are very spammy, in particular the framer log, and generate a lot of text that is not relevant to the TSCH protocol itself. This PR reduced the framer and RPL log levels for that particular example, assuming its mainly meant to demonstrate TSCH.
* `simplelink-cc13xx-cc26xx/rf/prop-mode.c` - fix a typo