### PR TITLE
Handle edge-case in tunslip6 causing crashes with certain flow label bytes

### DIFF
--- a/tools/serial-io/tunslip6.c
+++ b/tools/serial-io/tunslip6.c
@@ -162,6 +162,13 @@ is_sensible_string(const unsigned char *s, int len)
       return 0;
     }
   }
+
+  /* Edge-case: printable characters in flow label */
+  if(len >= 2 && (s[0] & 0xF0) == 0x60 
+              && (s[1] == '\r' || s[1] == '\n' || s[1] == '\t')) {
+    return 0;
+  }
+
   return 1;
 }
 


### PR DESCRIPTION
This change adds a heuristic to `is_sensible_string` in tunslip6 that should catch edge-cases where a packet starts with printable characters and produces output similar to this:

```
`
Packet from SLIP of length 102 - write TUN
0000 be ef 00 40 3a 40 fd 00 00 00 00 00 00 00 f6 ce 36 9c a8 2f 3a 4d fd 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 81 00 1b 74 1d b2 00 01 d2 65 76 5f 00 00 00 00 29 db 0a 00 00 00 00 00 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37
tunslip6: serial_to_tun: write: Invalid argument
ifconfig tun0 down
netstat -nr | awk '{ if ($2 == "tun0") print "route delete -net "$1; }' | sh
```

This can be triggered by running the following ping command:
```
$ ping fd00::f6ce:369c:a82f:3a4d -F 0xabeef
PING fd00::f6ce:369c:a82f:3a4d(fd00::f6ce:369c:a82f:3a4d) , flow 0xabeef, 56 data bytes
ping: sendmsg: Network is unreachable
```

What happens is we get a packet down tunslip6 which passes the `is_sensible_string` check and consists of a printable character and a newline (0x60 0x0a 0xbe 0xef) by sheer coincidence of the flow label hashing algorithm (more discussion on this in #1359).

This can be triggered by longer combinations too, such as `ping fd00::f6ce:369c:a82f:3a4d -F 0xd0aef` where we chain \` \r \n - essentially we need to be able to craft a packet that's made up of a backtick, any of \t, \r, any (or zero) printable characters and \n.

The first byte is going to be 0x60 (ASCII backtick), and we only have control of the lower nibble of the second byte hence the limitation on the second character of the payload that triggers this.

A workaround while this gets resolved is to run tunslip6 with `-v0` or `-v1` - changing the verbosity level actually avoids this crash.

I'm opening this PR as a discussion on how to fix this in the most effective manner - maybe there's a better approach than adding such a heuristic to `is_sensible_string`?

Resolves #1359.