### PR TITLE
Make sure sensors-process runs when needed in simplelink platform

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/platform.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/platform.c
@@ -259,7 +259,7 @@ platform_init_stage_three(void)
 
   LOG_INFO("Node ID: %d\n", node_id);
 
-#if BOARD_CONF_SENSORS_ENABLE
+#if BOARD_SENSORS_ENABLE
   process_start(&sensors_process, NULL);
 #endif
 


### PR DESCRIPTION
As in title.

Disclaimer: I don't have hardware to test this, but seems obvious enough (although surprising no one has noticed... 🤔 )