### PR TITLE
CC radios: make waiting time in read_frame dependent on the maximum packet size instead of using hardcoded values and fix maxPktLen for CC13xx

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-def.h
+++ b/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-def.h
@@ -71,6 +71,9 @@
 
 #define RADIO_BYTE_AIR_TIME  (1000000 / (RADIO_BIT_RATE / 8))
 
+#define RADIO_FRAME_DURATION(payload_len)                               \
+  US_TO_RTIMERTICKS(RADIO_BYTE_AIR_TIME * (RADIO_PHY_OVERHEAD + (payload_len)))
+
 /* Delay between GO signal and SFD */
 #define RADIO_DELAY_BEFORE_TX ((unsigned)US_TO_RTIMERTICKS(RADIO_PHY_HEADER_LEN * RADIO_BYTE_AIR_TIME))
 /* Delay between GO signal and start listening.

--- a/arch/cpu/cc26x0-cc13x0/rf-core/ieee-mode.c
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/ieee-mode.c
@@ -933,7 +933,7 @@ read_frame(void *buf, unsigned short buf_len)
   /* wait for entry to become finished */
   rtimer_clock_t t0 = RTIMER_NOW();
   while(entry->status == DATA_ENTRY_STATUS_BUSY
-      && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (RTIMER_SECOND / 250)));
+      && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + RADIO_FRAME_DURATION(MAX_PAYLOAD_LEN)));
 
   if(entry->status != DATA_ENTRY_STATUS_FINISHED) {
     /* No available data */

--- a/arch/cpu/cc26x0-cc13x0/rf-core/prop-mode.c
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/prop-mode.c
@@ -861,7 +861,7 @@ read_frame(void *buf, unsigned short buf_len)
   /* wait for entry to become finished */
   rtimer_clock_t t0 = RTIMER_NOW();
   while(entry->status == DATA_ENTRY_STATUS_BUSY
-      && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (RTIMER_SECOND / 50)));
+      && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + RADIO_FRAME_DURATION(MAX_PAYLOAD_LEN)));
 
 #if MAC_CONF_WITH_TSCH
   /* Make sure the flag is reset */

--- a/arch/cpu/cc26x0-cc13x0/rf-core/prop-mode.c
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/prop-mode.c
@@ -133,7 +133,6 @@ static int off(void);
 static rfc_propRxOutput_t rx_stats;
 /*---------------------------------------------------------------------------*/
 /* Defines and variables related to the .15.4g PHY HDR */
-#define DOT_4G_MAX_FRAME_LEN    2047
 #define DOT_4G_PHR_LEN             2
 
 /* PHY HDR bits */
@@ -169,8 +168,8 @@ static rfc_propRxOutput_t rx_stats;
  * a 4-byte CRC.
  *
  * In the future we can change this to support transmission of long frames,
- * for example as per .15.4g. the size of the TX and RX buffers would need
- * adjusted accordingly.
+ * for example as per .15.4g, which defines 2047 as the maximum frame size.
+ * The size of the TX and RX buffers would need to be adjusted accordingly.
  */
 #define MAX_PAYLOAD_LEN 125
 /*---------------------------------------------------------------------------*/
@@ -453,10 +452,9 @@ rf_cmd_prop_rx()
   cmd_rx_adv->rxConf.bAppendStatus = RF_CORE_RX_BUF_INCLUDE_CORR;
 
   /*
-   * Set the max Packet length. This is for the payload only, therefore
-   * 2047 - length offset
+   * Set the max Packet length. This is for the payload only.
    */
-  cmd_rx_adv->maxPktLen = DOT_4G_MAX_FRAME_LEN - cmd_rx_adv->lenOffset;
+  cmd_rx_adv->maxPktLen = RADIO_PHY_OVERHEAD + MAX_PAYLOAD_LEN;
 
   ret = rf_core_send_cmd((uint32_t)cmd_rx_adv, &cmd_status);
 

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-def.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-def.h
@@ -92,6 +92,9 @@
 
 #define RADIO_BYTE_AIR_TIME  (1000000 / (RADIO_BIT_RATE / 8))
 
+#define RADIO_FRAME_DURATION(payload_len)                               \
+  US_TO_RTIMERTICKS(RADIO_BYTE_AIR_TIME * (RADIO_PHY_OVERHEAD + (payload_len)))
+
 /* Delay between GO signal and SFD */
 #define RADIO_DELAY_BEFORE_TX ((unsigned)US_TO_RTIMERTICKS(RADIO_PHY_HEADER_LEN * RADIO_BYTE_AIR_TIME))
 /* Delay between GO signal and start listening.

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-mode.c
@@ -98,9 +98,6 @@
 /*---------------------------------------------------------------------------*/
 /* Timeout constants */
 
