### PR TITLE
Allow to set an initial CXXFLAGS value from the command line of application's Makefile

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -257,7 +257,7 @@ ifneq ($(MODULES_IMACROS),)
   CFLAGS += ${foreach d, $(MODULES_IMACROS), -imacros $(d)}
 endif
 
-CXXFLAGS = $(subst -std=c99,-std=gnu++11,$(CFLAGS))
+CXXFLAGS += $(subst -std=c99,-std=gnu++11,$(CFLAGS))
 CXXFLAGS += -fpermissive -fno-exceptions -fno-unwind-tables
 CXXFLAGS += -fno-threadsafe-statics -fno-rtti -fno-use-cxa-atexit
 


### PR DESCRIPTION
Currently, the Contiki-NG build system always overrides the value of CXXFLAGS. This is not correct - it should append rather than override this variable, so that the users can set their own initial value.