### PR TITLE
Add deprecation macro

### DIFF
--- a/os/sys/cc-gcc.h
+++ b/os/sys/cc-gcc.h
@@ -41,5 +41,7 @@
 
 #define CC_CONF_NORETURN __attribute__((__noreturn__))
 
+#define CC_CONF_DEPRECATED(msg) __attribute__((deprecated(msg)))
+
 #endif /* __GNUC__ */
 #endif /* _CC_GCC_H_ */

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -116,6 +116,16 @@
 #endif /* CC_CONF_NORETURN */
 
 /**
+ * Configure if the C compiler supports marking functions as deprecated
+ * e.g. with __attribute__((deprecated))
+ */
+#ifdef CC_CONF_DEPRECATED
+#define CC_DEPRECATED(msg) CC_CONF_DEPRECATED(msg)
+#else
+#define CC_DEPRECATED(msg)
+#endif /* CC_CONF_DEPRECATED */
+
+/**
  * Configure if the C compiler supports the assignment of struct value.
  */
 #ifdef CC_CONF_ASSIGN_AGGREGATE


### PR DESCRIPTION
This PR adds the `CC_DEPRECATED("Deprecation message")` macro as a gcc-specific shortcut for `__attribute__((deprecated("Deprecation message")))` to be used when altering API functions.

Example usage:
`CC_DEPRECATED("Use other_method instead") void some_method(void);`

Resulting in the following warning (or error with -Werror):
`error: 'some_method' is deprecated: Use other_method instead [-Werror=deprecated-declarations]`