### PR TITLE
Simplelink: disable framer logging, as it can be called in interrupt context

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/contiki-conf.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/contiki-conf.h
@@ -55,6 +55,11 @@
 /* Include CPU-related configurations */
 #include "cc13xx-cc26xx-conf.h"
 /*---------------------------------------------------------------------------*/
+#ifdef LOG_CONF_LEVEL_FRAMER
+#pragma message "LOG_CONF_LEVEL_FRAMER defined, undefining to disable printing in interrupt context"
+#undef LOG_CONF_LEVEL_FRAMER
+#endif
+/*---------------------------------------------------------------------------*/
 #endif /* CONTIKI_CONF_H_ */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
Otherwise the nodes may freeze or reboot when logging is enabled. (Seems that there may be a problem with the watchdog as well, as one would expect them to always reboot instead of freezing...)