### PR TITLE
Support alternate I2C pins for SensorTags on Simplelink and use for MPU-9250

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/Board.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/Board.h
@@ -100,6 +100,7 @@ extern "C" {
 #define Board_NVSEXTERNAL       CC1350STK_NVSSPI25X0
 
 #define Board_I2C0              CC1350STK_I2C0
+#define Board_I2C1              CC1350STK_I2C1
 
 #define Board_PIN_BUTTON0       CC1350STK_PIN_BTN1
 #define Board_PIN_BUTTON1       CC1350STK_PIN_BTN2

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/CC1350STK.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/CC1350STK.c
@@ -508,6 +508,15 @@ const I2CCC26XX_HWAttrsV1 i2cCC26xxHWAttrs[CC1350STK_I2CCOUNT] = {
         .sdaPin      = CC1350STK_I2C0_SDA0,
         .sclPin      = CC1350STK_I2C0_SCL0,
     },
+    {
+        .baseAddr    = I2C0_BASE,
+        .powerMngrId = PowerCC26XX_PERIPH_I2C0,
+        .intNum      = INT_I2C_IRQ,
+        .intPriority = ~0,
+        .swiPriority = 0,
+        .sdaPin      = CC1350STK_I2C0_SDA1,
+        .sclPin      = CC1350STK_I2C0_SCL1,
+    },
 #endif
 };
 
@@ -517,6 +526,11 @@ const I2C_Config I2C_config[CC1350STK_I2CCOUNT] = {
         .fxnTablePtr = &I2CCC26XX_fxnTable,
         .object      = &i2cCC26xxObjects[CC1350STK_I2C0],
         .hwAttrs     = &i2cCC26xxHWAttrs[CC1350STK_I2C0]
+    },
+    {
+        .fxnTablePtr = &I2CCC26XX_fxnTable,
+        .object      = &i2cCC26xxObjects[CC1350STK_I2C1],
+        .hwAttrs     = &i2cCC26xxHWAttrs[CC1350STK_I2C1]
     },
 #endif
 };

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/CC1350STK.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/CC1350STK.h
@@ -375,6 +375,7 @@ typedef enum CC1350STK_GPTimers {
 typedef enum CC1350STK_I2CName {
 #if TI_I2C_CONF_I2C0_ENABLE
     CC1350STK_I2C0 = 0,
+    CC1350STK_I2C1 = 1,
 #endif
 
     CC1350STK_I2CCOUNT

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/Board.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/Board.h
@@ -101,6 +101,7 @@ extern "C" {
 #define Board_NVSEXTERNAL       CC2650STK_NVSSPI25X0
 
 #define Board_I2C0              CC2650STK_I2C0
+#define Board_I2C1              CC2650STK_I2C1
 
 #define Board_PIN_BUTTON0       CC2650STK_PIN_BTN1
 #define Board_PIN_BUTTON1       CC2650STK_PIN_BTN2

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/CC2650STK.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/CC2650STK.c
@@ -508,6 +508,15 @@ const I2CCC26XX_HWAttrsV1 i2cCC26xxHWAttrs[CC2650STK_I2CCOUNT] = {
         .sdaPin      = CC2650STK_I2C0_SDA0,
         .sclPin      = CC2650STK_I2C0_SCL0,
     },
+    {
+        .baseAddr    = I2C0_BASE,
+        .powerMngrId = PowerCC26XX_PERIPH_I2C0,
+        .intNum      = INT_I2C_IRQ,
+        .intPriority = ~0,
+        .swiPriority = 0,
+        .sdaPin      = CC2650STK_I2C0_SDA1,
+        .sclPin      = CC2650STK_I2C0_SCL1,
+    },
 #endif
 };
 
@@ -517,6 +526,11 @@ const I2C_Config I2C_config[CC2650STK_I2CCOUNT] = {
         .fxnTablePtr = &I2CCC26XX_fxnTable,
         .object      = &i2cCC26xxObjects[CC2650STK_I2C0],
         .hwAttrs     = &i2cCC26xxHWAttrs[CC2650STK_I2C0]
+    },
+    {
+        .fxnTablePtr = &I2CCC26XX_fxnTable,
+        .object      = &i2cCC26xxObjects[CC2650STK_I2C1],
+        .hwAttrs     = &i2cCC26xxHWAttrs[CC2650STK_I2C1]
     },
 #endif
 };

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/CC2650STK.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/CC2650STK.h
@@ -376,6 +376,7 @@ typedef enum CC2650STK_GPTimers {
 typedef enum CC2650STK_I2CName {
 #if TI_I2C_CONF_I2C0_ENABLE
     CC2650STK_I2C0 = 0,
+    CC2650STK_I2C1 = 1,
 #endif
 
     CC2650STK_I2CCOUNT

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/mpu-9250-sensor.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/mpu-9250-sensor.c
@@ -434,7 +434,7 @@ initialise_cb(void *unused)
     return;
   }
 
-  i2c_handle = i2c_arch_acquire(Board_I2C0);
+  i2c_handle = i2c_arch_acquire(Board_I2C1);
 
   if(!i2c_handle) {
     return;
@@ -475,7 +475,7 @@ value(int type)
     return MPU_9250_READING_ERROR;
   }
 
-  i2c_handle = i2c_arch_acquire(Board_I2C0);
+  i2c_handle = i2c_arch_acquire(Board_I2C1);
 
   if(!i2c_handle) {
     return MPU_9250_READING_ERROR;
@@ -581,7 +581,7 @@ configure(int type, int enable)
       ctimer_stop(&startup_timer);
 
       if(PIN_getOutputValue(Board_MPU_POWER)) {
-        i2c_handle = i2c_arch_acquire(Board_I2C0);
+        i2c_handle = i2c_arch_acquire(Board_I2C1);
 
         if(!i2c_handle) {
           PIN_setOutputValue(pin_handle, Board_MPU_POWER, 0);


### PR DESCRIPTION
The TI CC2650 and CC1350 SensorTags use alternate I2C pins for the MPU-9250. 
Currently the Simplelink platform does not support that, causing the MPU driver to read -0.01 for all axes.

This PR adds support for those pins, makes them available under `Board_I2C1`, and updates the MPU-9250 driver to use them.

Fixes #1282.