### PR TITLE
Fix TMP007 and HDC1000 sensor readings on the Simplelink platform

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/hdc-1000-sensor.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/hdc-1000-sensor.c
@@ -94,7 +94,7 @@
 
 #define SWAP16(v) ((LO_UINT16(v) << 8) | HI_UINT16(v))
 
-#define LSB16(v)  (LO_UINT16(v)), (HI_UINT16(v))
+#define LSB16(v)  (HI_UINT16(v)), (LO_UINT16(v))
 /*---------------------------------------------------------------------------*/
 static I2C_Handle i2c_handle;
 /*---------------------------------------------------------------------------*/
@@ -258,9 +258,9 @@ convert(int32_t *temp, int32_t *hum)
   int32_t raw_hum = SWAP16(sensor_data.hum);
 
   /* Convert temperature to degrees C */
-  *temp = raw_temp * 100 * 165 / 65536 - 40000;
+  *temp = (raw_temp * 100 * 165) / 65536 - 4000;
   /* Convert relative humidity to a %RH value */
-  *hum = raw_hum * 100 * 100 / 65536;
+  *hum = (raw_hum * 100 * 100) / 65536;
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/tmp-007-sensor.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/tmp-007-sensor.c
@@ -108,8 +108,8 @@
 
 #define SWAP16(v)               ((LO_UINT16(v) << 8) | (HI_UINT16(v) << 0))
 
-#define LSB16(v)                (LO_UINT16(v)), (HI_UINT16(v))
-#define MSB16(v)                (HI_UINT16(v)), (LO_UINT16(v))
+#define LSB16(v)                (HI_UINT16(v)), (LO_UINT16(v))
+#define MSB16(v)                (LO_UINT16(v)), (HI_UINT16(v))
 /*---------------------------------------------------------------------------*/
 static const PIN_Config pin_table[] = {
   TMP_007_TMP_RDY | PIN_INPUT_EN | PIN_PULLUP | PIN_HYSTERESIS | PIN_IRQ_NEGEDGE,


### PR DESCRIPTION
This PR addresses a couple of issues in the TMP007 and HDC1000 drivers, causing them to return invalid readings when using the Simplelink platform.

This addresses two of the issues reported in #1282.