### PR TITLE
MAC: add MAC_TX_QUEUE_FULL error code, and account it in link stats separately

### DIFF
--- a/examples/benchmarks/result-visualization/run-analysis.py
+++ b/examples/benchmarks/result-visualization/run-analysis.py
@@ -41,6 +41,7 @@ class NodeStats:
         self.seqnums_received_on_root = set()
         self.parent_packets_tx = 0
         self.parent_packets_ack = 0
+        self.parent_packets_queue_dropped = 0
         self.energest_cpu_on = 0
         self.energest_cpu_sleep = 0
         self.energest_cpu_deep_sleep = 0
@@ -116,7 +117,11 @@ class NodeStats:
         else:
             self.rdc_joined = 0
 
-        return self.parent_packets_tx, self.parent_packets_ack, self.max_seqnum_sent, len(self.seqnums_received_on_root)
+        return self.parent_packets_tx, \
+            self.parent_packets_ack, \
+            self.parent_packets_queue_dropped, \
+            self.max_seqnum_sent, \
+            len(self.seqnums_received_on_root)
 
 
 ###########################################
@@ -234,16 +239,18 @@ def analyze_results(filename, is_testbed):
                 nodes[from_node].seqnums_received_on_root.add(seqnum)
                 continue
 
-            # 600142000 28 [INFO: Link Stats] num packets: tx=0 ack=0 rx=0 to=0014.0014.0014.0014
+            # 600142000 28 [INFO: Link Stats] num packets: tx=0 ack=0 rx=0 queue_drops=0 to=0014.0014.0014.0014
             if "num packets" in line:
                 tx = int(fields[7].split("=")[1])
                 ack = int(fields[8].split("=")[1])
                 rx = int(fields[9].split("=")[1])
-                to_addr = fields[10].split("=")[1]
+                queue_drops = int(fields[10].split("=")[1])
+                to_addr = fields[11].split("=")[1]
                 # only account for the (current) time source node
                 if nodes[node].tsch_time_source == to_addr:
                     nodes[node].parent_packets_tx += tx
                     nodes[node].parent_packets_ack += ack
+                    nodes[node].parent_packets_queue_dropped += queue_drops
                 continue
 
             # 960073000 8 [INFO: Energest  ] Total time  :   60000000
@@ -284,6 +291,7 @@ def analyze_results(filename, is_testbed):
     # link layer PAR
     total_ll_sent = 0
     total_ll_acked = 0
+    total_ll_queue_dropped = 0
     # end to end PDR
     total_e2e_sent = 0
     total_e2e_received = 0
@@ -291,16 +299,17 @@ def analyze_results(filename, is_testbed):
         n = nodes[k]
         if n.id == COORDINATOR_ID:
             continue
-        ll_sent, ll_acked, e2e_sent, e2e_received = n.calc()
+        ll_sent, ll_acked, ll_queue_dropped, e2e_sent, e2e_received = n.calc()
         if n.is_valid:
             r.append((n.id, n.pdr, n.par, n.rpl_parent_changes, n.rdc, n.rdc_joined, n.charge))
             total_ll_sent += ll_sent
             total_ll_acked += ll_acked
+            total_ll_queue_dropped += ll_queue_dropped
             total_e2e_sent += e2e_sent
             total_e2e_received += e2e_received
     ll_par = 100.0 * total_ll_acked / total_ll_sent if total_ll_sent else 0.0
     e2e_pdr = 100.0 * total_e2e_received / total_e2e_sent if total_e2e_sent else 0.0
-    return r, ll_par, e2e_pdr
+    return r, ll_par, total_ll_queue_dropped, e2e_pdr
 
 #######################################################
 # Plot the results of a given metric as a bar chart
@@ -344,9 +353,10 @@ def main():
     with open(input_file, "r") as f:
         is_testbed = "Starting COOJA logger" not in f.read()
 
-    results, ll_par, e2e_pdr = analyze_results(input_file, is_testbed)
+    results, ll_par, ll_queue_dropped, e2e_pdr = analyze_results(input_file, is_testbed)
 
-    print("Link-layer PAR={:.2f} End-to-end PDR={:.2f}".format(ll_par, e2e_pdr))
+    print("Link-layer PAR={:.2f} ({} packets queue dropped) End-to-end PDR={:.2f}".format(
+        ll_par, ll_queue_dropped, e2e_pdr))
 
     ids = [r[0] for r in results]
     plot(ids, [r[1] for r in results], "pdr", "Packet Delivery Ratio, %")

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -1589,8 +1589,7 @@ fragment_copy_payload_and_send(uint16_t uip_offset, linkaddr_t *dest) {
 
   /* Check tx result. */
   if((last_tx_status == MAC_TX_COLLISION) ||
-     (last_tx_status == MAC_TX_ERR) ||
-     (last_tx_status == MAC_TX_ERR_FATAL)) {
+     (last_tx_status >= MAC_TX_ERR)) {
     LOG_ERR("output: error in fragment tx, dropping subsequent fragments.\n");
     return 0;
   }

--- a/os/net/link-stats.h
+++ b/os/net/link-stats.h
@@ -72,6 +72,8 @@ struct link_packet_counter {
   link_packet_stat_t num_packets_acked;
   /* total number of unicast and broadcast packets received */
   link_packet_stat_t num_packets_rx;
+  /* total number of packets dropped before transmission due to insufficient memory */
+  link_packet_stat_t num_queue_drops;
 };
 
 

--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -527,7 +527,7 @@ csma_output_packet(mac_callback_t sent, void *ptr)
   } else {
     LOG_WARN("could not allocate neighbor, dropping packet\n");
   }
-  mac_call_sent_callback(sent, ptr, MAC_TX_ERR, 1);
+  mac_call_sent_callback(sent, ptr, MAC_TX_QUEUE_FULL, 1);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/os/net/mac/mac.h
+++ b/os/net/mac/mac.h
@@ -104,6 +104,11 @@ enum {
      fatal error. The upper layer does not need to try again, as the
      error will be fatal then as well. */
   MAC_TX_ERR_FATAL,
+
+  /**< The MAC layer transmission could not be performed because of
+     insufficient queue space, failure to allocate a neighbor,
+     or insufficient packet memory space. The upper layer may try again later. */
+  MAC_TX_QUEUE_FULL,
 };
 
 #endif /* MAC_H_ */

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -1147,7 +1147,7 @@ send_packet(mac_callback_t sent, void *ptr)
           tsch_packet_seqno, tsch_queue_nbr_packet_count(n),
           TSCH_QUEUE_NUM_PER_NEIGHBOR, tsch_queue_global_packet_count(),
           QUEUEBUF_NUM);
-      ret = MAC_TX_ERR;
+      ret = MAC_TX_QUEUE_FULL;
     } else {
       p->header_len = hdr_len;
       LOG_INFO("send packet to ");


### PR DESCRIPTION
Allows to collect statistics on queue losses, which are important for network performance evaluation.