### PR TITLE
Warn when using old GCC versions with platform nRF52840

### DIFF
--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -16,6 +16,17 @@ ifeq ("$(CC)","arm-none-eabi-gcc")
   endif
 endif
 
+# Warn if using anything older than version 6.x of arm-none-eabi-gcc on nrf52840
+ifeq ("$(TARGET)","nrf52840")
+  ifeq ("$(CC)","arm-none-eabi-gcc")
+    ifeq ($(shell test $(GCC_MAJOR_VERSION) -lt 6; echo $$?),0)
+        $(warning Warning: you're using a version of $(CC) that is known to create broken Contiki-NG executables for the nRF52840 platform.)
+        $(warning Issues reported include the inability to perform any radio communication.)
+        $(warning We recommend to upgrade your toolchain.)
+    endif
+  endif
+endif
+
 # Warn if using 4.6.x or older msp430-gcc
 ifeq ("$(CC)","msp430-gcc")
   ifeq ($(shell test $(GCC_MAJOR_VERSION) -lt 5; echo $$?),0)


### PR DESCRIPTION
Older GCC versions generate broken executables for the nRF52840 platform. 
The resulting binaries appear functional but are unable to send or receive any packets.

#1449 has seen this happen with arm-none-eabi-gcc 4.9.3, and I can reproduce it with arm-none-eabi-gcc 5.2.1.
This PR warns anyone using a version of gcc older than 6.x with the nRF52840 platform and prompts them to update their toolchain.

Closes #1449.