### PR TITLE
RPL: do not assume that a neighbor is unreachable if IPv6 neighbor discovery status is not REACHABLE

### DIFF
--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -223,9 +223,8 @@ rpl_parent_is_reachable(rpl_parent_t *p) {
     return 0;
   } else {
 #if UIP_ND6_SEND_NS
-    uip_ds6_nbr_t *nbr = rpl_get_nbr(p);
     /* Exclude links to a neighbor that is not reachable at a NUD level */
-    if(nbr == NULL || nbr->state != NBR_REACHABLE) {
+    if(rpl_get_nbr(p) == NULL) {
       return 0;
     }
 #endif /* UIP_ND6_SEND_NS */
@@ -886,12 +885,9 @@ best_parent(rpl_dag_t *dag, int fresh_only)
     }
 
 #if UIP_ND6_SEND_NS
-    {
-    uip_ds6_nbr_t *nbr = rpl_get_nbr(p);
     /* Exclude links to a neighbor that is not reachable at a NUD level */
-    if(nbr == NULL || nbr->state != NBR_REACHABLE) {
+    if(rpl_get_nbr(p) == NULL) {
       continue;
-    }
     }
 #endif /* UIP_ND6_SEND_NS */
 

--- a/os/net/routing/rpl-lite/rpl-neighbor.c
+++ b/os/net/routing/rpl-lite/rpl-neighbor.c
@@ -270,23 +270,6 @@ rpl_neighbor_is_fresh(rpl_nbr_t *nbr)
 }
 /*---------------------------------------------------------------------------*/
 int
-rpl_neighbor_is_reachable(rpl_nbr_t *nbr) {
-  if(nbr == NULL) {
-    return 0;
-  } else {
-#if UIP_ND6_SEND_NS
-    uip_ds6_nbr_t *ds6_nbr = rpl_get_ds6_nbr(nbr);
-    /* Exclude links to a neighbor that is not reachable at a NUD level */
-    if(ds6_nbr == NULL || ds6_nbr->state != NBR_REACHABLE) {
-      return 0;
-    }
-#endif /* UIP_ND6_SEND_NS */
-    /* If we don't have fresh link information, assume the nbr is reachable. */
-    return !rpl_neighbor_is_fresh(nbr) || curr_instance.of->nbr_has_usable_link(nbr);
-  }
-}
-/*---------------------------------------------------------------------------*/
-int
 rpl_neighbor_is_parent(rpl_nbr_t *nbr)
 {
   return nbr != NULL && nbr->rank < curr_instance.dag.rank;
@@ -378,12 +361,9 @@ best_parent(int fresh_only)
     }
 
 #if UIP_ND6_SEND_NS
-    {
-    uip_ds6_nbr_t *ds6_nbr = rpl_get_ds6_nbr(nbr);
     /* Exclude links to a neighbor that is not reachable at a NUD level */
-    if(ds6_nbr == NULL || ds6_nbr->state != NBR_REACHABLE) {
+    if(rpl_get_ds6_nbr(nbr) == NULL) {
       continue;
-    }
     }
 #endif /* UIP_ND6_SEND_NS */
 

--- a/os/net/routing/rpl-lite/rpl-neighbor.h
+++ b/os/net/routing/rpl-lite/rpl-neighbor.h
@@ -95,14 +95,6 @@ void rpl_neighbor_set_preferred_parent(rpl_nbr_t *nbr);
 int rpl_neighbor_is_fresh(rpl_nbr_t *nbr);
 
 /**
- * Tells wether we a given neighbor is reachable
- *
- * \param nbr The neighbor
- * \return 1 if the parent is reachable, 0 otherwise
-*/
-int rpl_neighbor_is_reachable(rpl_nbr_t *nbr);
-
-/**
  * Tells whether a nbr is acceptable as per the OF's definition
  *
  * \param nbr The neighbor

--- a/tests/07-simulation-base/08-ipv6-unicast.csc
+++ b/tests/07-simulation-base/08-ipv6-unicast.csc
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <simulation>
+    <title>Basic IPv6 test</title>
+    <randomseed>generated</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>sender</identifier>
+      <description>Sender</description>
+      <source>[CONTIKI_DIR]/tests/07-simulation-base/code-ipv6/sender/unicast-sender.c</source>
+      <commands>make TARGET=cooja clean
+make -j unicast-sender.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>receiver</identifier>
+      <description>Receiver</description>
+      <source>[CONTIKI_DIR]/tests/07-simulation-base/code-ipv6/receiver/udp-receiver.c</source>
+      <commands>make TARGET=cooja clean
+make -j udp-receiver.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>100.0</x>
+        <y>25.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <motetype_identifier>sender</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>94.96401380574989</x>
+        <y>21.247662337471553</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
+      </interface_config>
+      <motetype_identifier>receiver</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>2</z>
+    <height>160</height>
+    <location_x>38</location_x>
+    <location_y>13</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+    </plugin_config>
+    <width>680</width>
+    <z>1</z>
+    <height>240</height>
+    <location_x>109</location_x>
+    <location_y>377</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <scriptfile>[CONFIG_DIR]/ipv6.js</scriptfile>
+      <active>true</active>
+    </plugin_config>
+    <width>600</width>
+    <z>0</z>
+    <height>700</height>
+    <location_x>330</location_x>
+    <location_y>24</location_y>
+  </plugin>
+</simconf>
+

--- a/tests/07-simulation-base/09-ipv6-broadcast.csc
+++ b/tests/07-simulation-base/09-ipv6-broadcast.csc
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <simulation>
+    <title>Basic IPv6 test</title>
+    <randomseed>generated</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>sender</identifier>
+      <description>Sender</description>
+      <source>[CONTIKI_DIR]/tests/07-simulation-base/code-ipv6/sender/udp-sender.c</source>
+      <commands>make TARGET=cooja clean
+make -j udp-sender.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>receiver</identifier>
+      <description>Receiver</description>
+      <source>[CONTIKI_DIR]/tests/07-simulation-base/code-ipv6/receiver/udp-receiver.c</source>
+      <commands>make TARGET=cooja clean
+make -j udp-receiver.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>100.0</x>
+        <y>25.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <motetype_identifier>sender</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>94.96401380574989</x>
+        <y>21.247662337471553</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
+      </interface_config>
+      <motetype_identifier>receiver</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>2</z>
+    <height>160</height>
+    <location_x>38</location_x>
+    <location_y>13</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+    </plugin_config>
+    <width>680</width>
+    <z>1</z>
+    <height>240</height>
+    <location_x>109</location_x>
+    <location_y>377</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <scriptfile>[CONFIG_DIR]/ipv6.js</scriptfile>
+      <active>true</active>
+    </plugin_config>
+    <width>600</width>
+    <z>0</z>
+    <height>700</height>
+    <location_x>330</location_x>
+    <location_y>24</location_y>
+  </plugin>
+</simconf>
+

--- a/tests/07-simulation-base/code-ipv6/receiver/project-conf.h
+++ b/tests/07-simulation-base/code-ipv6/receiver/project-conf.h
@@ -1,5 +1,7 @@
 #define UIP_CONF_ND6_SEND_NS 1
 
+#define LOG_CONF_LEVEL_RPL              LOG_LEVEL_INFO
+
 #ifdef BUFSIZE
 #define UIP_CONF_BUFFER_SIZE BUFSIZE
 #endif /* BUFSIZE */

--- a/tests/07-simulation-base/code-ipv6/receiver/udp-receiver.c
+++ b/tests/07-simulation-base/code-ipv6/receiver/udp-receiver.c
@@ -41,6 +41,9 @@ PROCESS_THREAD(udp_process, ev, data)
 
   default_prefix = uip_ds6_default_prefix();
   uip_ip6addr_copy(&addr, default_prefix);
+  addr.u16[4] = UIP_HTONS(0x202);
+  addr.u16[5] = UIP_HTONS(2);
+  addr.u16[6] = UIP_HTONS(2);
   addr.u16[7] = UIP_HTONS(2);
   uip_ds6_addr_add(&addr, 0, ADDR_AUTOCONF);
 

--- a/tests/07-simulation-base/code-ipv6/sender/project-conf.h
+++ b/tests/07-simulation-base/code-ipv6/sender/project-conf.h
@@ -1,5 +1,7 @@
 #define UIP_CONF_ND6_SEND_NS 1
 
+#define LOG_CONF_LEVEL_RPL              LOG_LEVEL_INFO
+
 #ifdef BUFSIZE
 #define UIP_CONF_BUFFER_SIZE BUFSIZE
 #endif /* BUFSIZE */

--- a/tests/07-simulation-base/code-ipv6/sender/udp-sender.c
+++ b/tests/07-simulation-base/code-ipv6/sender/udp-sender.c
@@ -6,7 +6,7 @@
 
 #define UDP_PORT 61618
 
-#define SEND_INTERVAL		(4 * CLOCK_SECOND)
+#define SEND_INTERVAL		(60 * CLOCK_SECOND)
 
 static struct simple_udp_connection broadcast_connection;
 

--- a/tests/07-simulation-base/code-ipv6/sender/unicast-sender.c
+++ b/tests/07-simulation-base/code-ipv6/sender/unicast-sender.c
@@ -7,7 +7,7 @@
 
 #define UDP_PORT 61618
 
-#define SEND_INTERVAL		(4 * CLOCK_SECOND)
+#define SEND_INTERVAL		(60 * CLOCK_SECOND)
 
 static struct simple_udp_connection broadcast_connection;
 
@@ -58,6 +58,9 @@ PROCESS_THREAD(udp_process, ev, data)
     printf("Sending unicast\n");
     default_prefix = uip_ds6_default_prefix();
     uip_ip6addr_copy(&addr, default_prefix);
+    addr.u16[4] = UIP_HTONS(0x202);
+    addr.u16[5] = UIP_HTONS(2);
+    addr.u16[6] = UIP_HTONS(2);
     addr.u16[7] = UIP_HTONS(2);
     simple_udp_sendto(&broadcast_connection, buf, sizeof(buf), &addr);
   }

--- a/tests/07-simulation-base/ipv6.js
+++ b/tests/07-simulation-base/ipv6.js
@@ -1,0 +1,14 @@
+TIMEOUT(3665000);
+
+while(true) {
+  log.log(time + ":" + id + ":" + msg + "\n");
+  if (msg.equals('Data 60 received length 100')) {
+    log.testOK();
+  }
+  if (msg.indexOf('parent switch:') != -1 && msg.indexOf('-> (NULL IP addr)') != -1) {
+    /* root instability: should not happen in the simple test */
+    log.testFailed();
+  }
+
+  YIELD();
+}


### PR DESCRIPTION
Also, removes the function `rpl_neighbor_is_reachable` of RPL lite, as it was not used in the code.

Fixes #1498.