### PR TITLE
Fix snmp server compilation on z1, sky and jn516x

### DIFF
--- a/os/net/app-layer/snmp/snmp-api.h
+++ b/os/net/app-layer/snmp/snmp-api.h
@@ -78,7 +78,7 @@ typedef struct snmp_mib_resource_s snmp_mib_resource_t;
  */
 #define OID(name, ...) \
   static snmp_oid_t name = { \
-    .data = __VA_ARGS__, \
+    .data = { __VA_ARGS__ }, \
     .length = (sizeof((uint32_t[]){ __VA_ARGS__ }) / sizeof(uint32_t)) \
   };
 
@@ -93,7 +93,7 @@ typedef struct snmp_mib_resource_s snmp_mib_resource_t;
   snmp_mib_resource_t name = { \
     NULL, \
     { \
-      .data = __VA_ARGS__, \
+      .data = { __VA_ARGS__ }, \
       .length = (sizeof((uint32_t[]){ __VA_ARGS__ }) / sizeof(uint32_t)) \
     }, \
     handler \

--- a/tests/01-compile-base/Makefile
+++ b/tests/01-compile-base/Makefile
@@ -22,6 +22,9 @@ mqtt-client/native \
 coap/coap-example-client/native \
 coap/coap-example-server/native \
 coap/coap-plugtest-server/native \
+snmp-server/native \
+snmp-server/sky \
+snmp-server/z1 \
 
 TOOLS=
 

--- a/tests/04-compile-nxp-ports/Makefile
+++ b/tests/04-compile-nxp-ports/Makefile
@@ -1,7 +1,7 @@
 EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
-# build jn516x examples, covering IPv6, RPL, CoAP
+# build jn516x examples, covering IPv6, RPL, CoAP, SNMP
 EXAMPLES = \
 hello-world/jn516x \
 platform-specific/jn516x/dr1175-sensors/jn516x \
@@ -14,6 +14,7 @@ platform-specific/jn516x/tsch/tx-power-verification/node/jn516x \
 platform-specific/jn516x/tsch/uart1-test-node/jn516x \
 coap/coap-example-client/jn516x \
 coap/coap-example-server/jn516x \
+snmp-server/jn516x \
 rpl-border-router/jn516x \
 6tisch/simple-node/jn516x \
 libs/logging/jn516x \


### PR DESCRIPTION
Targets: z1, sky and jn516x were not compiling the snmp-server due to syntax issues.