### PR TITLE
Migrate sensniff to python3

### DIFF
--- a/examples/sensniff/Makefile
+++ b/examples/sensniff/Makefile
@@ -16,7 +16,6 @@ MAKE_NET=MAKE_NET_NULLNET
 # use a custom MAC driver: sensniff_mac_driver
 MAKE_MAC = MAKE_MAC_OTHER
 
-PYTHON ?= python
 SENSNIFF = $(CONTIKI)/tools/sensniff/sensniff.py
 
 ifeq ($(BAUDRATE),)
@@ -35,5 +34,5 @@ sniff:
 ifeq ($(wildcard $(SENSNIFF)), )
 	$(error Could not find the sensniff script. Did you run 'git submodule update --init' ?")
 else
-	$(PYTHON) $(SENSNIFF) $(SENSNIFF_FLAGS)
+	$(SENSNIFF) $(SENSNIFF_FLAGS)
 endif


### PR DESCRIPTION
This pull:

* Updates the `tools/sensniff` submodule to the latest version. This adds execute permission to the script and substitutes an obsolete function names for current ones. We change the shebang `python3`
* We update the respective example to call the script directly

Ticks off a box in #1453