### PR TITLE
Simulation Makefile: target for running single simulation & clean build

### DIFF
--- a/tests/Makefile.simulation-test
+++ b/tests/Makefile.simulation-test
@@ -48,10 +48,13 @@ endif
 	@echo "========== Summary =========="
 	@cat summary
 
-%.testlog: %.csc cooja
-	@$(CONTIKI)/tests/simexec.sh "$<" "$(CONTIKI)" "$(basename $@)" $(BASESEED) $(RUNCOUNT)
+%.testlog: cooja
+	@$(CONTIKI)/tests/simexec.sh "$(basename $@).csc" "$(CONTIKI)" "$(basename $@)" $(BASESEED) $(RUNCOUNT)
+
+%.csc: %.testlog ;
 
 clean:
+	@find . -type d -name "build" -exec rm -r {} +;
 	@rm -f *.*log report summary
 
 cooja: $(CONTIKI)/tools/cooja/dist/cooja.jar


### PR DESCRIPTION
This PR proposes useful changes to the `Makefile.simulation` system:

1. Makefile target that allow running single *.csc simulation (just by `make simulation.csc`)
2. `clean` target for simulation also removes all `build` dirs in the simulation