### PR TITLE
Bugfix: remote dual rf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 *.ihex
 *.pyc
 *~
-*.vscode
 build/*
 Makefile.target
 Makefile.*.defines

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.ihex
 *.pyc
 *~
+*.vscode
 build/*
 Makefile.target
 Makefile.*.defines

--- a/arch/platform/zoul/firefly-reva/board.h
+++ b/arch/platform/zoul/firefly-reva/board.h
@@ -332,7 +332,9 @@
  * 2.4GHz RF interface, the resistor can be removed to power-off the CC1200.
  * @{
  */
-#define REMOTE_DUAL_RF_ENABLED 1
+#ifndef REMOTE_DUAL_RF_ENABLED
+#define REMOTE_DUAL_RF_ENABLED  1
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/zoul/firefly/board.h
+++ b/arch/platform/zoul/firefly/board.h
@@ -331,7 +331,9 @@
  * 2.4GHz RF interface, the resistor can be removed to power-off the CC1200.
  * @{
  */
-#define REMOTE_DUAL_RF_ENABLED 1
+#ifndef REMOTE_DUAL_RF_ENABLED
+#define REMOTE_DUAL_RF_ENABLED  1
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/zoul/orion/board.h
+++ b/arch/platform/zoul/orion/board.h
@@ -225,7 +225,9 @@
  * Enables support for dual band operation (both CC1200 and 2.4GHz enabled).
  * @{
  */
-#define REMOTE_DUAL_RF_ENABLED 1
+#ifndef REMOTE_DUAL_RF_ENABLED
+#define REMOTE_DUAL_RF_ENABLED  1
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/zoul/remote-reva/board.h
+++ b/arch/platform/zoul/remote-reva/board.h
@@ -359,7 +359,9 @@
  * either position.  Enabling the definition below forces to skip this check.
  * @{
  */
-#define REMOTE_DUAL_RF_ENABLED 0
+#ifndef REMOTE_DUAL_RF_ENABLED
+#define REMOTE_DUAL_RF_ENABLED  0
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/zoul/remote-revb/board.h
+++ b/arch/platform/zoul/remote-revb/board.h
@@ -379,7 +379,9 @@
  * either position.  Enabling the definition below forces to skip this check.
  * @{
  */
-#define REMOTE_DUAL_RF_ENABLED 0
+#ifndef REMOTE_DUAL_RF_ENABLED
+#define REMOTE_DUAL_RF_ENABLED  0
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
The current implementation of the board header files for zoul platforms prevents enabling/disabling dual radio usage via an application's project-conf.h file as [explained here](https://github.com/Zolertia/Resources/wiki/RE-Mote-2.4GHz-dual-antenna#enabling-both-radios-in-contiki) (which should be standard behavior IMO). A simple preprocessor check solves this issue. 

~Second (and unrelated), vscode keeps adding an annoying hidden config folder and I really think this belongs in the gitignore. However, it's so minor of a change that I didn't really think dedicating an entire pull request to it was warranted.~