### PR TITLE
Add nRF52840 support to sensniff

### DIFF
--- a/arch/cpu/nrf52840/clock.c
+++ b/arch/cpu/nrf52840/clock.c
@@ -44,6 +44,7 @@
  *
  */
 /*---------------------------------------------------------------------------*/
+#include "contiki.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include "nrf.h"
@@ -52,7 +53,6 @@
 #include "nrf_drv_clock.h"
 #include "nrf_delay.h"
 #include "app_error.h"
-#include "contiki.h"
 
 /*---------------------------------------------------------------------------*/
 const nrf_drv_rtc_t rtc = NRF_DRV_RTC_INSTANCE(PLATFORM_RTC_INSTANCE_ID); /**< RTC instance used for platform clock */

--- a/arch/cpu/nrf52840/dbg.c
+++ b/arch/cpu/nrf52840/dbg.c
@@ -38,7 +38,7 @@
  *         Alex Stanoev <alex@astanoev.com>
  *
  */
-#include "nrf52840-conf.h"
+#include "contiki.h"
 #include "dev/uart0.h"
 #include "usb/usb-serial.h"
 

--- a/arch/cpu/nrf52840/dev/uart0.c
+++ b/arch/cpu/nrf52840/dev/uart0.c
@@ -89,7 +89,7 @@ uart0_init(unsigned long ubr)
   nrf_gpio_pin_set(TX_PIN);
   nrf_gpio_cfg_input(RX_PIN, NRF_GPIO_PIN_NOPULL);
 
-  nrf_uart_baudrate_set(UART_INSTANCE, NRF_UART_BAUDRATE_115200);
+  nrf_uart_baudrate_set(UART_INSTANCE, UART0_CONF_BAUD_RATE);
   nrf_uart_configure(UART_INSTANCE, NRF_UART_PARITY_EXCLUDED,
                      NRF_UART_HWFC_DISABLED);
   nrf_uart_txrx_pins_set(UART_INSTANCE, TX_PIN, RX_PIN);

--- a/arch/cpu/nrf52840/dev/watchdog.c
+++ b/arch/cpu/nrf52840/dev/watchdog.c
@@ -39,9 +39,9 @@
  * \author
  *         Wojciech Bober <wojciech.bober@nordicsemi.no>
  */
+#include "contiki.h"
 #include <nrfx_wdt.h>
 #include "app_error.h"
-#include "contiki.h"
 
 #include "sys/log.h"
 #define LOG_MODULE "WATCHDOG"

--- a/arch/cpu/nrf52840/nrf52840-conf.h
+++ b/arch/cpu/nrf52840/nrf52840-conf.h
@@ -4,6 +4,10 @@
 /*---------------------------------------------------------------------------*/
 #define NETSTACK_CONF_RADIO        nrf52840_ieee_driver
 /*---------------------------------------------------------------------------*/
+#ifndef UART0_CONF_BAUD_RATE
+#define UART0_CONF_BAUD_RATE       NRF_UART_BAUDRATE_115200
+#endif
+/*---------------------------------------------------------------------------*/
 #if NRF52840_NATIVE_USB
 
 #ifndef DBG_CONF_USB

--- a/arch/cpu/nrf52840/rf/nrf52840-ieee.c
+++ b/arch/cpu/nrf52840/rf/nrf52840-ieee.c
@@ -865,7 +865,9 @@ set_value(radio_param_t param, radio_value_t value)
 
     /* If we are powered on, apply immediately. */
     if(radio_is_powered()) {
+      off();
       set_channel(value);
+      on();
     }
     return RADIO_RESULT_OK;
   case RADIO_PARAM_RX_MODE:

--- a/arch/platform/nrf52840/common/temperature-sensor.c
+++ b/arch/platform/nrf52840/common/temperature-sensor.c
@@ -46,8 +46,8 @@
  *         Wojciech Bober <wojciech.bober@nordicsemi.no>
  *
  */
-#include "nrf_temp.h"
 #include "contiki.h"
+#include "nrf_temp.h"
 #include "temperature-sensor.h"
 
 const struct sensors_sensor temperature_sensor;

--- a/examples/sensniff/Makefile
+++ b/examples/sensniff/Makefile
@@ -1,7 +1,7 @@
 CONTIKI_PROJECT = sensniff
 CONTIKI = ../..
 
