### PR TITLE
Move doxygen modules to the correct location

### DIFF
--- a/arch/cpu/nrf52840/usb/usb-dfu-trigger.c
+++ b/arch/cpu/nrf52840/usb/usb-dfu-trigger.c
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
  *
  * All rights reserved.

--- a/arch/cpu/nrf52840/usb/usb-dfu-trigger.h
+++ b/arch/cpu/nrf52840/usb/usb-dfu-trigger.h
@@ -28,7 +28,13 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * \addtogroup nrf52840-usb
+ * \addtogroup nrf52840
+ * @{
+ *
+ * \addtogroup nrf52840-dev
+ * @{
+ *
+ * \addtogroup nrf52840-usb nRF52840 USB driver
  * @{
  *
  * \file
@@ -44,4 +50,8 @@ void dfu_trigger_usb_init(void);
 
 #endif /* USB_DFU_TRIGGER_H_ */
 
-/** @} */
+/**
+ * @}
+ * @}
+ * @}
+ */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/rat.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/rat.c
@@ -28,7 +28,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * \addtogroup cc13xx-cc26xx-rat
+ * \addtogroup cc13xx-cc26xx-rf-rat
  * @{
  *
  * \file


### PR DESCRIPTION
Those two doxygen modules were appearing at the top of the module tree:

https://contiki-ng.readthedocs.io/en/master/_api/modules.html

This PR moves to the a more suitable location in the tree