### PR TITLE
fix number of strncpy uses in the native platform

### DIFF
--- a/arch/platform/native/cfs-posix-dir.c
+++ b/arch/platform/native/cfs-posix-dir.c
@@ -66,7 +66,8 @@ cfs_readdir(struct cfs_dir *p, struct cfs_dirent *e)
   if(res == NULL) {
     return -1;
   }
-  strncpy(e->name, res->d_name, sizeof(e->name));
+  strncpy(e->name, res->d_name, sizeof(e->name) - 1);
+  e->name[sizeof(e->name) - 1] = '\0';
 #if defined(__APPLE2__) || defined(__CBM__)
   e->size = res->d_blocks;
 #else /* __APPLE2__ || __CBM__ */


### PR DESCRIPTION
This PR avoids the warning '__builtin_strncpy output may be truncated' showing up on newer compilers if strncpy is used in a way that might leave the resulting string without the null-terminating character.

This handles just the native platform, there are a few other places in Contiki-NG that seem to have similar strncpy uses.