### PR TITLE
native platform: disable the warning '__builtin_strncpy output may be truncated'

### DIFF
--- a/arch/platform/native/Makefile.native
+++ b/arch/platform/native/Makefile.native
@@ -22,6 +22,8 @@ endif
 
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
+CFLAGS += -Wno-stringop-truncation
+
 .SUFFIXES:
 
 # Enable nullmac by default


### PR DESCRIPTION
Building examples on the native platform with a recent compiler is currently broken. This PR disables one particular warning to enable building them again.

The error message is as below:
```
atis@atis-laptop:~/work/pull/contiki-ng/examples/hello-world$ make TARGET=native
  MKDIR     build/native/obj
  CC        ../../arch/platform/native/./platform.c
  CC        ../../arch/platform/native/./clock.c
  CC        ../../arch/platform/native/dev/xmem.c
  CC        ../../arch/platform/native/./cfs-posix.c
  CC        ../../arch/platform/native/./cfs-posix-dir.c
In file included from /usr/include/string.h:495,
                 from ../../arch/platform/native/./cfs-posix-dir.c:37:
In function ‘strncpy’,
    inlined from ‘cfs_readdir’ at ../../arch/platform/native/./cfs-posix-dir.c:69:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ output may be truncated copying 32 bytes from a string of length 255 [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [../../Makefile.include:357: build/native/obj/cfs-posix-dir.o] Error 1
```
