### PR TITLE
SimpleLink: fix receiving_packet() return value in the prop mode

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
@@ -633,10 +633,10 @@ receiving_packet(void)
    */
 
   if(cca_request() == CCA_STATE_BUSY) {
-    return 0;
+    return 1;
   }
 
-  return 1;
+  return 0;
 
 #endif
 }


### PR DESCRIPTION
Broken in #1255 

Fixes #1339