### PR TITLE
Enabled stack check on sky

### DIFF
--- a/arch/platform/sky/contiki-conf.h
+++ b/arch/platform/sky/contiki-conf.h
@@ -35,11 +35,6 @@
 #ifndef AES_128_CONF
 #define AES_128_CONF cc2420_aes_128_driver
 #endif /* AES_128_CONF */
-
-/* Disable the stack check library by default: .rom overflow otherwise */
-#ifndef STACK_CHECK_CONF_ENABLED
-#define STACK_CHECK_CONF_ENABLED 0
-#endif
 /*---------------------------------------------------------------------------*/
 #include "msp430-conf.h"
 /*---------------------------------------------------------------------------*/

--- a/examples/snmp-server/project-conf.h
+++ b/examples/snmp-server/project-conf.h
@@ -30,4 +30,4 @@
  */
 /*---------------------------------------------------------------------------*/
 
-#define LOG_CONF_LEVEL_SNMP     LOG_LEVEL_DBG
+#define LOG_CONF_LEVEL_SNMP     LOG_LEVEL_NONE


### PR DESCRIPTION
In this PR I enabled the Stack check on the sky port.

I believe that this was an old setting based on the comment.

If the comment is valid some unit test must fail.