### PR TITLE
Prevent integer wrapping in snmp-ber

### DIFF
--- a/os/net/app-layer/snmp/snmp-ber.c
+++ b/os/net/app-layer/snmp/snmp-ber.c
@@ -159,14 +159,16 @@ snmp_ber_encode_string_len(snmp_packet_t *snmp_packet, const char *str, uint32_t
 {
   uint32_t i;
 
-  str += length - 1;
-  for(i = 0; i < length; ++i) {
-    if(snmp_packet->used == snmp_packet->max) {
-      return 0;
-    }
+  if(length > 0) {
+    str += length - 1;
+    for(i = 0; i < length; ++i) {
+      if(snmp_packet->used == snmp_packet->max) {
+        return 0;
+      }
 
-    *snmp_packet->out-- = (uint8_t)*str--;
-    snmp_packet->used++;
+      *snmp_packet->out-- = (uint8_t)*str--;
+      snmp_packet->used++;
+    }
   }
 
   if(!snmp_ber_encode_length(snmp_packet, length)) {


### PR DESCRIPTION
The <code>str</code> variable is incremented by <code>length - 1</code>, which will wrap if <code>length</code> equals 0.