### PR TITLE
Update Github Actions: replace set-env with environment files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     # Construct the correct docker container image tag corresponding to this build
     - name: Figure out correct docker image tag
       run:
-        echo ::set-env name=DOCKER_IMG::$DOCKER_BASE_IMG:$(git log -1 --oneline -- tools/docker/ | cut -d" " -f1)
+        echo DOCKER_IMG=$DOCKER_BASE_IMG:$(git log -1 --oneline -- tools/docker/ | cut -d" " -f1) >> $GITHUB_ENV
 
     # Try to download the image from dockerhub. If it works, use it.
     #
@@ -59,7 +59,7 @@ jobs:
       run: |
         echo "Using $DOCKER_IMG for this run"
         echo "Pulling image $DOCKER_IMG from dockerhub";
-        docker pull $DOCKER_IMG || echo ::set-env name=DOCKER_NEED_BUILD::1
+        docker pull $DOCKER_IMG || echo DOCKER_NEED_BUILD=1 >> $GITHUB_ENV
 
     - name: Build docker image if required
       if: env.DOCKER_NEED_BUILD == '1'
@@ -101,7 +101,7 @@ jobs:
         # Set permissions for Docker mount
         sudo chown -R 1000:1000 $OUT_OF_TREE_TEST_PATH
         # Set up docker mount
-        echo ::set-env name=DOCKER_ARGS::-v `pwd`/$OUT_OF_TREE_TEST_PATH:/home/user/out-of-tree-tests
+        echo DOCKER_ARGS=-v `pwd`/$OUT_OF_TREE_TEST_PATH:/home/user/out-of-tree-tests >> $GITHUB_ENV
 
     # Fire up the container and run corresponding tests
     - name: Execute tests


### PR DESCRIPTION
Github Actions seem to fail due to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/