### PR TITLE
TSCH: add function tsch_queue_free_packets_to(), used to drop packets in neighbors' queue after schedule has changed

### DIFF
--- a/os/net/mac/tsch/tsch-queue.c
+++ b/os/net/mac/tsch/tsch-queue.c
@@ -319,6 +319,19 @@ tsch_queue_free_packet(struct tsch_packet *p)
   }
 }
 /*---------------------------------------------------------------------------*/
+/* Free all packets to a neighbor */
+void
+tsch_queue_free_packets_to(const linkaddr_t *addr)
+{
+  struct tsch_neighbor *n = NULL;
+  if(!tsch_is_locked()) {
+    n = tsch_queue_get_nbr(addr);
+    if(n != NULL) {
+      tsch_queue_flush_nbr_queue(n);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
 /* Updates neighbor queue state after a transmission */
 int
 tsch_queue_packet_sent(struct tsch_neighbor *n, struct tsch_packet *p,

--- a/os/net/mac/tsch/tsch-queue.h
+++ b/os/net/mac/tsch/tsch-queue.h
@@ -115,6 +115,11 @@ struct tsch_packet *tsch_queue_remove_packet_from_queue(struct tsch_neighbor *n)
  */
 void tsch_queue_free_packet(struct tsch_packet *p);
 /**
+ * \brief Flush packets to a specific address
+ * \param addr The address of the neighbor whose packets to free
+ */
+void tsch_queue_free_packets_to(const linkaddr_t *addr);
+/**
  * \brief Updates neighbor queue state after a transmission
  * \param n The neighbor queue we just sent from
  * \param p The packet that was just sent

--- a/os/services/orchestra/orchestra-rule-unicast-link-based.c
+++ b/os/services/orchestra/orchestra-rule-unicast-link-based.c
@@ -136,6 +136,10 @@ remove_uc_links(const linkaddr_t *linkaddr)
 
     remove_unicast_link(timeslot_rx, LINK_OPTION_RX);
     remove_unicast_link(timeslot_tx, LINK_OPTION_TX | LINK_OPTION_SHARED);
+
+    /* Packets to this address were marked with this slotframe and neighbor-specific timeslot;
+     * make sure they don't remain stuck in the queues after the link is removed. */
+    tsch_queue_free_packets_to(linkaddr);
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
+++ b/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
@@ -137,6 +137,12 @@ remove_uc_link(const linkaddr_t *linkaddr)
   if(l == NULL) {
     return;
   }
+  if(!ORCHESTRA_UNICAST_SENDER_BASED) {
+    /* Packets to this address were marked with this slotframe and neighbor-specific timeslot;
+     * make sure they don't remain stuck in the queues after the link is removed. */
+    tsch_queue_free_packets_to(linkaddr);
+  }
+
   /* Does our current parent need this timeslot? */
   if(timeslot == get_node_timeslot(&orchestra_parent_linkaddr)) {
     /* Yes, this timeslot is being used, return */


### PR DESCRIPTION
This is not a perfect solution, but a simple approach on how to deal with packets remaining in queues forever because the corresponding active cell has been removed.