### PR TITLE
Enable BSL support for CC1312r1

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/Makefile.cc1312r1
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/Makefile.cc1312r1
@@ -15,7 +15,7 @@ SUPPORTS_BLE_BEACON = 0
 SUPPORTS_HIGH_PA = 0
 
 ### Signal that we can be programmed with cc2538-bsl
-BOARD_SUPPORTS_BSL = 0
+BOARD_SUPPORTS_BSL = 1
 
 # Include the common board makefile
 include $(FAMILY_PATH)/launchpad/Makefile.launchpad


### PR DESCRIPTION
This will allow make .upload on BOARD=launchpad/cc1312r1
It works when a mass erase has been done using UniFlash.
And also works repeatedly when enabling boot loader with button 13 + reset:


```
# make -C examples/hello-world/ DEFINES=CCFG_CONF_ROM_BOOTLOADER_ENABLE=1,SET_CCFG_BL_CONFIG_BL_PIN_NUMBER=13 BOARD=launchpad/cc1312r1 -j hello-world.upload && make -C examples/hello-world/ PORT=/dev/ttyACM0 serialview
make: Entering directory '/home/jo/repos/contiki-ng/examples/hello-world'
using saved target 'simplelink'
  CC        /home/jo/repos/contiki-ng/arch/cpu/simplelink-cc13xx-cc26xx/./ccfg-conf.c
  CC        /home/jo/repos/contiki-ng/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-addr.c
  CC        /home/jo/repos/contiki-ng/arch/cpu/simplelink-cc13xx-cc26xx/dev/startup_cc13xx_cc26xx_gcc.c
  CC        hello-world.c
  LD        build/simplelink/launchpad/cc1312r1/hello-world.elf
  OBJCOPY   build/simplelink/launchpad/cc1312r1/hello-world.elf --> build/simplelink/launchpad/cc1312r1/hello-world.bin
python ../../tools/cc2538-bsl/cc2538-bsl.py -e -w -v build/simplelink/launchpad/cc1312r1/hello-world.bin
Opening port /dev/ttyACM0, baud 500000
Reading data from build/simplelink/launchpad/cc1312r1/hello-world.bin
Firmware file: Raw Binary
Connecting to target...
CC1310 PG2.0 (7x7mm): 352KB Flash, 20KB SRAM, CCFG.BL_CONFIG at 0x00057FD8
Primary IEEE Address: 00:12:4B:00:1E:17:7A:CC
    Performing mass erase
Erasing all main bank flash sectors
    Erase done
Writing 360448 bytes starting at address 0x00000000
Write 104 bytes at 0x00057F988
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0x040e8ebd)
rm build/simplelink/launchpad/cc1312r1/obj/startup_cc13xx_cc26xx_gcc.o hello-world.o
make: Leaving directory '/home/jo/repos/contiki-ng/examples/hello-world'
make: Entering directory '/home/jo/repos/contiki-ng/examples/hello-world'
using saved target 'simplelink'
rlwrap ../../tools/serial-io/serialdump -b115200 -T /dev/ttyACM0
connecting to /dev/ttyACM0 [OK]
[2020-11-23 11:29:48] ���<�<���������<�<����������<�����<�<��<����������<�����������������<������Hello, world
[2020-11-23 11:30:08] Hello, world

# make -C examples/hello-world/ DEFINES=CCFG_CONF_ROM_BOOTLOADER_ENABLE=1,SET_CCFG_BL_CONFIG_BL_PIN_NUMBER=13 BOARD=launchpad/cc1312r1 -j hello-world.upload && make -C examples/hello-world/ PORT=/dev/ttyACM0 serialview
make: Entering directory '/home/jo/repos/contiki-ng/examples/hello-world'
using saved target 'simplelink'
  CC        /home/jo/repos/contiki-ng/arch/cpu/simplelink-cc13xx-cc26xx/./ccfg-conf.c
  CC        /home/jo/repos/contiki-ng/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-addr.c
  CC        /home/jo/repos/contiki-ng/arch/cpu/simplelink-cc13xx-cc26xx/dev/startup_cc13xx_cc26xx_gcc.c
  CC        hello-world.c
  LD        build/simplelink/launchpad/cc1312r1/hello-world.elf
  OBJCOPY   build/simplelink/launchpad/cc1312r1/hello-world.elf --> build/simplelink/launchpad/cc1312r1/hello-world.bin
python ../../tools/cc2538-bsl/cc2538-bsl.py -e -w -v build/simplelink/launchpad/cc1312r1/hello-world.bin
Opening port /dev/ttyACM0, baud 500000
Reading data from build/simplelink/launchpad/cc1312r1/hello-world.bin
Firmware file: Raw Binary
Connecting to target...
CC1310 PG2.0 (7x7mm): 352KB Flash, 20KB SRAM, CCFG.BL_CONFIG at 0x00057FD8
Primary IEEE Address: 00:12:4B:00:1E:17:7A:CC
    Performing mass erase
Erasing all main bank flash sectors
    Erase done
Writing 360448 bytes starting at address 0x00000000
Write 104 bytes at 0x00057F988
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0x040e8ebd)
rm build/simplelink/launchpad/cc1312r1/obj/startup_cc13xx_cc26xx_gcc.o hello-world.o
make: Leaving directory '/home/jo/repos/contiki-ng/examples/hello-world'
make: Entering directory '/home/jo/repos/contiki-ng/examples/hello-world'
using saved target 'simplelink'
rlwrap ../../tools/serial-io/serialdump -b115200 -T /dev/ttyACM0
connecting to /dev/ttyACM0 [OK]
[2020-11-23 11:30:36] ���<�<���������<�<����������<�����<�<��<����������<�����������������<������Hello, world
[2020-11-23 11:30:56] Hello, world
[2020-11-23 11:31:06] Hello, world
[2020-11-23 11:31:16] Hello, world
[2020-11-23 11:31:26] Hello, world
[2020-11-23 11:31:36] Hello, world
[2020-11-23 11:31:46] Hello, world
[2020-11-23 11:31:56] Hello, world
```