### PR TITLE
nrf52840: Fix build when using SEGGER RTT

### DIFF
--- a/arch/platform/nrf52840/rtt/segger-rtt-conf.h
+++ b/arch/platform/nrf52840/rtt/segger-rtt-conf.h
@@ -53,7 +53,7 @@ Purpose : Implementation of SEGGER real-time transfer (RTT) which
 #if (defined __SES_ARM) || (defined __CROSSWORKS_ARM) || (defined __GNUC__)
   #ifdef __ARM_ARCH_6M__
     #define SEGGER_RTT_LOCK(SavedState)   {                                               \
-                                          asm volatile ("mrs   %0, primask  \n\t"         \
+                                          __asm__ volatile ("mrs   %0, primask  \n\t"     \
                                                         "mov   r1, $1     \n\t"           \
                                                         "msr   primask, r1  \n\t"         \
                                                         : "=r" (SavedState)               \
@@ -63,7 +63,7 @@ Purpose : Implementation of SEGGER real-time transfer (RTT) which
                                           }
 
     #define SEGGER_RTT_UNLOCK(SavedState) {                                               \
-                                          asm volatile ("msr   primask, %0  \n\t"         \
+                                          __asm__ volatile ("msr   primask, %0  \n\t"     \
                                                         :                                 \
                                                         : "r" (SavedState)                \
                                                         :                                 \
@@ -72,7 +72,7 @@ Purpose : Implementation of SEGGER real-time transfer (RTT) which
 
   #elif (defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__))
     #define SEGGER_RTT_LOCK(SavedState)   {                                               \
-                                          asm volatile ("mrs   %0, basepri  \n\t"         \
+                                          __asm__ volatile ("mrs   %0, basepri  \n\t"     \
                                                       "mov   r1, $128     \n\t"           \
                                                       "msr   basepri, r1  \n\t"           \
                                                       : "=r" (SavedState)                 \
@@ -81,7 +81,7 @@ Purpose : Implementation of SEGGER real-time transfer (RTT) which
                                                       );                                  \
                                           }
     #define SEGGER_RTT_UNLOCK(SavedState) {                                               \
-                                          asm volatile ("msr   basepri, %0  \n\t"         \
+                                          __asm__ volatile ("msr   basepri, %0  \n\t"     \
                                                         :                                 \
                                                         : "r" (SavedState)                \
                                                         :                                 \

--- a/arch/platform/nrf52840/rtt/segger-rtt.h
+++ b/arch/platform/nrf52840/rtt/segger-rtt.h
@@ -198,15 +198,6 @@ int SEGGER_RTT_printf(unsigned BufferIndex, const char * sFormat, ...);
 #define RTT_CTRL_BG_BRIGHT_CYAN       "\e[4;46m"
 #define RTT_CTRL_BG_BRIGHT_WHITE      "\e[4;47m"
 
-// simpler replacement for SEGGER's RTT printf library
-char dbg_buf[200];
-#define RTT_PRINTF(fmt, ...) do { tfp_sprintf(dbg_buf, fmt, ##__VA_ARGS__); SEGGER_RTT_WriteString(0, dbg_buf); } while(0)
-#define RTT_PRINT(str) do { SEGGER_RTT_WriteString(0, str); } while(0)
-
-// Use RTT for PRINTF() and LOG()
-#define PRINTF(fmt, ...) SEGGER_RTT_printf(0, fmt, ##__VA_ARGS__)
-#define LOG_CONF_OUTPUT(fmt, ...) SEGGER_RTT_printf(0, fmt, ##__VA_ARGS__)
-
 #endif
 
 /*************************** End of file ****************************/


### PR DESCRIPTION
The nRF52840 port uses the gnu99 style of inline asm definitions in SEGGER RTT code (`asm` as opposed to `__asm__`) and thus fails to compile.

This PR fixes that and allows us to build successfully with NRF52840_USE_RTT=1 defined.