### PR TITLE
Fix the length field check for SNMP input packets

### DIFF
--- a/os/net/app-layer/snmp/snmp-ber.c
+++ b/os/net/app-layer/snmp/snmp-ber.c
@@ -416,7 +416,7 @@ snmp_ber_decode_string_len_buffer(snmp_packet_t *snmp_packet, const char **str, 
 
   *str = (const char *)snmp_packet->in;
 
-  if(snmp_packet->used == 0 || snmp_packet->used - *length <= 0) {
+  if(snmp_packet->used == 0 || snmp_packet->used < *length) {
     return 0;
   }
 


### PR DESCRIPTION
The <code>*length</code> value in  can be controlled through an input packet, but it is not validated correctly. An attacker can thus cause an overflow of the <code>used</code> variable. This PR changes the check to a comparison instead of a subtraction.

Thanks to Tobias Scharnowski from Ruhr-University Bochum for the initial reporting of a missing length check.