### PR TITLE
TSCH: Enable hardware timestamps on nRF52840

### DIFF
--- a/arch/cpu/nrf52840/nrf52840-def.h
+++ b/arch/cpu/nrf52840/nrf52840-def.h
@@ -65,6 +65,14 @@
 #define TSCH_CONF_HW_FRAME_FILTERING  0
 #define TSCH_CONF_RADIO_ON_DURING_TIMESLOT 1
 
+/* Use hardware timestamps.
+ * Disabling this greatly impacts TSCH sync, especially on preview devkits.
+ */
+#ifndef TSCH_CONF_RESYNC_WITH_SFD_TIMESTAMPS
+#define TSCH_CONF_RESYNC_WITH_SFD_TIMESTAMPS 1
+#define TSCH_CONF_TIMESYNC_REMOVE_JITTER 0
+#endif
+
 #ifndef TSCH_CONF_BASE_DRIFT_PPM
 /*
  * The drift compared to "true" 10ms slots.


### PR DESCRIPTION
This PR enables TSCH hardware timestamps on nRF52840 to fix occasional TSCH desync issues, as well as the inability to use older nRF52840 preview development kits (PDK) in TSCH networks without them dropping out of sync almost immediately.

This contains the nRF52840 part of #1387, along with disabling `TSCH_CONF_TIMESYNC_REMOVE_JITTER` to align this platform with others using hardware timestamps.