### PR TITLE
Fix `printf` vs `PRINTF` typo

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/rf-core/rf-core.c
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/rf-core.c
@@ -747,7 +747,7 @@ void
 cc26xx_rf_cpe0_isr(void)
 {
   if(!rf_core_is_accessible()) {
-    printf("RF ISR called but RF not ready... PANIC!!\n");
+    PRINTF("RF ISR called but RF not ready... PANIC!!\n");
     if(rf_core_power_up() != RF_CORE_CMD_OK) {
       PRINTF("rf_core_power_up() failed\n");
       return;


### PR DESCRIPTION
`printf` would cause linker to include unnecessary functions.