### PR TITLE
CC1200: 802.15.4g mode fixes/improvements, and compile test added

### DIFF
--- a/arch/dev/radio/cc1200/cc1200-conf.h
+++ b/arch/dev/radio/cc1200/cc1200-conf.h
@@ -110,8 +110,8 @@
 #ifdef CC1200_CONF_802154G_CRC16
 #define CC1200_802154G_CRC16            CC1200_CONF_802154G_CRC16
 #else
-/* Use FCS type 0: CRC32 */
-#define CC1200_802154G_CRC16            0
+/* Use FCS type 1: CRC16 if 802154G is enabled, else use FCS type 0: CRC32 */
+#define CC1200_802154G_CRC16            CC1200_802154G
 #endif
 /*---------------------------------------------------------------------------*/
 /* The RF configuration to be used. */

--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -2420,7 +2420,7 @@ cc1200_rx_interrupt(void)
     }
 
     burst_read(CC1200_RXFIFO,
-               &phr,
+               (uint8_t *)&phr,
                PHR_LEN);
     payload_len = (phr.phra & 0x07);
     payload_len <<= 8;

--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -18,6 +18,7 @@ hello-world/nrf52840:BOARD=dongle \
 hello-world/openmote:BOARD=openmote-b \
 hello-world/openmote:BOARD=openmote-cc2538 \
 hello-world/zoul:BOARD=firefly-reva:DEFINES=ZOUL_CONF_USE_CC1200_RADIO=1 \
+hello-world/zoul:BOARD=firefly-reva:DEFINES=ZOUL_CONF_USE_CC1200_RADIO=1,CC1200_CONF_802154G=1 \
 hello-world/simplelink:BOARD=srf06/cc13x0 \
 hello-world/simplelink:BOARD=launchpad/cc1310 \
 hello-world/simplelink:BOARD=launchpad/cc1312r1 \


### PR DESCRIPTION
Compilation with 15.4g mode on CC1200 was failing with recent GCC versions. This fixes it.

Also it makes `CC1200_802154G_CRC16` dependent on `CC1200_802154G`, so that the 15.4g checksum is used by default when 15.4g is enabled.