### PR TITLE
Fix: make sure that increase the block_num only for counting BLOCK2 b…

### DIFF
--- a/os/net/app-layer/coap/coap-callback-api.c
+++ b/os/net/app-layer/coap/coap-callback-api.c
@@ -122,7 +122,8 @@ coap_request_callback(void *callback_data, coap_message_t *response)
     }
     callback_state->callback(callback_state);
     /* this is only for counting BLOCK2 blocks.*/
-    ++(state->block_num);
+    if (coap_is_option(state->response,COAP_OPTION_BLOCK2))
+      ++(state->block_num);
   } else {
     LOG_WARN("WRONG BLOCK %"PRIu32"/%"PRIu32"\n", state->res_block, state->block_num);
     ++(state->block_error);


### PR DESCRIPTION
I implement a coap client and a server resource that combining a transfer of block1 and block2 for Atomic Block-Wise POST with Block-Wise response as is presented in section 3.3 of RFC7959 3.3. by using the coap-callback-api. When works with both blocks1 and block2 the state->block_num increase when both kinds of blocks are received when we really want juts increase when blocks 2 are received. I propose to check the correct response option to increase the variable just when the response contains a block2. With this correction, my implementations work perfectly. May I pull request the Atomic Block-Wise POST with Block-Wise response too?