### PR TITLE
Misc. static-code-analysis fixes

### DIFF
--- a/os/lib/newlib/syscalls.c
+++ b/os/lib/newlib/syscalls.c
@@ -76,7 +76,7 @@ _sbrk(int incr)
   static uint8_t *heap_end = &_heap;
   uint8_t *prev_heap_end = heap_end;
 
-  if(heap_end + incr > &_eheap) {
+  if((uintptr_t)heap_end + incr > (uintptr_t)&_eheap) {
     PRINTF("Out of heap space!\n");
     errno = ENOMEM;
     return (caddr_t)-1;


### PR DESCRIPTION
This PR contains proposed fixes to misc. complaints from cppcheck and clang scan-build. Some might be a bit pedantic so we can cherry-pick whatever we want to keep after discussion.

The commit on coffee might warrant some discussion as I am not too familiar with the usage of that struct, but to me it seems you would want the the directory-descriptor name to be the same size as the file-header name which stores it.