-PLATFORMS_ONLY = cc2538dk openmote z1 zoul cc26x0-cc13x0 jn516x simplelink
+PLATFORMS_ONLY = cc2538dk openmote z1 zoul cc26x0-cc13x0 jn516x simplelink nrf52840
 
 PROJECT_SOURCEFILES += sensniff-mac.c netstack.c
 MODULES_REL += pool $(TARGET)

--- a/examples/sensniff/README.md
+++ b/examples/sensniff/README.md
@@ -51,12 +51,13 @@ The following radios have been tested:
 * CC2530/CC2531
 * CC1200
 * RF233
+* nRF52840
 
 Once you have the radio sorted out, you also need to configure character I/O.
 The firmware captures wireless frames and streams them over a serial line to
 the host where your device is connected. This can be achieved over UART or over
 CDC-ACM. The example makes zero assumptions about your hardware's capability,
-you have to configure thnigs explicitly. 
+you have to configure things explicitly.
 
 * Firstly, create a directory named the same as your platform. Crate a header
 file therein called `target-conf.h`. This will get included automatically.

--- a/examples/sensniff/nrf52840/target-conf.h
+++ b/examples/sensniff/nrf52840/target-conf.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef TARGET_CONF_H_
+#define TARGET_CONF_H_
+/*---------------------------------------------------------------------------*/
+/*
+ * Selection of Sensniff I/O Interface.
+ * Defaults to UART0 on the DK and USB on the dongle.
+ * Set NRF52840_NATIVE_USB=1 when building to use USB as sensniff's interface.
+ *
+ * Don't forget to also set a correct baud rate (460800 or higher) by defining
+ * the corresponding UART0_CONF_BAUD_RATE 
+ */
+#define NRF52840_IO_CONF_USB       NRF52840_NATIVE_USB
+/*---------------------------------------------------------------------------*/
+#if NRF52840_IO_CONF_USB == 0
+#define UART0_CONF_BAUD_RATE       NRF_UART_BAUDRATE_460800
+#endif
+/*---------------------------------------------------------------------------*/
+#define SENSNIFF_IO_DRIVER_H "pool/nrf52840-io.h"
+/*---------------------------------------------------------------------------*/
+#endif /* TARGET_CONF_H_ */
+/*---------------------------------------------------------------------------*/

--- a/examples/sensniff/pool/nrf52840-io.h
+++ b/examples/sensniff/pool/nrf52840-io.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#include "dev/uart0.h"
+#include "usb/usb-serial.h"
+/*---------------------------------------------------------------------------*/
+#ifndef NRF52840_IO_H_
+#define NRF52840_IO_H_
+/*---------------------------------------------------------------------------*/
+/*
+ * Select whether to use native USB as sensniff's I/O interface.
+ * If defined as 0, UART will be used. Set to 1 to use USB.
+ */
+#ifdef NRF52840_IO_CONF_USB
+#define NRF52840_IO_USB NRF52840_IO_CONF_USB
+#else
+#define NRF52840_IO_USB 0
+#endif
+/*---------------------------------------------------------------------------*/
+#if NRF52840_IO_USB
+#define sensniff_io_byte_out(b)  usb_serial_writeb(b)
+#define sensniff_io_flush()      usb_serial_flush()
+#define sensniff_io_set_input(f) usb_serial_set_input(f)
+#else
+#define sensniff_io_byte_out(b)  uart0_writeb(b)
+#define sensniff_io_flush()
+#define sensniff_io_set_input(f) uart0_set_input(f)
+#endif /* NRF52840_IO_USB */
+/*---------------------------------------------------------------------------*/
+#endif /* NRF52840_IO_H_ */
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR adds support for the nRF52840 to sensniff.

A few small issues popped up during this, and the fixes are part of this PR:
* Some device drivers had the wrong include order and were pulling in `nrf52840-conf.h` early.
* The UART baud rate was not configurable.
* The RF driver did not ramp up the radio after changing the channel, which is required to actually switch to it.

Both UART and USB transports are supported, with the USB transport used by default on the dongle and enabled by passing the usual `NRF52840_NATIVE_USB=1` make option for the dk.