### PR TITLE
nRF52840 RF init HFCLK fix

### DIFF
--- a/arch/cpu/nrf52840/rf/nrf52840-ieee.c
+++ b/arch/cpu/nrf52840/rf/nrf52840-ieee.c
@@ -520,6 +520,8 @@ init(void)
   /* Request the HF clock */
   nrf_clock_event_clear(NRF_CLOCK_EVENT_HFCLKSTARTED);
   nrf_clock_task_trigger(NRF_CLOCK_TASK_HFCLKSTART);
+  while(!nrf_clock_event_check(NRF_CLOCK_EVENT_HFCLKSTARTED));
+  nrf_clock_event_clear(NRF_CLOCK_EVENT_HFCLKSTARTED);
 
   /* Start the RF driver process */
   process_start(&nrf52840_ieee_rf_process, NULL);


### PR DESCRIPTION
This PR adds a busy wait for the HFCLK during init to avoid hardware dependent race conditions (nrf boards seem to not be affected, custom boards with less reputable crystals are).