### PR TITLE
Fixed variable declaration on headers on ARM GCC 10

### DIFF
--- a/arch/cpu/cc2538/dev/ecc-curve.h
+++ b/arch/cpu/cc2538/dev/ecc-curve.h
@@ -50,12 +50,12 @@
 /*
  * NIST P-256, X9.62 prime256v1
  */
-ecc_curve_info_t nist_p_256;
+extern ecc_curve_info_t nist_p_256;
 
 /*
  * NIST P-192, X9.62 prime192v1
  */
-ecc_curve_info_t nist_p_192;
+extern ecc_curve_info_t nist_p_192;
 
 #endif /* CURVE_INFO_H_ */
 

--- a/arch/dev/sensor/bme280/bme280.c
+++ b/arch/dev/sensor/bme280/bme280.c
@@ -44,6 +44,8 @@
 #include "dev/sensor/bme280/bme280-arch.h"
 #include "lib/sensors.h"
 
+bme280_mea_t bme280_mea;
+
 static struct {
   unsigned short dig_t1;
   signed short dig_t2;

--- a/arch/dev/sensor/bme280/bme280.h
+++ b/arch/dev/sensor/bme280/bme280.h
@@ -96,8 +96,7 @@ void bme280_read(uint8_t mode);
 
 #define BME280_MAX_WAIT                300 /* ms. Forced mode max wait */
 
-
-struct {
+typedef struct {
   int32_t t_overscale100;
   uint32_t h_overscale1024;
 #ifdef BME280_64BIT
@@ -105,6 +104,8 @@ struct {
 #else
   uint32_t p;
 #endif
-} bme280_mea;
+} bme280_mea_t;
+
+extern bme280_mea_t bme280_mea;
 
 #endif /* BME280_H */


### PR DESCRIPTION
I updated my local toolchain and noticed that the test to compile all arm targets was failling. Probably related to #1567.

The issue is better described here: https://gcc.gnu.org/gcc-10/porting_to.html

Basically from gcc 10 it defaults to -fno-common which does not allow variables to be declared in header files without the extern
