### PR TITLE
tcp-socket: Retain input buffer contents

### DIFF
--- a/os/net/ipv6/tcp-socket.c
+++ b/os/net/ipv6/tcp-socket.c
@@ -101,10 +101,11 @@ acked(struct tcp_socket *s)
 static void
 newdata(struct tcp_socket *s)
 {
-  uint16_t len, copylen, bytesleft;
+  uint16_t len, copylen, inputlen, bytesleft;
   uint8_t *dataptr;
   len = uip_datalen();
   dataptr = uip_appdata;
+  bytesleft = s->input_data_len;
 
   /* We have a segment with data coming in. We copy as much data as
      possible into the input buffer and call the input callback
@@ -113,21 +114,29 @@ newdata(struct tcp_socket *s)
      consumed. If there is data to be retained, the highest bytes of
      data are copied down into the input buffer. */
   do {
-    copylen = MIN(len, s->input_data_maxlen);
-    memcpy(s->input_data_ptr, dataptr, copylen);
+    copylen = MIN(len, s->input_data_maxlen - bytesleft);
+    inputlen = copylen + bytesleft;
+    memcpy(s->input_data_ptr + bytesleft, dataptr, copylen);
     if(s->input_callback) {
       bytesleft = s->input_callback(s, s->ptr,
-				    s->input_data_ptr, copylen);
+				    s->input_data_ptr, inputlen);
     } else {
       bytesleft = 0;
     }
     if(bytesleft > 0) {
-      PRINTF("tcp: newdata, bytesleft > 0 (%d) not implemented\n", bytesleft);
+      if(bytesleft > inputlen) {
+        PRINTF("tcp: newdata, tcp_socket_data_callback retains more data (%d)"
+              " than in buffer (%d)\n", bytesleft, inputlen);
+        bytesleft = inputlen;
+      }
+      memmove(s->input_data_ptr, s->input_data_ptr + inputlen - bytesleft, bytesleft);
     }
     dataptr += copylen;
     len -= copylen;
 
   } while(len > 0);
+
+  s->input_data_len = bytesleft;
 }
 /*---------------------------------------------------------------------------*/
 static void
@@ -272,6 +281,7 @@ tcp_socket_register(struct tcp_socket *s, void *ptr,
     return -1;
   }
   s->ptr = ptr;
+  s->input_data_len = 0;
   s->input_data_ptr = input_databuf;
   s->input_data_maxlen = input_databuf_len;
   s->output_data_len = 0;


### PR DESCRIPTION
When receiving data over a TCP socket, an application can return the number of bytes that are retained in the TCP input buffer until the next call  in `tcp_socket_data_callback_t`, according to the callback documentation in `tcp-socket.h`.
This pull request implements the documented behaviour where previously the return value was ignored and the TCP input buffer contents discarded.

The implementation uses the existing field `input_data_len` from `struct tcp_socket`. I have not seen it in use anywhere else and assume this was its original purpose. 
