### PR TITLE
Orchestra: upate the ORCHESTRA_LINKADDR_HASH2 function

### DIFF
--- a/os/services/orchestra/orchestra-conf.h
+++ b/os/services/orchestra/orchestra-conf.h
@@ -93,11 +93,15 @@
 #define ORCHESTRA_LINKADDR_HASH(addr)             ((addr != NULL) ? (addr)->u8[LINKADDR_SIZE - 1] : -1)
 #endif /* ORCHESTRA_CONF_LINKADDR_HASH */
 
-/* The hash function used to assign timeslot for a pair of given nodes. */
+/* The hash function used to assign timeslot for a pair of given nodes.
+ * The value of 264 is a good choice for the default slotframe size 17. It also a good choice for
+ * most other slotframe sizes: there are no prime numbers between 2 and 101 (inclusive) that
+ * produce modulo 1 when used to divide 264. This ensures that for any a1, a2 this is true:
+ * `ORCHESTRA_LINKADDR_HASH2(a1, a2) != ORCHESTRA_LINKADDR_HASH2(a2, a1)` */
 #ifdef ORCHESTRA_CONF_LINKADDR_HASH2
 #define ORCHESTRA_LINKADDR_HASH2                  ORCHESTRA_CONF_LINKADDR_HASH2
 #else /* ORCHESTRA_CONF_LINKADDR_HASH2 */
-#define ORCHESTRA_LINKADDR_HASH2(addr1, addr2)    ((addr1)->u8[LINKADDR_SIZE - 1] + 256 * (addr2)->u8[LINKADDR_SIZE - 1])
+#define ORCHESTRA_LINKADDR_HASH2(addr1, addr2)    ((addr1)->u8[LINKADDR_SIZE - 1] + 264 * (addr2)->u8[LINKADDR_SIZE - 1])
 #endif /* ORCHESTRA_CONF_LINKADDR_HASH2 */
 
 /* The maximum hash */


### PR DESCRIPTION
The current implementation is particularly bad for the default unicast slotframe size of 17. Since `256 % 17` is 1, it means that `ORCHESTRA_LINKADDR_HASH2(a1, a2) == ORCHESTRA_LINKADDR_HASH2(a2, a1)`. This leads to slot allocation that is clearly not what the link-based rule was meant to provide, as both directions of the link now get the same timeslot.

The value of 264 is a good choice for the default size 17. It also a good choice for most other slotframe sizes: there are no prime numbers between 2 and 101 (including) that produce modulo 1 when used to divide 264.