### PR TITLE
TSCH: fix filling and resetting of last_eb_nbr_addr

### DIFF
--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -272,6 +272,7 @@ resynchronize(const linkaddr_t *original_time_source_addr)
     /* We simply pick the last neighbor we receiver sync information from */
     tsch_queue_update_time_source(&last_eb_nbr_addr);
     tsch_join_priority = last_eb_nbr_jp + 1;
+    linkaddr_copy(&last_eb_nbr_addr, &linkaddr_null);
     /* Try to get in sync ASAP */
     tsch_schedule_keepalive(1);
     return 1;
@@ -400,7 +401,7 @@ eb_input(struct input_packet *current_input)
      * to switch to it in case we lose the link to our time source */
     struct tsch_neighbor *ts = tsch_queue_get_time_source();
     linkaddr_t *ts_addr = tsch_queue_get_nbr_address(ts);
-    if(ts_addr == NULL || !linkaddr_cmp(&last_eb_nbr_addr, ts_addr)) {
+    if(ts_addr == NULL || !linkaddr_cmp((linkaddr_t *)&frame.src_addr, ts_addr)) {
       linkaddr_copy(&last_eb_nbr_addr, (linkaddr_t *)&frame.src_addr);
       last_eb_nbr_jp = eb_ies.ie_join_priority;
     }


### PR DESCRIPTION
The fix in eb_input was already discussed and agreed in #890 - somehow it slipped through the cracks.

The fix in the function `resynchronize` adds resetting of the `last_eb_nbr_addr`  variable. Otherwise, after trying to resync on an address it once, the variable will be equal to the time source address. If there are no other EB sending neighbor, the variable will always remain equal to the time source address, and subsequent resync calls will just try to resync on the same neighbor.

