### PR TITLE
native platform minor changes

### DIFF
--- a/arch/platform/native/Makefile.native
+++ b/arch/platform/native/Makefile.native
@@ -22,8 +22,6 @@ endif
 
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
-CFLAGS += -Wno-stringop-truncation
-
 .SUFFIXES:
 
 # Enable nullmac by default

--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -263,9 +263,11 @@ platform_init_stage_two()
   set_lladdr();
   serial_line_init();
 
+#if SELECT_STDIN
   if(NULL == input_handler) {
     native_uart_set_input(serial_line_input_byte);
   }
+#endif
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
Changes:
-  fix compilation with SELECT_STDIN is set to 0
-  remove the -Wno-stringop-truncation flag - it's not recognized on older compilers, and is not necessary anymore now that strncpy uses have been fixed.