### PR TITLE
simple-udp: set the client process at registration

### DIFF
--- a/os/net/ipv6/simple-udp.c
+++ b/os/net/ipv6/simple-udp.c
@@ -110,6 +110,7 @@ simple_udp_register(struct simple_udp_connection *c,
 
   c->local_port = local_port;
   c->remote_port = remote_port;
+  c->client_process = PROCESS_CURRENT();
   if(remote_addr != NULL) {
     uip_ipaddr_copy(&c->remote_addr, remote_addr);
   }

--- a/os/net/ipv6/simple-udp.h
+++ b/os/net/ipv6/simple-udp.h
@@ -94,6 +94,8 @@ struct simple_udp_connection {
  *     be allocated. The remote IP address can be NULL, to
  *     indicate that packets from any IP address should be
  *     accepted.
+ *     Note that receive_callback is executed in the context
+ *     of the process which has called this function
  *
  */
 int simple_udp_register(struct simple_udp_connection *c,


### PR DESCRIPTION
fixes issue #1510 

In simple_udp_register(), the client process is never set, this PR fixes this.