### PR TITLE
Updated arm-gcc to 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         echo $DOCKER_IMG does not exist on dockerhub or pull failed
         echo This is normal for PR builds and for builds on forks
         echo Building from dockerfile
-        docker build tools/docker -t $DOCKER_IMG
+        docker build tools/docker -t $DOCKER_IMG --no-cache --pull
 
     # If i) the previous step built an image and ii) we are on the main
     # contiki-ng repo and iii) this is a push (merge commit) to one of the

--- a/os/net/app-layer/mqtt/mqtt-prop.c
+++ b/os/net/app-layer/mqtt/mqtt-prop.c
@@ -486,6 +486,7 @@ mqtt_get_next_in_prop(struct mqtt_connection *conn,
 {
   uint32_t prop_len;
   uint8_t prop_id_len_bytes;
+  uint16_t prop_id_decode;
 
   if(!conn->in_packet.has_props) {
     DBG("MQTT - Message has no input properties");
@@ -505,7 +506,9 @@ mqtt_get_next_in_prop(struct mqtt_connection *conn,
   prop_id_len_bytes =
     mqtt_decode_var_byte_int(conn->in_packet.curr_props_pos,
                              conn->in_packet.properties_len - (conn->in_packet.curr_props_pos - conn->in_packet.props_start),
-                             NULL, NULL, (uint16_t *)prop_id);
+                             NULL, NULL, (uint16_t *)&prop_id_decode);
+
+  *prop_id = prop_id_decode;
 
   DBG("MQTT - Decoded property ID %i (encoded using %i bytes)\n", *prop_id, prop_id_len_bytes);
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -52,9 +52,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
   && apt-get -qq clean
 
 # Install ARM toolchain
-RUN wget -nv https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2 && \
-  tar xjf gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2 -C /tmp/ && \
-  cp -f -r /tmp/gcc-arm-none-eabi-5_2-2015q4/* /usr/local/ && \
+RUN wget -nv https://github.com/Yagoor/gcc-arm-none-eabi/releases/download/9-2020-q2-update/gcc-arm-none-eabi-9-2020-q4-major-i386-linux.tar.bz2 && \
+  tar xjf gcc-arm-none-eabi-9-2020-q4-major-i386-linux.tar.bz2 -C /tmp/ && \
+  cp -f -r /tmp/gcc-arm-none-eabi-9-2020-q4-major/* /usr/local/ && \
   rm -rf /tmp/gcc-arm-none-eabi-* gcc-arm-none-eabi-*-linux.tar.bz2
 
 # Install msp430 toolchain


### PR DESCRIPTION
# Description

In this PR we are updating our old arm-gcc 5 to the latest version available at the moment arm-gcc 9

# Consequences

I expect this PR to break a few things. 
Example: The mqtt-client was not compiling with the following: "make BOARD=firefly DEFINES=MQTT_CONF_VERSION=5 TARGET=zoul"
This happened due to a new warning introduced on the GCC 9. "address-of-packed-member"

I expect that new warning will appear and they'll be fixed.

# Reason

In order to support the new arm boards we need to update the arm-gcc.
The new nRF53 uses the Cortex-M33 that is not suppported by the current arm-gcc.