### PR TITLE
Fix native target builds on macos

### DIFF
--- a/arch/cpu/native/net/tun6-net.c
+++ b/arch/cpu/native/net/tun6-net.c
@@ -49,6 +49,7 @@
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <net/if.h>
 
 /* Log configuration */
 #include "sys/log.h"


### PR DESCRIPTION
This PR fixes the bug shown below when trying to build `rpl-border-router` for `TARGET=native` on macos

```
~/contiki-ng/examples/rpl-border-router (develop)$ make TARGET=native
  MKDIR     build/native/obj
  CC        ../../arch/platform/native/./platform.c
  CC        ../../arch/platform/native/./clock.c
  CC        ../../arch/platform/native/dev/xmem.c
  CC        ../../arch/platform/native/./cfs-posix.c
  CC        ../../arch/platform/native/./cfs-posix-dir.c
  CC        ../../arch/platform/native/dev/buttons.c
  CC        ../../arch/cpu/native/net/tun6-net.c
../../arch/cpu/native/net/tun6-net.c:69:27: error: use of undeclared identifier 'IFNAMSIZ'
static char config_tundev[IFNAMSIZ + 1] = "tun0";
                          ^
1 error generated.
make: *** [build/native/obj/tun6-net.o] Error 1
```