### PR TITLE
add UIPBUF_ATTR_RSSI and UIPBUF_ATTR_LINK_QUALITY attibutes to uipbuf

### DIFF
--- a/examples/6tisch/timesync-demo/node.c
+++ b/examples/6tisch/timesync-demo/node.c
@@ -75,10 +75,12 @@ udp_rx_callback(struct simple_udp_connection *c,
 
     LOG_INFO("Received from ");
     LOG_INFO_6ADDR(sender_addr);
-    LOG_INFO_(", created at %lu, now %lu, latency %lu clock ticks\n",
+    LOG_INFO_(", created at %lu, now %lu, latency %lu clock ticks, rssi %d, lqi %u\n",
               (unsigned long)remote_time_clock_ticks,
               (unsigned long)local_time_clock_ticks,
-              (unsigned long)(local_time_clock_ticks - remote_time_clock_ticks));
+              (unsigned long)(local_time_clock_ticks - remote_time_clock_ticks),
+              (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI),
+              uipbuf_get_attr(UIPBUF_ATTR_LINK_QUALITY));
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/mqtt-client/mqtt-client.c
+++ b/examples/mqtt-client/mqtt-client.c
@@ -306,7 +306,7 @@ echo_reply_handler(uip_ipaddr_t *source, uint8_t ttl, uint8_t *data,
                    uint16_t datalen)
 {
   if(uip_ip6addr_cmp(source, uip_ds6_defrt_choose())) {
-    def_rt_rssi = sicslowpan_get_last_rssi();
+    def_rt_rssi = (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/cc26x0-web-demo.c
+++ b/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/cc26x0-web-demo.c
@@ -434,7 +434,7 @@ echo_reply_handler(uip_ipaddr_t *source, uint8_t ttl, uint8_t *data,
                    uint16_t datalen)
 {
   if(uip_ip6addr_cmp(source, uip_ds6_defrt_choose())) {
-    def_rt_rssi = sicslowpan_get_last_rssi();
+    def_rt_rssi = (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/nrf52dk/mqtt-demo/mqtt-demo.c
+++ b/examples/platform-specific/nrf52dk/mqtt-demo/mqtt-demo.c
@@ -234,7 +234,7 @@ echo_reply_handler(uip_ipaddr_t *source, uint8_t ttl, uint8_t *data,
                    uint16_t datalen)
 {
   if(uip_ip6addr_cmp(source, uip_ds6_defrt_choose())) {
-    def_rt_rssi = sicslowpan_get_last_rssi();
+    def_rt_rssi = (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -193,7 +193,6 @@ static uint8_t curr_page;
 static int last_tx_status;
 /** @} */
 
-
 static int last_rssi;
 
 /* ----------------------------------------------------------------- */
@@ -1886,9 +1885,12 @@ input(void)
   buffer = (uint8_t *)UIP_IP_BUF;
   buffer_size = UIP_BUFSIZE;
 
-  /* Save the RSSI of the incoming packet in case the upper layer will
+  /* Save the RSSI and LQI of the incoming packet in case the upper layer will
      want to query us for it later. */
   last_rssi = (signed short)packetbuf_attr(PACKETBUF_ATTR_RSSI);
+  uipbuf_set_attr(UIPBUF_ATTR_RSSI, packetbuf_attr(PACKETBUF_ATTR_RSSI));
+  uipbuf_set_attr(UIPBUF_ATTR_LINK_QUALITY, packetbuf_attr(PACKETBUF_ATTR_LINK_QUALITY));
+
 
 #if SICSLOWPAN_CONF_FRAG
 

--- a/os/net/ipv6/sicslowpan.h
+++ b/os/net/ipv6/sicslowpan.h
@@ -336,7 +336,7 @@ struct sicslowpan_nh_compressor {
 
 };
 
-int sicslowpan_get_last_rssi(void);
+extern CC_DEPRECATED("Use UIPBUF_ATTR_RSSI instead") int sicslowpan_get_last_rssi(void);
 
 extern const struct network_driver sicslowpan_driver;
 

--- a/os/net/ipv6/uipbuf.h
+++ b/os/net/ipv6/uipbuf.h
@@ -201,6 +201,8 @@ enum {
   UIPBUF_ATTR_PHYSICAL_NETWORK_ID, /**< Physical network ID (mapped to PAN ID)*/
   UIPBUF_ATTR_MAX_MAC_TRANSMISSIONS, /**< MAX transmissions of the packet MAC */
   UIPBUF_ATTR_FLAGS,   /**< Flags that can control lower layers.  see above. */
+  UIPBUF_ATTR_RSSI, /**< Last packet's RSSI */
+  UIPBUF_ATTR_LINK_QUALITY, /**< Last packet's LQI */
   UIPBUF_ATTR_MAX
 };
 


### PR DESCRIPTION
Adds these fields to the uipbuf, and replaces the function `sicslowpan_get_last_rssi()` which provided similar functionality, but was not as clean in API sense (also, I could not find it when required, so made this change before discovering it exists :P)