### PR TITLE
Add option to set the initial security level

### DIFF
--- a/os/net/ipv6/uipbuf.h
+++ b/os/net/ipv6/uipbuf.h
@@ -187,8 +187,15 @@ void uipbuf_init(void);
 /* Avoid using prefix compression on the packet (6LoWPAN) */
 #define UIPBUF_ATTR_FLAGS_6LOWPAN_NO_PREFIX_COMPRESSION   0x02
 
-/* MAC will set the default for this packet */
+
+/* Use this initial security level if defined */
+#ifdef UIPBUF_ATTR_LLSEC_STARTUP_LEVEL
+#define UIPBUF_ATTR_LLSEC_LEVEL_MAC_DEFAULT UIPBUF_ATTR_LLSEC_STARTUP_LEVEL
+#else
+/* Else MAC will set the default for this packet */
 #define UIPBUF_ATTR_LLSEC_LEVEL_MAC_DEFAULT               0xffff
+#endif
+
 
 /**
  * \brief The attributes defined for uipbuf attributes function.


### PR DESCRIPTION
Issue 2 in #1610 states:

The first DIO message is sent without security.
This will allow a unsecure node picking up the DIO and joining un-securely because of the first issue.
this is because output() in sicslowpan.c sets security level to 0 first time for some reason.

An optional initial security level can be provided  (UIPBUF_ATTR_LLSEC_STARTUP_LEVEL). It non is given the previous behaviour remains (#define UIPBUF_ATTR_LLSEC_LEVEL_MAC_DEFAULT               0xffff).