### PR TITLE
Check RPL Target prefix length and buffer boundary.

### DIFF
--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -744,6 +744,19 @@ dao_input_storing(void)
       case RPL_OPTION_TARGET:
         /* Handle the target option. */
         prefixlen = buffer[i + 3];
+        if(prefixlen == 0) {
+          /* Ignore option targets with a prefix length of 0. */
+          break;
+        }
+        if(prefixlen > 128) {
+          LOG_ERR("Too large target prefix length %d\n", prefixlen);
+          return;
+        }
+        if(i + 4 + ((prefixlen + 7) / CHAR_BIT) > buffer_length) {
+          LOG_ERR("Insufficient space to copy RPL Target of %d bits\n",
+                  prefixlen);
+          return;
+        }
         memset(&prefix, 0, sizeof(prefix));
         memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
         break;
@@ -981,6 +994,19 @@ dao_input_nonstoring(void)
       case RPL_OPTION_TARGET:
         /* Handle the target option. */
         prefixlen = buffer[i + 3];
+        if(prefixlen == 0) {
+          /* Ignore option targets with a prefix length of 0. */
+          break;
+        }
+        if(prefixlen > 128) {
+          LOG_ERR("Too large target prefix length %d\n", prefixlen);
+          return;
+        }
+        if(i + 4 + ((prefixlen + 7) / CHAR_BIT) > buffer_length) {
+          LOG_ERR("Insufficient space to copy RPL Target of %d bits\n",
+                  prefixlen);
+          return;
+        }
         memset(&prefix, 0, sizeof(prefix));
         memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
         break;


### PR DESCRIPTION
RPL-Classic accepts RPL Target options in DAO messages with invalid prefix lengths. Additionally, it does not check whether there are enough bytes in the packets to copy a prefix of this length. This PR adds checks for these conditions so that the DAO message can be discarded.