### PR TITLE
propose remove static from process declaration for better debug

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -1561,8 +1561,7 @@ fragment_copy_payload_and_send(uint16_t uip_offset, linkaddr_t *dest) {
  *  packet/fragments are put in packetbuf and delivered to the 802.15.4
  *  MAC.
  */
-static uint8_t
-output(const linkaddr_t *localdest)
+uint8_t sicslowpan_output(const linkaddr_t *localdest)
 {
   int frag_needed;
 
@@ -1798,8 +1797,7 @@ output(const linkaddr_t *localdest)
  * \note We do not check for overlapping sicslowpan fragments
  * (it is a SHALL in the RFC 4944 and should never happen)
  */
-static void
-input(void)
+void sicslowpan_input(void)
 {
   /* size of the IP packet (read from fragment) */
   uint16_t frag_size = 0;
@@ -2121,8 +2119,8 @@ sicslowpan_get_last_rssi(void)
 const struct network_driver sicslowpan_driver = {
   "sicslowpan",
   sicslowpan_init,
-  input,
-  output
+  sicslowpan_input,
+  sicslowpan_output
 };
 /*--------------------------------------------------------------------*/
 /** @} */

--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -136,7 +136,8 @@ static void packet_sent(struct neighbor_queue *n,
     struct packet_queue *q,
     int status,
     int num_transmissions);
-static void transmit_from_queue(void *ptr);
+#define transmit_from_queue csma_transmit_from_queue
+void transmit_from_queue(void *ptr);
 /*---------------------------------------------------------------------------*/
 static struct neighbor_queue *
 neighbor_queue_from_addr(const linkaddr_t *addr)
@@ -253,7 +254,7 @@ send_one_packet(struct neighbor_queue *n, struct packet_queue *q)
   return last_sent_ok;
 }
 /*---------------------------------------------------------------------------*/
-static void
+void
 transmit_from_queue(void *ptr)
 {
   struct neighbor_queue *n = ptr;

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -993,7 +993,7 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
 /*---------------------------------------------------------------------------*/
 /* Protothread for slot operation, called from rtimer interrupt
  * and scheduled from tsch_schedule_slot_operation */
-static
+
 PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
 {
   TSCH_DEBUG_INTERRUPT();

--- a/os/net/routing/rpl-lite/rpl-timers.c
+++ b/os/net/routing/rpl-lite/rpl-timers.c
@@ -68,7 +68,8 @@ clock_time_t RPL_PROBING_DELAY_FUNC(void);
 #define PERIODIC_DELAY_SECONDS     60
 #define PERIODIC_DELAY             ((PERIODIC_DELAY_SECONDS) * CLOCK_SECOND)
 
-static void handle_dis_timer(void *ptr);
+#define handle_dis_timer rpl_handle_dis_timer
+void handle_dis_timer(void *ptr);
 static void handle_dio_timer(void *ptr);
 static void handle_unicast_dio_timer(void *ptr);
 static void send_new_dao(void *ptr);
@@ -79,7 +80,8 @@ static void handle_dao_ack_timer(void *ptr);
 #if RPL_WITH_PROBING
 static void handle_probing_timer(void *ptr);
 #endif /* RPL_WITH_PROBING */
-static void handle_periodic_timer(void *ptr);
+#define handle_periodic_timer rpl_handle_periodic_timer
+void handle_periodic_timer(void *ptr);
 static void handle_state_update(void *ptr);
 
 /*---------------------------------------------------------------------------*/
@@ -98,7 +100,7 @@ rpl_timers_schedule_periodic_dis(void)
   }
 }
 /*---------------------------------------------------------------------------*/
-static void
+void
 handle_dis_timer(void *ptr)
 {
   if(!rpl_dag_root_is_root() &&
@@ -508,7 +510,7 @@ rpl_timers_init(void)
   rpl_timers_schedule_periodic_dis();
 }
 /*---------------------------------------------------------------------------*/
-static void
+void
 handle_periodic_timer(void *ptr)
 {
   if(curr_instance.used) {

--- a/os/sys/process.h
+++ b/os/sys/process.h
@@ -271,7 +271,7 @@ typedef unsigned char process_num_events_t;
  * \hideinitializer
  */
 #define PROCESS_THREAD(name, ev, data) 				\
-static PT_THREAD(process_thread_##name(struct pt *process_pt,	\
+PT_THREAD(process_thread_##name(struct pt *process_pt,	\
 				       process_event_t ev,	\
 				       process_data_t data))
 


### PR DESCRIPTION
Propos remove `static` from process pt-thread, since it is not affects code optimisation, but provides debug symbols.

* stack-trace on crash does not show names of a static symbols. statics shown only by routine adress. Therefore it is not a trivial to resolve - what process executes at crush.

* Also static declaration prevents declare process-thread visible to other units. Most cases it is not a problem, but it is unnesasary limitation.

* It is still not a problem declare process-thread with static explicit.