### PR TITLE
Include LWM2M protocol version in registration message

### DIFF
--- a/os/services/lwm2m/lwm2m-rd-client.c
+++ b/os/services/lwm2m/lwm2m-rd-client.c
@@ -726,7 +726,8 @@ periodic_process(coap_timer_t *timer)
         coap_init_message(session_info->request, COAP_TYPE_CON, COAP_POST, 0);
         coap_set_header_uri_path(session_info->request, "/rd");
 
-        snprintf(query_data, sizeof(query_data) - 1, "?ep=%s&lt=%d&b=%s", session_info->ep, session_info->lifetime, session_info->binding);
+        snprintf(query_data, sizeof(query_data) - 1, "?lwm2m=%s&ep=%s&lt=%d&b=%s",
+                             LWM2M_PROTOCOL_VERSION, session_info->ep, session_info->lifetime, session_info->binding);
         coap_set_header_uri_query(session_info->request, query_data);
 
         len = set_rd_data(session_info);

--- a/os/services/lwm2m/lwm2m-rd-client.h
+++ b/os/services/lwm2m/lwm2m-rd-client.h
@@ -59,6 +59,8 @@ typedef enum {
 #define LWM2M_RD_CLIENT_DEREGISTER_FAILED  4
 #define LWM2M_RD_CLIENT_DISCONNECTED       5
 
+#define LWM2M_PROTOCOL_VERSION     "1.0"
+
 #include "lwm2m-object.h"
 #include "lwm2m-queue-mode-conf.h"
 #include "coap-endpoint.h"


### PR DESCRIPTION
Adds a preprocessor definition LWM2M_PROTOCOL_VERSION; set it to "1.0".  Extend query_data to include this with the key "lwm2m=".

Fixes #1389 