### PR TITLE
nrf52840: Always build power driver

### DIFF
--- a/arch/cpu/nrf52840/Makefile.nrf52840
+++ b/arch/cpu/nrf52840/Makefile.nrf52840
@@ -72,9 +72,11 @@ NRF52_SDK_C_SRCS += components/boards/boards.c \
   modules/nrfx/drivers/src/nrfx_gpiote.c \
   modules/nrfx/drivers/src/nrfx_rng.c \
   modules/nrfx/drivers/src/nrfx_wdt.c \
+  modules/nrfx/drivers/src/nrfx_power.c \
   modules/nrfx/mdk/system_nrf52840.c \
   integration/nrfx/legacy/nrf_drv_clock.c \
   integration/nrfx/legacy/nrf_drv_rng.c \
+  integration/nrfx/legacy/nrf_drv_power.c \
   components/libraries/fifo/app_fifo.c \
 
 NRF52_SDK_ASM_SRCS = modules/nrfx/mdk/gcc_startup_nrf52840.S

--- a/arch/cpu/nrf52840/usb/Makefile.usb
+++ b/arch/cpu/nrf52840/usb/Makefile.usb
@@ -10,9 +10,7 @@ NRF52_SDK_C_SRCS += components/libraries/usbd/app_usbd.c \
   components/libraries/usbd/app_usbd_serial_num.c \
   components/libraries/usbd/app_usbd_string_desc.c \
   components/libraries/atomic/nrf_atomic.c \
-  integration/nrfx/legacy/nrf_drv_power.c \
   modules/nrfx/drivers/src/nrfx_usbd.c \
-  modules/nrfx/drivers/src/nrfx_power.c \
   modules/nrfx/drivers/src/nrfx_systick.c \
   modules/nrfx/soc/nrfx_atomic.c
 


### PR DESCRIPTION
#1501 introduced a bug where the nrf52840 platform will crash unless USB support is compiled in.
This is caused by a missing IRQ handler after enabling the power driver in sdk_config.h but not compiling in the relevant SDK sources.

This PR moves the power driver away from this conditional build.