### PR TITLE
oppila platform

### DIFF
--- a/arch/platform/oppila/Makefile.oppila
+++ b/arch/platform/oppila/Makefile.oppila
@@ -1,0 +1,82 @@
+### Oppila Makefile
+
+ifndef CONTIKI
+  $(error CONTIKI not defined! You must specify where CONTIKI resides!)
+endif
+
+### If no board is specified the default option is the OMote
+BOARD ?= omote
+BOARDS = omote orouter
+
+PYTHON = python
+BSL_FLAGS += -e -w -v
+
+BSL_SPEED ?= 460800
+
+# Works in Linux and probably on OSX too (RTCC example)
+CFLAGS += -DDATE="\"`date +"%02u %02d %02m %02y %02H %02M %02S"`\""
+
+### Configure the build for the board and pull in board-specific sources
+CONTIKI_TARGET_DIRS += . dev
+CONTIKI_TARGET_DIRS += $(BOARD)
+PLATFORM_ROOT_DIR = $(CONTIKI_NG_RELOC_PLATFORM_DIR)/$(TARGET)
+
+### Include the board dir if one exists
+-include $(PLATFORM_ROOT_DIR)/$(BOARD)/Makefile.$(BOARD)
+
+### Include
+CONTIKI_TARGET_SOURCEFILES += platform.c board-buttons.c
+CONTIKI_TARGET_SOURCEFILES += $(BOARD_SOURCEFILES)
+
+CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
+
+### Define the CPU directory
+CONTIKI_CPU = $(CONTIKI_NG_RELOC_CPU_DIR)/cc2538
+include $(CONTIKI_CPU)/Makefile.cc2538
+
+MODULES += $(CONTIKI_NG_STORAGE_DIR)/cfs
+
+BSL = $(CONTIKI_NG_TOOLS_DIR)/cc2538-bsl/cc2538-bsl.py
+
+MOTES := $(shell python $(CONTIKI_NG_TOOLS_DIR)/motelist/motelist.py --omit-header \
+                 | grep $(MOTELIST_OPPILA) | cut -f1 -d " ")
+
+### If PORT is defined, override to keep backward compatibility
+ifdef PORT
+  MOTES := $(PORT)
+endif
+
+### Check the BSL script exists
+ifeq ($(wildcard $(BSL)), )
+%.upload:
+	@echo "ERROR: Could not find the cc2538-bsl script. Did you run 'git submodule update --init' ?"
+else
+### Upload to every MOTE
+%.upload: $(foreach MOTE,$(MOTES),%.$(MOTE))
+	@# Dummy recipe to prevent "No rule to make *.upload errors"
+endif
+
+### Variable that expands into a pattern rule to upload to a given MOTE.
+### Requires $(MOTE) to be defined
+### $$$$ Double escapes $s that need to be passed to the shell - once for when
+### make parses UPLOAD_RULE, and once for when the expanded rule is parsed by make.
+define UPLOAD_RULE
+%.$(MOTE): $(OUT_BIN) $(OUT_ELF)
+	@echo "Flashing $(MOTE)"
+	@BSL_ADDRESS=`$(OBJDUMP) -h $(BUILD_DIR_BOARD)/$$*.elf | grep -B1 LOAD | \
+	             grep -Ev 'LOAD|\-\-' | awk '{print "0x" $$$$5}' | \
+	             sort -g | head -1`; \
+	$(PYTHON) $(BSL) $(BSL_FLAGS) -b $(BSL_SPEED) -a $$$${BSL_ADDRESS} -p $(MOTE) $$<
+endef
+
+### Create an upload rule for every MOTE connected
+$(foreach MOTE,$(MOTES),$(eval $(UPLOAD_RULE)))
+
+.PHONY: oppila-motes
+
+oppila-motes:
+	@echo $(MOTES)
+
+### For the login etc targets
+BAUDRATE ?= 115200
+PORT = $(USBDEVPREFIX)$(firstword $(MOTES))

--- a/arch/platform/oppila/README.md
+++ b/arch/platform/oppila/README.md
@@ -1,7 +1,7 @@
 Oppila Microsystems - http://www.oppila.in
 ---------------------------------------------------------------
 
-The Oppila is based on TI's CC2538 SoC (System on Chip), featuring an ARM Cortex-M3 running at 16/32 MHz and with 32 kbytes of RAM and 512 kbytes of FLASH. It has the following key features:
+The Oppila is based on TI's CC2538 SoC (System on Chip), featuring an ARM Cortex-M3 running at 32 MHz and with 32 kbytes of RAM and 512 kbytes of FLASH. It has the following key features:
 
   * ISM 2.4-GHz IEEE 802.15.4 & Zigbee compliant.
   * AES-128/256, SHA2 Hardware Encryption Engine.
@@ -15,6 +15,27 @@ The oppila has the following key features:
   * Deep Sleep support with RAM retention for ultra-low energy consumption.
   * Native USB support (CDC-ACM). SLIP over UART for border routers is no longer a bottleneck.
   * DMA transfers for increased performance (RAM to/from RF, RAM to/from USB).