-/* How long to wait for the rx read entry to become ready */
-#define TIMEOUT_DATA_ENTRY_BUSY (RTIMER_SECOND / 200)
-
 /* How long to wait for RX to become active after scheduled */
 #define TIMEOUT_ENTER_RX_WAIT   (RTIMER_SECOND >> 10)
 /*---------------------------------------------------------------------------*/
@@ -465,7 +462,7 @@ read(void *buf, unsigned short buf_len)
   const rtimer_clock_t t0 = RTIMER_NOW();
   /* Only wait if the Radio timer is accessing the entry */
   while((data_entry->status == DATA_ENTRY_BUSY) &&
-        RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + TIMEOUT_DATA_ENTRY_BUSY)) ;
+        RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + RADIO_FRAME_DURATION(MAX_PAYLOAD_LEN))) ;
 
   if(data_entry->status != DATA_ENTRY_FINISHED) {
     /* No available data */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
@@ -105,7 +105,6 @@ static volatile uint8_t is_receiving_packet;
 #endif
 /*---------------------------------------------------------------------------*/
 /* Defines and variables related to the .15.4g PHY HDR */
-#define DOT_4G_MAX_FRAME_LEN    2047
 #define DOT_4G_PHR_NUM_BYTES    2
 #define DOT_4G_LEN_OFFSET       0xFC
 #define DOT_4G_SYNCWORD         0x0055904E
@@ -143,8 +142,8 @@ static volatile uint8_t is_receiving_packet;
  * a 4-byte CRC.
  *
  * In the future we can change this to support transmission of long frames,
- * for example as per .15.4g. the size of the TX and RX buffers would need
- * adjusted accordingly.
+ * for example as per .15.4g, which defines 2047 as the maximum frame size.
+ * The size of the TX and RX buffers would need to be adjusted accordingly.
  */
 #define MAX_PAYLOAD_LEN 125
 /*---------------------------------------------------------------------------*/
@@ -265,7 +264,7 @@ init_rf_params(void)
 
   cmd_rx.syncWord0 = DOT_4G_SYNCWORD;
   cmd_rx.syncWord1 = 0x00000000;
-  cmd_rx.maxPktLen = DOT_4G_MAX_FRAME_LEN - DOT_4G_LEN_OFFSET;
+  cmd_rx.maxPktLen = RADIO_PHY_OVERHEAD + MAX_PAYLOAD_LEN;
   cmd_rx.hdrConf.numHdrBits = DOT_4G_PHR_NUM_BYTES * 8;
   cmd_rx.lenOffset = DOT_4G_LEN_OFFSET;
   cmd_rx.pQueue = data_queue_init(sizeof(lensz_t));

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
@@ -151,8 +151,6 @@ static volatile uint8_t is_receiving_packet;
 /* How long to wait for the RF to enter RX in rf_cmd_ieee_rx */
 #define TIMEOUT_ENTER_RX_WAIT   (RTIMER_SECOND >> 10)
 
-/* How long to wait for the rx read entry to become ready */
-#define TIMEOUT_DATA_ENTRY_BUSY (RTIMER_SECOND / 250)
 /*---------------------------------------------------------------------------*/
 /*
  * Offset of the end of SFD when compared to the radio HW-generated timestamp.
@@ -479,7 +477,7 @@ read(void *buf, unsigned short buf_len)
   /* Only wait if the Radio is accessing the entry */
   const rtimer_clock_t t0 = RTIMER_NOW();
   while((data_entry->status == DATA_ENTRY_BUSY) &&
-        RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + TIMEOUT_DATA_ENTRY_BUSY));
+         RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + RADIO_FRAME_DURATION(MAX_PAYLOAD_LEN)));
 
 #if MAC_CONF_WITH_TSCH
   /* Make sure the flag is reset */


### PR DESCRIPTION
The discussion and motivation for this is in #1528 .

TL;DR: 
1. Make the waiting time in read_frame() dependent on RADIO_BYTE_AIR_TIME multiplied by the sum of RADIO_CONST_PHY_OVERHEAD and MAX_PAYLOAD_LEN (and round the result up in rtimer ticks, and add some small guard time). It will work correctly and efficiency in different datarates, unlike the current approach which uses a constant time.
2. Set `cmd_rx_adv->maxPktLen` to the actual max frame size supported by the current config of the Contiki-NG network stack. Previously the value 2047 from the standard was used. This lead to receivers occasionally being on for a very long time while up to 2047 bytes were received, even when the packet would be dropped anyway because of the network stack not being able to process it.