### PR TITLE
sicslowpan: Check that there is enough space in the buffer to copy the payload.

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -2038,6 +2038,10 @@ input(void)
   /* copy the payload if buffer is non-null - which is only the case with first fragment
      or packets that are non fragmented */
   if(buffer != NULL) {
+    if(uncomp_hdr_len + packetbuf_payload_len > buffer_size) {
+      LOG_ERR("input: cannot copy the payload into the buffer\n");
+      return;
+    }
     memcpy((uint8_t *)buffer + uncomp_hdr_len, packetbuf_ptr + packetbuf_hdr_len, packetbuf_payload_len);
   }
 


### PR DESCRIPTION
Before copying <code>packetbuf_payload_len</code> bytes, we must verify that there is enough room in the buffer from the <code>uncomp_hdr_len</code> offset.