### PR TITLE
fix process exiting - vs immediate restart process after exiting.

### DIFF
--- a/os/sys/process.c
+++ b/os/sys/process.c
@@ -137,18 +137,6 @@ exit_process(struct process *p, struct process *fromprocess)
 
   if(process_is_running(p)) {
     /* Process was running */
-    p->state = PROCESS_STATE_NONE;
-
-    /*
-     * Post a synchronous event to all processes to inform them that
-     * this process is about to exit. This will allow services to
-     * deallocate state associated with this process.
-     */
-    for(q = process_list; q != NULL; q = q->next) {
-      if(p != q) {
-        call_process(q, PROCESS_EVENT_EXITED, (process_data_t)p);
-      }
-    }
 
     if(p->thread != NULL && p != fromprocess) {
       /* Post the exit event to the process that is about to exit. */
@@ -169,6 +157,20 @@ exit_process(struct process *p, struct process *fromprocess)
   }
 
   process_current = old_current;
+
+  if(process_is_running(p)) {
+    /* Process was running */
+    p->state = PROCESS_STATE_NONE;
+
+    /*
+     * Post a synchronous event to all processes to inform them that
+     * this process is about to exit. This will allow services to
+     * deallocate state associated with this process.
+     */
+    for(q = process_list; q != NULL; q = q->next) {
+        call_process(q, PROCESS_EVENT_EXITED, (process_data_t)p);
+    }
+  }
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/sys/process.c
+++ b/os/sys/process.c
@@ -156,8 +156,6 @@ exit_process(struct process *p, struct process *fromprocess)
     }
   }
 
-  process_current = old_current;
-
   if(process_is_running(p)) {
     /* Process was running */
     p->state = PROCESS_STATE_NONE;
@@ -171,6 +169,8 @@ exit_process(struct process *p, struct process *fromprocess)
         call_process(q, PROCESS_EVENT_EXITED, (process_data_t)p);
     }
   }
+
+  process_current = old_current;
 }
 /*---------------------------------------------------------------------------*/
 static void


### PR DESCRIPTION
this patch inspirited by a couple of hours debuging nontrivial aplication bug - servicing protothreads are strangely hungs, and later i see that them not even starts as planed. process_start fails without any side-effects. and that was fails, since protothread try start service just processing event PROCESS_EVENT_EXITED, on same service exited.

What happend in current implementation:
1) all running-processes notifyes about exiting process. If some of them wants to restart exiting-process, `process_start` fails, since exiting-process still in running-list
2) exiting-process removes from runnig-list. 

With this patch have:
1) exiting-process notifyes with PROCESS_EVENT_EXITED.
2) exiting-process removes from runnig-list. 
3) all running-processes notifyes about exiting process. And there any of them can restart exited process.
