### PR TITLE
uipbuf: Do not assume that there is enough space for a following extension header

### DIFF
--- a/os/net/ipv6/uipbuf.c
+++ b/os/net/ipv6/uipbuf.c
@@ -118,6 +118,9 @@ uipbuf_get_next_header(uint8_t *buffer, uint16_t size, uint8_t *protocol, bool s
 
   /* Check if the buffer is large enough for the next header */
   if(uip_is_proto_ext_hdr(*protocol)) {
+    if(curr_hdr_len + sizeof(struct uip_ext_hdr) > size) {
+      return NULL;
+    }
     next_ext = (struct uip_ext_hdr *)next_header;
     next_hdr_len = (next_ext->len << 3) + 8;
   } else {


### PR DESCRIPTION
When processing IPv6 extension headers in uipbuf.c, we need to check the offset before casting to a <code>uip_ext_hdr</code> pointer.