### PR TITLE
Allow the button HAL to deal with buttons connected on different ports

### DIFF
--- a/os/dev/button-hal.h
+++ b/os/dev/button-hal.h
@@ -111,6 +111,19 @@
 #define BUTTON_HAL_WITH_DESCRIPTION 1
 #endif
 /*---------------------------------------------------------------------------*/
+/**
+ * \brief Number of different ports that buttons are connected to
+ *
+ * For example, if our PCB has 3 buttons conncted to pins P0.1, P0,6 and P2.3
+ * then the platform configuration should define this to value 2 (one for each
+ * of ports 0 and 2)
+ */
+#ifdef BUTTON_HAL_CONF_PORT_COUNT
+#define BUTTON_HAL_PORT_COUNT BUTTON_HAL_CONF_PORT_COUNT
+#else
+#define BUTTON_HAL_PORT_COUNT 1
+#endif
+/*---------------------------------------------------------------------------*/
 #define BUTTON_HAL_STATE_RELEASED 0
 #define BUTTON_HAL_STATE_PRESSED  1
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR fixes a bug that prevents the button HAL from working properly in port/pin numbering mode when we have buttons connected to >1 ports (e.g. one button on some pin on port 0 and a different button on some pin of port 1).

Instead of using a single press/release handler for all buttons, we associate a separate handler for each port (each handler can already handle all pins within the same port). We expect the platform configuration to tell us how many different ports have buttons connected to them, and we default to 1.

Tested on Launchpad (raw pin numbering scheme) and on nRF52840 DK and Dongle (port/pin numbering scheme).

@alexstanoev 

Fixes #1317