### PR TITLE
Add readme badges for community engagement spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 [![GitHub Release Date](https://img.shields.io/github/release-date/contiki-ng/contiki-ng.svg)](https://github.com/contiki-ng/contiki-ng/releases/latest)
 [![Last commit](https://img.shields.io/github/last-commit/contiki-ng/contiki-ng.svg)](https://github.com/contiki-ng/contiki-ng/commit/HEAD)
 
+[![Stack Overflow Tag](https://img.shields.io/badge/Stack%20Overflow%20tag-Contiki--NG-blue?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/contiki-ng)
+[![Gitter](https://img.shields.io/badge/Gitter-Contiki--NG-blue?logo=gitter)](https://gitter.im/contiki-ng)
+[![Twitter](https://img.shields.io/badge/Twitter-%40contiki__ng-blue?logo=twitter)](https://twitter.com/contiki_ng)
+
 Contiki-NG is an open-source, cross-platform operating system for Next-Generation IoT devices. It focuses on dependable (secure and reliable) low-power communication and standard protocols, such as IPv6/6LoWPAN, 6TiSCH, RPL, and CoAP. Contiki-NG comes with extensive documentation, tutorials, a roadmap, release cycle, and well-defined development flow for smooth integration of community contributions.
 
 Unless explicitly stated otherwise, Contiki-NG sources are distributed under


### PR DESCRIPTION
This pull adds to our README shields.io badges with links to the various spaces we use for engagement with the community. Just because we can :)

I am showing two possible places here, one below the existing row of badges, or an alternative at the bottom. Choice up for debate!

Live view: https://github.com/g-oikonomou/contiki-ng/blob/contrib/social-badges/README.md