### PR TITLE
Verify DIO prefix info lengths in RPL-Classic

### DIFF
--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -447,6 +447,14 @@ dio_input(void)
           goto discard;
         }
         dio.prefix_info.length = buffer[i + 2];
+
+        if(dio.prefix_info.length > sizeof(uip_ipaddr_t) * 8) {
+          LOG_WARN("Invalid DAG prefix info, len %u > %u\n",
+                   dio.prefix_info.length, (unsigned)(sizeof(uip_ipaddr_t) * 8));
+          RPL_STAT(rpl_stats.malformed_msgs++);
+          goto discard;
+        }
+
         dio.prefix_info.flags = buffer[i + 3];
         /* valid lifetime is ingnored for now - at i + 4 */
         /* preferred lifetime stored in lifetime */


### PR DESCRIPTION
By sending a DIO with a too large length in the prefix info option, it is possible to cause a buffer overflow when copying the prefix in the <code>set_ip_from_prefix</code> function. In this PR, we insert a validation check that discards the DIO if this value is too large.