### PR TITLE
Support color coding log prefixes based on log level

### DIFF
--- a/os/sys/log-conf.h
+++ b/os/sys/log-conf.h
@@ -82,6 +82,13 @@
 #define LOG_OUTPUT(...) printf(__VA_ARGS__)
 #endif /* LOG_CONF_OUTPUT */
 
+/* Color the prefix based on the log level. Disabled by default */
+#ifdef LOG_CONF_WITH_COLOR
+#define LOG_WITH_COLOR LOG_CONF_WITH_COLOR
+#else /* LOG_CONF_WITH_COLOR */
+#define LOG_WITH_COLOR 0
+#endif /* LOG_CONF_WITH_COLOR */
+
 /*
  * Custom output function to prefix logs with level and module.
  *

--- a/os/sys/log.h
+++ b/os/sys/log.h
@@ -65,6 +65,39 @@
 #define LOG_LEVEL_INFO         3 /* Basic info */
 #define LOG_LEVEL_DBG          4 /* Detailled debug */
 
+/* Log coloring */
+#define TC_RESET   "\033[0m"
+#define TC_BLACK   "\033[0;30m"
+#define TC_RED     "\033[0;31m"
+#define TC_GREEN   "\033[0;32m"
+#define TC_YELLOW  "\033[0;33m"
+#define TC_BLUE    "\033[0;34m"
+#define TC_MAGENTA "\033[0;35m"
+#define TC_CYAN    "\033[0;36m"
+#define TC_WHITE   "\033[0;37m"
+
+#define LOG_COLOR_RESET TC_RESET
+
+#ifndef LOG_COLOR_ERR
+#define LOG_COLOR_ERR   TC_RED
+#endif
+
+#ifndef LOG_COLOR_WARN
+#define LOG_COLOR_WARN  TC_YELLOW
+#endif
+
+#ifndef LOG_COLOR_INFO
+#define LOG_COLOR_INFO  TC_BLUE
+#endif
+
+#ifndef LOG_COLOR_DBG
+#define LOG_COLOR_DBG   TC_WHITE
+#endif
+
+#ifndef LOG_COLOR_PRI
+#define LOG_COLOR_PRI   TC_CYAN
+#endif
+
 /* Per-module log level */
 
 struct log_module {
@@ -103,14 +136,20 @@ extern struct log_module all_modules[];
 
 /* Main log function */
 
-#define LOG(newline, level, levelstr, ...) do {  \
+#define LOG(newline, level, levelstr, levelcolor, ...) do {  \
                             if(level <= (LOG_LEVEL)) { \
                               if(newline) { \
+                                if(LOG_WITH_COLOR) { \
+                                  LOG_OUTPUT(levelcolor); \
+                                } \
                                 if(LOG_WITH_MODULE_PREFIX) { \
                                   LOG_OUTPUT_PREFIX(level, levelstr, LOG_MODULE); \
                                 } \
                                 if(LOG_WITH_LOC) { \
                                   LOG_OUTPUT("[%s: %d] ", __FILE__, __LINE__); \
+                                } \
+                                if(LOG_WITH_COLOR) { \
+                                  LOG_OUTPUT(LOG_COLOR_RESET); \
                                 } \
                               } \
                               LOG_OUTPUT(__VA_ARGS__); \
@@ -147,17 +186,17 @@ extern struct log_module all_modules[];
                          } while (0)
 
 /* More compact versions of LOG macros */
-#define LOG_PRINT(...)         LOG(1, 0, "PRI", __VA_ARGS__)
-#define LOG_ERR(...)           LOG(1, LOG_LEVEL_ERR, "ERR", __VA_ARGS__)
-#define LOG_WARN(...)          LOG(1, LOG_LEVEL_WARN, "WARN", __VA_ARGS__)
-#define LOG_INFO(...)          LOG(1, LOG_LEVEL_INFO, "INFO", __VA_ARGS__)
-#define LOG_DBG(...)           LOG(1, LOG_LEVEL_DBG, "DBG", __VA_ARGS__)
+#define LOG_PRINT(...)         LOG(1, 0, "PRI", LOG_COLOR_PRI, __VA_ARGS__)
+#define LOG_ERR(...)           LOG(1, LOG_LEVEL_ERR, "ERR", LOG_COLOR_ERR, __VA_ARGS__)
+#define LOG_WARN(...)          LOG(1, LOG_LEVEL_WARN, "WARN", LOG_COLOR_WARN, __VA_ARGS__)
+#define LOG_INFO(...)          LOG(1, LOG_LEVEL_INFO, "INFO", LOG_COLOR_INFO, __VA_ARGS__)
+#define LOG_DBG(...)           LOG(1, LOG_LEVEL_DBG, "DBG", LOG_COLOR_DBG, __VA_ARGS__)
 
-#define LOG_PRINT_(...)         LOG(0, 0, "PRI", __VA_ARGS__)
-#define LOG_ERR_(...)           LOG(0, LOG_LEVEL_ERR, "ERR", __VA_ARGS__)
-#define LOG_WARN_(...)          LOG(0, LOG_LEVEL_WARN, "WARN", __VA_ARGS__)
-#define LOG_INFO_(...)          LOG(0, LOG_LEVEL_INFO, "INFO", __VA_ARGS__)
-#define LOG_DBG_(...)           LOG(0, LOG_LEVEL_DBG, "DBG", __VA_ARGS__)
+#define LOG_PRINT_(...)         LOG(0, 0, "PRI", LOG_COLOR_PRI, __VA_ARGS__)
+#define LOG_ERR_(...)           LOG(0, LOG_LEVEL_ERR, "ERR", LOG_COLOR_ERR, __VA_ARGS__)
+#define LOG_WARN_(...)          LOG(0, LOG_LEVEL_WARN, "WARN", LOG_COLOR_WARN, __VA_ARGS__)
+#define LOG_INFO_(...)          LOG(0, LOG_LEVEL_INFO, "INFO", LOG_COLOR_INFO, __VA_ARGS__)
+#define LOG_DBG_(...)           LOG(0, LOG_LEVEL_DBG, "DBG", LOG_COLOR_DBG, __VA_ARGS__)
 
 #define LOG_PRINT_LLADDR(...)  LOG_LLADDR(0, __VA_ARGS__)
 #define LOG_ERR_LLADDR(...)    LOG_LLADDR(LOG_LEVEL_ERR, __VA_ARGS__)


### PR DESCRIPTION
When debugging it is useful for the log prefix to be coloured based on the log level. This helps spot error messages when printing a large number of messages at other levels.