### PR TITLE
Add spinlock on LDREXB/STREXB-pair for cortex mutex lock

### DIFF
--- a/arch/cpu/arm/cortex-m/mutex-cortex.h
+++ b/arch/cpu/arm/cortex-m/mutex-cortex.h
@@ -59,15 +59,15 @@ typedef uint8_t mutex_t;
 static inline bool
 mutex_cortex_try_lock(volatile mutex_t *mutex)
 {
-  int status = 1;
-
-  if(__LDREXB(mutex) == 0) {
-    status = __STREXB(1, mutex);
-  }
+  do {
+    if(__LDREXB(mutex) != 0) {
+      return false;
+    }
+  } while(__STREXB(1, mutex) != 0);
 
   __DMB();
 
-  return status == 0 ? true : false;
+  return true;
 }
 /*---------------------------------------------------------------------------*/
 static inline void


### PR DESCRIPTION
This PR fixes #1544 by adding a spinlock to the LDREXB+STREXB procedure. This avoids mutex lock fail in cases where we are  interrupted after LDREXB but ISR does not actually lock the mutex (see details in #1544). Note that this does not add a spinlock to the lock itself, if it is actually taken, we still immediately return.