### PR TITLE
rpl-lite: fix out-of-bounds write warning in rpl_set_prefix_from_addr()

### DIFF
--- a/os/net/routing/rpl-lite/rpl.c
+++ b/os/net/routing/rpl-lite/rpl.c
@@ -163,7 +163,7 @@ rpl_set_prefix_from_addr(uip_ipaddr_t *addr, unsigned len, uint8_t flags)
   }
 
   /* Try and initialize prefix */
-  memset(&curr_instance.dag.prefix_info.prefix, 0, sizeof(rpl_prefix_t));
+  memset(&curr_instance.dag.prefix_info.prefix, 0, sizeof(uip_ipaddr_t));
   memcpy(&curr_instance.dag.prefix_info.prefix, addr, (len + 7) / 8);
   curr_instance.dag.prefix_info.length = len;
   curr_instance.dag.prefix_info.lifetime = RPL_ROUTE_INFINITE_LIFETIME;


### PR DESCRIPTION
The previous call to `memset` wrote zeroes after the `prefix` member,
causing `-Warray-bounds` to issue warnings in GCC. This changes the
`memset` to only write zeroes to the `prefix` member before using `memcpy` to
copy the `prefix` from the `addr` argument. The remaining members of the
`prefix_info` struct are initialized using assignment expressions after
the `memcpy`.