### PR TITLE
TSCH: fix TSCH_CLOCK_TO_SLOTS macro used for deciding whether to leave the TSCH network

### DIFF
--- a/os/net/mac/tsch/tsch-const.h
+++ b/os/net/mac/tsch/tsch-const.h
@@ -83,7 +83,7 @@
 
 /* Convert rtimer ticks to clock and vice versa */
 #define TSCH_CLOCK_TO_TICKS(c) (((c) * RTIMER_SECOND) / CLOCK_SECOND)
-#define TSCH_CLOCK_TO_SLOTS(c, timeslot_length) (TSCH_CLOCK_TO_TICKS(c) / timeslot_length)
+#define TSCH_CLOCK_TO_SLOTS(c, timeslot_length) ((TSCH_CLOCK_TO_TICKS(c) + timeslot_length - 1) / timeslot_length)
 
 #endif /* __TSCH_CONST_H__ */
 /** @} */


### PR DESCRIPTION
If the TSCH timeslot length is long and/or TSCH_DESYNC_THRESHOLD is small, the macro currently can return zero, which breaks TSCH operation.