### PR TITLE
nrf52840: Implement USB power events for hotplug support

### DIFF
--- a/arch/cpu/nrf52840/usb/Makefile.usb
+++ b/arch/cpu/nrf52840/usb/Makefile.usb
@@ -10,7 +10,9 @@ NRF52_SDK_C_SRCS += components/libraries/usbd/app_usbd.c \
   components/libraries/usbd/app_usbd_serial_num.c \
   components/libraries/usbd/app_usbd_string_desc.c \
   components/libraries/atomic/nrf_atomic.c \
+  integration/nrfx/legacy/nrf_drv_power.c \
   modules/nrfx/drivers/src/nrfx_usbd.c \
+  modules/nrfx/drivers/src/nrfx_power.c \
   modules/nrfx/drivers/src/nrfx_systick.c \
   modules/nrfx/soc/nrfx_atomic.c
 

--- a/arch/cpu/nrf52840/usb/usb-serial.c
+++ b/arch/cpu/nrf52840/usb/usb-serial.c
@@ -181,14 +181,14 @@ usbd_user_ev_handler(app_usbd_event_type_t event)
 void
 usb_serial_init(void)
 {
+  static const app_usbd_config_t usbd_config = {
+    .ev_state_proc = usbd_user_ev_handler
+  };
+
   ret_code_t ret;
   app_usbd_class_inst_t const *class_cdc_acm;
 
   app_usbd_serial_num_generate();
-
-  static const app_usbd_config_t usbd_config = {
-    .ev_state_proc = usbd_user_ev_handler
-  };
 
   ret = app_usbd_init(&usbd_config);
   if(ret != NRF_SUCCESS) {

--- a/arch/cpu/nrf52840/usb/usb-serial.c
+++ b/arch/cpu/nrf52840/usb/usb-serial.c
@@ -43,6 +43,7 @@
  */
 #include "contiki.h"
 
+#include "nrf_drv_power.h"
 #include "nrf_drv_usbd.h"
 #include "app_usbd.h"
 #include "app_usbd_core.h"
@@ -138,6 +139,45 @@ cdc_acm_port_ev_handler(app_usbd_class_inst_t const *p_inst,
   }
 }
 /*---------------------------------------------------------------------------*/
+static void
+usbd_user_ev_handler(app_usbd_event_type_t event)
+{
+  switch(event) {
+  case APP_USBD_EVT_STOPPED:
+  {
+    tx_buffer_busy = 0;
+    enabled = 0;
+    app_usbd_disable();
+    break;
+  }
+
+  case APP_USBD_EVT_POWER_DETECTED:
+  {
+    if(!nrf_drv_usbd_is_enabled()) {
+      app_usbd_enable();
+    }
+    break;
+  }
+
+  case APP_USBD_EVT_POWER_REMOVED:
+  {
+    tx_buffer_busy = 0;
+    enabled = 0;
+    app_usbd_stop();
+    break;
+  }
+
+  case APP_USBD_EVT_POWER_READY:
+  {
+    app_usbd_start();
+    break;
+  }
+
+  default:
+    break;
+  }
+}
+/*---------------------------------------------------------------------------*/
 void
 usb_serial_init(void)
 {
@@ -146,7 +186,11 @@ usb_serial_init(void)
 
   app_usbd_serial_num_generate();
 
-  ret = app_usbd_init(NULL);
+  static const app_usbd_config_t usbd_config = {
+    .ev_state_proc = usbd_user_ev_handler
+  };
+
+  ret = app_usbd_init(&usbd_config);
   if(ret != NRF_SUCCESS) {
     return;
   }
@@ -158,11 +202,13 @@ usb_serial_init(void)
     return;
   }
 
+  ret = app_usbd_power_events_enable();
+  if(ret != NRF_SUCCESS) {
+    return;
+  }
+
   enabled = 0;
   buffered_data = 0;
-
-  app_usbd_enable();
-  app_usbd_start();
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/platform/nrf52840/config/sdk_config.h
+++ b/arch/platform/nrf52840/config/sdk_config.h
@@ -3950,7 +3950,7 @@
 // <i> Enable processing power events in USB event handler.
 
 #ifndef APP_USBD_CONFIG_POWER_EVENTS_PROCESS
-#define APP_USBD_CONFIG_POWER_EVENTS_PROCESS 0
+#define APP_USBD_CONFIG_POWER_EVENTS_PROCESS 1
 #endif
 
 // <e> APP_USBD_CONFIG_EVENT_QUEUE_ENABLE - Enable event queue.
@@ -4212,6 +4212,92 @@
 #ifndef NRFX_SYSTICK_ENABLED
 #define NRFX_SYSTICK_ENABLED 1
 #endif
+
+
+
+// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
+//==========================================================
+#ifndef NRFX_POWER_ENABLED
+#define NRFX_POWER_ENABLED 1
+#endif
+// <o> NRFX_POWER_CONFIG_IRQ_PRIORITY  - Interrupt priority
+ 
+// <0=> 0 (highest) 
+// <1=> 1 
+// <2=> 2 
+// <3=> 3 
+// <4=> 4 
+// <5=> 5 
+// <6=> 6 
+// <7=> 7 
+
+#ifndef NRFX_POWER_CONFIG_IRQ_PRIORITY
+#define NRFX_POWER_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// <q> NRFX_POWER_CONFIG_DEFAULT_DCDCEN  - The default configuration of main DCDC regulator
+ 
+
+// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
+
+#ifndef NRFX_POWER_CONFIG_DEFAULT_DCDCEN
+#define NRFX_POWER_CONFIG_DEFAULT_DCDCEN 0
+#endif
+
+// <q> NRFX_POWER_CONFIG_DEFAULT_DCDCENHV  - The default configuration of High Voltage DCDC regulator
+ 
+
+// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
+
+#ifndef NRFX_POWER_CONFIG_DEFAULT_DCDCENHV
+#define NRFX_POWER_CONFIG_DEFAULT_DCDCENHV 0
+#endif
+
+// </e>
+
+
+
+// <e> POWER_ENABLED - nrf_drv_power - POWER peripheral driver - legacy layer
+//==========================================================
+#ifndef POWER_ENABLED
+#define POWER_ENABLED 1
+#endif
+// <o> POWER_CONFIG_IRQ_PRIORITY  - Interrupt priority
+ 
+
+// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
+// <0=> 0 (highest) 
+// <1=> 1 
+// <2=> 2 
+// <3=> 3 
+// <4=> 4 
+// <5=> 5 
+// <6=> 6 
+// <7=> 7 
+
+#ifndef POWER_CONFIG_IRQ_PRIORITY
+#define POWER_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// <q> POWER_CONFIG_DEFAULT_DCDCEN  - The default configuration of main DCDC regulator
+ 
+
+// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
+
+#ifndef POWER_CONFIG_DEFAULT_DCDCEN
+#define POWER_CONFIG_DEFAULT_DCDCEN 0
+#endif
+
+// <q> POWER_CONFIG_DEFAULT_DCDCENHV  - The default configuration of High Voltage DCDC regulator
+ 
+
+// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
+
+#ifndef POWER_CONFIG_DEFAULT_DCDCENHV
+#define POWER_CONFIG_DEFAULT_DCDCENHV 0
+#endif
+
+// </e>
 
 // <<< end of configuration section >>>
 #endif //SDK_CONFIG_H


### PR DESCRIPTION
Enabling the USB stack on boot works for the nRF52840 dongle, however, it can fail to enumerate on custom boards or on the DK when the native USB port is plugged in after boot.

This commit handles USB power events to enable and disable the nRF USB stack when the USB power state changes. This is necessary to make USB hotplugging work in any order.

Tested on both a DK and a dongle.