### PR TITLE
nrf52840: Use correct flash and RAM length in dk linker script

### DIFF
--- a/arch/cpu/nrf52840/ld/nrf52840.ld
+++ b/arch/cpu/nrf52840/ld/nrf52840.ld
@@ -5,8 +5,8 @@ GROUP(-lgcc -lc -lnosys)
 
 MEMORY
 {
-  FLASH (rx) : ORIGIN = 0x0, LENGTH = 0x80000
-  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x10000
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x100000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x40000
 }
 
 INCLUDE "nrf_common.ld"


### PR DESCRIPTION
The nRF52840 port is using incorrect lengths for both flash and RAM, resulting in reduced space being made available to the user application for the non-bootloader (dk) target. 
This pull request replaces them with the correct values in the linker script.

Discovered by @schuschu
