### PR TITLE
TSCH: disable the burst bit by default

### DIFF
--- a/os/net/mac/tsch/tsch-conf.h
+++ b/os/net/mac/tsch/tsch-conf.h
@@ -329,7 +329,7 @@
 #ifdef TSCH_CONF_BURST_MAX_LEN
 #define TSCH_BURST_MAX_LEN TSCH_CONF_BURST_MAX_LEN
 #else
-#define TSCH_BURST_MAX_LEN 32
+#define TSCH_BURST_MAX_LEN 0
 #endif
 
 /* 6TiSCH Minimal schedule slotframe length */


### PR DESCRIPTION
The new IEEE 802.15.4-2020 standard provided some more detail on how the frame pending bit should be used:

> When operating in TSCH mode, the frame pending bit can only be set if there is not a link scheduled in the following timeslot.

> At all other times, the frame pending bit shall be set to zero on transmission and ignored on reception.

It is not said whether this check should be done on both sides or just on the transmission side (which cannot be fully aware of the links scheduled on the receiver side).

Given that this feature may break hard cells (issue #994) and it is message and computationally complex to implement the lookahead in the schedule to be standard compatible, it is best to disable it by default.
