### PR TITLE
TSCH: fix backup link selection 

### DIFF
--- a/os/net/mac/tsch/tsch-schedule.c
+++ b/os/net/mac/tsch/tsch-schedule.c
@@ -450,13 +450,15 @@ tsch_schedule_get_next_active_link(struct tsch_asn_t *asn, uint16_t *time_offset
           }
 
           /* Maintain backup_link */
-          if(curr_backup == NULL) {
-            /* Check if 'l' best can be used as backup */
-            if(new_best != l && (l->link_options & LINK_OPTION_RX)) { /* Does 'l' have Rx flag? */
+          /* Check if 'l' best can be used as backup */
+          if(new_best != l && (l->link_options & LINK_OPTION_RX)) { /* Does 'l' have Rx flag? */
+            if(curr_backup == NULL || l->slotframe_handle < curr_backup->slotframe_handle) {
               curr_backup = l;
             }
-            /* Check if curr_best can be used as backup */
-            if(new_best != curr_best && (curr_best->link_options & LINK_OPTION_RX)) { /* Does curr_best have Rx flag? */
+          }
+          /* Check if curr_best can be used as backup */
+          if(new_best != curr_best && (curr_best->link_options & LINK_OPTION_RX)) { /* Does curr_best have Rx flag? */
+            if(curr_backup == NULL || curr_best->slotframe_handle < curr_backup->slotframe_handle) {
               curr_backup = curr_best;
             }
           }

--- a/os/net/mac/tsch/tsch-slot-operation.c
+++ b/os/net/mac/tsch/tsch-slot-operation.c
@@ -1035,9 +1035,18 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
       is_drift_correction_used = 0;
       /* Get a packet ready to be sent */
       current_packet = get_packet_and_neighbor_for_link(current_link, &current_neighbor);
-      /* There is no packet to send, and this link does not have Rx flag. Instead of doing
-       * nothing, switch to the backup link (has Rx flag) if any. */
-      if(current_packet == NULL && !(current_link->link_options & LINK_OPTION_RX) && backup_link != NULL) {
+      uint8_t do_skip_best_link = 0;
+      if(current_packet == NULL && backup_link != NULL) {
+        /* There is no packet to send, and this link does not have Rx flag. Instead of doing
+         * nothing, switch to the backup link (has Rx flag) if any
+         * and if the current link cannot Rx or both links can Rx, but the backup link has priority. */
+        if(!(current_link->link_options & LINK_OPTION_RX)
+            || backup_link->slotframe_handle < current_link->slotframe_handle) {
+          do_skip_best_link = 1;
+        }
+      }
+
+      if(do_skip_best_link) {
         /* skipped a Tx link, refresh its backoff */
         update_link_backoff(current_link);
 

--- a/tests/07-simulation-base/26-cooja-rpl-tsch-orchestra-perfect-link.csc
+++ b/tests/07-simulation-base/26-cooja-rpl-tsch-orchestra-perfect-link.csc
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>RPL+TSCH</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype660</identifier>
+      <description>RPL/TSCH Node</description>
+      <source>[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
+      <commands EXPORT="discard">make TARGET=cooja clean
+make -j node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=1 MAKE_WITH_STORING_ROUTING=1 MAKE_WITH_LINK_BASED_ORCHESTRA=1 DEFINES=LINK_STATS_CONF_PACKET_COUNTERS=1,TSCH_CONF_KEEPALIVE_TIMEOUT=1024,TSCH_CONF_MAX_KEEPALIVE_TIMEOUT=1024</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-1.285769821276336</x>
+        <y>38.58045647334346</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype660</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-19.324109516886306</x>
+        <y>76.23135780254927</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype660</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>242</width>
+    <z>4</z>
+    <height>160</height>
+    <location_x>11</location_x>
+    <location_y>241</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.TrafficVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <viewport>1.7405603810040515 0.0 0.0 1.7405603810040515 47.95980153208088 -42.576134155447555</viewport>
+    </plugin_config>
+    <width>236</width>
+    <z>3</z>
+    <height>230</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1031</width>
+    <z>0</z>
+    <height>394</height>
+    <location_x>273</location_x>
+    <location_y>6</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.TimeLine
+    <plugin_config>
+      <mote>0</mote>
+      <mote>1</mote>
+      <showRadioRXTX />
+      <showRadioHW />
+      <showRadioChannels />
+      <zoomfactor>16529.88882215865</zoomfactor>
+    </plugin_config>
+    <width>1304</width>
+    <z>2</z>
+    <height>311</height>
+    <location_x>0</location_x>
+    <location_y>412</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>TIMEOUT(1860000); /* Time out after 31 minutes */&#xD;
+while(true) {;&#xD;
+  WAIT_UNTIL(id == 2 &amp;&amp; msg.contains("Link Stats"));&#xD;
+  log.log(msg + "\n");&#xD;
+  fields = msg.split(" ");&#xD;
+  if(fields.length >= 9) {&#xD;
+    tx = parseInt(fields[5].split("=")[1]);&#xD;
+    ack = parseInt(fields[6].split("=")[1]);&#xD;
+    if(tx > 0 &amp;&amp; tx == ack) {&#xD;
+      log.testOK(); /* Report test success and quit */&#xD;
+    }&#xD;
+  }&#xD;
+  YIELD();&#xD;
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <width>764</width>
+    <z>1</z>
+    <height>995</height>
+    <location_x>963</location_x>
+    <location_y>111</location_y>
+  </plugin>
+
+</simconf>
+


### PR DESCRIPTION
There are two issues fixed by this PR:
1. in backup link selection, they are not prioritized by slotframe handle.
2. if the best link has no packets to send, the final decision to use either the best link of the backup link also does not take into account the slotframe handle. 

This lets the regression test pass with almost 100% packet ACK rate. The only loss appears to be very occasional (1 packet of 1500), because of the conflict by design between multiple Orchestra slotframes.