+
+In terms of hardware support, the following drivers have been implemented for the oppila-based platforms:
+
+    CC2538 System-on-Chip:
+        Standard Cortex M3 peripherals (NVIC, SCB, SysTick)
+        Sleep Timer (underpins rtimers)
+        SysTick (underpins the platform clock and Contiki's timers infrastructure)
+        RF (2.4GHz)
+        UART
+        Watchdog (in watchdog mode)
+        USB (in CDC-ACM)
+        uDMA Controller (RAM to/from USB and RAM to/from RF)
+        Low power modes
+        Random number generator
+        General-Purpose Timers. NB: GPT0 is in use by the platform code, the remaining GPTs are available for application development.
+        ADC
+        Cryptoprocessor (AES-ECB/CBC/CTR/CBC-MAC/GCM/CCM-128/192/256, SHA-256)
+        Public Key Accelerator (ECDH, ECDSA)
+        Flash-based port of Coffee
+        LEDs
+        Buttons
  
 Check the board's specific README files for more information.
 

--- a/arch/platform/oppila/README.md
+++ b/arch/platform/oppila/README.md
@@ -1,0 +1,241 @@
+Oppila Microsystems - http://www.oppila.in
+---------------------------------------------------------------
+
+The Oppila is based on TI's CC2538 SoC (System on Chip), featuring an ARM Cortex-M3 running at 16/32 MHz and with 32 kbytes of RAM and 512 kbytes of FLASH. It has the following key features:
+
+  * ISM 2.4-GHz IEEE 802.15.4 & Zigbee compliant.
+  * AES-128/256, SHA2 Hardware Encryption Engine.
+  * ECC-128/256, RSA Hardware Acceleration Engine for Secure Key Exchange.
+  * Power input with wide range 3.7-30VDC.
+
+Port Features
+
+The oppila has the following key features:
+
+  * Deep Sleep support with RAM retention for ultra-low energy consumption.
+  * Native USB support (CDC-ACM). SLIP over UART for border routers is no longer a bottleneck.
+  * DMA transfers for increased performance (RAM to/from RF, RAM to/from USB).
+ 
+Check the board's specific README files for more information.
+
+Requirements
+
+To start using Contiki with the Oppila, the following is required:
+
+    An Oppila platform board.
+    A toolchain to compile Contiki for the CC2538.
+    Drivers so that your OS can communicate with your hardware.
+    Software to upload images to the CC2538
+
+Install a Toolchain
+
+	The toolchain used to build contiki is arm-gcc, also used by other arm-based Contiki ports. If you are using Instant Contiki, you may have a version 
+	pre-installed in your system.
+
+The platform is currently being used/tested with "GNU Tools for ARM Embedded Processors" (https://launchpad.net/gcc-arm-embedded). The current recommended version and the one being used by Contiki's regression tests on Travis is shown below.
+
+	$ arm-none-eabi-gcc --version
+	arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 5.2.1 20151202 (release) [ARM/embedded-5-branch revision 231848]
+	Copyright (C) 2015 Free Software Foundation, Inc.
+	This is free software; see the source for copying conditions.  There is NO
+	warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Drivers
+
+	The oppila boards can be programmed and debugged over JTAG and USB. The board has a CP2104 serial-to-USB module,the driver is commonly found in most	      OS, but if required it can be downloaded from 
+	
+	<https://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
+
+The CC2538 USB Vendor and Product IDs are the following:
+
+    VID 0x0451
+    PID 0x16C8
+
+The implementation in Contiki is pure CDC-ACM: The Linux and OS X kernels know exactly what to do and drivers are not required.
+
+On windows, you will need to provide a driver. You have two options:
+
+    Use the signed or unsigned driver provided by TI in CC2538 Foundation Firmware. You will find them both under the drivers directory.
+    Download a generic Virtual Serial Port driver and modify it so it works for the CC2538.
+
+For the latter option:
+
+    Download this LUFA CDC-ACM driver.
+    Adjust the VID and PID near the end with the values at the start of this section.
+    Next time you get prompted for the driver, include the directory containing the .inf file in the search path and the driver will be installed.
+
+Software to Program the Nodes
+
+	The oppila can be programmed via the jtag interface or via the serial boot loader on the chip.
+
+	Both the OMote and ORouter has a mini JTAG 10-pin male header, compatible with the SmartRF06 development board, which can be used to flash and debug
+	the platforms. Alternatively one could use the JLink programmer with a 20-to-10 pin converter like the following: https://www.olimex.com/Products/ARM/	      JTAG/ARM-JTAG-20-10/. 
+
+	The serial boot loader on the chip is exposed to the user via the USB interface.The board has built-in support to flash over USB using the BSL.It 
+	requires to unlock the bootloader by manually pressing the `BSL button` and `reset button`.
+
+Instructions to flash for different OS are given below.
+
+    On Windows:
+       * Nodes can be programmed with TI's ArmProgConsole or the SmartRF Flash Programmer 2. The README should be self-explanatory. With ArmProgConsole, 
+	 upload the file with a .bin extension. (jtag + serial)
+       * Nodes can also be programmed via the serial boot loader in the cc2538. In tools/cc2538-bsl/ you can find cc2538-bsl.py this is a python script that 
+	 can download firmware to your node via a serial connection. If you use this option you just need to make sure you have a working version of python 	       installed. You can read the README in the same directory for more info. (serial)
+
+    On Linux:
+        Nodes can be programmed with TI's UniFlash tool. With UniFlash, use the file with .elf extension. (jtag + serial)
+        Nodes can also be programmed via the serial boot loader in the cc2538. No extra software needs to be installed. (serial)
+
+    On OSX:
+        The cc2538-bsl.py script in tools/cc2538-bsl/ is the only option. No extra software needs to be installed. (serial)
+
+The file with a .oppila extension is a copy of the .elf file.
+
+Use the Port
+
+The following examples are intended to work off-the-shelf:
+
+    Examples under examples/zolertia/zoul
+    MQTT example examples/cc2538dk/mqtt-demo
+    Border router: examples/ipv6/rpl-border-router
+    Webserver: examples/webserver-ipv6
+    CoAP example: examples/er-rest-example/
+
+Build your First Examples
+
+	It is recommended to start with the oppila-demo, it is a simple example that walkthroughs the oppila features (can be compiled for both the OMote and 	      the ORouter), such as the built-in sensors, LEDs, user button operation modes (press, release, hold-press), radio (Rime broadcast).
+
+	The Makefile.target includes the TARGET= argument, predefining which is the target platform to compile for, it is automatically included at 
+	compilation. The BOARD= argument is using as a glue switch to pull in specific platform files, for example the specific OMote core drivers. If no 	      BOARD argument is given, it will default to omote and compile for the OMote platform.
+
+	To generate or override an existing one, you can run:
+
+	make TARGET=oppila savetarget
+
+	Then you can just run make to compile an application, otherwise you will need to do make TARGET=oppila.
+
+	Alternatively you can export the following to your work environment:
+
+	export BOARD=omote or export BOARD=orouter
+
+	This will avoid having to type this argument at each compilation.
+
+	If you want to upload the compiled firmware to a node via the serial boot loader you need first to either manually enable the boot loader, or just let 	      the Co-Processor detect the flash sequence and do it on your behalf, as simple as not pressing anything at all!
+
+	Then use make oppila-demo.upload.
+
+	The PORT argument could be used to specify in which port the device is connected, in case we have multiple devices connected at the same time.
+
+	To generate an assembly listing of the compiled firmware, run make oppila-demo.lst. This may be useful for debugging or optimizing your application 
+	code. To intersperse the C source code within the assembly listing, you must instruct the compiler to include debugging information by adding 
+	CFLAGS += -g to the project Makefile and rebuild by running make clean oppila-demo.lst.
+
+	To enable printing debug output to your console, use the make login to get the information over the USB programming/debugging port, or alternatively 
+	use make serialview to also add a timestamp in each print.
+	Node IEEE/RIME/IPv6 Addresses
+
+	Nodes will generally autoconfigure their IPv6 address based on their IEEE address. The IEEE address can be read directly from the CC2538 Info Page, or 	      it can be hard-coded. Additionally, the user may specify a 2-byte value at build time, which will be used as the IEEE address' 2 LSBs.
+
+	To configure the IEEE address source location (Info Page or hard-coded), use the IEEE_ADDR_CONF_HARDCODED define in contiki-conf.h:
+
+	    0: Info Page
+	    1: Hard-coded
+
+	If IEEE_ADDR_CONF_HARDCODED is defined as 1, the IEEE address will take its value from the IEEE_ADDR_CONF_ADDRESS define. If IEEE_ADDR_CONF_HARDCODED 	      is defined as 0, the IEEE address can come from either the primary or secondary location in the Info Page. To use the secondary address, define 
+	IEEE_ADDR_CONF_USE_SECONDARY_LOCATION as 1.
+
+	Additionally, you can override the IEEE's 2 LSBs, by using the NODEID make variable. The value of NODEID will become the value of the 
+	IEEE_ADDR_NODE_ID pre-processor define. If NODEID is not defined, IEEE_ADDR_NODE_ID will not get defined either. For example:
+
+	make NODEID=0x79ab
+
+	This will result in the 2 last bytes of the IEEE address getting set to 0x79 0xAB
+
+	Note: Some early production devices do not have am IEEE address written on the Info Page. For those devices, using value 0 above will result in a Rime 	      address of all 0xFFs. If your device is in this category, define IEEE_ADDR_CONF_HARDCODED to 1 and specify NODEID to differentiate between devices.
+
+Low-Power Modes
+
+	The CC2538 port supports power modes for low energy consumption. The SoC will enter a low power mode as part of the main loop when there are no more 
+	events to service.
+
+	LPM support can be disabled in its entirety by setting LPM_CONF_ENABLE to 0 in contiki-conf.h or project-conf.h.
+
+	The Low-Power module uses a simple heuristic to determine the best power mode, depending on anticipated Deep Sleep duration and the state of various 
+	peripherals.
+
+In a nutshell, the algorithm first answers the following questions:
+
+    		Is the RF off?
+    		Are all registered peripherals permitting PM1+?
+    		Is the Sleep Timer scheduled to fire an interrupt?
+
+	If the answer to any of the above question is "No", the SoC will enter PM0. If the answer to all questions is "Yes", the SoC will enter one of PMs 
+	0/1/2 depending on the expected Deep Sleep duration and subject to user configuration and application requirements.
+
+	At runtime, the application may enable/disable some Power Modes by making calls to lpm_set_max_pm(). For example, to avoid PM2 an application could 
+	call lpm_set_max_pm(1). Subsequently, to re-enable PM2 the application would call lpm_set_max_pm(2).
+
+	The LPM module can be configured with a hard maximum permitted power mode.
+
+		#define LPM_CONF_MAX_PM        N
+
+	Where N corresponds to the PM number. Supported values are 0, 1, 2. PM3 is not supported. Thus, if the value of the define is 1, the SoC will only 
+	ever enter PMs 0 or 1 but never 2 and so on.
+
+	The configuration directive LPM_CONF_MAX_PM sets a hard upper boundary. For instance, if LPM_CONF_MAX_PM is defined as 1, calls to lpm_set_max_pm() 
+	can only enable/disable PM1. In this scenario, PM2 can not be enabled at runtime.
+
+	When setting LPM_CONF_MAX_PM to 0 or 1, the entire SRAM will be available. Crucially, when value 2 is used the linker will automatically stop using 	      the SoC's SRAM non-retention area, resulting in a total available RAM of 16MB instead of 32MB.
+
+LPM and Duty Cycling Driver
+
+	LPM is highly related to the operations of the Radio Duty Cycling (RDC) driver of the Contiki network stack and will work correctly with ContikiMAC 	      and NullRDC.
+
+        With ContikiMAC, PMs 0/1/2 are supported subject to user configuration.
+    	When NullRDC is in use, the radio will be always on. As a result, the algorithm discussed above will always choose PM0 and will never attempt to 	      drop to PM1/2.
+
+Build headless nodes
+
+	It is possible to turn off all character I/O for nodes not connected to a PC. Doing this will entirely disable the UART as well as the USB controller,        preserving energy in the long term. The define used to achieve this is (1: Quiet, 0: Normal output):
+
+		#define CC2538_CONF_QUIET      0
+
+	Setting this define to 1 will automatically set the following to 0:
+
+    	USB_SERIAL_CONF_ENABLE
+    	UART_CONF_ENABLE
+    	STARTUP_CONF_VERBOSE
+
+Code Size Optimisations
+
+	The build system currently uses optimization level -Os, which is controlled indirectly through the value of the SMALL make variable. This value can be 	      overridden by example makefiles, or it can be changed directly in platform/oppila/Makefile.oppila.
+
+	Historically, the -Os flag has caused problems with some toolchains. If you are using one of the toolchains documented in this README, you should be 
+	able to use it without issues. If for whatever reason you do come across problems, try setting SMALL=0 or replacing -Os with -O2 in cpu/cc2538/Makefile.cc2538.
+
+Doxygen Documentation
+
+	This port's code has been documented with doxygen. To build the documentation, navigate to $(CONTIKI)/doc and run make. This will build the entire 
+	contiki documentation and may take a while.
+
+	If you want to build this platform's documentation only and skip the remaining platforms, run this:
+
+	make basedirs="platform/oppila core cpu/cc2538 examples/oppila examples/cc2538dk"
+
+	Once you've built the docs, open $(CONTIKI)/doc/html/index.html and enjoy.
+
+Other Versions of this Guide
+
+If you prefer this guide in other formats, use the excellent [pandoc] to convert it.
+
+        pdf: pandoc -s --toc README.md -o README.pdf
+        html: pandoc -s --toc README.md -o README.html
+
+More Reading
+
+    Oppila website
+    CC2538 System-on-Chip Solution
+
+Maintainers
+
+The Oppila is maintained by Oppila Microsystems pvt ltd

--- a/arch/platform/oppila/contiki-conf.h
+++ b/arch/platform/oppila/contiki-conf.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila
+ * @{
+ *
+ * \file
+ *  Configuration for the oppila platform
+ */
+#ifndef CONTIKI_CONF_H_
+#define CONTIKI_CONF_H_
+
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+/*---------------------------------------------------------------------------*/
+/* Include Project Specific conf */
+#ifdef PROJECT_CONF_PATH
+#include PROJECT_CONF_PATH
+#endif /* PROJECT_CONF_PATH */
+/*---------------------------------------------------------------------------*/
+#include "cc2538-def.h"
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Serial Boot Loader Backdoor configuration
+ *
+ * @{
+ */
+#ifndef FLASH_CCA_CONF_BOOTLDR_BACKDOOR
+#define FLASH_CCA_CONF_BOOTLDR_BACKDOOR 1 /**<Enable the boot loader backdoor */
+#endif
+
+#ifndef FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN
+#define FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN 3 /**< Pin PA_3 (BSL button) activates the boot loader */
+#endif
+
+#ifndef FLASH_CCA_CONF_BOOTLDR_BACKDOOR_ACTIVE_HIGH
+#define FLASH_CCA_CONF_BOOTLDR_BACKDOOR_ACTIVE_HIGH 0 /**< A logic low level activates the boot loader */
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name CC2538 System Control configuration
+ *
+ * @{
+ */
+#ifndef SYS_CTRL_CONF_OSC32K_USE_XTAL
+#define SYS_CTRL_CONF_OSC32K_USE_XTAL   1 /**< Use the on-board 32.768-kHz crystal */
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/* board.h assumes that basic configuration is done */
+#include "board.h"
+/*---------------------------------------------------------------------------*/
+/* Include CPU-related configuration */
+#include "cc2538-conf.h"
+/*---------------------------------------------------------------------------*/
+#endif /* CONTIKI_CONF_H_ */
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/arch/platform/oppila/dev/adc-omote.c
+++ b/arch/platform/oppila/dev/adc-omote.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-adc-interface
+ * @{
+ *
+ * \file
+ * Generic driver for the oppila ADC interface
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "sys/clock.h"
+#include "dev/ioc.h"
+#include "dev/gpio.h"
+#include "dev/adc.h"
+#include "adc-omote.h"
+#include "omote-sensors.h"
+#include <stdio.h>
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+static uint8_t decimation_rate;
+static uint8_t enabled_channels;
+/*---------------------------------------------------------------------------*/
+static int
+set_decimation_rate(uint8_t rate)
+{
+  switch(rate) {
+  case SOC_ADC_ADCCON_DIV_64:
+  case SOC_ADC_ADCCON_DIV_128:
+  case SOC_ADC_ADCCON_DIV_256:
+  case SOC_ADC_ADCCON_DIV_512:
+    decimation_rate = rate;
+    break;
+  default:
+    return OMOTE_SENSORS_ERROR;
+  }
+
+  return decimation_rate;
+}
+/*---------------------------------------------------------------------------*/
+static int
+get_channel_pin(int type)
+{
+  if((OMOTE_SENSORS_ADC1) && (type == OMOTE_SENSORS_ADC1)) {
+    return SOC_ADC_ADCCON_CH_AIN0 + ADC_SENSORS_ADC1_PIN;
+  }
+  if((OMOTE_SENSORS_ADC2) && (type == OMOTE_SENSORS_ADC2)) {
+    return SOC_ADC_ADCCON_CH_AIN0 + ADC_SENSORS_ADC2_PIN;
+  }
+  if((OMOTE_SENSORS_ADC3) && (type == OMOTE_SENSORS_ADC3)) {
+    return SOC_ADC_ADCCON_CH_AIN0 + ADC_SENSORS_ADC3_PIN;
+  }
+  if((OMOTE_SENSORS_ADC4) && (type == OMOTE_SENSORS_ADC4)) {
+    return SOC_ADC_ADCCON_CH_AIN0 + ADC_SENSORS_ADC4_PIN;
+  }
+  if((OMOTE_SENSORS_ADC5) && (type == OMOTE_SENSORS_ADC5)) {
+    return SOC_ADC_ADCCON_CH_AIN0 + ADC_SENSORS_ADC5_PIN;
+  }
+  return OMOTE_SENSORS_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value(int type)
+{
+  int channel;
+  int16_t res;
+
+  if(!(type & enabled_channels)) {
+    PRINTF("ADC: channel not enabled\n");
+    return OMOTE_SENSORS_ERROR;
+  }
+
+  channel = get_channel_pin(type);
+
+  if(channel == OMOTE_SENSORS_ERROR) {
+    PRINTF("ADC: pin not active\n");
+    return OMOTE_SENSORS_ERROR;
+  }
+
+  res = adc_get(channel, ADC_SENSORS_REFERENCE, decimation_rate);
+
+  /* Only allow negative values if using differential input */
+  if((ADC_SENSORS_REFERENCE != SOC_ADC_ADCCON_REF_EXT_DIFF) && (res < 0)) {
+    res = 0;
+  }
+
+  return res;
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  switch(type) {
+  case SENSORS_HW_INIT:
+
+    /* This should filter out disabled sensors as its value should be zero */
+    if((value < OMOTE_SENSORS_ADC_MIN) || (value > OMOTE_SENSORS_ADC_ALL)) {
+      PRINTF("ADC: invalid adc pin mask (0x%02X)\n", value);
+      return OMOTE_SENSORS_ERROR;
+    }
+
+    GPIO_SOFTWARE_CONTROL(GPIO_A_BASE, value);
+    GPIO_SET_INPUT(GPIO_A_BASE, value);
+
+    if(value & OMOTE_SENSORS_ADC1) {
+      ioc_set_over(GPIO_A_NUM, ADC_SENSORS_ADC1_PIN, IOC_OVERRIDE_ANA);
+    }
+    if(value & OMOTE_SENSORS_ADC2) {
+      ioc_set_over(GPIO_A_NUM, ADC_SENSORS_ADC2_PIN, IOC_OVERRIDE_ANA);
+    }
+    if(value & OMOTE_SENSORS_ADC3) {
+      ioc_set_over(GPIO_A_NUM, ADC_SENSORS_ADC3_PIN, IOC_OVERRIDE_ANA);
+    }
+    if(value & OMOTE_SENSORS_ADC4) {
+      ioc_set_over(GPIO_A_NUM, ADC_SENSORS_ADC4_PIN, IOC_OVERRIDE_ANA);
+    }
+    if(value & OMOTE_SENSORS_ADC5) {
+      ioc_set_over(GPIO_A_NUM, ADC_SENSORS_ADC5_PIN, IOC_OVERRIDE_ANA);
+    }
+    adc_init();
+    set_decimation_rate(SOC_ADC_ADCCON_DIV_512);
+    enabled_channels |= value;
+    PRINTF("ADC: enabled channels 0x%02X\n", enabled_channels);
+    break;
+
+  case OMOTE_SENSORS_CONFIGURE_TYPE_DECIMATION_RATE:
+    return set_decimation_rate((uint8_t)value);
+
+  default:
+    return OMOTE_SENSORS_ERROR;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+status(int type)
+{
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(adc_omote, ADC_OMOTE, value, configure, status);
+/*---------------------------------------------------------------------------*/
+/** @} */
+

--- a/arch/platform/oppila/dev/adc-omote.h
+++ b/arch/platform/oppila/dev/adc-omote.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-sensors
+ * @{
+ *
+ * \defgroup oppila-adc-interface Oppila Generic ADC interface
+ *
+ * Driver for the omote ADC interface
+ * @{
+ *
+ * \file
+ * Header file for the OMote ADC interface
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef ADC_OMOTE_H_
+#define ADC_OMOTE_H_
+/*---------------------------------------------------------------------------*/
+#include "lib/sensors.h"
+#include "dev/soc-adc.h"
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Generic ADC sensors
+ * @{
+ */
+#define ADC_OMOTE "ADC sensor interface"
+#define ADC_SENSORS_PORT_BASE    GPIO_PORT_TO_BASE(ADC_SENSORS_PORT)
+
+#ifdef ADC_SENSORS_CONF_REFERENCE
+#define ADC_SENSORS_REFERENCE ADC_SENSORS_CONF_REFERENCE
+#else
+#define ADC_SENSORS_REFERENCE SOC_ADC_ADCCON_REF_AVDD5
+#endif
+
+/*
+ * PA0-PA1 are hardcoded to UART0 and PA3 is hardcoded to BSL button
+ */
+#define OMOTE_SENSORS_ADC_MIN     2  /**< PA1 pin mask */
+
+/* ADC1 is connected with LDR sensor*/
+#if ADC_SENSORS_ADC1_PIN >= OMOTE_SENSORS_ADC_MIN
+#define OMOTE_SENSORS_ADC1        GPIO_PIN_MASK(ADC_SENSORS_ADC1_PIN)
+#else
+#define OMOTE_SENSORS_ADC1        0
+#endif
+/* ADC2 */
+#if ADC_SENSORS_ADC2_PIN >= OMOTE_SENSORS_ADC_MIN
+#define OMOTE_SENSORS_ADC2        GPIO_PIN_MASK(ADC_SENSORS_ADC2_PIN)
+#else
+#define OMOTE_SENSORS_ADC2        0
+#endif
+/* ADC3 */
+#if ADC_SENSORS_ADC3_PIN >= OMOTE_SENSORS_ADC_MIN
+#define OMOTE_SENSORS_ADC3        GPIO_PIN_MASK(ADC_SENSORS_ADC3_PIN)
+#else
+#define OMOTE_SENSORS_ADC3        0
+#endif
+/* ADC4 */
+#if ADC_SENSORS_ADC4_PIN >= OMOTE_SENSORS_ADC_MIN
+#define OMOTE_SENSORS_ADC4        GPIO_PIN_MASK(ADC_SENSORS_ADC4_PIN)
+#else
+#define OMOTE_SENSORS_ADC4        0
+#endif
+/* ADC5 */
+#if ADC_SENSORS_ADC5_PIN >= OMOTE_SENSORS_ADC_MIN
+#define OMOTE_SENSORS_ADC5        GPIO_PIN_MASK(ADC_SENSORS_ADC5_PIN)
+#else
+#define OMOTE_SENSORS_ADC5        0
+#endif
+/*
+ * This is safe as the disabled sensors should have a zero value thus not
+ * affecting the mask operations
+ */
+#define OMOTE_SENSORS_ADC_ALL     (OMOTE_SENSORS_ADC1 + OMOTE_SENSORS_ADC2 + \
+                                  OMOTE_SENSORS_ADC3 + OMOTE_SENSORS_ADC4 + \
+                                  OMOTE_SENSORS_ADC5 )
+/** @} */
+/*---------------------------------------------------------------------------*/
+extern const struct sensors_sensor adc_omote;
+/*---------------------------------------------------------------------------*/
+#endif /* ADC_OMOTE_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */
+

--- a/arch/platform/oppila/dev/adc-sensors.c
+++ b/arch/platform/oppila/dev/adc-sensors.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-adc-sensors
+ * @{
+ *
+ * \file
+ * Generic driver for the Oppila ADC wrapper for analogue sensors
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "sys/clock.h"
+#include "dev/ioc.h"
+#include "dev/gpio.h"
+#include "dev/adc.h"
+#include "adc-sensors.h"
+#include "adc-omote.h"
+#include "omote-sensors.h"
+#include <stdio.h>
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+typedef struct {
+  int type;
+  uint8_t pin_mask;
+  uint8_t vdd3;
+} adc_info_t;
+
+typedef struct {
+  uint8_t sensors_num;
+  uint8_t sensors_ports;
+  adc_info_t sensor[ADC_SENSORS_MAX];
+} adc_wrapper_t;
+
+static adc_wrapper_t sensors;
+/*---------------------------------------------------------------------------*/
+static uint16_t
+convert_to_value(uint8_t index)
+{
+  uint32_t value;
+  value = adc_omote.value(sensors.sensor[index].pin_mask);
+
+  if(value == OMOTE_SENSORS_ERROR) {
+    PRINTF("ADC sensors: failed retrieving data\n");
+    return ADC_WRAPPER_ERROR;
+  }
+
+  if(!sensors.sensor[index].vdd3) {
+    value *= ADC_WRAPPER_EXTERNAL_VREF;
+    value /= ADC_WRAPPER_EXTERNAL_VREF_CROSSVAL;
+  }
+
+  if(sensors.sensor[index].type) {
+    /* Light dependant resistor (LDR) resistance value*/
+    value = (10230 - (value * 10)) / value;
+    /* TODO: With the resistance we could calculate the lux as 63*R^(-0.7) */
+    return (uint16_t)value;
+  }
+    else {
+    return ADC_WRAPPER_ERROR;
+  }
+
+  return ADC_WRAPPER_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t
+is_sensor_in_list(int type)
+{
+  uint8_t i;
+
+  for(i = 0; i <= sensors.sensors_num; i++) {
+    if(sensors.sensor[i].type == type) {
+      return i + 1;
+    }
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value(int type)
+{
+  uint8_t index;
+  uint16_t sensor_value;
+
+  index = is_sensor_in_list(type);
+
+  if(!index) {
+    PRINTF("ADC sensors: sensor not registered\n");
+    return ADC_WRAPPER_SUCCESS;
+  }
+
+  /* Restore index value after the check */
+  index -= 1;
+  sensor_value = convert_to_value(index);
+
+  return sensor_value;
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  uint8_t pin_mask = GPIO_PIN_MASK(value);
+
+  if(type != ANALOG_GROVE_LIGHT) {
+    PRINTF("ADC sensors: sensor not supported, check adc_wrapper.h header\n");
+    return ADC_WRAPPER_ERROR;
+  }
+
+  if(sensors.sensors_num >= ADC_SENSORS_MAX) {
+    PRINTF("ADC sensors: all adc channels available have been assigned\n");
+    return ADC_WRAPPER_ERROR;
+  }
+
+  if((value < 0x01) || (value > 0x07) || (value == BUTTON_USER_PIN)) {
+    PRINTF("ADC sensors: invalid pin value, (PA0-PA1, PA3) are reserved\n");
+    return ADC_WRAPPER_ERROR;
+  }
+
+  if(sensors.sensors_ports & pin_mask) {
+    PRINTF("ADC sensors: a sensor has been already assigned to this pin\n");
+    return ADC_WRAPPER_ERROR;
+  }
+
+  if(type) {
+    if(adc_omote.configure(SENSORS_HW_INIT, pin_mask) == OMOTE_SENSORS_ERROR) {
+      return ADC_WRAPPER_ERROR;
+    }
+    sensors.sensor[sensors.sensors_num].type = type;
+    sensors.sensor[sensors.sensors_num].pin_mask = pin_mask;
+    sensors.sensor[sensors.sensors_num].vdd3 = 1;
+  }
+  else{
+    return ADC_WRAPPER_ERROR;
+  }
+
+  PRINTF("ADC sensors: type %u mask 0x%02X vdd3 %u\n",
+         sensors.sensor[sensors.sensors_num].type,
+         sensors.sensor[sensors.sensors_num].pin_mask,
+         sensors.sensor[sensors.sensors_num].vdd3);
+
+  sensors.sensors_num++;
+  sensors.sensors_ports |= pin_mask;
+
+  return ADC_WRAPPER_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(adc_sensors, ADC_SENSORS, value, configure, NULL);
+/*---------------------------------------------------------------------------*/
+/** @} */
+

--- a/arch/platform/oppila/dev/adc-sensors.h
+++ b/arch/platform/oppila/dev/adc-sensors.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-sensors
+ * @{
+ *
+ * \defgroup oppila-adc-sensors OMote adc wrapper to use analogue sensors
+ * @{
+ *
+ * \file
+ * Header file for the OMote ADC sensors API
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef ADC_SENSORS_H_
+#define ADC_SENSORS_H_
+/*---------------------------------------------------------------------------*/
+#include "lib/sensors.h"
+#include "dev/soc-adc.h"
+#include "dev/adc-omote.h"
+/*---------------------------------------------------------------------------*/
+#define ADC_WRAPPER_SUCCESS                 0x00
+#define ADC_WRAPPER_ERROR                   (-1)
+#define ADC_WRAPPER_EXTERNAL_VREF           5000
+#define ADC_WRAPPER_EXTERNAL_VREF_CROSSVAL  3000
+/*---------------------------------------------------------------------------*/
+#define ANALOG_GROVE_LIGHT                  0x01
+/* -------------------------------------------------------------------------- */
+#define ADC_SENSORS "ADC sensors API"
+/* -------------------------------------------------------------------------- */
+extern const struct sensors_sensor adc_sensors;
+/*---------------------------------------------------------------------------*/
+#endif /* ADC_SENSORS_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */
+

--- a/arch/platform/oppila/dev/adxl345.c
+++ b/arch/platform/oppila/dev/adxl345.c
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * Copyright (c) 2020, Oppila Microsystems - <http://www.oppila.in>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         Device drivers for adxl345 accelerometer
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include "contiki.h"
+#include "adxl345.h"
+#include "dev/i2c.h"
+#include "lib/sensors.h"
+/*---------------------------------------------------------------------------*/
+#define DEBUG 1
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+#define ADXL345_INT_PORT_BASE  GPIO_PORT_TO_BASE(I2C_INT_PORT)
+#define ADXL345_INT_PIN_MASK   GPIO_PIN_MASK(I2C_INT_PIN)
+/*---------------------------------------------------------------------------*/
+static uint8_t enabled;
+/*---------------------------------------------------------------------------*/
+/* Callback pointers when interrupt occurs */
+void (*accm_int1_cb)(uint8_t reg);
+void (*accm_int2_cb)(uint8_t reg);
+/*---------------------------------------------------------------------------*/
+/* Bitmasks for the interrupts */
+static uint16_t int1_mask = 0, int2_mask = 0;
+
+/* Default values for adxl345 at startup.
+ * This will be sent to the adxl345 in a
+ * stream at init to set it up in a default state
+ */
+
+static uint8_t adxl345_default_settings[] = {
+  /* Note, as the two first two bulks are to be written in a stream, they contain
+   * the register address as first byte in that section.
+   * 0--14 are in one stream, start at ADXL345_THRESH_TAP
+   */
+  /* XXX NB Register address, not register value!! */
+  ADXL345_THRESH_TAP,
+  ADXL345_THRESH_TAP_DEFAULT,
+  ADXL345_OFSX_DEFAULT,
+  ADXL345_OFSY_DEFAULT,
+  ADXL345_OFSZ_DEFAULT,
+  ADXL345_DUR_DEFAULT,
+  ADXL345_LATENT_DEFAULT,
+  ADXL345_WINDOW_DEFAULT,
+  ADXL345_THRESH_ACT_DEFAULT,
+  ADXL345_THRESH_INACT_DEFAULT,
+  ADXL345_TIME_INACT_DEFAULT,
+  ADXL345_ACT_INACT_CTL_DEFAULT,
+  ADXL345_THRESH_FF_DEFAULT,
+  ADXL345_TIME_FF_DEFAULT,
+  ADXL345_TAP_AXES_DEFAULT,
+
+  /* 15--19 start at ADXL345_BW_RATE */
+  /* XXX NB Register address, not register value!! */
+  ADXL345_BW_RATE,    
+  ADXL345_BW_RATE_DEFAULT,
+  ADXL345_POWER_CTL_DEFAULT,
+  ADXL345_INT_ENABLE_DEFAULT,
+  ADXL345_INT_MAP_DEFAULT,
+
+  /* These two: 20, 21 write separately */
+  ADXL345_DATA_FORMAT_DEFAULT,
+  ADXL345_FIFO_CTL_DEFAULT
+};
+/*---------------------------------------------------------------------------*/
+PROCESS(accmeter_process, "Accelerometer process");
+/*---------------------------------------------------------------------------*/
+static int
+accm_write_reg(uint8_t reg, uint8_t val)
+{
+  uint8_t tx_buf[] = {reg, val};
+  
+  i2c_master_enable();
+  if(i2c_burst_send(ADXL345_ADDR, tx_buf, 2) == I2C_MASTER_ERR_NONE) {
+    return ADXL345_SUCCESS;
+  }
+  return ADXL345_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+/* First byte in stream must be the register address to begin writing to.
+ * The data is then written from second byte and increasing.
+ */
+static int
+accm_write_stream(uint8_t len, uint8_t *data)
+{
+  if((data == NULL) || (len <= 0)) {
+    PRINTF("TSL256X: invalid write values\n");
+    return ADXL345_ERROR;
+  }
+
+  i2c_master_enable();
+  if(i2c_burst_send(ADXL345_ADDR, data, len) == I2C_MASTER_ERR_NONE) {
+    return ADXL345_SUCCESS;
+  }
+  return ADXL345_ERROR;
+}
+
+/*---------------------------------------------------------------------------*/
+static uint8_t
+accm_read_reg(uint8_t reg)
+{
+  uint8_t retval = 0;
+  i2c_master_enable();
+  if(i2c_single_send(ADXL345_ADDR, reg) == I2C_MASTER_ERR_NONE) {
+    while(i2c_master_busy());
+    if(i2c_burst_receive(ADXL345_ADDR, &retval, 1) == I2C_MASTER_ERR_NONE);
+  }
+  return retval;
+}
+/*---------------------------------------------------------------------------*/
+/* Read an axis of the accelerometer (x, y or z). Return value is a signed
+ * 10 bit int.
+ * The resolution of the acceleration measurement can be increased up to 13 bit,
+ * but will change the data format of this read out. Refer to the data sheet if
+ * so is wanted/needed.
+ */
+int16_t
+accm_read_axis(enum ADXL345_AXIS axis)
+{
+  int16_t rd = 0;
+  uint8_t tmp[2];
+  if(axis > Z_AXIS) {
+    return 0;
+  }
+  
+  i2c_master_enable();
+  if(i2c_single_send(ADXL345_ADDR, ADXL345_DATAX0 + axis) == I2C_MASTER_ERR_NONE) {
+    while(i2c_master_busy());
+    if(i2c_burst_receive(ADXL345_ADDR, &tmp[0], 2) == I2C_MASTER_ERR_NONE);
+  }
+
+  rd = (int16_t)(tmp[0] | (tmp[1]<<8));  
+  return rd;
+}
+/*---------------------------------------------------------------------------*/
+int
+accm_set_grange(uint8_t grange)
+{
+  uint8_t tempreg = 0;
+
+  if(grange > ADXL345_RANGE_16G) {
+    PRINTF("ADXL345: grange invalid: %u\n", grange);
+    return ADXL345_ERROR;
+  }
+
+  if(!enabled) {
+    return ADXL345_ERROR;
+  }
+
+  /* Keep the previous contents of the register, zero out the last two bits */
+  tempreg = (accm_read_reg(ADXL345_DATA_FORMAT) & 0xFC);
+  PRINTF("ADXL345 tempreg: %u, grange: %u\n", tempreg, grange);
+  
+  tempreg |= grange;
+  accm_write_reg(ADXL345_DATA_FORMAT, tempreg);
+
+  // Pasted manually.
+  tempreg = accm_read_reg(ADXL345_DATA_FORMAT);
+  PRINTF("ADXL345 Result register: %u\n", tempreg);
+  
+  return ADXL345_SUCCESS;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+accm_init(void)
+{
+  PRINTF("ADXL345: init\n");
+  accm_int1_cb = NULL;
+  accm_int2_cb = NULL;
+
+  /* Set up ports and pins for I2C communication */
+  i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
+           I2C_SCL_NORMAL_BUS_SPEED);
+  
+  /* Set up ports and pins for interrups. */
+  /* Configure the interrupts pins */
+  GPIO_SOFTWARE_CONTROL(ADXL345_INT_PORT_BASE, ADXL345_INT_PIN_MASK);
+  GPIO_SET_INPUT(ADXL345_INT_PORT_BASE, ADXL345_INT_PIN_MASK);
+
+  /* set default register values. */
+  accm_write_stream(15, &adxl345_default_settings[0]);
+  accm_write_stream(5, &adxl345_default_settings[15]);
+  accm_write_reg(ADXL345_DATA_FORMAT, adxl345_default_settings[20]);
+  accm_write_reg(ADXL345_FIFO_CTL, adxl345_default_settings[21]);
+  
+  /* Pull-up resistor, detect falling edge */
+  GPIO_DETECT_EDGE(ADXL345_INT_PORT_BASE, ADXL345_INT_PIN_MASK);
+  GPIO_TRIGGER_SINGLE_EDGE(ADXL345_INT_PORT_BASE, ADXL345_INT_PIN_MASK);
+  GPIO_DETECT_FALLING(ADXL345_INT_PORT_BASE, ADXL345_INT_PIN_MASK);
+  //gpio_register_callback(adxl_interrupt_handler, I2C_INT_PORT, I2C_INT_PIN);
+
+  process_start(&accmeter_process, NULL);
+
+  /* Enable interrupts */
+  GPIO_ENABLE_INTERRUPT(ADXL345_INT_PORT_BASE, ADXL345_INT_PIN_MASK);
+
+  ioc_set_over(I2C_INT_PORT, I2C_INT_PIN, IOC_OVERRIDE_PUE);
+    
+  // Test local mode: OK
+  //PRINTF("Test ADXL345_LATENT: 0x%02x\n",accm_read_reg(ADXL345_LATENT));
+  //PRINTF("Test ADXL345_ACT_INACT_CTL: 0x%02x\n",accm_read_reg(ADXL345_ACT_INACT_CTL));
+
+  enabled = 1;
+}
+/*---------------------------------------------------------------------------*/
+void
+accm_stop(void)
+{
+  accm_write_reg(ADXL345_INT_ENABLE, ~(int1_mask | int2_mask));
+  accm_write_reg(ADXL345_INT_MAP, ~int2_mask);
+  enabled = 0;
+}
+/*---------------------------------------------------------------------------*/
+int
+accm_set_irq(uint8_t int1, uint8_t int2)
+{
+  if(!enabled) {
+    return ADXL345_ERROR;
+  }
+
+  /* Set the corresponding interrupt mapping to INT1 or INT2 */
+  PRINTF("ADXL345: IRQs set to INT1: 0x%02X IRQ2: 0x%02X\n", int1, int2);
+
+  int1_mask = int1;
+  int2_mask = int2;
+
+  accm_write_reg(ADXL345_INT_ENABLE, (int1 | int2));
+  /* int1 bits are zeroes in the map register so this is for both ints */
+  accm_write_reg(ADXL345_INT_MAP, int2);
+  
+  return ADXL345_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+/* Invoked after an interrupt happened. Reads the interrupt source reg at the
+ * accelerometer, which resets the interrupts, and invokes the corresponding
+ * callback. It passes the source register value so the callback can determine
+ * what interrupt happened, if several interrupts are mapped to the same pin.
+ */
+static void
+poll_handler(void)
+{
+  uint8_t ireg = 0;
+  ireg = accm_read_reg(ADXL345_INT_SOURCE);
+
+  /* Invoke callbacks for the corresponding interrupts */
+  if(ireg & int1_mask){
+    if(accm_int1_cb != NULL){
+      PRINTF("ADXL345: INT1 cb invoked\n");
+      accm_int1_cb(ireg);
+    }
+  } else if(ireg & int2_mask){
+    if(accm_int2_cb != NULL){
+      PRINTF("ADXL345: INT2 cb invoked\n");
+      accm_int2_cb(ireg);
+    }
+  } else {
+      PRINTF("ADXL345: No event from ADXL\n");
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* This process is sleeping until an interrupt from the accelerometer occurs,
+ * which polls this process from the interrupt service routine. */
+PROCESS_THREAD(accmeter_process, ev, data)
+{
+  PROCESS_POLLHANDLER(poll_handler());
+  PROCESS_EXITHANDLER();
+  PROCESS_BEGIN();
+  while(1) {
+    PROCESS_WAIT_EVENT_UNTIL(0);
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  if(type != SENSORS_ACTIVE) {
+    return ADXL345_ERROR;
+  }
+
+  if(value) {
+    accm_init();
+  } else {
+    accm_stop();
+  }
+  enabled = value;
+  return ADXL345_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+static int
+status(int type)
+{
+  switch(type) {
+  case SENSORS_ACTIVE:
+  case SENSORS_READY:
+    return enabled;
+  }
+  return ADXL345_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value(int type)
+{
+  if(!enabled) {
+    return ADXL345_ERROR;
+  }
+
+  if((type != X_AXIS) && (type != Y_AXIS) && (type != Z_AXIS)) {
+    return ADXL345_ERROR;
+  }
+
+  switch(type) {
+    case X_AXIS:
+      return accm_read_axis(X_AXIS);
+    case Y_AXIS:
+      return accm_read_axis(Y_AXIS);
+    case Z_AXIS:
+      return accm_read_axis(Z_AXIS);
+    default:
+      return ADXL345_ERROR;
+  }
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(adxl345, ADXL345_SENSOR, value, configure, status);
+/*---------------------------------------------------------------------------*/

--- a/arch/platform/oppila/dev/adxl345.h
+++ b/arch/platform/oppila/dev/adxl345.h
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * Copyright (c) 2020, Oppila Microsystems - <http://www.oppila.in>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         Device drivers header file for adxl345 accelerometer.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef ADXL345_H_
+#define ADXL345_H_
+#include <stdio.h>
+#include "dev/i2c.h"
+#include "lib/sensors.h"
+/*---------------------------------------------------------------------------*/
+/* Used in accm_read_axis(), eg accm_read_axis(X_AXIS) */
+enum ADXL345_AXIS {
+  X_AXIS = 0,
+  Y_AXIS = 2,
+  Z_AXIS = 4,
+};
+/* -------------------------------------------------------------------------- */
+/* Init the accelerometer: ports, pins, registers, interrupts (none enabled),
+ * I2C, default threshold values etc.
+ */
+void accm_init(void);
+
+/* Read an axis of the accelerometer (x, y or z). Return value is a signed 10
+ * bit int.
+ * The resolution of the acceleration measurement can be increased up to 13 bit,
+ * but will change the data format of this read out. Refer to the data sheet if
+ * so is wanted/needed.
+ */
+int16_t accm_read_axis(enum ADXL345_AXIS axis);
+
+/* Sets the g-range, ie the range the accelerometer measures (ie 2g means -2 to
+ * +2 g on every axis). Possible values:
+ * - ADXL345_RANGE_2G
+ * - ADXL345_RANGE_4G
+ * - ADXL345_RANGE_8G
+ * - ADXL345_RANGE_16G
+ */
+int accm_set_grange(uint8_t grange);
+
+/* Map interrupt (FF, tap, dbltap etc) to interrupt pin (IRQ_INT1, IRQ_INT2).
+ * This must come after accm_init() as the registers will otherwise be
+ * overwritten.
+ */
+int accm_set_irq(uint8_t int1, uint8_t int2);
+
+/* Macros for setting the pointers to callback functions from the interrupts.
+ * The function will be called with an uint8_t as parameter, containing the
+ * interrupt flag register from the ADXL345. That way, several interrupts can be
+ * mapped to the same pin and be read
+ */
+#define ACCM_REGISTER_INT1_CB(ptr)   accm_int1_cb = ptr;
+#define ACCM_REGISTER_INT2_CB(ptr)   accm_int2_cb = ptr;
+/* -------------------------------------------------------------------------- */
+/* Application definitions, change if required by application. */
+
+/* Time after an interrupt that subsequent interrupts are suppressed. Should
+ * later be turned into one specific time per type of interrupt (tap, freefall.
+ * etc)
+ */
+#define SUPPRESS_TIME_INT1    CLOCK_SECOND/4
+#define SUPPRESS_TIME_INT2    CLOCK_SECOND/4
+
+/* Suggested defaults according to the data sheet etc */
+#define ADXL345_THRESH_TAP_DEFAULT      0x48  /* 4.5g (0x30 == 3.0g) */
+//#define ADXL345_THRESH_TAP_DEFAULT      0x10  /* 1.0g (0x10 == 1.0g) */
+#define ADXL345_OFSX_DEFAULT            0x00  /* for calibration only */
+#define ADXL345_OFSY_DEFAULT            0x00
+#define ADXL345_OFSZ_DEFAULT            0x00
+#define ADXL345_DUR_DEFAULT             0x20  /* 20 ms (datasheet: 10ms++) */
+#define ADXL345_LATENT_DEFAULT          0x50  /* 100 ms (datasheet: 20ms++) */
+//#define ADXL345_LATENT_DEFAULT          0x10  /* 100 ms (datasheet: 20ms++) */
+#define ADXL345_WINDOW_DEFAULT          0xFF  /* 320 ms (datasheet: 80ms++) */
+#define ADXL345_THRESH_ACT_DEFAULT      0x15  /* 1.3g (62.5 mg/LSB) */
+#define ADXL345_THRESH_INACT_DEFAULT    0x08  /* 0.5g (62.5 mg/LSB) */
+#define ADXL345_TIME_INACT_DEFAULT      0x02  /* 2 s (1 s/LSB) */
+#define ADXL345_ACT_INACT_CTL_DEFAULT   0xFF  /* all axis, ac-coupled */
+#define ADXL345_THRESH_FF_DEFAULT       0x09  /* 563 mg */
+#define ADXL345_TIME_FF_DEFAULT         0x20  /* 60 ms */
+#define ADXL345_TAP_AXES_DEFAULT        0x07  /* all axis, no suppression */
+
+#define ADXL345_BW_RATE_DEFAULT         (0x00 | ADXL345_SRATE_100) /* 100 Hz */
+/* link bit set, no autosleep, start normal measuring */
+#define ADXL345_POWER_CTL_DEFAULT       0x28
+#define ADXL345_INT_ENABLE_DEFAULT      0x00    /* no interrupts enabled */
+#define ADXL345_INT_MAP_DEFAULT         0x00    /* all mapped to int_1 */
+
+/* XXX NB: In the data format register, data format of axis readings is chosen
+ * between left or right justify. This affects the position of the MSB/LSB and is
+ * different depending on g-range and resolution. If changed, make sure this is
+ * reflected in the _read_axis() function. Also, the resolution can be increased
+ * from 10 bit to at most 13 bit, but this also changes position of MSB etc on data
+ * format so check this in read_axis() too.
+ */
+/* right-justify, 2g, 10-bit mode, int is active high */
+#define ADXL345_DATA_FORMAT_DEFAULT     (0x00 | ADXL345_RANGE_2G)
+#define ADXL345_FIFO_CTL_DEFAULT        0x00    /* FIFO bypass mode */
+
+/* -------------------------------------------------------------------------- */
+/* Reference definitions, should not be changed */
+/* adxl345 slave address */
+#define ADXL345_ADDR            0x53
+
+/* ADXL345 registers */
+#define ADXL345_DEVID           0x00
+/* registers 0x01 to 0x1C are reserved, do not access */
+#define ADXL345_THRESH_TAP      0x1D
+#define ADXL345_OFSX            0x1E
+#define ADXL345_OFSY            0x1F
+#define ADXL345_OFSZ            0x20
+#define ADXL345_DUR             0x21
+#define ADXL345_LATENT          0x22
+#define ADXL345_WINDOW          0x23
+#define ADXL345_THRESH_ACT      0x24
+#define ADXL345_THRESH_INACT    0x25
+#define ADXL345_TIME_INACT      0x26
+#define ADXL345_ACT_INACT_CTL   0x27
+#define ADXL345_THRESH_FF       0x28
+#define ADXL345_TIME_FF         0x29
+#define ADXL345_TAP_AXES        0x2A
+#define ADXL345_ACT_TAP_STATUS  0x2B
+#define ADXL345_BW_RATE         0x2C
+#define ADXL345_POWER_CTL       0x2D
+#define ADXL345_INT_ENABLE      0x2E
+#define ADXL345_INT_MAP         0x2F
+#define ADXL345_INT_SOURCE      0x30
+#define ADXL345_DATA_FORMAT     0x31
+#define ADXL345_DATAX0          0x32  /* read only, LSByte X, two's complement */
+#define ADXL345_DATAX1          0x33  /* read only, MSByte X */
+#define ADXL345_DATAY0          0x34  /* read only, LSByte Y */
+#define ADXL345_DATAY1          0x35  /* read only, MSByte X */
+#define ADXL345_DATAZ0          0x36  /* read only, LSByte Z */
+#define ADXL345_DATAZ1          0x37  /* read only, MSByte X */
+#define ADXL345_FIFO_CTL        0x38
+#define ADXL345_FIFO_STATUS     0x39  /* read only */
+
+/* ADXL345 interrupts */
+#define ADXL345_INT_DISABLE     0X00  /* used for disabling interrupts */
+#define ADXL345_INT_OVERRUN     0X01
+#define ADXL345_INT_WATERMARK   0X02
+#define ADXL345_INT_FREEFALL    0X04
+#define ADXL345_INT_INACTIVITY  0X08
+#define ADXL345_INT_ACTIVITY    0X10
+#define ADXL345_INT_DOUBLETAP   0X20
+#define ADXL345_INT_TAP         0X40
+#define ADXL345_INT_DATAREADY   0X80
+
+/* Accelerometer hardware ports, pins and registers on the msp430 µC */
+#define ADXL345_DIR        P1DIR
+#define ADXL345_PIN        P1PIN
+#define ADXL345_REN        P1REN
+#define ADXL345_SEL        P1SEL
+#define ADXL345_SEL2       P1SEL2
+#define ADXL345_INT1_PIN   (1<<6)    /* P1.6 */
+#define ADXL345_INT2_PIN   (1<<7)    /* P1.7 */
+//#define ADXL345_IES        P1IES
+//#define ADXL345_IE         P1IE
+//#define ADXL345_IFG        P1IFG
+//#define ADXL345_VECTOR     PORT1_VECTOR
+
+/* g-range for DATA_FORMAT register */
+#define ADXL345_RANGE_2G    0x00
+#define ADXL345_RANGE_4G    0x01
+#define ADXL345_RANGE_8G    0x02
+#define ADXL345_RANGE_16G   0x03
+
+
+/* The adxl345 has programmable sample rates, but unexpected results may occur
+ * if the wrong  rate and I2C bus speed is used (see datasheet p 17). Sample
+ * rates in Hz. This setting does not change the internal sampling rate, just
+ * how often it is piped to the output registers (ie the interrupt features use
+ * the full sample rate internally).
+ * Example use:
+ *   adxl345_set_reg(ADXL345_BW_RATE, ((_ADXL345_STATUS & LOW_POWER)
+ *                  | ADXL345_SRATE_50));
+ */
+
+/* XXX NB don't use at all as I2C data rate<= 400kHz */
+#define ADXL345_SRATE_3200    0x0F
+/* XXX NB don't use at all as I2C data rate<= 400kHz */
+#define ADXL345_SRATE_1600    0x0E
+#define ADXL345_SRATE_800     0x0D  /* when I2C data rate == 400 kHz */
+#define ADXL345_SRATE_400     0x0C  /* when I2C data rate == 400 kHz */
+#define ADXL345_SRATE_200     0x0B  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_100     0x0A  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_50      0x09  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_25      0x08  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_12_5    0x07  /* 12.5 Hz, when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_6_25    0x06  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_3_13    0x05  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_1_56    0x04  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_0_78    0x03  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_0_39    0x02  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_0_20    0x01  /* when I2C data rate >= 100 kHz */
+#define ADXL345_SRATE_0_10    0x00  /* 0.10 Hz, when I2C data rate >= 100 kHz */
+/* -------------------------------------------------------------------------- */
+/* Callback pointers for the interrupts */
+extern void (*accm_int1_cb)(uint8_t reg);
+extern void (*accm_int2_cb)(uint8_t reg);
+/* -------------------------------------------------------------------------- */
+#define ACCM_INT1              0x01
+#define ACCM_INT2              0x02
+#define ADXL345_SUCCESS        0x00
+#define ADXL345_ERROR          (-1)
+/* -------------------------------------------------------------------------- */
+#define ADXL345_SENSOR         "ADXL345 sensor"
+/* -------------------------------------------------------------------------- */
+extern const struct sensors_sensor adxl345;
+/* -------------------------------------------------------------------------- */
+/* -------------------------------------------------------------------------- */
+#endif /* ifndef ADXL345_H_ */

--- a/arch/platform/oppila/dev/bmp180.c
+++ b/arch/platform/oppila/dev/bmp180.c
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup OMote-bmp180-sensor
+ * @{
+ *
+ * BMP180 driver implementation
+ *
+ * \file
+ *  Driver for the external BMP180 atmospheric pressure sensor
+ */
+/*---------------------------------------------------------------------------*/
+//#include "contiki.h"
+//#include "dev/i2c.h"
+#include "dev/gpio.h"
+#include "dev/omote-sensors.h"
+#include "lib/sensors.h"
+#include "bmp180.h"
+/*---------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+static uint8_t enabled = 0;
+/*---------------------------------------------------------------------------*/
+typedef struct {
+  int16_t ac1;
+  int16_t ac2;
+  int16_t ac3;
+  uint16_t ac4;
+  uint16_t ac5;
+  uint16_t ac6;
+  int16_t b1;
+  int16_t b2;
+  int16_t mb;
+  int16_t mc;
+  int16_t md;
+} bmp180_calibration_values;
+
+typedef struct {
+  uint8_t oversampling_mode;
+  int32_t b5;
+  bmp180_calibration_values calib;
+} bmp180_config;
+
+static bmp180_config bmp180_values;
+/*---------------------------------------------------------------------------*/
+static int
+bmp180_read_reg(uint8_t reg, uint8_t *buf, uint8_t num)
+{
+  if((buf == NULL) || (num <= 0)) {
+    PRINTF("BMP180: invalid read values\n");
+    return BMP180_ERROR;
+  }
+
+  i2c_master_enable();
+  if(i2c_single_send(BMP180_ADDR, reg) == I2C_MASTER_ERR_NONE) {
+    while(i2c_master_busy());
+    if(i2c_burst_receive(BMP180_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
+      return BMP180_SUCCESS;
+    }
+  }
+  return BMP180_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp180_write_reg(uint8_t *buf, uint8_t num)
+{
+  if((buf == NULL) || (num <= 0)) {
+    PRINTF("BMP180: invalid write values\n");
+    return BMP180_ERROR;
+  }
+
+  i2c_master_enable();
+  if(i2c_burst_send(BMP180_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
+    return BMP180_SUCCESS;
+  }
+  return BMP180_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp180_read_calib(void)
+{
+  uint8_t buf[BMP180_CALIB_TABLE_SIZE];
+
+  if(bmp180_read_reg(BMP180_AC1_CALIB, buf,
+                     BMP180_CALIB_TABLE_SIZE) == BMP180_SUCCESS) {
+
+    /*  MSB first */
+    bmp180_values.calib.ac1 = ((buf[0] << 8) + buf[1]);
+    bmp180_values.calib.ac2 = ((buf[2] << 8) + buf[3]);
+    bmp180_values.calib.ac3 = ((buf[4] << 8) + buf[5]);
+    bmp180_values.calib.ac4 = ((buf[6] << 8) + buf[7]);
+    bmp180_values.calib.ac5 = ((buf[8] << 8) + buf[9]);
+    bmp180_values.calib.ac6 = ((buf[10] << 8) + buf[11]);
+    bmp180_values.calib.b1 = ((buf[12] << 8) + buf[13]);
+    bmp180_values.calib.b2 = ((buf[14] << 8) + buf[15]);
+    bmp180_values.calib.mb = ((buf[16] << 8) + buf[17]);
+    bmp180_values.calib.mc = ((buf[18] << 8) + buf[19]);
+    bmp180_values.calib.md = ((buf[20] << 8) + buf[21]);
+
+    return BMP180_SUCCESS;
+  }
+
+  PRINTF("BMP180: failed to read calibration\n");
+  return BMP180_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp180_read_uncompensated_pressure(int32_t *pressure)
+{
+  uint8_t buf[3];
+  uint16_t delay;
+  int32_t upres;
+
+  buf[0] = BMP180_CTRL_REG;
+
+  switch(bmp180_values.oversampling_mode) {
+  case BMP180_MODE_ULTRA_LOW_POWER:
+    buf[1] = BMP180_CTRL_REG_PRESS_4_5MS;
+    delay = BMP180_DELAY_4_5MS;
+    break;
+  case BMP180_MODE_STANDARD:
+    buf[1] = BMP180_CTRL_REG_PRESS_7_5MS;
+    delay = BMP180_DELAY_7_5MS;
+    break;
+  case BMP180_MODE_HIGH_RES:
+    buf[1] = BMP180_CTRL_REG_PRESS_13_5MS;
+    delay = BMP180_DELAY_13_5MS;
+    break;
+  case BMP180_MODE_ULTRA_HIGH_RES:
+    buf[1] = BMP180_CTRL_REG_PRESS_25_5MS;
+    delay = BMP180_DELAY_25_5MS;
+    break;
+  default:
+    return BMP180_ERROR;
+  }
+
+  if(bmp180_write_reg(buf, 2) == BMP180_SUCCESS) {
+    clock_delay_usec(delay);
+    if(bmp180_read_reg(BMP180_DATA_MSB, buf, 3) == BMP180_SUCCESS) {
+      upres = (buf[0] << 16) + (buf[1] << 8) + buf[2];
+      *pressure = (upres >> (8 - bmp180_values.oversampling_mode));
+      return BMP180_SUCCESS;
+    }
+  }
+  return BMP180_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp180_read_uncompensated_temperature(int32_t *temp)
+{
+  uint8_t buf[2];
+  buf[0] = BMP180_CTRL_REG;
+  buf[1] = BMP180_CTRL_REG_TEMP;
+
+  if(bmp180_write_reg(buf, 2) == BMP180_SUCCESS) {
+    clock_delay_usec(BMP180_DELAY_4_5MS);
+    if(bmp180_read_reg(BMP180_DATA_MSB, buf, 2) == BMP180_SUCCESS) {
+      *temp = (int32_t)((buf[0] << 8) + buf[1]);
+      return BMP180_SUCCESS;
+    }
+  }
+  return BMP180_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp180_read_temperature(int16_t *temp)
+{
+  int32_t ut = 0;
+  int32_t x1, x2;
+
+  if(bmp180_read_uncompensated_temperature(&ut) == BMP180_ERROR) {
+    return BMP180_ERROR;
+  }
+
+  x1 = ((int32_t)ut - (int32_t)bmp180_values.calib.ac6)
+    * (int32_t)bmp180_values.calib.ac5 >> 15;
+  x2 = ((int32_t)bmp180_values.calib.mc << 11) / (x1 + bmp180_values.calib.md);
+  bmp180_values.b5 = x1 + x2;
+  *temp = (int16_t)((bmp180_values.b5 + 8) >> 4);
+  return BMP180_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp180_read_pressure(int32_t *pressure)
+{
+  int32_t ut = 0;
+  int32_t up = 0;
+  int32_t x1, x2, b6, x3, b3, p;
+  uint32_t b4, b7;
+
+  if(bmp180_read_uncompensated_pressure(&up) == BMP180_ERROR) {
+    return BMP180_ERROR;
+  }
+
+  if(bmp180_read_uncompensated_temperature(&ut) == BMP180_ERROR) {
+    return BMP180_ERROR;
+  }
+
+  b6 = bmp180_values.b5 - 4000;
+  x1 = (bmp180_values.calib.b2 * (b6 * b6 >> 12)) >> 11;
+  x2 = bmp180_values.calib.ac2 * b6 >> 11;
+  x3 = x1 + x2;
+  b3 = ((((int32_t)bmp180_values.calib.ac1) * 4 + x3) + 2) >> 2;
+
+  x1 = (bmp180_values.calib.ac3 * b6) >> 13;
+  x2 = (bmp180_values.calib.b1 * ((b6 * b6) >> 12)) >> 16;
+  x3 = ((x1 + x2) + 2) >> 2;
+  b4 = (bmp180_values.calib.ac4 * ((uint32_t)(x3 + 32768))) >> 15;
+  b7 = ((uint32_t)up - b3) * 50000;
+
+  if(b7 < 0x80000000) {
+    p = (b7 << 1) / b4;
+  } else {
+    p = (b7 / b4) << 1;
+  }
+
+  x1 = (p >> 8) * (p >> 8);
+  x1 = (x1 * 3038) >> 16;
+  x2 = (-7357 * p) >> 16;
+  *pressure = (p + ((x1 + x2 + 3791) >> 4));
+  *pressure /= 10;
+
+  return BMP180_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  if((type != BMP180_ACTIVE) && (type != BMP180_OVERSAMPLING)) {
+    PRINTF("BMP180: invalid start value\n");
+    return BMP180_ERROR;
+  }
+
+  if(type == BMP180_ACTIVE) {
+    if(value) {
+      i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
+               I2C_SCL_NORMAL_BUS_SPEED);
+
+      /* Read the calibration values */
+      if(bmp180_read_calib() != BMP180_ERROR) {
+        PRINTF("BMP180: sensor started\n");
+        enabled = 1;
+        bmp180_values.oversampling_mode = BMP180_MODE_ULTRA_LOW_POWER;
+        return BMP180_SUCCESS;
+      }
+
+      PRINTF("BMP180: failed to enable\n");
+      return BMP180_ERROR;
+    } else {
+      enabled = 0;
+      return BMP180_SUCCESS;
+    }
+  } else if(type == BMP180_OVERSAMPLING) {
+    if((value < BMP180_MODE_ULTRA_LOW_POWER) ||
+       (value > BMP180_MODE_ULTRA_HIGH_RES)) {
+      PRINTF("BMP180: invalid oversampling value\n");
+      return BMP180_ERROR;
+    }
+    bmp180_values.oversampling_mode = value;
+    return BMP180_SUCCESS;
+  }
+
+  return BMP180_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+status(int type)
+{
+  switch(type) {
+  case SENSORS_ACTIVE:
+  case SENSORS_READY:
+    return enabled;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp180_read_sensor(int32_t *value, uint8_t type)
+{
+  int16_t temp = 0;
+
+  /* The temperature is required to compensate the pressure value */
+  if(bmp180_read_temperature(&temp) != BMP180_SUCCESS) {
+    return BMP180_ERROR;
+  }
+
+  switch(type) {
+  case BMP180_READ_PRESSURE:
+    return bmp180_read_pressure(value);
+
+  case BMP180_READ_TEMP:
+    *value = (int16_t) temp;
+    return BMP180_SUCCESS;
+  }
+
+  return BMP180_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value(int type)
+{
+  int32_t value;
+
+  if(!enabled) {
+    PRINTF("BMP180: sensor not started\n");
+    return BMP180_ERROR;
+  }
+
+  if((type != BMP180_READ_PRESSURE) && (type != BMP180_READ_TEMP)) {
+    PRINTF("BMP180: invalid read value\n");
+    return BMP180_ERROR;
+  }
+
+  if(bmp180_read_sensor(&value, type) == BMP180_SUCCESS) {
+    return (int)value;
+  }
+
+  PRINTF("BMP180: fail to read\n");
+  return BMP180_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(bmp180, BMP180_SENSOR, value, configure, status);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/arch/platform/oppila/dev/bmp180.h
+++ b/arch/platform/oppila/dev/bmp180.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup OMote-sensors
+ * @{
+ *
+ * \defgroup OMote-bmp180-sensor BMP180 Sensor
+ *
+ * Driver for the BMP180 sensor
+ *
+ * BMP180 digital atmospheric pressure and temperature driver
+ * @{
+ *
+ * \file
+ * Header file for the external BMP180 Sensor Driver
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef BMP180_H_
+#define BMP180_H_
+#include <stdio.h>
+#include "lib/sensors.h"
+#include "dev/omote-sensors.h"
+#include "i2c.h"
+/* -------------------------------------------------------------------------- */
+/**
+ * \name BMP180 address and registers
+ * @{
+ */
+/* -------------------------------------------------------------------------- */
+#define BMP180_ADDR                      0x77
+/* -------------------------------------------------------------------------- */
+/* Control register */
+#define BMP180_CTRL_REG                  0xF4
+/* Read uncompensated temperature  */
+#define BMP180_CTRL_REG_TEMP             0x2E
+/* Read uncompensated pressure, no oversampling */
+#define BMP180_CTRL_REG_PRESS_4_5MS      0x34
+/* Read uncompensated pressure, oversampling 1*/
+#define BMP180_CTRL_REG_PRESS_7_5MS      0x74
+/* Read uncompensated pressure, oversampling 2 */
+#define BMP180_CTRL_REG_PRESS_13_5MS     0xB4
+/* Read uncompensated pressure, oversampling 3 */
+#define BMP180_CTRL_REG_PRESS_25_5MS     0xF4
+/* -------------------------------------------------------------------------- */
+#define BMP180_DATA_MSB                  0xF6
+#define BMP180_DATA_LSB                  0xF7
+/* 19-bit resolution */
+#define BMP180_DATA_XLSB                 0xF8
+/* -------------------------------------------------------------------------- */
+/* Calibration registers, 16-bit wide */
+#define BMP180_AC1_CALIB                 0xAA
+#define BMP180_AC2_CALIB                 0xAC
+#define BMP180_AC3_CALIB                 0xAE
+#define BMP180_AC4_CALIB                 0xB0
+#define BMP180_AC5_CALIB                 0xB2
+#define BMP180_AC6_CALIB                 0xB4
+#define BMP180_B1_CALIB                  0xB6
+#define BMP180_B2_CALIB                  0xB8
+#define BMP180_MB_CALIB                  0xBA
+#define BMP180_MC_CALIB                  0xBC
+#define BMP180_MD_CALIB                  0xBE
+#define BMP180_CALIB_TABLE_SIZE          22    /**< size in bytes */
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name BMP180 operation modes
+ * @{
+ */
+#define BMP180_MODE_ULTRA_LOW_POWER      0x00
+#define BMP180_MODE_STANDARD             0x01
+#define BMP180_MODE_HIGH_RES             0x02
+#define BMP180_MODE_ULTRA_HIGH_RES       0x03
+/* -------------------------------------------------------------------------- */
+#define BMP180_DELAY_4_5MS               4700
+#define BMP180_DELAY_7_5MS               7700
+#define BMP180_DELAY_13_5MS              13700
+#define BMP180_DELAY_25_5MS              25700
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name BMP180 return and command values
+ * @{
+ */
+#define BMP180_SUCCESS         0x00
+#define BMP180_ERROR             -1
+
+#define BMP180_ACTIVE          SENSORS_ACTIVE
+#define BMP180_OVERSAMPLING    0x00
+#define BMP180_READ_PRESSURE   0x01
+#define BMP180_READ_TEMP       0x02
+/** @} */
+/* -------------------------------------------------------------------------- */
+#define BMP180_SENSOR "BMP180 pressure and temperature sensor"
+/* -------------------------------------------------------------------------- */
+extern const struct sensors_sensor bmp180;
+/* -------------------------------------------------------------------------- */
+#endif
+/* -------------------------------------------------------------------------- */
+/**
+ * @}
+ * @}
+ */
+

--- a/arch/platform/oppila/dev/board-buttons.c
+++ b/arch/platform/oppila/dev/board-buttons.c
@@ -1,0 +1,62 @@
+/* 
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila
+ * @{
+ *
+ * \defgroup oppila-buttons user button
+ *
+ * Generic module controlling the user button
+ * @{
+ *
+ * \file
+ * Defines the Oppila user button for use with the button HAL
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/button-hal.h"
+/*---------------------------------------------------------------------------*/
+#if PLATFORM_HAS_BUTTON
+/*---------------------------------------------------------------------------*/
+BUTTON_HAL_BUTTON(button_user, "User button", \
+                  GPIO_PORT_PIN_TO_GPIO_HAL_PIN(BUTTON_USER_PORT, BUTTON_USER_PIN), \
+                  GPIO_HAL_PIN_CFG_PULL_UP, BUTTON_HAL_ID_USER_BUTTON, true);
+/*---------------------------------------------------------------------------*/
+BUTTON_HAL_BUTTONS(&button_user);
+/*---------------------------------------------------------------------------*/
+#endif
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/arch/platform/oppila/dev/omote-sensors.c
+++ b/arch/platform/oppila/dev/omote-sensors.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-sensors
+ * @{
+ *
+ * Generic module controlling sensors on the oppila platform
+ * @{
+ *
+ * \file
+ * Implementation of a generic module controlling OMote sensors
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/cc2538-sensors.h"
+#include "dev/button-sensor.h"
+
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+/** \brief Exports global symbols for the sensor API */
+SENSORS(&vdd3_sensor, &cc2538_temp_sensor);
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/arch/platform/oppila/dev/omote-sensors.h
+++ b/arch/platform/oppila/dev/omote-sensors.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila
+ * @{
+ *
+ * \defgroup oppila-sensors Oppila sensors
+ *
+ * \file
+ * Implementation of a generic module controlling OMote sensors
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef OMOTE_SENSORS_H_
+#define OMOTE_SENSORS_H_
+/*---------------------------------------------------------------------------*/
+#include "lib/sensors.h"
+#include "dev/cc2538-sensors.h"
+/*---------------------------------------------------------------------------*/
+/**
+ * \name OMote sensor constants
+ *
+ * These constants are used by various sensors on the OMote. They can be used
+ * to configure ADC decimation rate (where applicable), enable interrupts, etc.
+ * @{
+ */
+#define HW_INT_OVER_THRS                              0x01
+#define HW_INT_BELOW_THRS                             0x02
+#define HW_INT_DISABLE                                0x03
+#define OMOTE_SENSORS_CONFIGURE_TYPE_DECIMATION_RATE   0x0100
+#define OMOTE_SENSORS_ERROR                            CC2538_SENSORS_ERROR
+/** @} */
+/*---------------------------------------------------------------------------*/
+#endif /* OMOTE_SENSORS_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/arch/platform/oppila/doxygen-group.txt
+++ b/arch/platform/oppila/doxygen-group.txt
@@ -1,0 +1,8 @@
+/**
+ * \defgroup oppila-platform Oppila-based platform
+ * The Oppila platform is based on the CC2538 by Texas Instruments
+ * based on an ARM Cortex-M3 core and a IEEE 802.15.4 radio.
+ *
+ * The Oppila platform was designed at Oppila Microsystems in 2020
+ * \ingroup cc2538-platforms
+ */

--- a/arch/platform/oppila/omote/Makefile.omote
+++ b/arch/platform/oppila/omote/Makefile.omote
@@ -1,0 +1,5 @@
+MOTELIST_OPPILA := OMote
+CONTIKI_TARGET_SOURCEFILES += sensor_platform.c adxl345.c 
+CONTIKI_TARGET_SOURCEFILES += bmp180.c omote-sensors.c 
+CONTIKI_TARGET_SOURCEFILES += adc-omote.c adc-sensors.c
+BOARD_SOURCEFILES += board.c leds-arch.c

--- a/arch/platform/oppila/omote/README.md
+++ b/arch/platform/oppila/omote/README.md
@@ -1,0 +1,57 @@
+Oppila Microsystems omote platform -  http://www.oppila.in
+-------------------------------------------------------------------------
+
+The omote platform is a IoT Hardware development platform based
+on TI's CC2538 system on chip (SoC), featuring an ARM Cortex-M3 with 512KB
+flash, 32Kb RAM, 2.4GHz RF interface , and the
+following goodies:
+
+* ISM 2.4-GHz IEEE 802.15.4 & Zigbee compliant.
+* AES-128/256, SHA2 Hardware Encryption Engine.
+* ECC-128/256, RSA Hardware Acceleration Engine for Secure Key Exchange.
+* On board sensors LDR, ADXL345 and BMP180
+* Power input with wide range 3.7-30VDC.
+* Programming over BSL by enetring into bootloader mode
+* On-board micro USB connector for USB 2.0 applications.
+* Two LEDs
+* User, BSL and Reset buttons.
+* On-board printed PCB 2.4Ghz antenna. 
+
+Port Features
+
+The omote has the following key features:
+
+  * Deep Sleep support with RAM retention for ultra-low energy consumption.
+  * Native USB support (CDC-ACM). SLIP over UART for border routers is no longer a bottleneck.
+  * DMA transfers for increased performance (RAM to/from RF, RAM to/from USB).
+
+In terms of hardware support, the following drivers have been implemented for the oppila-based platforms:
+
+    CC2538 System-on-Chip:
+	Standard Cortex M3 peripherals (NVIC, SCB, SysTick)
+        Sleep Timer (underpins rtimers)
+        SysTick (underpins the platform clock and Contiki's timers infrastructure)
+        RF (2.4GHz)
+        UART
+        Watchdog (in watchdog mode)
+        USB (in CDC-ACM)
+        uDMA Controller (RAM to/from USB and RAM to/from RF)
+        Low power modes
+        Random number generator
+        General-Purpose Timers. NB: GPT0 is in use by the platform code, the remaining GPTs are available for application development.
+        ADC
+        Cryptoprocessor (AES-ECB/CBC/CTR/CBC-MAC/GCM/CCM-128/192/256, SHA-256)
+        Public Key Accelerator (ECDH, ECDSA)
+        Flash-based port of Coffee
+        LEDs
+        Buttons
+
+The omote has 13 pinouts to connect boolean,digital and analog sensors based on I2C,UART,and SPI Protocols as well as other sensors or actuators you may need to connect.
+
+More Reading
+============
+1. [Oppila Microsystems omote website](http://www.oppila.in)
+2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
+
+[cc2538]: http://www.ti.com/product/cc2538     "CC2538"
+*/

--- a/arch/platform/oppila/omote/README.md
+++ b/arch/platform/oppila/omote/README.md
@@ -25,27 +25,6 @@ The omote has the following key features:
   * Native USB support (CDC-ACM). SLIP over UART for border routers is no longer a bottleneck.
   * DMA transfers for increased performance (RAM to/from RF, RAM to/from USB).
 
-In terms of hardware support, the following drivers have been implemented for the oppila-based platforms:
-
-    CC2538 System-on-Chip:
-	Standard Cortex M3 peripherals (NVIC, SCB, SysTick)
-        Sleep Timer (underpins rtimers)
-        SysTick (underpins the platform clock and Contiki's timers infrastructure)
-        RF (2.4GHz)
-        UART
-        Watchdog (in watchdog mode)
-        USB (in CDC-ACM)
-        uDMA Controller (RAM to/from USB and RAM to/from RF)
-        Low power modes
-        Random number generator
-        General-Purpose Timers. NB: GPT0 is in use by the platform code, the remaining GPTs are available for application development.
-        ADC
-        Cryptoprocessor (AES-ECB/CBC/CTR/CBC-MAC/GCM/CCM-128/192/256, SHA-256)
-        Public Key Accelerator (ECDH, ECDSA)
-        Flash-based port of Coffee
-        LEDs
-        Buttons
-
 The omote has 13 pinouts to connect boolean,digital and analog sensors based on I2C,UART,and SPI Protocols as well as other sensors or actuators you may need to connect.
 
 More Reading

--- a/arch/platform/oppila/omote/board.c
+++ b/arch/platform/oppila/omote/board.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup omote
+ * @{
+ *
+ * \file
+ *  Board-initialisation for the Oppila's OMote platform
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include <stdint.h>
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+static void
+configure_unused_pins(void)
+{
+  /* FIXME */
+}
+/*---------------------------------------------------------------------------*/
+void
+board_init()
+{
+  configure_unused_pins();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ */
+

--- a/arch/platform/oppila/omote/board.h
+++ b/arch/platform/oppila/omote/board.h
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/*
+ * \addtogroup omote
+ * @{
+ *
+ * \defgroup omote
+ *
+ * This file provides connectivity information on LEDs, Buttons, UART and
+ * other OMote peripherals
+ *
+ * This file can be used as the basis to configure other platforms using the
+ * cc2538 SoC.
+ * @{
+ *
+ * There are on board sensors like LDR, BMP180 and ADXL335 
+ *
+ * \file
+ * Header file with definitions related to the I/O connections on the Oppila 
+ * Microsystems OMote, cc2538-based
+ *
+ * \note   Do not include this file directly. It gets included by contiki-conf
+ *         after all relevant directives have been set.
+ */         
+/* ---------------------------------------------------------------------------*/
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#include "dev/gpio.h"
+#include "dev/nvic.h"
+/*---------------------------------------------------------------------------*/
+/** \name OMote LED configuration
+ *
+ * LEDs on the OMote 
+ * - LED1 (Green)    -> PD0
+ * - LED2 (Green1    -> PD4 
+ * @{
+ */
+/*---------------------------------------------------------------------------*/
+#define LEDS_ARCH_L1_PORT GPIO_D_NUM
+#define LEDS_ARCH_L1_PIN  0
+#define LEDS_ARCH_L2_PORT GPIO_D_NUM
+#define LEDS_ARCH_L2_PIN  4
+
+#define LEDS_CONF_GREEN     1
+#define LEDS_CONF_GREEN1    2
+
+#define LEDS_CONF_COUNT   2
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name USB configuration
+ */
+#ifdef USB_PULLUP_PORT
+#undef USB_PULLUP_PORT
+#endif
+#ifdef USB_PULLUP_PIN
+#undef USB_PULLUP_PIN
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name UART configuration
+ *
+ * On the OMote, the UARTs are connected to the following ports/pins:
+ *
+ * - UART0:
+ *   - RX:  PA0
+ *   - TX:  PA1
+ * - UART1:
+ *   - RX:  PC1
+ *   - TX:  PC0
+ *   - CTS: disabled as default
+ *   - RTS: disabled as default
+ *
+ * @{
+ */
+#define UART0_RX_PORT            GPIO_A_NUM
+#define UART0_RX_PIN             0
+#define UART0_TX_PORT            GPIO_A_NUM
+#define UART0_TX_PIN             1
+
+#define UART1_RX_PORT            GPIO_C_NUM
+#define UART1_RX_PIN             1
+#define UART1_TX_PORT            GPIO_C_NUM
+#define UART1_TX_PIN             0
+#define UART1_CTS_PORT           (-1)
+#define UART1_CTS_PIN            (-1)
+#define UART1_RTS_PORT           (-1)
+#define UART1_RTS_PIN            (-1)
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name ADC configuration
+ *
+ * These values configure which CC2538 pins and ADC channels to use for the ADC
+ * inputs. By default the OMote allows four out-of-the-box ADC pins.
+ *
+ * The OMote allows both 3.3V and 5V analogue sensors
+ * ADC inputs can only be on port A.
+ * @{
+ */
+
+#define ADC_SENSORS_PORT         GPIO_A_NUM    /**< ADC GPIO control port */
+
+#ifndef ADC_SENSORS_CONF_ADC1_PIN
+#define ADC_SENSORS_ADC1_PIN     5             /**< LDR sensor is connected    */
+#else
+#if ((ADC_SENSORS_CONF_ADC1_PIN != -1) && (ADC_SENSORS_CONF_ADC1_PIN != 5))
+#error "ADC1 channel should be mapped to PA5 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC1_PIN ADC_SENSORS_CONF_ADC1_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC3_PIN
+#define ADC_SENSORS_ADC3_PIN     2             /**< ADC3 to PA2     */
+#else
+#if ((ADC_SENSORS_CONF_ADC3_PIN != -1) && (ADC_SENSORS_CONF_ADC3_PIN != 2))
+#error "ADC3 channel should be mapped to PA2 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC3_PIN ADC_SENSORS_CONF_ADC3_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC2_PIN
+#define ADC_SENSORS_ADC2_PIN     4             /**< ADC2 to PA4     */
+#else
+#if ((ADC_SENSORS_CONF_ADC2_PIN != -1) && (ADC_SENSORS_CONF_ADC2_PIN != 4))
+#error "ADC2 channel should be mapped to PA2 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC2_PIN ADC_SENSORS_CONF_ADC2_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC4_PIN
+#define ADC_SENSORS_ADC4_PIN     6             /**< ADC4 to PA6     */
+#else
+#if ((ADC_SENSORS_CONF_ADC4_PIN != -1) && (ADC_SENSORS_CONF_ADC4_PIN != 6))
+#error "ADC2 channel should be mapped to PA2 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC4_PIN ADC_SENSORS_CONF_ADC4_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC5_PIN
+#define ADC_SENSORS_ADC5_PIN     7             /**< ADC5 to PA7     */
+#else
+#if ((ADC_SENSORS_CONF_ADC5_PIN != -1) && (ADC_SENSORS_CONF_ADC5_PIN != 7))
+#error "ADC2 channel should be mapped to PA2 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC5_PIN ADC_SENSORS_CONF_ADC5_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_MAX
+#define ADC_SENSORS_MAX          4             /**< Maximum sensors    */
+#else
+#define ADC_SENSORS_MAX          ADC_SENSORS_CONF_MAX
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name OMote Button configuration
+ *
+ * Buttons on the OMote are connected as follows:
+ * - BUTTON_USER  -> PB0, S1 user button,
+ * - BUTTON_BSL   -> PA3, bootloader button
+ * - BUTTON_RESET -> RESET_N line, S2 reset the CC2538
+ * 
+ * @{
+ */
+#define BUTTON_USER_PORT       GPIO_B_NUM
+#define BUTTON_USER_PIN        0
+#define BUTTON_USER_VECTOR     GPIO_B_IRQn
+
+#define PLATFORM_HAS_BUTTON     1
+#define PLATFORM_SUPPORTS_BUTTON_HAL 1
+
+
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name SPI (SSI1) configuration
+ *
+ * These values configure which CC2538 pins to use for the SPI (SSI1) lines
+ * TX -> MOSI, RX -> MISO
+ * @{
+ */
+#define SPI1_CLK_PORT            GPIO_C_NUM
+#define SPI1_CLK_PIN             4
+#define SPI1_TX_PORT             GPIO_C_NUM
+#define SPI1_TX_PIN              5
+#define SPI1_RX_PORT             GPIO_C_NUM
+#define SPI1_RX_PIN              6
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name I2C configuration
+ *
+ * These values configure which CC2538 pins to use for the I2C lines
+ * 
+ * The I2C is exposed over the J6 header, using a 2-pin connector
+ * @{
+ */
+#define I2C_SCL_PORT             GPIO_C_NUM
+#define I2C_SCL_PIN              3
+#define I2C_SDA_PORT             GPIO_C_NUM
+#define I2C_SDA_PIN              2
+#define I2C_INT_PORT             GPIO_D_NUM
+#define I2C_INT_PIN              1
+#define I2C_INT_VECTOR           GPIO_D_IRQn
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name CC2538 TSCH configuration
+ *
+ * @{
+ */
+#define RADIO_PHY_OVERHEAD        CC2538_PHY_OVERHEAD
+#define RADIO_BYTE_AIR_TIME       CC2538_BYTE_AIR_TIME
+#define RADIO_DELAY_BEFORE_TX     CC2538_DELAY_BEFORE_TX
+#define RADIO_DELAY_BEFORE_RX     CC2538_DELAY_BEFORE_RX
+#define RADIO_DELAY_BEFORE_DETECT CC2538_DELAY_BEFORE_DETECT
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Device string used on startup
+ * @{
+ */
+#define BOARD_STRING "Oppila Microsystems OMote platform"
+/** @} */
+
+#endif /* BOARD_H_ */
+
+/**
+ * @}
+ * @}
+ */

--- a/arch/platform/oppila/omote/leds-arch.c
+++ b/arch/platform/oppila/omote/leds-arch.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/leds.h"
+#include "dev/gpio-hal.h"
+
+#include <stdbool.h>
+/*---------------------------------------------------------------------------*/
+const leds_t leds_arch_leds[] = {
+  {
+    .pin = GPIO_PORT_PIN_TO_GPIO_HAL_PIN(LEDS_ARCH_L1_PORT, LEDS_ARCH_L1_PIN),
+    .negative_logic = false
+  },
+  {
+    .pin = GPIO_PORT_PIN_TO_GPIO_HAL_PIN(LEDS_ARCH_L2_PORT, LEDS_ARCH_L2_PIN),
+    .negative_logic = false
+  }
+};
+/*---------------------------------------------------------------------------*/

--- a/arch/platform/oppila/omote/sensor_platform.c
+++ b/arch/platform/oppila/omote/sensor_platform.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-platforms
+ * @{
+ *
+ * \defgroup Oppila Development Kit platform
+ */
+/*---------------------------------------------------------------------------*/
+#include "lib/sensors.h"
+void
+platform_init_stage_four()
+{
+process_start(&sensors_process, NULL);
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */
+

--- a/arch/platform/oppila/orouter/Makefile.orouter
+++ b/arch/platform/oppila/orouter/Makefile.orouter
@@ -1,0 +1,7 @@
+MOTELIST_OPPILA := orouter
+MODULES += $(CONTIKI_NG_DRIVERS_DIR)/enc28j60
+CC2538_ENC28J60_ARCH ?= gpio
+ifeq ($(WITH_IP64),1)
+CFLAGS += -DUIP_FALLBACK_INTERFACE=ip64_uip_fallback_interface
+endif
+BOARD_SOURCEFILES += board.c enc28j60-arch-$(CC2538_ENC28J60_ARCH).c leds-arch.c

--- a/arch/platform/oppila/orouter/README.md
+++ b/arch/platform/oppila/orouter/README.md
@@ -1,0 +1,41 @@
+Oppila Microsystems - http://www.oppila.in
+------------------------------------------------------------
+The ORouter is a routing device that forwards data packets 
+between networks.ORouter is capable of IPV4/IPV6 routing device.
+The device integrates the ENC28J60 ethernet module,
+supporting up to 30VDC.The micro-USB is used for both 
+powering the device over USB (5VDC), and programming/debugging.
+Oppila border router for 2.4 GHz IEEE 802.15.4, 6LoWPAN, and 
+ZigBee applications orouter is havnig following features
+
+ * ARM Cortex-M3 with 512KB flash and 32KB RAM (16KB retention), 32MHz.
+ * ISM 2.4-GHz IEEE 802.15.4 & Zigbee compliant.
+ * on-board PCB for 2.4GHz antenna
+ * RJ45 ethernet connector
+ * Ethernet 10BASE-T IPv4/IP64
+ * On-board CP2104 to flash over its micro-USB connector
+ * LED, buttons 
+ * AES-128/256, SHA2 Hardware Encryption Engine.
+ * ECC-128/256, RSA Hardware Acceleration Engine for Secure Key Exchange.
+
+Other features
+==============
+
+	This radio is compatible with existing and trending protocols such as Thread, but you can also develop your own applications on top of very well 
+	supported protocols like 6LoWPAN and IEEE 802.15.4, without vendor restrictions or licenses.
+	
+	The maximum range is between 100 meters and 20 km, with highly configurable radio parameters such as modulation, data rate, transmission power, etc.
+
+	Increased security with on-board hardware security (SHA2, AES-128/256, ECC-128/256 and RSA for secure key exchange)
+
+	Out of the box connectivity with IPv6 and IPv4 networks and services, using IP64 (NAT64, DHCP64)
+
+
+More Reading
+============
+1. [Oppila Microsystems orouter website](http://www.oppila.in)
+2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
+
+[cc2538]: http://www.ti.com/product/cc2538     "CC2538"
+*/
+

--- a/arch/platform/oppila/orouter/board.c
+++ b/arch/platform/oppila/orouter/board.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-orouter-ethernet-router
+ * @{
+ *
+ * \file
+ *  Board-initialisation for the Oppila Ethernet ORouter
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include <stdint.h>
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+static void
+configure_unused_pins(void)
+{
+  // FIXME
+}
+/*---------------------------------------------------------------------------*/
+void
+board_init()
+{
+  configure_unused_pins();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ */
+

--- a/arch/platform/oppila/orouter/board.h
+++ b/arch/platform/oppila/orouter/board.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2012, Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (c) 2020, Oppila Microsystems <http://www.oppila.in>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/* 
+ * \addtogroup oppila-platforms
+ * @{
+ *
+ * \defgroup oppila-orouter-ethernet-router Oppila IoT Ethernet ORouter
+ *
+ * The Oppila ORouter includes an Ethernet ENC28J60 controller, operating over IPv4/IP64.
+ * It features a RF interface (2.4GHz) with on board PCB antenna
+ *
+ * This file provides connectivity information on LED, Buttons, UART and
+ * other peripherals
+ * @{
+ *
+ * \file
+ * Header file with definitions related to the I/O connections on the Oppila's
+ * Ethernet ORouter
+ *
+ * \note   Do not include this file directly. It gets included by contiki-conf
+ *         after all relevant directives have been set.
+ */         
+/*---------------------------------------------------------------------------*/
+#ifndef BOARD_H_
+#define BOARD_H_
+
+#include "dev/gpio.h"
+#include "dev/nvic.h"
+/*---------------------------------------------------------------------------*/
+/** \name Orouter Ethernet Router LED configuration
+ *
+ * LEDs on the eth-gw are connected as follows:
+ * - LED1 (Green)    -> PD2
+ * @{
+ */
+/*---------------------------------------------------------------------------*/
+#define LEDS_ARCH_L1_PORT GPIO_D_NUM
+#define LEDS_ARCH_L1_PIN  2
+
+#define LEDS_CONF_RED     1
+
+#define LEDS_CONF_COUNT   1
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name USB configuration
+ *
+ * The USB pullup for D+ is not included in this platform
+ */
+#ifdef USB_PULLUP_PORT
+#undef USB_PULLUP_PORT
+#endif
+#ifdef USB_PULLUP_PIN
+#undef USB_PULLUP_PIN
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name UART configuration
+ *
+ * On the eth-gw, the UARTs are connected to the following ports/pins:
+ *
+ * - UART0:
+ *   - RX:  PA0
+ *   - TX:  PA1
+ * @{
+ */
+#define UART0_RX_PORT            GPIO_A_NUM
+#define UART0_RX_PIN             0
+#define UART0_TX_PORT            GPIO_A_NUM
+#define UART0_TX_PIN             1
+
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ORouter button configuration
+ *
+ * Buttons on the eth-gw are connected as follows:
+ * - BUTTON_USER  -> PA3,Sw2 user button, shared with bootloader
+ * - BUTTON_RESET -> RESET_N line
+ * @{
+ */
+/** BUTTON_USER -> PA3 */
+#define BUTTON_USER_PORT       GPIO_A_NUM
+#define BUTTON_USER_PIN        3
+#define BUTTON_USER_VECTOR     GPIO_A_IRQn
+
+#define PLATFORM_HAS_BUTTON    1
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name SPI (SSI0) configuration
+ *
+ * These values configure which CC2538 pins to use for the SPI (SSI0) lines,
+ * TX -> MOSI, RX -> MISO
+ * @{
+ */
+#define SPI0_CLK_PORT             GPIO_B_NUM
+#define SPI0_CLK_PIN              2
+#define SPI0_TX_PORT              GPIO_B_NUM
+#define SPI0_TX_PIN               1
+#define SPI0_RX_PORT              GPIO_B_NUM
+#define SPI0_RX_PIN               3
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Ethernet ENC28J60 configuration
+ *
+ * These values configure the required pins to drive an external Ethernet
+ * module.
+ * @{
+ */
+#define ETH_SPI_INSTANCE           0
+#define ETH_SPI_CLK_PORT           SPI0_CLK_PORT
+#define ETH_SPI_CLK_PIN            SPI0_CLK_PIN
+#define ETH_SPI_MOSI_PORT          SPI0_TX_PORT
+#define ETH_SPI_MOSI_PIN           SPI0_TX_PIN
+#define ETH_SPI_MISO_PORT          SPI0_RX_PORT
+#define ETH_SPI_MISO_PIN           SPI0_RX_PIN
+#define ETH_SPI_CSN_PORT           GPIO_B_NUM
+#define ETH_SPI_CSN_PIN            5
+#define ETH_INT_PORT               GPIO_D_NUM
+#define ETH_INT_PIN                0
+#define ETH_RESET_PORT             GPIO_D_NUM
+#define ETH_RESET_PIN              1
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Device string used on startup
+ * @{
+ */
+#define BOARD_STRING "Opilla Microsystem Ethernet ORouter"
+/** @} */
+
+#endif /* BOARD_H_ */
+
+/**
+ * @}
+ * @}
+ */
+

--- a/arch/platform/oppila/orouter/enc28j60-arch-gpio.c
+++ b/arch/platform/oppila/orouter/enc28j60-arch-gpio.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2012-2013, Thingsquare, http://www.thingsquare.com/.
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-orouter-ethernet-router
+ * @{
+ *
+ * \defgroup oppila-eth-arch-gpio Oppila ENC28J60 GPIO arch
+ *
+ * ENC28J60 eth-gw GPIO arch specifics
+ * @{
+ *
+ * \file
+ * eth-gw GPIO arch specifics
+ */
+/*---------------------------------------------------------------------------*/
+#include "clock.h"
+#include "dev/gpio.h"
+/*---------------------------------------------------------------------------*/
+#define CLK_PORT    GPIO_PORT_TO_BASE(ETH_SPI_CLK_PORT)
+#define CLK_BIT     GPIO_PIN_MASK(ETH_SPI_CLK_PIN)
+#define MOSI_PORT   GPIO_PORT_TO_BASE(ETH_SPI_MOSI_PORT)
+#define MOSI_BIT    GPIO_PIN_MASK(ETH_SPI_MOSI_PIN)
+#define MISO_PORT   GPIO_PORT_TO_BASE(ETH_SPI_MISO_PORT)
+#define MISO_BIT    GPIO_PIN_MASK(ETH_SPI_MISO_PIN)
+#define CSN_PORT    GPIO_PORT_TO_BASE(ETH_SPI_CSN_PORT)
+#define CSN_BIT     GPIO_PIN_MASK(ETH_SPI_CSN_PIN)
+#define RESET_PORT  GPIO_PORT_TO_BASE(ETH_RESET_PORT)
+#define RESET_BIT   GPIO_PIN_MASK(ETH_RESET_PIN)
+/*---------------------------------------------------------------------------*/
+/* Delay in us */
+#define DELAY 10
+/*---------------------------------------------------------------------------*/
+static void
+delay(void)
+{
+  clock_delay_usec(DELAY);
+}
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_select(void)
+{
+  GPIO_CLR_PIN(CSN_PORT, CSN_BIT);
+  delay();
+}
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_deselect(void)
+{
+  GPIO_SET_PIN(CSN_PORT, CSN_BIT);
+}
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_init(void)
+{
+  /* Set all pins to GPIO mode */
+  GPIO_SOFTWARE_CONTROL(CLK_PORT, CLK_BIT);
+  GPIO_SOFTWARE_CONTROL(MOSI_PORT, MOSI_BIT);
+  GPIO_SOFTWARE_CONTROL(MISO_PORT, MISO_BIT);
+  GPIO_SOFTWARE_CONTROL(CSN_PORT, CSN_BIT);
+  GPIO_SOFTWARE_CONTROL(RESET_PORT, RESET_BIT);
+
+  /* CSN, MOSI, CLK and RESET are output pins */
+  GPIO_SET_OUTPUT(CSN_PORT, CSN_BIT);
+  GPIO_SET_OUTPUT(MOSI_PORT, MOSI_BIT);
+  GPIO_SET_OUTPUT(CLK_PORT, CLK_BIT);
+  GPIO_SET_OUTPUT(RESET_PORT, RESET_BIT);
+
+  /* MISO is an input pin */
+  GPIO_SET_INPUT(MISO_PORT, MISO_BIT);
+
+  /* Enable the device */
+  GPIO_SET_INPUT(RESET_PORT, RESET_BIT);
+
+  /* The CS pin is active low, so we set it high when we haven't
+     selected the chip. */
+  enc28j60_arch_spi_deselect();
+
+  /* The CLK is active low, we set it high when we aren't using it. */
+  GPIO_CLR_PIN(CLK_PORT, CLK_BIT);
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+enc28j60_arch_spi_write(uint8_t output)
+{
+  int i;
+  uint8_t input;
+  input = 0;
+
+  for(i=0; i < 8; i++) {
+    /* Write data on MOSI pin */
+    if(output & 0x80) {
+      GPIO_SET_PIN(MOSI_PORT, MOSI_BIT);
+    } else {
+      GPIO_CLR_PIN(MOSI_PORT, MOSI_BIT);
+    }
+    output <<= 1;
+
+    /* Set clock high  */
+    GPIO_SET_PIN(CLK_PORT, CLK_BIT);
+    delay();
+
+    /* Read data from MISO pin */
+    input <<= 1;
+    if(GPIO_READ_PIN(MISO_PORT, MISO_BIT) != 0) {
+      input |= 0x1;
+    }
+
+    /* Set clock low */
+    GPIO_CLR_PIN(CLK_PORT, CLK_BIT);
+    delay();
+  }
+  return input;
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+enc28j60_arch_spi_read(void)
+{
+  return enc28j60_arch_spi_write(0);
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */
+

--- a/arch/platform/oppila/orouter/enc28j60-arch-spi.c
+++ b/arch/platform/oppila/orouter/enc28j60-arch-spi.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2014, CETIC.
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-orouter-ethernet-router
+ * @{
+ *
+ * \defgroup orouter-eth-arch-spi Oppila ENC28J60 SPI arch
+ *
+ * ENC28J60 eth-gw SPI arch specifics
+ * @{
+ *
+ * \file
+ * eth-gw SPI arch specifics
+ */
+/*---------------------------------------------------------------------------*/
+#include "dev/spi-arch-legacy.h"
+#include "dev/spi-legacy.h"
+#include "dev/gpio.h"
+/*---------------------------------------------------------------------------*/
+#define RESET_PORT  GPIO_PORT_TO_BASE(ETH_RESET_PORT)
+#define RESET_BIT   GPIO_PIN_MASK(ETH_RESET_PIN)
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_init(void)
+{
+  spix_init(ETH_SPI_INSTANCE);
+  spix_cs_init(ETH_SPI_CSN_PORT, ETH_SPI_CSN_PIN);
+  spix_set_mode(ETH_SPI_INSTANCE, SSI_CR0_FRF_MOTOROLA, 0, 0, 8);
+  GPIO_SOFTWARE_CONTROL(RESET_PORT, RESET_BIT);
+  GPIO_SET_OUTPUT(RESET_PORT, RESET_BIT);
+  GPIO_SET_INPUT(RESET_PORT, RESET_BIT);
+}
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_select(void)
+{
+  SPIX_CS_CLR(ETH_SPI_CSN_PORT, ETH_SPI_CSN_PIN);
+}
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_deselect(void)
+{
+  SPIX_CS_SET(ETH_SPI_CSN_PORT, ETH_SPI_CSN_PIN);
+}
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_write(uint8_t output)
+{
+  SPIX_WAITFORTxREADY(ETH_SPI_INSTANCE);
+  SPIX_BUF(ETH_SPI_INSTANCE) = output;
+  SPIX_WAITFOREOTx(ETH_SPI_INSTANCE);
+  SPIX_WAITFOREORx(ETH_SPI_INSTANCE);
+  uint32_t dummy = SPIX_BUF(ETH_SPI_INSTANCE);
+  (void) dummy;
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+enc28j60_arch_spi_read(void)
+{
+  SPIX_WAITFORTxREADY(ETH_SPI_INSTANCE);
+  SPIX_BUF(ETH_SPI_INSTANCE) = 0;
+  SPIX_WAITFOREOTx(ETH_SPI_INSTANCE);
+  SPIX_WAITFOREORx(ETH_SPI_INSTANCE);
+  return SPIX_BUF(ETH_SPI_INSTANCE);
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */
+

--- a/arch/platform/oppila/orouter/ip64-conf.h
+++ b/arch/platform/oppila/orouter/ip64-conf.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2012, Thingsquare, http://www.thingsquare.com/.
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef IP64_CONF_H
+#define IP64_CONF_H
+/*---------------------------------------------------------------------------*/
+#include "ip64/ip64-eth-interface.h"
+/*---------------------------------------------------------------------------*/
+#define IP64_CONF_UIP_FALLBACK_INTERFACE ip64_eth_interface
+#define IP64_CONF_INPUT                  ip64_eth_interface_input
+#include "enc28j60-ip64-driver.h"
+#define IP64_CONF_ETH_DRIVER             enc28j60_ip64_driver
+/*---------------------------------------------------------------------------*/
+#endif /* IP64_CONF_H */

--- a/arch/platform/oppila/orouter/leds-arch.c
+++ b/arch/platform/oppila/orouter/leds-arch.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/leds.h"
+#include "dev/gpio-hal.h"
+
+#include <stdbool.h>
+/*---------------------------------------------------------------------------*/
+const leds_t leds_arch_leds[] = {
+  {
+    .pin = GPIO_PORT_PIN_TO_GPIO_HAL_PIN(LEDS_ARCH_L1_PORT, LEDS_ARCH_L1_PIN),
+    .negative_logic = false
+  },
+};
+/*---------------------------------------------------------------------------*/

--- a/arch/platform/oppila/platform.c
+++ b/arch/platform/oppila/platform.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-platforms
+ * @{
+ *
+ * \defgroup Oppila Development Kit platform
+ *
+ * The Oppila is a platform by Oppila Microsytems, based on the
+ * cc2538 SoC with an ARM Cortex-M3 core.
+ * @{
+ *
+ * \file
+ *   Main module for the oppila platform
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/adc.h"
+#include "dev/leds.h"
+#include "dev/uart.h"
+#include "dev/serial-line.h"
+#include "dev/slip.h"
+#include "dev/cc2538-rf.h"
+#include "dev/udma.h"
+#include "dev/crypto.h"
+#include "usb/usb-serial.h"
+#include "lib/random.h"
+#include "net/netstack.h"
+#include "net/mac/framer/frame802154.h"
+#include "net/linkaddr.h"
+#include "sys/platform.h"
+#include "soc.h"
+#include "cpu.h"
+#include "reg.h"
+#include "ieee-addr.h"
+#include "lpm.h"
+#include "dev/button-hal.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+/* Log configuration */
+#include "sys/log.h"
+#define LOG_MODULE "OPPILA"
+#define LOG_LEVEL LOG_LEVEL_MAIN
+/*---------------------------------------------------------------------------*/
+static void
+fade(leds_mask_t l)
+{
+  volatile int i;
+  int k, j;
+  for(k = 0; k < 800; ++k) {
+    j = k > 400 ? 800 - k : k;
+
+    leds_on(l);
+    for(i = 0; i < j; ++i) {
+      __asm("nop");
+    }
+    leds_off(l);
+    for(i = 0; i < 400 - j; ++i) {
+      __asm("nop");
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+set_rf_params(void)
+{
+  uint16_t short_addr;
+  uint8_t ext_addr[8];
+
+  ieee_addr_cpy_to(ext_addr, 8);
+
+  short_addr = ext_addr[7];
+  short_addr |= ext_addr[6] << 8;
+
+  NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, IEEE802154_PANID);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_16BIT_ADDR, short_addr);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, IEEE802154_DEFAULT_CHANNEL);
+  NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
+}
+/*---------------------------------------------------------------------------*/
+void
+platform_init_stage_one(void)
+{
+  soc_init();
+
+  leds_init();
+  fade(LEDS_GREEN);
+}
+/*---------------------------------------------------------------------------*/
+void
+platform_init_stage_two()
+{
+  /*
+   * Character I/O Initialisation.
+   * When the UART receives a character it will call serial_line_input_byte to
+   * notify the core. The same applies for the USB driver.
+   *
+   * If slip-arch is also linked in afterwards (e.g. if we are a border router)
+   * it will overwrite one of the two peripheral input callbacks. Characters
+   * received over the relevant peripheral will be handled by
+   * slip_input_byte instead
+   */
+#if UART_CONF_ENABLE
+  uart_init(0);
+  uart_init(1);
+  uart_set_input(SERIAL_LINE_CONF_UART, serial_line_input_byte);
+#endif
+
+#if USB_SERIAL_CONF_ENABLE
+  usb_serial_init();
+  usb_serial_set_input(serial_line_input_byte);
+#endif
+
+  serial_line_init();
+
+  /* Initialise the H/W RNG engine. */
+  random_init(0);
+
+  udma_init();
+
+#if CRYPTO_CONF_INIT
+  crypto_init();
+  crypto_disable();
+#endif
+
+  /* Populate linkaddr_node_addr */
+  ieee_addr_cpy_to(linkaddr_node_addr.u8, LINKADDR_SIZE);
+
+  INTERRUPTS_ENABLE();
+
+  fade(LEDS_GREEN);
+}
+/*---------------------------------------------------------------------------*/
+void
+platform_init_stage_three()
+{
+  LOG_INFO("%s\n", BOARD_STRING);
+
+  set_rf_params();
+
+  soc_print_info();
+
+  adc_init();
+
+  button_hal_init();
+
+  fade(LEDS_ORANGE);
+}
+/*---------------------------------------------------------------------------*/
+void
+platform_idle()
+{
+  /* We have serviced all pending events. Enter a Low-Power mode. */
+  lpm_enter();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/examples/dev/button-hal/Makefile
+++ b/examples/dev/button-hal/Makefile
@@ -3,7 +3,7 @@ CONTIKI = ../../..
 
 all: $(CONTIKI_PROJECT)
 
-PLATFORMS_ONLY += cc26x0-cc13x0 cc2538dk openmote zoul simplelink
+PLATFORMS_ONLY += cc26x0-cc13x0 cc2538dk openmote oppila zoul simplelink
 PLATFORMS_ONLY += cooja native
 
 include $(CONTIKI)/Makefile.include

--- a/examples/dev/omote-led/Makefile
+++ b/examples/dev/omote-led/Makefile
@@ -1,0 +1,10 @@
+CONTIKI_PROJECT = omote-leds-example
+CONTIKI = ../../..
+
+MODULES_REL += $(TARGET)
+
+PLATFORMS_ONLY = oppila
+
+all: $(CONTIKI_PROJECT)
+
+include $(CONTIKI)/Makefile.include

--- a/examples/dev/omote-led/omote-leds-example.c
+++ b/examples/dev/omote-led/omote-leds-example.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/leds.h"
+#include "sys/etimer.h"
+
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+static struct etimer et;
+static uint8_t counter;
+/*---------------------------------------------------------------------------*/
+PROCESS(leds_example, "LED HAL Example");
+AUTOSTART_PROCESSES(&leds_example);
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(leds_example, ev, data)
+{
+  PROCESS_BEGIN();
+
+  counter = 0;
+
+  etimer_set(&et, CLOCK_SECOND);
+
+  while(1) {
+
+    PROCESS_YIELD();
+
+    if(ev == PROCESS_EVENT_TIMER && data == &et) {
+      if((counter & 3) == 0) {
+        leds_set(LEDS_ALL);
+      } else if((counter & 3) == 1) {
+        leds_off(LEDS_ALL);
+      } else if((counter & 3) == 2) {
+        leds_on(LEDS_ALL);
+      }
+      counter++;
+      etimer_set(&et, CLOCK_SECOND);
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/ip64-router/Makefile
+++ b/examples/ip64-router/Makefile
@@ -3,9 +3,9 @@ all: $(CONTIKI_PROJECT)
 CONTIKI=../..
 
 # Currently only supported on Orion, the only platform with 802.15.4 + Ethernet
-PLATFORMS_ONLY = zoul
-BOARDS_ONLY = orion
-BOARD = orion
+PLATFORMS_ONLY = zoul oppila
+BOARDS_ONLY = orion orouter
+BOARD = orion orouter
 WITH_IP64 = 1
 
 include $(CONTIKI)/Makefile.include

--- a/examples/mqtt-client/Makefile
+++ b/examples/mqtt-client/Makefile
@@ -10,6 +10,6 @@ MODULES += $(CONTIKI_NG_APP_LAYER_DIR)/mqtt
 
 MODULES_REL += arch/platform/$(TARGET)
 
-PLATFORMS_ONLY = cc26x0-cc13x0 cc2538dk openmote zoul native simplelink cooja
+PLATFORMS_ONLY = cc26x0-cc13x0 cc2538dk openmote oppila zoul native simplelink cooja
 
 include $(CONTIKI)/Makefile.include

--- a/examples/mqtt-client/arch/platform/oppila/Makefile.oppila
+++ b/examples/mqtt-client/arch/platform/oppila/Makefile.oppila
@@ -1,0 +1,1 @@
+MODULES_REL += arch/cpu/cc2538

--- a/examples/mqtt-client/arch/platform/oppila/module-macros.h
+++ b/examples/mqtt-client/arch/platform/oppila/module-macros.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/* Enable MQTT client extensions */
+#define MQTT_CLIENT_CONF_WITH_EXTENSIONS 1
+/*---------------------------------------------------------------------------*/

--- a/examples/mqtt-client/arch/platform/oppila/mqtt-client-extensions.c
+++ b/examples/mqtt-client/arch/platform/oppila/mqtt-client-extensions.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "builtin-sensors.h"
+#include "mqtt-client.h"
+
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+MQTT_CLIENT_EXTENSIONS(&builtin_sensors_vdd3, &builtin_sensors_cc2538_temp);
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/oppila/Makefile
+++ b/examples/platform-specific/oppila/Makefile
@@ -1,0 +1,13 @@
+CONTIKI_PROJECT =  test-bmp180 test-grove-light-sensor test-adxl345.c
+
+CONTIKI_TARGET_SOURCEFILES += bmp180.c adc-sensors.c adxl345.c
+
+all: $(CONTIKI_PROJECT)
+
+PLATFORMS_ONLY = oppila 
+
+CONTIKI = ../../..
+
+include $(CONTIKI)/Makefile.dir-variables
+
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/oppila/README.md
+++ b/examples/platform-specific/oppila/README.md
@@ -1,0 +1,48 @@
+Oppila test examples
+============================================
+
+The following tests are valid for the OMote platform
+
+Compile and install an example
+-------------------
+
+To flash either hardware platform use the same `TARGET=oppila` and the following:
+
+* OMote : `BOARD=omote`
+
+An example on how to compile is shown next:
+
+`make TARGET=oppila BOARD=omote`
+
+Or alternatively if you just type `make`, it will default to use the `BOARD=omote`.
+
+To upload an example to your Oppila device, just add the `.upload` target as:
+
+`make TARGET=oppila BOARD=omote oppila-demo.upload`
+
+Optionally you can select a specific USB port to flash a given device, in Linux
+and assuming there is a device at the `/dev/ttyUSB0`:
+
+`make TARGET=oppila BOARD=omote oppila-demo.upload PORT=/dev/ttyUSB0`
+
+If you ommit the `PORT` argument, the system will flash all Oppila devices connected over USB.
+
+Visualize the console output
+-------------------
+
+Just type `make login` to open a connection to the console via USB.
+As above to specify a given port use the `PORT=/dev/ttyUSB0` argument.
+
+Alternatively you can save the above `PORT`, `TARGET` or `BOARD` as follows:
+
+`export TARGET=oppila BOARD=omote PORT=/dev/ttyUSB0`
+
+This will save you to type these when running a command on the terminal
+
+Documentation and guides
+-------------------
+
+More information about the platforms, guides and specific documentation can be found at [Oppila Microsystems Wiki][wiki]
+
+[wiki]: https://www.oppila.in
+

--- a/examples/platform-specific/oppila/orouter/README.md
+++ b/examples/platform-specific/oppila/orouter/README.md
@@ -1,0 +1,46 @@
+OMote IP64 README file
+========================
+
+This example shows how to use the Oppila's Ethernet orouter, based on the Oppila and ENC28J60 modules, with active POE support.
+
+IP64 router
+-----------------
+The router packs a built-in webserver and optionally can run on 2.4GHz radio interface.
+
+````
+#define NETSTACK_CONF_RADIO         cc2538_rf_driver
+#define ANTENNA_SELECT_DEF_CONF  ANTENNA_SELECT_2_4GHZ
+````
+To compile and flash run:
+
+````
+cd ip64-router
+make TARGET=oppila BOARD=oroutern ip64-router.upload
+````
+
+As default we enable the `DHCP` support for autoconfiguration.  Just connect to a DHCP-enabled device to obtain an IPv4 IP address and that's it!.
+
+HTTP client examples
+-----------------
+
+There are available 2 examples ready to use using the `http-socket` library:
+
+* The `client` example just makes a HTTP `GET` request to a know page and retrieves
+  the result.
+
+* The `ifttt-client` example sends a HTTP `POST` request to [IFTTT](https://ifttt.com/recipes) whenever the user button is pressed, building an Internet button to connect to several channels and applications, such as `Drive`, `Evernote` and many others.
+
+To configure the `IFTTT` demo just edit the `project-conf.h` file and change the name of the event and write your API key:
+
+````
+#define IFTTT_EVENT   "button"
+#define IFTTT_KEY     "XXXXXX"
+````
+
+To compile and flash:
+
+````
+cd client
+make TARGET=oppila ifttt-client.upload
+````
+

--- a/examples/platform-specific/oppila/orouter/client/Makefile
+++ b/examples/platform-specific/oppila/orouter/client/Makefile
@@ -1,0 +1,16 @@
+CONTIKI_PROJECT = client ifttt-client
+all: $(CONTIKI_PROJECT)
+
+BOARD = orouter
+
+WITH_IP64 = 1
+
+PLATFORMS_ONLY = oppila
+BOARDS_ONLY = orouter
+
+CONTIKI = ../../../../..
+
+include $(CONTIKI)/Makefile.dir-variables
+MODULES += $(CONTIKI_NG_APP_LAYER_DIR)/http-socket
+
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/oppila/orouter/client/client.c
+++ b/examples/platform-specific/oppila/orouter/client/client.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki-net.h"
+#include "http-socket.h"
+#include "ipv6/ip64-addr.h"
+#include "dev/leds.h"
+#include "net/routing/routing.h"
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+static struct http_socket s;
+static char data_received[HTTP_CLIENT_BUFFER_LEN];
+static int bytes_received = 0;
+static int restarts;
+static struct ctimer reconnect_timer;
+static const char *url = "http://httpbin.org/ip";
+/*---------------------------------------------------------------------------*/
+static void callback(struct http_socket *s, void *ptr,
+                     http_socket_event_t e,
+                     const uint8_t *data, uint16_t datalen);
+/*---------------------------------------------------------------------------*/
+PROCESS(http_example_process, "HTTP Example");
+AUTOSTART_PROCESSES(&http_example_process);
+/*---------------------------------------------------------------------------*/
+static void
+reconnect(void *dummy)
+{
+  http_socket_get(&s, url, 0, 0, callback, NULL);
+}
+/*---------------------------------------------------------------------------*/
+static void
+restart(void)
+{
+  int scale;
+  restarts++;
+  printf("Number of restarts %d\n", restarts);
+
+  scale = restarts;
+  if(scale > 5) {
+    scale = 5;
+  }
+  ctimer_set(&reconnect_timer, random_rand() % ((CLOCK_SECOND * 10) << scale),
+              reconnect, NULL);
+}
+/*---------------------------------------------------------------------------*/
+static void
+callback(struct http_socket *s, void *ptr,
+         http_socket_event_t e,
+         const uint8_t *data, uint16_t datalen)
+{
+  uint8_t i;
+
+  if(e == HTTP_SOCKET_ERR) {
+    printf("HTTP socket error\n");
+  } else if(e == HTTP_SOCKET_TIMEDOUT) {
+    printf("HTTP socket error: timed out\n");
+    restart();
+  } else if(e == HTTP_SOCKET_ABORTED) {
+    printf("HTTP socket error: aborted\n");
+    restart();
+  } else if(e == HTTP_SOCKET_HOSTNAME_NOT_FOUND) {
+    printf("HTTP socket error: hostname not found\n");
+    restart();
+  } else if(e == HTTP_SOCKET_CLOSED) {
+
+    if(bytes_received) {
+      printf("HTTP socket received data:\n\n");
+      for(i=0; i<bytes_received; i++) {
+        printf("%c", data_received[i]);
+      }
+      printf("\n");
+      bytes_received = 0;
+    }
+
+  } else if(e == HTTP_SOCKET_DATA) {
+    strcat(data_received, (const char *)data);
+    bytes_received += datalen;
+    printf("HTTP socket received %d bytes of data\n", datalen);
+  }
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(http_example_process, ev, data)
+{
+  static struct etimer et;
+  uip_ip4addr_t ip4addr;
+  uip_ip6addr_t ip6addr;
+
+  PROCESS_BEGIN();
+
+  uip_ipaddr(&ip4addr, 8, 8, 8, 8);
+  ip64_addr_4to6(&ip4addr, &ip6addr);
+  uip_nameserver_update(&ip6addr, UIP_NAMESERVER_INFINITE_LIFETIME);
+
+  etimer_set(&et, CLOCK_SECOND * 20);
+  PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+  http_socket_init(&s);
+  http_socket_get(&s, url, 0, 0, callback, NULL);
+  leds_on(LEDS_RED);
+  restarts = 0;
+  etimer_set(&et, CLOCK_SECOND);
+
+  while(1) {
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+    etimer_reset(&et);
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/oppila/orouter/client/ifttt-client.c
+++ b/examples/platform-specific/oppila/orouter/client/ifttt-client.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki-net.h"
+#include "http-socket.h"
+#include "ipv6/ip64-addr.h"
+#include "dev/leds.h"
+#include "net/routing/routing.h"
+#include "dev/button-hal.h"
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+static struct http_socket s;
+static char data_received[HTTP_CLIENT_BUFFER_LEN];
+static char url_buffer[HTTP_CLIENT_BUFFER_LEN];
+static int bytes_received = 0;
+static int restarts;
+static struct ctimer reconnect_timer;
+/*---------------------------------------------------------------------------*/
+static void callback(struct http_socket *s, void *ptr,
+                     http_socket_event_t e,
+                     const uint8_t *data, uint16_t datalen);
+/*---------------------------------------------------------------------------*/
+PROCESS(http_example_process, "IFTTT HTTP Example");
+AUTOSTART_PROCESSES(&http_example_process);
+/*---------------------------------------------------------------------------*/
+static void
+reconnect(void *dummy)
+{
+  leds_on(LEDS_GREEN);
+  http_socket_post(&s, url_buffer, NULL, 0, NULL, callback, NULL);
+}
+/*---------------------------------------------------------------------------*/
+static void
+restart(void)
+{
+  int scale;
+  restarts++;
+  printf("Number of restarts %d\n", restarts);
+  leds_off(LEDS_GREEN);
+
+  scale = restarts;
+  if(scale > 5) {
+    scale = 5;
+  }
+
+  ctimer_set(&reconnect_timer, random_rand() % ((CLOCK_SECOND * 10) << scale),
+              reconnect, NULL);
+}
+/*---------------------------------------------------------------------------*/
+static void
+callback(struct http_socket *s, void *ptr,
+         http_socket_event_t e,
+         const uint8_t *data, uint16_t datalen)
+{
+  uint8_t i;
+
+  if(e == HTTP_SOCKET_ERR) {
+    printf("HTTP socket error\n");
+  } else if(e == HTTP_SOCKET_TIMEDOUT) {
+    printf("HTTP socket error: timed out\n");
+    restart();
+  } else if(e == HTTP_SOCKET_ABORTED) {
+    printf("HTTP socket error: aborted\n");
+    restart();
+  } else if(e == HTTP_SOCKET_HOSTNAME_NOT_FOUND) {
+    printf("HTTP socket error: hostname not found\n");
+    restart();
+  } else if(e == HTTP_SOCKET_CLOSED) {
+
+    if(bytes_received) {
+      printf("HTTP socket received data:\n\n");
+      for(i=0; i<bytes_received; i++) {
+        printf("%c", data_received[i]);
+      }
+      printf("\n");
+      bytes_received = 0;
+      leds_off(LEDS_GREEN);
+    }
+
+  } else if(e == HTTP_SOCKET_DATA) {
+    strcat(data_received, (const char *)data);
+    bytes_received += datalen;
+    printf("HTTP socket received %d bytes of data\n", datalen);
+  }
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(http_example_process, ev, data)
+{
+  static struct etimer et;
+  uip_ip4addr_t ip4addr;
+  uip_ip6addr_t ip6addr;
+
+  PROCESS_BEGIN();
+
+  uip_ipaddr(&ip4addr, 8, 8, 8, 8);
+  ip64_addr_4to6(&ip4addr, &ip6addr);
+  uip_nameserver_update(&ip6addr, UIP_NAMESERVER_INFINITE_LIFETIME);
+
+  etimer_set(&et, CLOCK_SECOND * 20);
+  PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+  memset(url_buffer, 0, HTTP_CLIENT_BUFFER_LEN);
+  snprintf(url_buffer, HTTP_CLIENT_BUFFER_LEN,
+           "http://maker.ifttt.com/trigger/%s/with/key/%s",
+           IFTTT_EVENT, IFTTT_KEY);
+
+  http_socket_init(&s);
+
+  restarts = 0;
+
+  while(1) {
+    PROCESS_YIELD();
+    if(ev == button_hal_release_event) {
+      leds_on(LEDS_GREEN);
+      printf("Button pressed! sending a POST to IFTTT\n");
+      http_socket_post(&s, url_buffer, NULL, 0, NULL, callback, NULL);
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/oppila/orouter/client/project-conf.h
+++ b/examples/platform-specific/oppila/orouter/client/project-conf.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+/* Prevent the router from dropping below LPM2 to avoid RAM overflow */
+#define LPM_CONF_MAX_PM             0
+
+/*---------------------------------------------------------------------------*/
+#define NETSTACK_CONF_RADIO              cc2538_rf_driver
+
+#define ANTENNA_SELECT_DEF_CONF       ANTENNA_SELECT_2_4GHZ
+
+#define UIP_CONF_TCP                     1
+#define RESOLV_CONF_SUPPORTS_MDNS        0
+#define NETSTCK_ROUTING_STATE_SIZE       3
+#define NBR_TABLE_CONF_MAX_NEIGHBORS     3
+
+#define HTTP_CLIENT_BUFFER_LEN           256
+
+#define IFTTT_EVENT   "button"
+#define IFTTT_KEY     "XXXXXX"
+/*---------------------------------------------------------------------------*/
+#endif /* PROJECT_CONF_H_ */
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/oppila/orouter/ip64-router/Makefile
+++ b/examples/platform-specific/oppila/orouter/ip64-router/Makefile
@@ -1,0 +1,15 @@
+CONTIKI_PROJECT = ip64-router
+all: $(CONTIKI_PROJECT)
+
+BOARD = orouter
+
+CONTIKI = ../../../../..
+
+WITH_IP64 = 1
+
+PROJECT_SOURCEFILES += httpd-simple.c
+
+PLATFORMS_ONLY = oppila
+BOARDS_ONLY = orouter
+
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/oppila/orouter/ip64-router/httpd-simple.c
+++ b/examples/platform-specific/oppila/orouter/ip64-router/httpd-simple.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         A simple web server forwarding page generation to a protothread
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ *         Niclas Finne <nfi@sics.se>
+ *         Joakim Eriksson <joakime@sics.se>
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include <string.h>
+#include "contiki-net.h"
+#include "httpd-simple.h"
+#define webserver_log_file(...)
+#define webserver_log(...)
+
+#ifndef WEBSERVER_CONF_CFS_CONNS
+#define CONNS UIP_TCP_CONNS
+#else /* WEBSERVER_CONF_CFS_CONNS */
+#define CONNS WEBSERVER_CONF_CFS_CONNS
+#endif /* WEBSERVER_CONF_CFS_CONNS */
+
+#ifndef WEBSERVER_CONF_CFS_URLCONV
+#define URLCONV 0
+#else /* WEBSERVER_CONF_CFS_URLCONV */
+#define URLCONV WEBSERVER_CONF_CFS_URLCONV
+#endif /* WEBSERVER_CONF_CFS_URLCONV */
+/*---------------------------------------------------------------------------*/
+#define STATE_WAITING 0
+#define STATE_OUTPUT  1
+/*---------------------------------------------------------------------------*/
+MEMB(conns, struct httpd_state, CONNS);
+/*---------------------------------------------------------------------------*/
+#define ISO_nl      0x0a
+#define ISO_space   0x20
+#define ISO_period  0x2e
+#define ISO_slash   0x2f
+/*---------------------------------------------------------------------------*/
+static const char *NOT_FOUND = "<html><body bgcolor=\"white\">"
+"<center>"
+"<h1>404 - file not found</h1>"
+"</center>"
+"</body>"
+"</html>";
+/*---------------------------------------------------------------------------*/
+static
+PT_THREAD(send_string(struct httpd_state *s, const char *str))
+{
+  PSOCK_BEGIN(&s->sout);
+
+  SEND_STRING(&s->sout, str);
+
+  PSOCK_END(&s->sout);
+}
+/*---------------------------------------------------------------------------*/
+const char http_content_type_html[] = "Content-type: text/html\r\n\r\n";
+static
+PT_THREAD(send_headers(struct httpd_state *s, const char *statushdr))
+{
+  /* char *ptr; */
+
+  PSOCK_BEGIN(&s->sout);
+
+  SEND_STRING(&s->sout, statushdr);
+  SEND_STRING(&s->sout, http_content_type_html);
+  PSOCK_END(&s->sout);
+}
+/*---------------------------------------------------------------------------*/
+const char http_header_200[] = "HTTP/1.0 200 OK\r\nServer: Contiki/Oppila/\r\nConnection: close\r\n";
+const char http_header_404[] = "HTTP/1.0 404 Not found\r\nServer: Contiki/Oppila/\r\nConnection: close\r\n";
+static
+PT_THREAD(handle_output(struct httpd_state *s))
+{
+  PT_BEGIN(&s->outputpt);
+
+  s->script = NULL;
+  s->script = httpd_simple_get_script(&s->filename[1]);
+  if(s->script == NULL) {
+    strncpy(s->filename, "/notfound.html", sizeof(s->filename));
+    PT_WAIT_THREAD(&s->outputpt,
+                   send_headers(s, http_header_404));
+    PT_WAIT_THREAD(&s->outputpt,
+                   send_string(s, NOT_FOUND));
+    uip_close();
+    webserver_log_file(&uip_conn->ripaddr, "404 - not found");
+    PT_EXIT(&s->outputpt);
+  } else {
+    PT_WAIT_THREAD(&s->outputpt,
+                   send_headers(s, http_header_200));
+    PT_WAIT_THREAD(&s->outputpt, s->script(s));
+  }
+  s->script = NULL;
+  PSOCK_CLOSE(&s->sout);
+  PT_END(&s->outputpt);
+}
+/*---------------------------------------------------------------------------*/
+const char http_get[] = "GET ";
+const char http_index_html[] = "/index.html";
+/*---------------------------------------------------------------------------*/
+static
+PT_THREAD(handle_input(struct httpd_state *s))
+{
+  PSOCK_BEGIN(&s->sin);
+
+  PSOCK_READTO(&s->sin, ISO_space);
+
+  if(strncmp(s->inputbuf, http_get, 4) != 0) {
+    PSOCK_CLOSE_EXIT(&s->sin);
+  }
+  PSOCK_READTO(&s->sin, ISO_space);
+
+  if(s->inputbuf[0] != ISO_slash) {
+    PSOCK_CLOSE_EXIT(&s->sin);
+  }
+
+#if URLCONV
+  s->inputbuf[PSOCK_DATALEN(&s->sin) - 1] = 0;
+  urlconv_tofilename(s->filename, s->inputbuf, sizeof(s->filename));
+#else /* URLCONV */
+  if(s->inputbuf[1] == ISO_space) {
+    strncpy(s->filename, http_index_html, sizeof(s->filename));
+  } else {
+    s->inputbuf[PSOCK_DATALEN(&s->sin) - 1] = 0;
+    strncpy(s->filename, s->inputbuf, sizeof(s->filename));
+  }
+#endif /* URLCONV */
+
+  webserver_log_file(&uip_conn->ripaddr, s->filename);
+
+  s->state = STATE_OUTPUT;
+
+  while(1) {
+    PSOCK_READTO(&s->sin, ISO_nl);
+  }
+
+  PSOCK_END(&s->sin);
+}
+/*---------------------------------------------------------------------------*/
+static void
+handle_connection(struct httpd_state *s)
+{
+  handle_input(s);
+  if(s->state == STATE_OUTPUT) {
+    handle_output(s);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+httpd_appcall(void *state)
+{
+  struct httpd_state *s = (struct httpd_state *)state;
+
+  if(uip_closed() || uip_aborted() || uip_timedout()) {
+    if(s != NULL) {
+      s->script = NULL;
+      memb_free(&conns, s);
+    }
+  } else if(uip_connected()) {
+    s = (struct httpd_state *)memb_alloc(&conns);
+    if(s == NULL) {
+      uip_abort();
+      webserver_log_file(&uip_conn->ripaddr, "reset (no memory block)");
+      return;
+    }
+    tcp_markconn(uip_conn, s);
+    PSOCK_INIT(&s->sin, (uint8_t *)s->inputbuf, sizeof(s->inputbuf) - 1);
+    PSOCK_INIT(&s->sout, (uint8_t *)s->inputbuf, sizeof(s->inputbuf) - 1);
+    PT_INIT(&s->outputpt);
+    s->script = NULL;
+    s->state = STATE_WAITING;
+    timer_set(&s->timer, CLOCK_SECOND * 10);
+    handle_connection(s);
+  } else if(s != NULL) {
+    if(uip_poll()) {
+      if(timer_expired(&s->timer)) {
+        uip_abort();
+        s->script = NULL;
+        memb_free(&conns, s);
+        webserver_log_file(&uip_conn->ripaddr, "reset (timeout)");
+      }
+    } else {
+      timer_restart(&s->timer);
+    }
+    handle_connection(s);
+  } else {
+    uip_abort();
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+httpd_init(void)
+{
+  tcp_listen(UIP_HTONS(80));
+  memb_init(&conns);
+#if URLCONV
+  urlconv_init();
+#endif /* URLCONV */
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/oppila/orouter/ip64-router/httpd-simple.h
+++ b/examples/platform-specific/oppila/orouter/ip64-router/httpd-simple.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         A simple webserver
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ *         Niclas Finne <nfi@sics.se>
+ *         Joakim Eriksson <joakime@sics.se>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef HTTPD_SIMPLE_H_
+#define HTTPD_SIMPLE_H_
+
+#include "contiki-net.h"
+#ifndef WEBSERVER_CONF_CFS_PATHLEN
+#define HTTPD_PATHLEN 2
+#else /* WEBSERVER_CONF_CFS_CONNS */
+#define HTTPD_PATHLEN WEBSERVER_CONF_CFS_PATHLEN
+#endif /* WEBSERVER_CONF_CFS_CONNS */
+/*---------------------------------------------------------------------------*/
+struct httpd_state;
+typedef char (* httpd_simple_script_t)(struct httpd_state *s);
+/*---------------------------------------------------------------------------*/
+struct httpd_state {
+  struct timer timer;
+  struct psock sin, sout;
+  struct pt outputpt;
+  char inputbuf[HTTPD_PATHLEN + 24];
+/*char outputbuf[UIP_TCP_MSS]; */
+  char filename[HTTPD_PATHLEN];
+  httpd_simple_script_t script;
+  char state;
+};
+/*---------------------------------------------------------------------------*/
+void httpd_init(void);
+void httpd_appcall(void *state);
+httpd_simple_script_t httpd_simple_get_script(const char *name);
+/*---------------------------------------------------------------------------*/
+#define SEND_STRING(s, str) PSOCK_SEND(s, (uint8_t *)str, strlen(str))
+/*---------------------------------------------------------------------------*/
+#endif /* HTTPD_SIMPLE_H_ */

--- a/examples/platform-specific/oppila/orouter/ip64-router/ip64-router.c
+++ b/examples/platform-specific/oppila/orouter/ip64-router/ip64-router.c
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-orouter
+ * @{
+ *
+ * \file
+ *  Example of an Ethernet IP64 router with weberver
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "contiki-lib.h"
+#include "contiki-net.h"
+#include "net/ipv6/uip.h"
+#include "net/ipv6/uip-ds6.h"
+#include "net/ipv6/uip-ds6-nbr.h"
+#include "net/routing/routing.h"
+#include "dev/leds.h"
+#include "ip64/ip64.h"
+#include "net/netstack.h"
+#include "httpd-simple.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+/*---------------------------------------------------------------------------*/
+#define BUFFER_LENGTH                  256
+/*---------------------------------------------------------------------------*/
+#define LEDS_DHCP                      LEDS_GREEN
+#define WEBSERVER_CONF_LOADTIME        0
+#define WEBSERVER_CONF_FILESTATS       0
+#define WEBSERVER_CONF_NEIGHBOR_STATUS 0
+/*---------------------------------------------------------------------------*/
+PROCESS(router_node_process, "Router node w/ webserver");
+/*---------------------------------------------------------------------------*/
+#if WEBSERVER_CONF_ROUTE_LINKS
+  #define BUF_USES_STACK 1
+#endif
+
+PROCESS(webserver_nogui_process, "Web server");
+PROCESS_THREAD(webserver_nogui_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  httpd_init();
+
+  while(1) {
+    PROCESS_WAIT_EVENT_UNTIL(ev == tcpip_event);
+    httpd_appcall(data);
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+AUTOSTART_PROCESSES(&router_node_process,&webserver_nogui_process);
+/*---------------------------------------------------------------------------*/
+static const char *TOP = "<html><head><title>Oppila IP64 Router</title></head><body>\n";
+static const char *BOTTOM = "</body></html>\n";
+#if BUF_USES_STACK
+static char *bufptr, *bufend;
+#define ADD(...) do {                                               \
+    bufptr += snprintf(bufptr, bufend - bufptr, __VA_ARGS__);       \
+  } while(0)
+#else
+static char buf[BUFFER_LENGTH];
+static int blen;
+#define ADD(...) do {                                               \
+    blen += snprintf(&buf[blen], sizeof(buf) - blen, __VA_ARGS__);  \
+  } while(0)
+#endif
+
+/*---------------------------------------------------------------------------*/
+static void
+ipaddr_add(const uip_ipaddr_t *addr)
+{
+  uint16_t a;
+  int i, f;
+  for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
+    a = (addr->u8[i] << 8) + addr->u8[i + 1];
+    if(a == 0 && f >= 0) {
+      if(f++ == 0) ADD("::");
+    } else {
+      if(f > 0) {
+        f = -1;
+      } else if(i > 0) {
+        ADD(":");
+      }
+      ADD("%x", a);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+static
+PT_THREAD(generate_routes(struct httpd_state *s))
+{
+  static uip_ds6_route_t *r;
+  static uip_ds6_nbr_t *nbr;
+#if BUF_USES_STACK
+  char buf[BUFFER_LENGTH];
+#endif
+#if WEBSERVER_CONF_LOADTIME
+  static clock_time_t numticks;
+  numticks = clock_time();
+#endif
+
+  PSOCK_BEGIN(&s->sout);
+  SEND_STRING(&s->sout, TOP);
+#if BUF_USES_STACK
+  bufptr = buf;bufend=bufptr+sizeof(buf);
+#else
+  blen = 0;
+#endif
+  ADD("Neighbors<pre>");
+
+  for(nbr = uip_ds6_nbr_head();
+      nbr != NULL;
+      nbr = uip_ds6_nbr_next(nbr)) {
+
+#if WEBSERVER_CONF_NEIGHBOR_STATUS
+#if BUF_USES_STACK
+      {
+        char* j = bufptr + 25;
+        ipaddr_add(&nbr->ipaddr);
+        while (bufptr < j) ADD(" ");
+        switch (nbr->state) {
+          case NBR_INCOMPLETE: ADD(" INCOMPLETE");break;
+          case NBR_REACHABLE: ADD(" REACHABLE");break;
+          case NBR_STALE: ADD(" STALE");break;
+          case NBR_DELAY: ADD(" DELAY");break;
+          case NBR_PROBE: ADD(" NBR_PROBE");break;
+        }
+      }
+#else
+      {
+        uint8_t j = blen + 25;
+        ipaddr_add(&nbr->ipaddr);
+        while (blen < j) ADD(" ");
+        switch (nbr->state) {
+          case NBR_INCOMPLETE: ADD(" INCOMPLETE");break;
+          case NBR_REACHABLE: ADD(" REACHABLE");break;
+          case NBR_STALE: ADD(" STALE");break;
+          case NBR_DELAY: ADD(" DELAY");break;
+          case NBR_PROBE: ADD(" NBR_PROBE");break;
+        }
+      }
+#endif
+#else
+      ipaddr_add(&nbr->ipaddr);
+#endif
+
+      ADD("\n");
+#if BUF_USES_STACK
+      if(bufptr > bufend - 45) {
+        SEND_STRING(&s->sout, buf);
+        bufptr = buf; bufend = bufptr + sizeof(buf);
+      }
+#else
+      if(blen > sizeof(buf) - 45) {
+        SEND_STRING(&s->sout, buf);
+        blen = 0;
+      }
+#endif
+  }
+  ADD("</pre>Routes<pre>");
+  SEND_STRING(&s->sout, buf);
+#if BUF_USES_STACK
+  bufptr = buf; bufend = bufptr + sizeof(buf);
+#else
+  blen = 0;
+#endif
+
+  for(r = uip_ds6_route_head(); r != NULL; r = uip_ds6_route_next(r)) {
+
+#if BUF_USES_STACK
+#if WEBSERVER_CONF_ROUTE_LINKS
+    ADD("<a href=http://[");
+    ipaddr_add(&r->ipaddr);
+    ADD("]/status.shtml>");
+    ipaddr_add(&r->ipaddr);
+    ADD("</a>");
+#else
+    ipaddr_add(&r->ipaddr);
+#endif
+#else
+#if WEBSERVER_CONF_ROUTE_LINKS
+    ADD("<a href=http://[");
+    ipaddr_add(&r->ipaddr);
+    ADD("]/status.shtml>");
+    SEND_STRING(&s->sout, buf);
+    blen = 0;
+    ipaddr_add(&r->ipaddr);
+    ADD("</a>");
+#else
+    ipaddr_add(&r->ipaddr);
+#endif
+#endif
+    ADD("/%u (via ", r->length);
+    ipaddr_add(uip_ds6_route_nexthop(r));
+    if(1 || (r->state.lifetime < 600)) {
+      ADD(") %lus\n", (unsigned long)r->state.lifetime);
+    } else {
+      ADD(")\n");
+    }
+    SEND_STRING(&s->sout, buf);
+#if BUF_USES_STACK
+    bufptr = buf; bufend = bufptr + sizeof(buf);
+#else
+    blen = 0;
+#endif
+  }
+  ADD("</pre>");
+
+#if WEBSERVER_CONF_FILESTATS
+  static uint16_t numtimes;
+  ADD("<br><i>This page sent %u times</i>",++numtimes);
+#endif
+
+#if WEBSERVER_CONF_LOADTIME
+  numticks = clock_time() - numticks + 1;
+  ADD(" <i>(%u.%02u sec)</i>", numticks / CLOCK_SECOND,
+      (100 * (numticks % CLOCK_SECOND)) / CLOCK_SECOND));
+#endif
+
+  SEND_STRING(&s->sout, buf);
+  SEND_STRING(&s->sout, BOTTOM);
+
+  PSOCK_END(&s->sout);
+}
+/*---------------------------------------------------------------------------*/
+httpd_simple_script_t
+httpd_simple_get_script(const char *name)
+{
+  return generate_routes;
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(router_node_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  static struct etimer et;
+
+  /* Turn radio off while initialazing */
+  NETSTACK_MAC.off();
+
+  /* Initialize the IP64 module so we'll start translating packets */
+  ip64_init();
+
+  printf("Waiting for an address...\n");
+
+  /* Wait to get a DHCP address */
+  etimer_set(&et, CLOCK_SECOND * 5);
+
+  while(1) {
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+    leds_toggle(LEDS_DHCP);
+
+    if(ip64_hostaddr_is_configured()) {
+
+      const uip_ip4addr_t *hostaddr = ip64_get_hostaddr();
+      const uip_ip4addr_t *netmask = ip64_get_netmask();
+      const uip_ip4addr_t *gwaddr = ip64_get_draddr();
+
+      printf("IPv4 DHCP address: %d.%d.%d.%d\n", hostaddr->u8[0],
+                                                 hostaddr->u8[1],
+                                                 hostaddr->u8[2],
+                                                 hostaddr->u8[3]);
+      printf("Netmask : %d.%d.%d.%d\n", netmask->u8[0], netmask->u8[1],
+                                        netmask->u8[2], netmask->u8[3]);
+      printf("Gateway: %d.%d.%d.%d\n", gwaddr->u8[0], gwaddr->u8[1],
+                                       gwaddr->u8[2], gwaddr->u8[3]);
+      break;
+    }
+    etimer_reset(&et);
+  }
+
+  leds_off(LEDS_DHCP);
+
+  /* Set us up as a RPL root node. */
+  NETSTACK_ROUTING.root_start();
+
+  /* ... and do nothing more. */
+  while(1) {
+    PROCESS_WAIT_EVENT();
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/examples/platform-specific/oppila/orouter/ip64-router/project-conf.h
+++ b/examples/platform-specific/oppila/orouter/ip64-router/project-conf.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-examples
+ * @{
+ *
+ * \defgroup oppila-orouter
+ *
+ * Implements a simple IP64 router with a webserver
+ *
+ * @{
+ *
+ * \file
+ *  Configuration file for the Oppila's Orouter IP64 router
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+/* Prevent the router from dropping below LPM2 to avoid RAM overflow */
+#define LPM_CONF_MAX_PM             0
+
+#define NETSTACK_CONF_RADIO         cc2538_rf_driver
+
+/* USe DHCP */
+#define IP64_CONF_DHCP              1
+
+/* Webserver settings */
+#define WEBSERVER_CONF_ROUTE_LINKS  0
+#define UIP_CONF_RECEIVE_WINDOW     128
+#define WEBSERVER_CONF_CFS_CONNS    2
+#define UIP_CONF_BUFFER_SIZE        900
+#define UIP_CONF_TCP                  1
+#define UIP_CONF_TCP_MSS            128
+
+#endif /* PROJECT_CONF_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/examples/platform-specific/oppila/project-conf.h
+++ b/examples/platform-specific/oppila/project-conf.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-examples
+ * @{
+ *
+ * \file
+ * Project specific configuration defines for the basic OMote examples
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#define BROADCAST_CHANNEL     129
+
+/* Use the following I2C address for the BME280 sensor (from MikroElektronika) */
+#define BME280_CONF_ADDR         0x76
+
+#endif /* PROJECT_CONF_H_ */
+
+/** @} */

--- a/examples/platform-specific/oppila/test-adxl345.c
+++ b/examples/platform-specific/oppila/test-adxl345.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/*
+ * \addtogroup oppila-examples
+ * @{
+ *
+ * \defgroup oppila-adxl345-test ADXL345 sensor test
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include "contiki.h"
+#include "dev/leds.h"
+#include "dev/adxl345.h"
+/*---------------------------------------------------------------------------*/
+#define LED_INT_ONTIME        (CLOCK_SECOND / 2)
+#define ACCM_READ_INTERVAL    CLOCK_SECOND
+/*---------------------------------------------------------------------------*/
+static process_event_t led_off_event;
+static struct etimer led_etimer;
+static struct etimer et;
+/*---------------------------------------------------------------------------*/
+PROCESS(accel_process, "Test Accel process");
+PROCESS(led_process, "LED handling process");
+AUTOSTART_PROCESSES(&accel_process, &led_process);
+/*---------------------------------------------------------------------------*/
+/* As several interrupts can be mapped to one interrupt pin, when interrupt
+ * strikes, the adxl345 interrupt source register is read. This function prints
+ * out which interrupts occurred. Note that this will include all interrupts,
+ * even those mapped to 'the other' pin, and those that will always signal even
+ * if not enabled (such as watermark).
+ */
+void
+print_int(uint16_t reg)
+{
+  if(reg & ADXL345_INT_FREEFALL) {
+    printf("Freefall ");
+  }
+  if(reg & ADXL345_INT_INACTIVITY) {
+    printf("InActivity ");
+  }
+  if(reg & ADXL345_INT_ACTIVITY) {
+    printf("Activity ");
+  }
+  if(reg & ADXL345_INT_DOUBLETAP) {
+    printf("DoubleTap ");
+  }
+  if(reg & ADXL345_INT_TAP) {
+    printf("Tap ");
+  }
+  printf("\n");
+}
+/*---------------------------------------------------------------------------*/
+/* accelerometer free fall detection callback */
+
+void
+accm_ff_cb(uint8_t reg)
+{
+  leds_on(LEDS_BLUE);
+  process_post(&led_process, led_off_event, NULL);
+  printf("~~[%u] Freefall detected! (0x%02X) -- ",
+         ((uint16_t)clock_time()) / 128, reg);
+  print_int(reg);
+}
+/*---------------------------------------------------------------------------*/
+/* accelerometer tap and double tap detection callback */
+
+void
+accm_tap_cb(uint8_t reg)
+{
+  process_post(&led_process, led_off_event, NULL);
+  if(reg & ADXL345_INT_DOUBLETAP) {
+    leds_on(LEDS_GREEN);
+    printf("~~[%u] DoubleTap detected! (0x%02X) -- ",
+           ((uint16_t)clock_time()) >> 7, reg);
+  } else {
+    leds_on(LEDS_RED);
+    printf("~~[%u] Tap detected! (0x%02X) -- ",
+           ((uint16_t)clock_time()) >> 7, reg);
+  }
+  print_int(reg);
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(led_process, ev, data) {
+  PROCESS_BEGIN();
+  while(1) {
+    PROCESS_WAIT_EVENT_UNTIL(ev == led_off_event);
+    etimer_set(&led_etimer, LED_INT_ONTIME);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&led_etimer));
+    leds_off(LEDS_RED + LEDS_GREEN + LEDS_BLUE);
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/* Main process, setups  */
+PROCESS_THREAD(accel_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  /* Register the event used for lighting up an LED when interrupt strikes. */
+  led_off_event = process_alloc_event();
+
+  /* Start and setup the accelerometer with default values, eg no interrupts
+   * enabled.
+   */
+  SENSORS_ACTIVATE(adxl345);
+
+  /* Register the callback functions for each interrupt */
+  ACCM_REGISTER_INT1_CB(accm_ff_cb);
+  ACCM_REGISTER_INT2_CB(accm_tap_cb);
+
+  /* Set what strikes the corresponding interrupts. Several interrupts per
+   * pin is possible. For the eight possible interrupts, see adxl345.h and
+   * adxl345 datasheet.
+   */
+  accm_set_irq(ADXL345_INT_FREEFALL, ADXL345_INT_TAP + ADXL345_INT_DOUBLETAP);
+
+  while(1) {
+    printf("x: %d y: %d z: %d\n", adxl345.value(X_AXIS), 
+                                  adxl345.value(Y_AXIS), 
+                                  adxl345.value(Z_AXIS));
+
+    etimer_set(&et, ACCM_READ_INTERVAL);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+

--- a/examples/platform-specific/oppila/test-bmp180.c
+++ b/examples/platform-specific/oppila/test-bmp180.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-examples
+ * @{
+ *
+ * \defgroup oppila-bmp180-test BMP180 pressure and temperature sensor test
+ *
+ * Demonstrates the use of the BMP180 pressure and temperature sensor
+ * @{
+ *
+ * \file
+ *         Test file for the BMP180 digital pressure and temp sensor
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include "contiki.h"
+#include "dev/i2c.h"
+#include "dev/leds.h"
+#include "dev/bmp180.h"
+/*---------------------------------------------------------------------------*/
+#define SENSOR_READ_INTERVAL (CLOCK_SECOND)
+/*---------------------------------------------------------------------------*/
+PROCESS(remote_bmp180_process, "BMP180 test process");
+AUTOSTART_PROCESSES(&remote_bmp180_process);
+/*---------------------------------------------------------------------------*/
+static struct etimer et;
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(remote_bmp180_process, ev, data)
+{
+  PROCESS_BEGIN();
+  static uint16_t pressure;
+  static int16_t temperature;
+
+  /* Use Contiki's sensor macro to enable the sensor */
+  SENSORS_ACTIVATE(bmp180);
+
+  /* And periodically poll the sensor */
+
+  while(1) {
+    etimer_set(&et, SENSOR_READ_INTERVAL);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+    pressure = bmp180.value(BMP180_READ_PRESSURE);
+    temperature = bmp180.value(BMP180_READ_TEMP);
+
+    if((pressure != BMP180_ERROR) && (temperature != BMP180_ERROR)) {
+      printf("Pressure = %u.%u(hPa), ", pressure / 10, pressure % 10);
+      printf("Temperature = %d.%u(ºC)\n", temperature / 10, temperature % 10);
+    } else {
+      printf("Error, enable the DEBUG flag in the BMP180 driver for info, ");
+      printf("or check if the sensor is properly connected\n");
+      PROCESS_EXIT();
+    }
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */
+

--- a/examples/platform-specific/oppila/test-grove-light-sensor.c
+++ b/examples/platform-specific/oppila/test-grove-light-sensor.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, Oppila Microsystems - http://www.oppila.in
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup oppila-examples
+ * @{
+ *
+ * \defgroup oppila-grove-light-sensor-test Grove's LDR sensor v.1.0 test
+ *
+ * Demonstrates the operation of the Grove's analog LDR
+ * @{
+ *
+ * \file
+ *  Grove's LDR sensor example using the ADC sensors wrapper
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include "contiki.h"
+#include "dev/leds.h"
+#include "dev/adc-sensors.h"
+/*---------------------------------------------------------------------------*/
+#define ADC_PIN              5
+#define SENSOR_READ_INTERVAL (CLOCK_SECOND / 4)
+/*---------------------------------------------------------------------------*/
+PROCESS(remote_grove_light_process, "Grove LDR test process");
+AUTOSTART_PROCESSES(&remote_grove_light_process);
+/*---------------------------------------------------------------------------*/
+static struct etimer et;
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(remote_grove_light_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  uint16_t ldr;
+
+  /* Use pin number not mask, for example if using the PA5 pin then use 5 */
+  adc_sensors.configure(ANALOG_GROVE_LIGHT, 5);
+
+  /* And periodically poll the sensor */
+
+  while(1) {
+    etimer_set(&et, SENSOR_READ_INTERVAL);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+    ldr = adc_sensors.value(ANALOG_GROVE_LIGHT);
+
+    if(ldr != ADC_WRAPPER_ERROR) {
+      printf("LDR (resistor) = %u\n", ldr);
+    } else {
+      printf("Error, enable the DEBUG flag in adc-wrapper.c for info\n");
+      PROCESS_EXIT();
+    }
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */
+

--- a/examples/sensniff/Makefile
+++ b/examples/sensniff/Makefile
@@ -1,7 +1,7 @@
 CONTIKI_PROJECT = sensniff
 CONTIKI = ../..
 
-PLATFORMS_ONLY = cc2538dk openmote z1 zoul cc26x0-cc13x0 jn516x simplelink
+PLATFORMS_ONLY = cc2538dk openmote oppila z1 zoul cc26x0-cc13x0 jn516x simplelink
 
 PROJECT_SOURCEFILES += sensniff-mac.c netstack.c
 MODULES_REL += pool $(TARGET)

--- a/examples/sensniff/oppila/target-conf.h
+++ b/examples/sensniff/oppila/target-conf.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef TARGET_CONF_H_
+#define TARGET_CONF_H_
+/*---------------------------------------------------------------------------*/
+/*
+ * Selection of Sensniff I/O Interface.
+ * Define CC2538_IO_CONF_USB as 0 to use UART as sensniff's interface.
+ * This will default to using UART0, unless you also define
+ * CC2538_IO_CONF_USE_UART1 as 1.
+ *
+ * Don't forget to also set a correct baud rate (460800 or higher) by defining
+ * the corresponding UART0_CONF_BAUD_RATE or UART1_CONF_BAUD_RATE
+ */
+#define CC2538_IO_CONF_USB         0
+#define CC2538_IO_CONF_USE_UART1   0
+/*---------------------------------------------------------------------------*/
+#if CC2538_IO_CONF_USB
+#define USB_SERIAL_CONF_ENABLE     1
+#else
+#define UART0_CONF_BAUD_RATE  460800
+#endif
+/*---------------------------------------------------------------------------*/
+#define SENSNIFF_IO_DRIVER_H "pool/cc2538-io.h"
+/*---------------------------------------------------------------------------*/
+#endif /* TARGET_CONF_H_ */
+/*---------------------------------------------------------------------------*/

--- a/examples/storage/antelope-shell/Makefile
+++ b/examples/storage/antelope-shell/Makefile
@@ -5,7 +5,7 @@ include $(CONTIKI)/Makefile.dir-variables
 MODULES += $(CONTIKI_NG_STORAGE_DIR)/antelope $(CONTIKI_NG_SERVICES_DIR)/unit-test
 
 # does not fit on Sky
-PLATFORMS_ONLY= cc2538dk zoul
+PLATFORMS_ONLY= cc2538dk oopila zoul
 
 CONTIKI_PROJECT = shell-db
 all: $(CONTIKI_PROJECT)

--- a/examples/storage/cfs-coffee/Makefile
+++ b/examples/storage/cfs-coffee/Makefile
@@ -1,6 +1,6 @@
 CONTIKI = ../../..
 
-PLATFORMS_ONLY= cc2538dk zoul sky
+PLATFORMS_ONLY= cc2538dk oppila zoul sky
 
 include $(CONTIKI)/Makefile.dir-variables
 

--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -61,6 +61,9 @@ platform-specific/nrf52dk/blink-hello/nrf52dk \
 platform-specific/nrf52dk/coap-demo/coap-client/nrf52dk:SERVER_IPV6_EP=ffff \
 platform-specific/nrf52dk/mqtt-demo/nrf52dk \
 platform-specific/nrf52dk/timer-test/nrf52dk \
+platform-specific/oppila/orouter/client/oppila:BOARD=orouter \
+platform-specific/oppila/orouter/ip64-router/oppila:BOARD=orouter \
+platform-specific/oppila/oppila \
 platform-specific/zoul/at-test/zoul \
 platform-specific/zoul/orion/client/zoul:BOARD=orion \
 platform-specific/zoul/orion/ip64-router/zoul:BOARD=orion \


### PR DESCRIPTION
This ia a port for the Oppila platform developed by Oppila Microsystems and this platform suits best for real time IOT applications.The base support is based on the powerful CC2538 with 32-bit ARM Cortex-M3 (32MHz, 32KB RAM and 512KB flash) System on Chip (SoC), USB 2.0 and a built-in 2.4 GHz compatible with the IEEE 802.15.4 standard.

This platform includes Development board called Omote and a Router called Orouter. OMote is a lightweight and powerful IOT development board, with 3 on board sensors like LDR, BMP180 and Accelerometer. The Omote is an ultra-low power hardware platform for real time IOT applications. The micro-USB is used for both powering the device over USB (5VDC),and programming/debugging using the BSL. Bootloader should be unlocked by manually pressing the BSL button and reset button. Board can be flashed using following command

make TARGET=oppila oppila-demo.upload

The orouter is a routing device that forwards data packets between networks.It is capable of IPV4/IPV6 routing device.The device integrates the ENC28J60 ethernet module.The micro-USB is used for both powering the device over USB (5VDC),and programming/debugging. Bootloader should be unlocked by manually pressing the BSL button and reset button. Board can be flashed using following command

make TARGET=oppila BOARD=orouter oppila-demo.upload

Boards are available at sales@oppila.in – Oppila Microsystems pvt ltd Banglore