### PR TITLE
Allow overriding the default optimization levels

### DIFF
--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -35,13 +35,20 @@ LDFLAGS += -mthumb -mlittle-endian
 
 OBJDUMP_FLAGS += --disassemble --source --disassembler-options=force-thumb
 
+### Caller can override the default compiler optimization levels
+ifndef OPTIMIZATIONS
+
 ### Are we building with code size optimisations?
 SMALL ?= 1
 ifeq ($(SMALL),1)
-  CFLAGS += -Os
+  OPTIMIZATIONS = -Os
 else
-  CFLAGS += -O2
+  OPTIMIZATIONS = -O2
 endif
+
+endif
+
+CFLAGS += $(OPTIMIZATIONS)
 
 ### Use CMSIS from arch/cpu/arm/common
 CONTIKI_ARM_DIRS += . 


### PR DESCRIPTION
Add the OPTIMIZATIONS variable that allows the build environment to
override the default compilation optimization level on ARM. This can
be used to generate easily debuggable code, for example:

make OPTIMIZATIONS="-Og -g"

This flag can also be embedded in the Makefile of a platform or an
application to create multiple build configurations in combination with
BUILD_DIR_CONFIG