### PR TITLE
Reject unencrypted frames in csma_security_parse_frame() (Issue 1610)

### DIFF
--- a/os/net/mac/csma/csma-security.c
+++ b/os/net/mac/csma/csma-security.c
@@ -238,8 +238,14 @@ csma_security_parse_frame(void)
   }
 
   if(packetbuf_attr(PACKETBUF_ATTR_SECURITY_LEVEL) == 0) {
+    /* From https://github.com/contiki-ng/contiki-ng/issues/1610 */
+    /* This should reject unencrypted packets */
+    #ifdef LLSEC802154_REJECT_INSECURE
+    return FRAMER_FAILED;
+    #else
     /* No security - no more processing required */
     return hdr_len;
+    #endif
   }
 
   LOG_INFO("LLSEC-IN: ");


### PR DESCRIPTION
When using link layer security on "non-TSCH" mode (e.g. cc1352 prop mode) packets are secured and decrypted, but unsecure communication is allowed.

Issue 1 in #1610 states:

in csma_security_parse_frame() unsecure frames are not dropped:

if(packetbuf_attr(PACKETBUF_ATTR_SECURITY_LEVEL) == 0) { /* No security - no more processing required */ return hdr_len; }
This should result in a FRAMER_FAILED instead.

Code has been modified with a #define to opt to reject insecure packets, or leave as the original contiki-ng default. 

    #ifdef LLSEC802154_REJECT_INSECURE
    return FRAMER_FAILED;
    #else
    /* No security - no more processing required */
    return hdr_len;
    #endif
