### PR TITLE
Removed unused function uip_ds6_get_least_lifetime_neighbor()

### DIFF
--- a/os/net/ipv6/uip-ds6-nbr.c
+++ b/os/net/ipv6/uip-ds6-nbr.c
@@ -667,25 +667,6 @@ uip_ds6_nbr_refresh_reachable_state(const uip_ipaddr_t *ipaddr)
     stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
   }
 }
-/*---------------------------------------------------------------------------*/
-uip_ds6_nbr_t *
-uip_ds6_get_least_lifetime_neighbor(void)
-{
-  uip_ds6_nbr_t *nbr = uip_ds6_nbr_head();
-  uip_ds6_nbr_t *nbr_expiring = NULL;
-  while(nbr != NULL) {
-    if(nbr_expiring != NULL) {
-      clock_time_t curr = stimer_remaining(&nbr->reachable);
-      if(curr < stimer_remaining(&nbr->reachable)) {
-        nbr_expiring = nbr;
-      }
-    } else {
-      nbr_expiring = nbr;
-    }
-    nbr = uip_ds6_nbr_next(nbr);
-  }
-  return nbr_expiring;
-}
 #endif /* UIP_ND6_SEND_NS */
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/os/net/ipv6/uip-ds6-nbr.h
+++ b/os/net/ipv6/uip-ds6-nbr.h
@@ -247,16 +247,5 @@ void uip_ds6_neighbor_periodic(void);
 void uip_ds6_nbr_refresh_reachable_state(const uip_ipaddr_t *ipaddr);
 #endif /* UIP_ND6_SEND_NS */
 
-/**
- * \brief
- *    This searches inside the neighbor table for the neighbor that is about to
- *    expire the next.
- *
- * \return
- *    A reference to the neighbor about to expire the next or NULL if
- *    table is empty.
- */
-uip_ds6_nbr_t *uip_ds6_get_least_lifetime_neighbor(void);
-
 #endif /* UIP_DS6_NEIGHBOR_H_ */
 /** @} */


### PR DESCRIPTION
Apart from being unused, this function always returned the first neighbor due to a bug.