### PR TITLE
[MQTT5] Fix application payload handling

### DIFF
--- a/examples/mqtt-client/mqtt-client.c
+++ b/examples/mqtt-client/mqtt-client.c
@@ -320,8 +320,8 @@ static void
 pub_handler(const char *topic, uint16_t topic_len, const uint8_t *chunk,
             uint16_t chunk_len)
 {
-  LOG_DBG("Pub Handler: topic='%s' (len=%u), chunk_len=%u\n", topic,
-          topic_len, chunk_len);
+  LOG_DBG("Pub Handler: topic='%s' (len=%u), chunk_len=%u, chunk='%s'\n", topic,
+          topic_len, chunk_len, chunk);
 
   /* If we don't like the length, ignore */
   if(topic_len != 23 || chunk_len != 1) {

--- a/os/net/app-layer/mqtt/mqtt.c
+++ b/os/net/app-layer/mqtt/mqtt.c
@@ -1454,6 +1454,10 @@ tcp_input(struct tcp_socket *s,
       if(conn->in_publish_msg.first_chunk) {
         conn->in_publish_msg.payload_chunk_length -= conn->in_packet.properties_len +
           conn->in_packet.properties_enc_len;
+
+        /* Payload chunk should point past the MQTT properties and to the payload itself */
+        conn->in_publish_msg.payload_chunk += conn->in_packet.properties_len +
+          conn->in_packet.properties_enc_len;
       }
 #endif
 
@@ -1511,6 +1515,9 @@ tcp_input(struct tcp_socket *s,
 #if MQTT_5
     if(conn->in_publish_msg.first_chunk) {
       conn->in_publish_msg.payload_chunk_length -= conn->in_packet.properties_len +
+        conn->in_packet.properties_enc_len;
+      /* Payload chunk should point past the MQTT properties and to the payload itself */
+      conn->in_publish_msg.payload_chunk += conn->in_packet.properties_len +
         conn->in_packet.properties_enc_len;
     }
 #endif


### PR DESCRIPTION
In MQTT5, the PUBLISH VHDR contains property bytes as well (https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901106). Even if no properties are sent, a single 0 byte is included to encode the length of the non-existing properties. This then erroneously ends up in `payload_chunk`, which is meant to be the actual application payload. This PR ensures that `payload_chunk` points past the property-related parts of the packet.

This PR also enhances the MQTT test suite to check the integrity of the application payload.

Closes #1341.