### PR TITLE
Removed unused vars from code-ipv6 tests

### DIFF
--- a/tests/07-simulation-base/code-ipv6/receiver/udp-receiver.c
+++ b/tests/07-simulation-base/code-ipv6/receiver/udp-receiver.c
@@ -33,7 +33,6 @@ receiver(struct simple_udp_connection *c,
 PROCESS_THREAD(udp_process, ev, data)
 {
   static struct etimer periodic_timer;
-  static struct etimer send_timer;
   uip_ipaddr_t addr;
   static int alive;
   const uip_ipaddr_t *default_prefix;

--- a/tests/07-simulation-base/code-ipv6/sender/udp-sender.c
+++ b/tests/07-simulation-base/code-ipv6/sender/udp-sender.c
@@ -34,7 +34,6 @@ receiver(struct simple_udp_connection *c,
 PROCESS_THREAD(udp_process, ev, data)
 {
   static struct etimer periodic_timer;
-  static struct etimer send_timer;
   uip_ipaddr_t addr;
 
   PROCESS_BEGIN();

--- a/tests/07-simulation-base/code-ipv6/sender/unicast-sender.c
+++ b/tests/07-simulation-base/code-ipv6/sender/unicast-sender.c
@@ -35,7 +35,6 @@ receiver(struct simple_udp_connection *c,
 PROCESS_THREAD(udp_process, ev, data)
 {
   static struct etimer periodic_timer;
-  static struct etimer send_timer;
   uip_ipaddr_t addr;
 
   PROCESS_BEGIN();


### PR DESCRIPTION
Applied fixes proposed in #1458 