### PR TITLE
fix tsch update_current_bacokff for overlaped links

### DIFF
--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -370,6 +370,18 @@ get_packet_and_neighbor_for_link(struct tsch_link *link, struct tsch_neighbor **
 
   return p;
 }
+
+static
+void tsch_slot_operation_update_current_bacokff(void){
+    if(current_link != NULL
+        && (current_link->link_options & LINK_OPTION_TX)
+        && (current_link->link_options & LINK_OPTION_SHARED) )
+    {
+      /* Decrement the backoff window for all neighbors able to transmit over
+       * this Tx, Shared link. */
+      tsch_queue_update_all_backoff_windows(&current_link->addr);
+    }
+}
 /*---------------------------------------------------------------------------*/
 uint64_t
 tsch_get_network_uptime_ticks(void)
@@ -1027,6 +1039,9 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
       /* There is no packet to send, and this link does not have Rx flag. Instead of doing
        * nothing, switch to the backup link (has Rx flag) if any. */
       if(current_packet == NULL && !(current_link->link_options & LINK_OPTION_RX) && backup_link != NULL) {
+        // skiped TX slot, so refresh it's backoff if one has blocked
+        tsch_slot_operation_update_current_bacokff();
+
         current_link = backup_link;
         current_packet = get_packet_and_neighbor_for_link(current_link, &current_neighbor);
       }
@@ -1095,13 +1110,7 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
       rtimer_clock_t time_to_next_active_slot;
       /* Schedule next wakeup skipping slots if missed deadline */
       do {
-        if(current_link != NULL
-            && current_link->link_options & LINK_OPTION_TX
-            && current_link->link_options & LINK_OPTION_SHARED) {
-          /* Decrement the backoff window for all neighbors able to transmit over
-           * this Tx, Shared link. */
-          tsch_queue_update_all_backoff_windows(&current_link->addr);
-        }
+        tsch_slot_operation_update_current_bacokff();
 
         /* A burst link was scheduled. Replay the current link at the
         next time offset */


### PR DESCRIPTION
provide update tsch current_bacokff for links tha are overlaped by other active links.

this fixes situation when backed-off link newer activates, due hide by other activities

the scenario of a bug:
have pair of links on same slot configuration:
linkA - tx|shared at slot1
linkB - rx at slot1
linkA have interference, and therefore failes transmit. Due to shared, It increase some backoff - window =2
every time slot1 choosed linkA and backup link B. But since backoff - works linkB.
So have that linkA never updates it's backoff