### PR TITLE
Fix bug with MQTT payloads > 255 bytes

### DIFF
--- a/os/net/app-layer/mqtt/mqtt.h
+++ b/os/net/app-layer/mqtt/mqtt.h
@@ -439,7 +439,7 @@ struct mqtt_in_packet {
   /* Not the same as payload in the MQTT sense, it also contains the variable
    * header.
    */
-  uint8_t payload_pos;
+  uint16_t payload_pos;
   uint8_t payload[MQTT_INPUT_BUFF_SIZE];
 
   /* Start of MQTT payload (after VHDR) */


### PR DESCRIPTION
Fixes https://github.com/contiki-ng/contiki-ng/issues/1335

MQTT payload sizes larger than 255 bytes are now handled correctly.

If the payload size is up to `MQTT_INPUT_BUFF_SIZE` bytes (default 512), it is handed to the application in one chunk:

```
tcp_input with 504 bytes of data:
MQTT - Read VHDR '30'
MQTT - Read Variable Byte Integer byte 245
MQTT - Read Variable Byte Integer byte 3
MQTT - Finished reading remaining length byte
MQTT - Read PUBLISH topic len 57
MQTT - topic_pos: 0 copy_bytes: 57
MQTT - Got topic '<TOPIC>'- Copied 442 payload bytes
MQTT - Copied bytes: 
30 2C BF D1 69 94 68 0B F3 07 CC F0 28 04 A2 00 FD 4B A9 FF 93 C0 26 80 10 60 9C A8 1B FD 28 28 0B 09 04 02 0C 00 06 1D 00 86 80 22 B8 5E 2A 00 50 01 38 48 41 51 C2 00 60 83 32 82 03 85 7E B0 06 40 25 94 46 96 10 C0 29 94 14 24 18 59 00 86 54 00 26 21 9C 02 80 45 29 60 C4 2C 81 6C 43 99 01 B0 0B B0 09 FC 1E 28 7F 60 0E 02 24 00 39 0A B2 96 0A 41 16 64 26 E8 63 00 11 10 96 C3 4C 7B 15 B0 F3 03 8B C7 9F 90 4F 22 BE 49 BC 9B F9 48 F2 B3 E5 AB CB DF 98 CF 33 BE 6B BC DF F9 D0 F3 C3 E7 CB D0 1F A1 4F 44 BE 8D BD 23 FA 58 F4 D3 E9 EB D4 5F A9 CF 55 BE AF BD 67 FA E0 F5 E3 EC 0B D8 9F B2 4F 66 BE D1 BD AB FB 68 F6 F3 EE 2B DC DF BA CF 77 BE F3 BD EF FB F0 F0 03 E0 4B C1 1F 83 4F 08 BE 15 BC 33 F8 78 F1 13 E2 6B C5 5F 8B CF 19 BE 37 BC 77 F9 00 F2 23 E4 8B C9 9F 94 4F 2A BE 59 BC BB F9 88 F3 33 E6 AB CD DF 9C CF 3B BE 7B BC FF FA 10 F4 43 E8 CB D2 1F A5 4F 4C BE 9D BD 43 FA 98 F5 53 EA EB D6 5F AD CF 5D BE BF BD 87 FB 20 F6 63 ED 0B DA 9F B6 4F 6E BE E1 BD CB FB A8 F7 73 EF 2B DE DF BE CF 7F BE 03 BC 0F F8 30 F0 83 E1 4B C3 1F 87 4F 10 BE 25 BC 53 F8 B8 F1 93 E3 6B C7 5F 8F CF 21 BE 47 BC 97 F9 40 F2 A3 E5 8B CB 9F 98 4F 32 BE 69 BC DB F9 C8 F3 B3 E7 AB CF DF A0 CF 43 BE 8B BD 1F FA 50 F4 C3 E9 CB D4 1F A9 4F 54 BE AD BD 63 FA D8 F5 D3 EB EB D8 5F B1 CF 65 BE CF BD A7 FB 60 F6 E3 EE 0B DC 9F BA 4F 76 BE F1 BD EB 

MQTT - Finished reading packet!
MQTT - total data was 502 bytes of data. 
MQTT - First chunk? 1
MQTT - Got PUBLISH, called once per manageable chunk of message.
MQTT - Handling publish on topic '<TOPIC>'
MQTT - This chunk is 442 bytes
[INFO: mqtt-client] Application received publish for topic '<TOPIC>'. Payload size is 442 bytes.
[INFO: mqtt-client] Chunk size is 442 bytes. First chunk: 1
[INFO: mqtt-client] Pub Handler: topic='<TOPIC>' (len=57), chunk_len=442, chunk='<CHUNK>'
MQTT - (handle_publish) resetting packet.
```

If the payload is larger than `MQTT_INPUT_BUFF_SIZE` bytes, it is handed to the application in multiple chunks:

```
tcp_input with 512 bytes of data:
MQTT - Read VHDR '30'
MQTT - Read Variable Byte Integer byte 173
MQTT - Read Variable Byte Integer byte 7
MQTT - Finished reading remaining length byte
MQTT - Read PUBLISH topic len 57
MQTT - topic_pos: 0 copy_bytes: 57
MQTT - Got topic '<TOPIC>'- Copied 450 payload bytes
MQTT - Copied bytes: 
31 2C BF D1 69 94 68 0B F3 07 CC F0 28 04 A2 00 FD 4B A9 FF 93 C0 26 80 10 60 9C A8 1B FD 28 28 0B 09 04 02 0C 00 06 1D 00 86 80 22 B8 5E 2A 00 50 01 38 48 41 51 C2 00 60 83 32 82 03 85 7E B0 06 40 25 94 46 96 10 C0 29 94 14 24 18 59 00 86 54 00 26 21 9C 02 80 45 29 60 C4 2C 81 6C 43 99 01 B0 0B B0 09 FC 1E 28 7F 60 0E 02 24 00 39 0A B2 96 0A 41 16 64 26 E8 63 00 11 10 96 C3 4C 7B 15 B0 F3 03 8B C7 9F 90 4F 22 BE 49 BC 9B F9 48 F2 B3 E5 AB CB DF 98 CF 33 BE 6B BC DF F9 D0 F3 C3 E7 CB D0 1F A1 4F 44 BE 8D BD 23 FA 58 F4 D3 E9 EB D4 5F A9 CF 55 BE AF BD 67 FA E0 F5 E3 EC 0B D8 9F B2 4F 66 BE D1 BD AB FB 68 F6 F3 EE 2B DC DF BA CF 77 BE F3 BD EF FB F0 F0 03 E0 4B C1 1F 83 4F 08 BE 15 BC 33 F8 78 F1 13 E2 6B C5 5F 8B CF 19 BE 37 BC 77 F9 00 F2 23 E4 8B C9 9F 94 4F 2A BE 59 BC BB F9 88 F3 33 E6 AB CD DF 9C CF 3B BE 7B BC FF FA 10 F4 43 E8 CB D2 1F A5 4F 4C BE 9D BD 43 FA 98 F5 53 EA EB D6 5F AD CF 5D BE BF BD 87 FB 20 F6 63 ED 0B DA 9F B6 4F 6E BE E1 BD CB FB A8 F7 73 EF 2B DE DF BE CF 7F BE 03 BC 0F F8 30 F0 83 E1 4B C3 1F 87 4F 10 BE 25 BC 53 F8 B8 F1 93 E3 6B C7 5F 8F CF 21 BE 47 BC 97 F9 40 F2 A3 E5 8B CB 9F 98 4F 32 BE 69 BC DB F9 C8 F3 B3 E7 AB CF DF A0 CF 43 BE 8B BD 1F FA 50 F4 C3 E9 CB D4 1F A9 4F 54 BE AD BD 63 FA D8 F5 D3 EB EB D8 5F B1 CF 65 BE CF BD A7 FB 60 F6 E3 EE 0B DC 9F BA 4F 76 BE F1 BD EB FB E8 F7 F3 E0 2B C0 DF 
tcp_input with 98 bytes of data:
- Copied 62 payload bytes
MQTT - Copied bytes: 
31 2C BF D1 69 94 68 0B F3 07 CC F0 28 04 A2 00 FD 4B A9 FF 93 C0 26 80 10 60 9C A8 1B FD 28 28 0B 09 04 02 0C 00 06 1D 00 86 80 22 B8 5E 2A 00 50 01 38 48 41 51 C2 00 60 83 32 82 03 85 
MQTT - Got PUBLISH, called once per manageable chunk of message.
MQTT - Handling publish on topic '<TOPIC>'
MQTT - This chunk is 512 bytes
[INFO: mqtt-client] Application received publish for topic '<TOPIC>'. Payload size is 882 bytes.
[INFO: mqtt-client] Chunk size is 512 bytes. First chunk: 1
[INFO: mqtt-client] Pub Handler: topic='<TOPIC>' (len=57), chunk_len=512, chunk='<CHUNK>'
- Copied 36 payload bytes
MQTT - Copied bytes: 
4B BE 9B BD 3F FA 90 F5 43 EA CB D6 1F AD 4F 5C BE BD BD 83 FB 18 F6 53 EC EB DA 5F B5 CF 6D BE DF BD C7 FB 
tcp_input with 334 bytes of data:
- Copied 334 payload bytes
MQTT - Copied bytes: 
4B BE 9B BD 3F FA 90 F5 43 EA CB D6 1F AD 4F 5C BE BD BD 83 FB 18 F6 53 EC EB DA 5F B5 CF 6D BE DF BD C7 FB A0 F7 63 EF 0B DE 9F BE 4F 7E BE 01 BC 0B F8 28 F0 73 E1 2B C2 DF 86 CF 0F BE 23 BC 4F F8 B0 F1 83 E3 4B C7 1F 8F 4F 20 BE 45 BC 93 F9 38 F2 93 E5 6B CB 5F 97 CF 31 BE 67 BC D7 F9 C0 F3 A3 E7 8B CF 9F A0 4F 42 BE 89 BD 1B FA 48 F4 B3 E9 AB D3 DF A8 CF 53 BE AB BD 5F FA D0 F5 C3 EB CB D8 1F B1 4F 64 BE CD BD A3 FB 58 F6 D3 ED EB DC 5F B9 CF 75 BE EF BD E7 FB E0 F7 E3 E0 0B C0 9F 82 4F 06 BE 11 BC 2B F8 68 F0 F3 E2 2B C4 DF 8A CF 17 BE 33 BC 6F F8 F0 F2 03 E4 4B C9 1F 93 4F 28 BE 55 BC B3 F9 78 F3 13 E6 6B CD 5F 9B CF 39 BE 77 BC F7 FA 00 F4 23 E8 8B D1 9F A4 4F 4A BE 99 BD 3B FA 88 F5 33 EA AB D5 DF AC CF 5B BE BB BD 7F FB 10 F6 43 EC CB DA 1F B5 4F 6C BE DD BD C3 FB 98 F7 53 EE EB DE 5F BD CF 7D BE FF BC 07 F8 20 F0 63 E1 0B C2 9F 86 4F 0E BE 21 BC 4B F8 A8 F1 73 E3 2B C6 DF 8E CF 1F BE 43 BC 8F F9 30 F2 83 E5 4B CB 1F 97 4F 30 BE 65 BC D3 F9 B8 F3 93 E7 6B CF 5F 9F CF 41 BE 87 BD 

MQTT - Finished reading packet!
MQTT - total data was 942 bytes of data. 
MQTT - First chunk? 0
MQTT - Got PUBLISH, called once per manageable chunk of message.
MQTT - Handling publish on topic '<TOPIC>'
MQTT - This chunk is 370 bytes
[INFO: mqtt-client] Chunk size is 370 bytes. First chunk: 0
[INFO: mqtt-client] Pub Handler: topic='<TOPIC>' (len=57), chunk_len=370, chunk='<CHUNK>'
MQTT - (handle_publish) resetting packet.
```
Since my application performs a hash check on the received data, I can confirm that all the data is handed to the application correctly.

Should a test for this be added anywhere? If yes, where?