### PR TITLE
Improve cc26xx/cc13xx watchdog

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/dev/contiki-watchdog.c
+++ b/arch/cpu/cc26x0-cc13x0/dev/contiki-watchdog.c
@@ -125,6 +125,7 @@ watchdog_start(void)
 
   watchdog_periodic();
   ti_lib_watchdog_reset_enable();
+  ti_lib_watchdog_enable();
 
   lock_config(lock_status);
 }

--- a/arch/cpu/cc26x0-cc13x0/dev/contiki-watchdog.c
+++ b/arch/cpu/cc26x0-cc13x0/dev/contiki-watchdog.c
@@ -103,7 +103,7 @@ lock_config(uint32_t status)
 }
 /*---------------------------------------------------------------------------*/
 /**
- * \brief Initialises the CC26xx WDT
+ * \brief Initialises the CC13xx/CC26xx WDT
  *
  * Simply locks the config so that future calls will lock properly.
  * The WDT is not started yet. To start it, watchdog_start() must be called.
@@ -115,7 +115,7 @@ watchdog_init(void)
 }
 /*---------------------------------------------------------------------------*/
 /**
- * \brief Starts the CC26xx WDT
+ * \brief Starts the CC13xx/CC26xx WDT
  */
 void
 watchdog_start(void)
@@ -130,7 +130,7 @@ watchdog_start(void)
 }
 /*---------------------------------------------------------------------------*/
 /**
- * \brief Refreshes the CC26xx WDT
+ * \brief Refreshes the CC13xx/CC26xx WDT
  */
 void
 watchdog_periodic(void)

--- a/arch/cpu/cc26x0-cc13x0/dev/contiki-watchdog.c
+++ b/arch/cpu/cc26x0-cc13x0/dev/contiki-watchdog.c
@@ -105,13 +105,12 @@ lock_config(uint32_t status)
 /**
  * \brief Initialises the CC26xx WDT
  *
- * Simply sets the reload counter to a default value. The WDT is not started
- * yet. To start it, watchdog_start() must be called.
+ * Simply locks the config so that future calls will lock properly.
+ * The WDT is not started yet. To start it, watchdog_start() must be called.
  */
 void
 watchdog_init(void)
 {
-  ti_lib_watchdog_reload_set(WATCHDOG_TIMER_TOP_TICK);
   lock_config(LOCK_REGISTERS_UNLOCKED);
 }
 /*---------------------------------------------------------------------------*/
@@ -123,7 +122,7 @@ watchdog_start(void)
 {
   uint32_t lock_status = unlock_config();
 
-  watchdog_periodic();
+  ti_lib_watchdog_reload_set(WATCHDOG_TIMER_TOP_TICK);
   ti_lib_watchdog_reset_enable();
   ti_lib_watchdog_enable();
 
@@ -136,7 +135,7 @@ watchdog_start(void)
 void
 watchdog_periodic(void)
 {
-  ti_lib_watchdog_reload_set(WATCHDOG_TIMER_TOP_TICK);
+  /* Clearing interrupt also resets counter */
   ti_lib_watchdog_int_clear();
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR:

1. Sets the INTEN bit in the WD CTL register via call to `ti_lib_watchdog_enable()`. The [Technical Reference Manual (TRM)](https://www.ti.com/lit/pdf/swcu117) states this must be set to enable the WDT (even though it works without it today). So this change is simply for conformity with TRM.
2. Remove unnecessary `ti_lib_watchdog_reload_set()` from init()
3. Fixes `watchdog_periodic()`: The current call to `ti_lib_watchdog_reload_set()` does nothing since the registers are locked. In addition, it is superfluous because `ti_lib_watchdog_int_clear()` actually resets the counter (see Table 15-5 in TRM) - it's this which avoids the WD triggering today. Since there is no interrupt registered, the actual time needed for a reboot to be triggered is 2 x the configured timeout-value (the first timeout simply sets the interrupt-bit, which we clear). We could fix this by mimicking simplelink-platform and do unlock and reload instead of int_clear() - this would cause a reboot to happen if periodic is not called for 1 x configured timeout-value (the actual reboot would not happen until one more timeout-value). But it might be a unpopular move if users has become reliant on the 2x property...one option could be to double the default timeout. Lastly we could leave as-is, i.e. use int_clear(), which is what is currently in this PR - a bonus is that this is probably more efficient (no need to unlock).