### PR TITLE
Add buffer boundary check in sicslowpan

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -1247,8 +1247,8 @@ uncompress_hdr_iphc(uint8_t *buf, uint16_t buf_size, uint16_t ip_len)
   last_nextheader =  &SICSLOWPAN_IP_BUF(buf)->proto;
   ip_payload = SICSLOWPAN_IPPAYLOAD_BUF(buf);
 
+  CHECK_READ_SPACE(1);
   while(nhc && (*hc06_ptr & SICSLOWPAN_NHC_MASK) == SICSLOWPAN_NHC_EXT_HDR) {
-    CHECK_READ_SPACE(1);
     uint8_t eid = (*hc06_ptr & 0x0e) >> 1;
     /* next header compression flag */
     uint8_t nh = (*hc06_ptr & 0x01);
@@ -1259,8 +1259,8 @@ uncompress_hdr_iphc(uint8_t *buf, uint16_t buf_size, uint16_t ip_len)
     nhc = nh;
 
     hc06_ptr++;
+    CHECK_READ_SPACE(1);
     if(!nh) {
-      CHECK_READ_SPACE(1);
       next = *hc06_ptr;
       hc06_ptr++;
       LOG_DBG("uncompression: next header is inlined. Next: %d\n", next);
@@ -1306,7 +1306,8 @@ uncompress_hdr_iphc(uint8_t *buf, uint16_t buf_size, uint16_t ip_len)
     exthdr->next = next;
     last_nextheader = &exthdr->next;
 
-    CHECK_READ_SPACE(len);
+    /* The loop condition needs to read one byte after the next len bytes in the buffer. */
+    CHECK_READ_SPACE(len + 1);
     memcpy((uint8_t *)exthdr + UIP_EXT_HDR_LEN, hc06_ptr, len);
     hc06_ptr += len;
 


### PR DESCRIPTION
This PR adds a buffer boundary check before reading from hc06_ptr in a loop condition in the <code>uncompress_hdr_iphc</code> function. The behavior is visible when injecting certain packets into Contiki-NG when running in native mode with ASAN enabled.