### PR TITLE
docs: fix simple typo, structrure -> structure

### DIFF
--- a/os/net/ipv6/psock.h
+++ b/os/net/ipv6/psock.h
@@ -106,7 +106,7 @@ struct psock_buf {
 /**
  * The representation of a protosocket.
  *
- * The protosocket structrure is an opaque structure with no user-visible
+ * The protosocket structure is an opaque structure with no user-visible
  * elements.
  */
 struct psock {


### PR DESCRIPTION
There is a small typo in os/net/ipv6/psock.h.

Should read `structure` rather than `structrure`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md