### PR TITLE
Install nrfjprog and nrfutil in docker image

### DIFF
--- a/tests/08-native-runs/mqtt-client.sh
+++ b/tests/08-native-runs/mqtt-client.sh
@@ -27,7 +27,9 @@ PUB_PAYLD=1
 
 # Start mosquitto server
 echo "Starting mosquitto daemon"
-mosquitto &> /dev/null &
+echo "listener 1883" > mosquitto.conf
+echo "allow_anonymous true" >> mosquitto.conf
+mosquitto -c mosquitto.conf &> /dev/null &
 MOSQID=$!
 sleep 2
 
@@ -93,6 +95,7 @@ rm make.log
 rm make.err
 rm $CLIENT_LOG $CLIENT_ERR
 rm $MOSQ_SUB_LOG $MOSQ_SUB_ERR
+rm mosquitto.conf
 
 # We do not want Make to stop -> Return 0
 # The Makefile will check if a log contains FAIL at the end

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     python-dev \
     python-pip \
     python3-pip \
+    python3-setuptools \
     python-serial \
     rlwrap \
     sudo \
@@ -43,6 +44,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     srecord \
     uml-utilities \
     unzip \
+    libusb-1.0-0 \
     valgrind \
     wget \
     smitools \
@@ -85,6 +87,15 @@ RUN wget -nv https://developer.nordicsemi.com/nRF5_IoT_SDK/nRF5_IoT_SDK_v0.9.x/n
 
 ENV NRF52_SDK_ROOT /usr/nrf52-sdk
 
+# Install nRF Command Line tools
+RUN wget -nv https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-12-1/nRFCommandLineTools10121Linuxi386.tar.gz && \
+  mkdir /tmp/nrf-cli-tools && \
+  tar xzf nRFCommandLineTools10121Linuxi386.tar.gz -C /tmp/nrf-cli-tools && \
+  dpkg -i /tmp/nrf-cli-tools/JLink_Linux_V688a_i386.deb && \
+  dpkg -i /tmp/nrf-cli-tools/nRF-Command-Line-Tools_10_12_1_Linux-i386.deb && \
+  ln -s /opt/SEGGER/JLink_V688a/libjlinkarm.so /opt/SEGGER/JLink_V688a/libjlinkarm_x86.so && \
+  rm -rf nRFCommandLineTools10121Linuxi386.tar.gz /tmp/nrf-cli-tools
+
 # Install sphinx and sphinx_rtd_theme, required for building and testing the
 # readthedocs API documentation
 RUN pip -q install --upgrade pip
@@ -92,6 +103,10 @@ RUN pip -q install setuptools && pip -q install sphinx_rtd_theme sphinx
 # Install matplotlib for result visualization
 RUN pip3 -q install --upgrade pip
 RUN pip3 -q install matplotlib
+
+# Install nrfutil and work around broken pc_ble_driver_py dependency
+RUN pip3 -q install nrfutil && \
+  pip3 -q install --no-deps -t /usr/local/lib/python3.6/dist-packages --python-version 3.6 --ignore-requires-python --upgrade nrfutil
 
 # Create user, enable X forwarding, add to group dialout
 # -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix
@@ -112,6 +127,8 @@ ENV HOME                /home/user
 ENV CONTIKI_NG          ${HOME}/contiki-ng
 ENV COOJA               ${CONTIKI_NG}/tools/cooja
 ENV                     PATH="${HOME}:${PATH}"
+ENV                     LC_ALL=C.UTF-8
+ENV                     LANG=C.UTF-8
 WORKDIR                 ${HOME}
 
 # Create Cooja shortcut


### PR DESCRIPTION
This PR installs all utilities needed to program devices supported by the nrf52840 platform on the docker image.

A couple of workarounds for upstream issues are in place:
* The 32-bit `nrfjprog` looks for `libjlinkarm_x86.so` but the library is called `libjlinkarm.so`.
* `nrfutil` has a broken dependency `pc_ble_driver_py` which causes pip to install an old version that's incompatible with Python 3. We upgrade it ignoring that dependency, as it's only needed for BLE OTA updates.
* `nrfutil` requires the `C.UTF-8` locale to be used.

Closes #1536

Requires #1550 first