### PR TITLE
Improve gcc version detection and revert obsolete make warning

### DIFF
--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -3,8 +3,8 @@
 # GCC specific definitions and actions
 #
 
-GCC_MAJOR_VERSION := $(shell $(CC) -v 2>&1 | grep "gcc version" | cut -b 13)
-GCC_MINOR_VERSION := $(shell $(CC) -v 2>&1 | grep "gcc version" | cut -b 15)
+GCC_MAJOR_VERSION := $(shell $(CC) -dumpversion | cut -d "." -f 1)
+GCC_MINOR_VERSION := $(shell $(CC) -dumpversion | cut -d "." -f 2)
 
 # Warn if using version 6.3.x of arm-none-eabi-gcc
 ifeq ("$(CC)","arm-none-eabi-gcc")

--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -16,17 +16,6 @@ ifeq ("$(CC)","arm-none-eabi-gcc")
   endif
 endif
 
-# Warn if using anything older than version 6.x of arm-none-eabi-gcc on nrf52840
-ifeq ("$(TARGET)","nrf52840")
-  ifeq ("$(CC)","arm-none-eabi-gcc")
-    ifeq ($(shell test $(GCC_MAJOR_VERSION) -lt 6; echo $$?),0)
-        $(warning Warning: you're using a version of $(CC) that is known to create broken Contiki-NG executables for the nRF52840 platform.)
-        $(warning Issues reported include the inability to perform any radio communication.)
-        $(warning We recommend to upgrade your toolchain.)
-    endif
-  endif
-endif
-
 # Warn if using 4.6.x or older msp430-gcc
 ifeq ("$(CC)","msp430-gcc")
   ifeq ($(shell test $(GCC_MAJOR_VERSION) -lt 5; echo $$?),0)


### PR DESCRIPTION
The root cause for the compiler version warning added in #1462 was fixed by #1478 so this can be reverted safely.
This also closes #1449.

This PR also improves the gcc version detection for warnings as the current approach doesn't handle double digit versions correctly and misinterprets gcc 10 as 1.