### PR TITLE
Add test simulation for MspMote clock deviation functionality

### DIFF
--- a/tests/07-simulation-base/26-tsch-drift-z1.csc
+++ b/tests/07-simulation-base/26-tsch-drift-z1.csc
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <simulation>
+    <title>Clock drift test</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.mspmote.Z1MoteType
+      <identifier>z11</identifier>
+      <description>Z1 Mote Type #z11</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
+      <commands EXPORT="discard">make TARGET=z1 clean
+      make -j node.z1 TARGET=z1</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDefaultSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+    </motetype>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-1.285769821276336</x>
+        <y>38.58045647334346</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>0.9999975</deviation>
+      </interface_config>
+      <motetype_identifier>z11</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>10</x>
+        <y>50</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>2</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1</deviation>
+      </interface_config>
+      <motetype_identifier>z11</motetype_identifier>
+    </mote>
+
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>242</width>
+    <z>4</z>
+    <height>160</height>
+    <location_x>11</location_x>
+    <location_y>241</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.TrafficVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <viewport>1.7405603810040515 0.0 0.0 1.7405603810040515 47.95980153208088 -42.576134155447555</viewport>
+    </plugin_config>
+    <width>236</width>
+    <z>3</z>
+    <height>230</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter>ID:2</filter>
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1031</width>
+    <z>0</z>
+    <height>394</height>
+    <location_x>273</location_x>
+    <location_y>6</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.TimeLine
+    <plugin_config>
+      <mote>0</mote>
+      <mote>1</mote>
+      <showRadioRXTX />
+      <showRadioHW />
+      <showRadioChannels />
+      <zoomfactor>1000</zoomfactor>
+    </plugin_config>
+    <width>1304</width>
+    <z>2</z>
+    <height>311</height>
+    <location_x>0</location_x>
+    <location_y>412</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>TIMEOUT(600000); /* Time out after 10 minutes */&#xD;
+/* Wait until TSCH drift is printed */&#xD;
+log.log("Waiting for TSCH drift to be detected\n");&#xD;
+counter = 0;&#xD;
+while(true) {;&#xD;
+  WAIT_UNTIL(msg.contains("drift"));&#xD;
+  log.log(msg + "\n");&#xD;
+  if(msg.contains("drift 2 ppm")) {&#xD;
+    if(++counter >= 5) {;&#xD;
+      log.testOK(); /* Report test success and quit */&#xD;
+    }&#xD;
+  }&#xD;
+  YIELD();&#xD;
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <width>764</width>
+    <z>1</z>
+    <height>995</height>
+    <location_x>963</location_x>
+    <location_y>111</location_y>
+  </plugin>
+</simconf>


### PR DESCRIPTION
This test is designed to fail until the clock deviation functionality is fixed in Cooja.

The following PR should be applied: https://github.com/contiki-ng/cooja/pull/50