### PR TITLE
Minor cleanup in resolv service

### DIFF
--- a/os/services/resolv/resolv.c
+++ b/os/services/resolv/resolv.c
@@ -220,7 +220,7 @@ struct namemap {
   uint8_t err;
   uint8_t server;
 #if RESOLV_CONF_SUPPORTS_MDNS
-  int is_mdns:1, is_probe:1;
+  int is_mdns : 1, is_probe : 1;
 #endif
   char name[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
 };
@@ -239,7 +239,7 @@ process_event_t resolv_event_found;
 
 PROCESS(resolv_process, "DNS resolver");
 
-static void resolv_found(char *name, uip_ipaddr_t * ipaddr);
+static void resolv_found(char *name, uip_ipaddr_t *ipaddr);
 
 /** \internal The DNS question message structure. */
 struct dns_question {
@@ -259,8 +259,8 @@ enum {
 static uint8_t mdns_state;
 
 static const uip_ipaddr_t resolv_mdns_addr =
-  { { 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfb } };
+{ { 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfb } };
 #include "net/ipv6/uip-ds6.h"
 
 static int mdns_needs_host_announce;
@@ -290,16 +290,17 @@ decode_name(const unsigned char *query, char *dest,
     if(n & 0xc0) {
       const uint16_t offset = query[0] + ((n & ~0xC0) << 8);
 
-      LOG_DBG_("<skip-to-%d>",offset);
+      LOG_DBG_("<skip-to-%d>", offset);
       query = packet + offset;
       n = *query++;
     }
 
-    if(!n)
+    if(!n) {
       break;
+    }
 
     for(; n; --n) {
-      LOG_DBG_("%c",*query);
+      LOG_DBG_("%c", *query);
 
       *dest++ = *query++;
 
@@ -333,8 +334,9 @@ dns_name_isequal(const unsigned char *queryptr, const char *name,
 {
   unsigned char n = *queryptr++;
 
-  if(*name == 0)
+  if(*name == 0) {
     return 0;
+  }
 
   while(n) {
     if(n & 0xc0) {
@@ -359,8 +361,9 @@ dns_name_isequal(const unsigned char *queryptr, const char *name,
     }
   }
 
-  if(*name == '.')
+  if(*name == '.') {
     ++name;
+  }
 
   return name[0] == 0;
 }
@@ -388,7 +391,7 @@ skip_name(unsigned char *query)
       LOG_DBG_("%c", *query);
       ++query;
       --n;
-    };
+    }
     LOG_DBG_(".");
   } while(*query != 0);
   LOG_DBG_("\n");
@@ -450,7 +453,7 @@ mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
 #if !RESOLV_CONF_MDNS_INCLUDE_GLOBAL_V6_ADDRS
        && uip_is_addr_linklocal(&uip_ds6_if.addr_list[i].ipaddr)
 #endif
-      ) {
+       ) {
       if(!*count) {
         queryptr = encode_name(queryptr, resolv_hostname);
       } else {
@@ -459,11 +462,11 @@ mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
         *queryptr++ = sizeof(struct dns_hdr);
       }
 
-      *queryptr++ = (uint8_t) ((NATIVE_DNS_TYPE) >> 8);
-      *queryptr++ = (uint8_t) ((NATIVE_DNS_TYPE));
+      *queryptr++ = (uint8_t)((NATIVE_DNS_TYPE) >> 8);
+      *queryptr++ = (uint8_t)((NATIVE_DNS_TYPE));
 
-      *queryptr++ = (uint8_t) ((DNS_CLASS_IN | 0x8000) >> 8);
-      *queryptr++ = (uint8_t) ((DNS_CLASS_IN | 0x8000));
+      *queryptr++ = (uint8_t)((DNS_CLASS_IN | 0x8000) >> 8);
+      *queryptr++ = (uint8_t)((DNS_CLASS_IN | 0x8000));
 
       *queryptr++ = 0;
       *queryptr++ = 0;
@@ -473,7 +476,7 @@ mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
       *queryptr++ = 0;
       *queryptr++ = sizeof(uip_ipaddr_t);
 
-      uip_ipaddr_copy((uip_ipaddr_t*)queryptr, &uip_ds6_if.addr_list[i].ipaddr);
+      uip_ipaddr_copy((uip_ipaddr_t *)queryptr, &uip_ds6_if.addr_list[i].ipaddr);
       queryptr += sizeof(uip_ipaddr_t);
       ++(*count);
     }
@@ -493,7 +496,6 @@ mdns_prep_host_announce_packet(void)
     uint16_t ttl[2];
     uint16_t len;
     uint8_t data[8];
-
   } nsec_record = {
     UIP_HTONS(DNS_TYPE_NSEC),
     UIP_HTONS(DNS_CLASS_IN | 0x8000),
@@ -502,7 +504,7 @@ mdns_prep_host_announce_packet(void)
 
     {
       0xc0,
-      sizeof(struct dns_hdr), /* Name compression. Re-using the name of first record. */
+      sizeof(struct dns_hdr), /* Name compression. Re-use name of 1st record. */
       0x00,
       0x04,
 
@@ -544,10 +546,10 @@ mdns_prep_host_announce_packet(void)
 
   /* This platform might be picky about alignment. To avoid the possibility
    * of doing an unaligned write, we are going to do this manually. */
-  ((uint8_t*)&hdr->numanswers)[1] = total_answers;
-  ((uint8_t*)&hdr->numextrarr)[1] = 1;
+  ((uint8_t *)&hdr->numanswers)[1] = total_answers;
+  ((uint8_t *)&hdr->numextrarr)[1] = 1;
 
-  return (queryptr - (unsigned char *)uip_appdata);
+  return queryptr - (unsigned char *)uip_appdata;
 }
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
 /*---------------------------------------------------------------------------*/
@@ -641,16 +643,16 @@ check_entries(void)
       query = encode_name(query, namemapptr->name);
 #if RESOLV_CONF_SUPPORTS_MDNS
       if(namemapptr->is_probe) {
-        *query++ = (uint8_t) ((DNS_TYPE_ANY) >> 8);
-        *query++ = (uint8_t) ((DNS_TYPE_ANY));
+        *query++ = (uint8_t)((DNS_TYPE_ANY) >> 8);
+        *query++ = (uint8_t)((DNS_TYPE_ANY));
       } else
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
       {
-        *query++ = (uint8_t) ((NATIVE_DNS_TYPE) >> 8);
-        *query++ = (uint8_t) ((NATIVE_DNS_TYPE));
+        *query++ = (uint8_t)((NATIVE_DNS_TYPE) >> 8);
+        *query++ = (uint8_t)((NATIVE_DNS_TYPE));
       }
-      *query++ = (uint8_t) ((DNS_CLASS_IN) >> 8);
-      *query++ = (uint8_t) ((DNS_CLASS_IN));
+      *query++ = (uint8_t)((DNS_CLASS_IN) >> 8);
+      *query++ = (uint8_t)((DNS_CLASS_IN));
 #if RESOLV_CONF_SUPPORTS_MDNS
       if(namemapptr->is_mdns) {
         if(namemapptr->is_probe) {
@@ -665,28 +667,28 @@ check_entries(void)
           hdr->numauthrr = UIP_HTONS(count);
         }
         uip_udp_packet_sendto(resolv_conn, uip_appdata,
-                              (query - (uint8_t *) uip_appdata),
+                              (query - (uint8_t *)uip_appdata),
                               &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
 
         LOG_DBG("(i=%d) Sent MDNS %s for \"%s\"\n", i,
-               namemapptr->is_probe?"probe":"request",namemapptr->name);
+                namemapptr->is_probe ? "probe" : "request", namemapptr->name);
       } else {
         uip_udp_packet_sendto(resolv_conn, uip_appdata,
-                              (query - (uint8_t *) uip_appdata),
+                              (query - (uint8_t *)uip_appdata),
                               (const uip_ipaddr_t *)
-                                uip_nameserver_get(namemapptr->server),
+                              uip_nameserver_get(namemapptr->server),
                               UIP_HTONS(DNS_PORT));
 
         LOG_DBG("(i=%d) Sent DNS request for \"%s\"\n", i,
-               namemapptr->name);
+                namemapptr->name);
       }
 #else /* RESOLV_CONF_SUPPORTS_MDNS */
       uip_udp_packet_sendto(resolv_conn, uip_appdata,
-                            (query - (uint8_t *) uip_appdata),
+                            (query - (uint8_t *)uip_appdata),
                             uip_nameserver_get(namemapptr->server),
                             UIP_HTONS(DNS_PORT));
       LOG_DBG("(i=%d) Sent DNS request for \"%s\"\n", i,
-             namemapptr->name);
+              namemapptr->name);
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
       break;
     }
@@ -713,10 +715,11 @@ newdata(void)
   queryptr = (unsigned char *)hdr + sizeof(*hdr);
   i = 0;
 
-  LOG_DBG("flags1=0x%02X flags2=0x%02X nquestions=%d, nanswers=%d, nauthrr=%d, nextrarr=%d\n",
-     hdr->flags1, hdr->flags2, (uint8_t) nquestions, (uint8_t) nanswers,
-     (uint8_t) uip_ntohs(hdr->numauthrr),
-     (uint8_t) uip_ntohs(hdr->numextrarr));
+  LOG_DBG("flags1=0x%02X flags2=0x%02X nquestions=%d, nanswers=%d, " \
+          "nauthrr=%d, nextrarr=%d\n",
+          hdr->flags1, hdr->flags2, (uint8_t)nquestions, (uint8_t)nanswers,
+          (uint8_t)uip_ntohs(hdr->numauthrr),
+          (uint8_t)uip_ntohs(hdr->numextrarr));
 
   if(is_request && (nquestions == 0)) {
     /* Skip requests with no questions. */
@@ -729,7 +732,7 @@ newdata(void)
   for(; nquestions > 0;
       queryptr = skip_name(queryptr) + sizeof(struct dns_question),
       --nquestions
-  ) {
+      ) {
 #if RESOLV_CONF_SUPPORTS_MDNS
     if(!is_request) {
       /* If this isn't a request, we don't need to bother
@@ -740,7 +743,8 @@ newdata(void)
     }
 
     {
-      struct dns_question *question = (struct dns_question *)skip_name(queryptr);
+      struct dns_question *question =
+        (struct dns_question *)skip_name(queryptr);
 
 #if !ARCH_DOESNT_NEED_ALIGNED_STRUCTS
       static struct dns_question aligned;
@@ -749,7 +753,7 @@ newdata(void)
 #endif /* !ARCH_DOESNT_NEED_ALIGNED_STRUCTS */
 
       LOG_DBG("Question %d: type=%d class=%d\n", ++i,
-                   uip_htons(question->type), uip_htons(question->class));
+              uip_htons(question->type), uip_htons(question->class));
 
       if(((uip_ntohs(question->class) & 0x7FFF) != DNS_CLASS_IN) ||
          ((question->type != UIP_HTONS(DNS_TYPE_ANY)) &&
@@ -871,10 +875,10 @@ newdata(void)
     char debug_name[40];
     decode_name(queryptr, debug_name, uip_appdata);
     LOG_DBG("Answer %d: \"%s\", type %d, class %d, ttl %"PRIu32", length %d\n",
-                 ++i, debug_name, uip_ntohs(ans->type),
-                 uip_ntohs(ans->class) & 0x7FFF,
-                 (uint32_t)((uint32_t) uip_ntohs(ans->ttl[0]) << 16) | (uint32_t)
-                 uip_ntohs(ans->ttl[1]), uip_ntohs(ans->len));
+            ++i, debug_name, uip_ntohs(ans->type),
+            uip_ntohs(ans->class) & 0x7FFF,
+            (uint32_t)((uint32_t)uip_ntohs(ans->ttl[0]) << 16) |
+            (uint32_t)uip_ntohs(ans->ttl[1]), uip_ntohs(ans->len));
 #endif /* LOG_LEVEL == LOG_LEVEL_DBG */
 
     /* Check the class and length of the answer to make sure
@@ -906,9 +910,10 @@ newdata(void)
         }
         if((namemapptr->state == STATE_UNUSED)
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
-          || (namemapptr->state == STATE_DONE && clock_seconds() > namemapptr->expiration)
+           || (namemapptr->state == STATE_DONE &&
+               clock_seconds() > namemapptr->expiration)
 #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
-        ) {
+           ) {
           available_i = i;
         }
       }
@@ -928,13 +933,12 @@ newdata(void)
 
         if(dns_name_isequal(queryptr, resolv_hostname, uip_appdata)) {
           /* Oh snap, they say they are us! We had better report them... */
-          resolv_found(resolv_hostname, (uip_ipaddr_t *) ans->ipaddr);
+          resolv_found(resolv_hostname, (uip_ipaddr_t *)ans->ipaddr);
         }
         namemapptr = NULL;
         goto skip_to_next_answer;
       }
       namemapptr = &names[i];
-
     } else
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
     {
@@ -943,31 +947,31 @@ newdata(void)
     }
 
 /*  This is disabled for now, so that we don't fail on CNAME records.
-#if RESOLV_VERIFY_ANSWER_NAMES
+ #if RESOLV_VERIFY_ANSWER_NAMES
     if(namemapptr && !dns_name_isequal(queryptr, namemapptr->name, uip_appdata)) {
       LOG_DBG("Answer name doesn't match question...!\n");
       goto skip_to_next_answer;
     }
-#endif
-*/
+ #endif
+ */
 
     LOG_DBG("Answer for \"%s\" is usable.\n", namemapptr->name);
 
     namemapptr->state = STATE_DONE;
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
-    namemapptr->expiration = (uint32_t) uip_ntohs(ans->ttl[0]) << 16 |
-        (uint32_t) uip_ntohs(ans->ttl[1]);
+    namemapptr->expiration = (uint32_t)uip_ntohs(ans->ttl[0]) << 16 |
+      (uint32_t)uip_ntohs(ans->ttl[1]);
     LOG_DBG("Expires in %"PRIu32" seconds\n", namemapptr->expiration);
 
     namemapptr->expiration += clock_seconds();
 #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
 
-    uip_ipaddr_copy(&namemapptr->ipaddr, (uip_ipaddr_t *) ans->ipaddr);
+    uip_ipaddr_copy(&namemapptr->ipaddr, (uip_ipaddr_t *)ans->ipaddr);
 
     resolv_found(namemapptr->name, &namemapptr->ipaddr);
     break;
 
-  skip_to_next_answer:
+skip_to_next_answer:
     queryptr = (unsigned char *)skip_name(queryptr) + 10 + uip_htons(ans->len);
     --nanswers;
   }
@@ -976,7 +980,7 @@ newdata(void)
      since this one doesn't know the answer */
 #if RESOLV_CONF_SUPPORTS_MDNS
   if(nanswers == 0 && UIP_UDP_BUF->srcport != UIP_HTONS(MDNS_PORT)
-      && hdr->id != 0)
+     && hdr->id != 0)
 #else
   if(nanswers == 0)
 #endif
@@ -986,7 +990,6 @@ newdata(void)
       process_post(&resolv_process, PROCESS_EVENT_TIMER, NULL);
     }
   }
-
 }
 /*---------------------------------------------------------------------------*/
 #if RESOLV_CONF_SUPPORTS_MDNS
@@ -1002,7 +1005,8 @@ resolv_set_hostname(const char *hostname)
   /* Add the .local suffix if it isn't already there */
   if(strlen(resolv_hostname) < 7 ||
      strcasecmp(resolv_hostname + strlen(resolv_hostname) - 6, ".local") != 0) {
-    strncat(resolv_hostname, ".local", RESOLV_CONF_MAX_DOMAIN_NAME_SIZE - strlen(resolv_hostname));
+    strncat(resolv_hostname, ".local",
+            RESOLV_CONF_MAX_DOMAIN_NAME_SIZE - strlen(resolv_hostname));
   }
 
   LOG_DBG("hostname changed to \"%s\"\n", resolv_hostname);
@@ -1035,8 +1039,8 @@ PROCESS_THREAD(mdns_probe_process, ev, data)
   /* Wait extra time if specified in data */
   if(NULL != data) {
     LOG_DBG("mdns-probe: Probing will begin in %ld clocks\n",
-           (long)*(clock_time_t *) data);
-    etimer_set(&delay, *(clock_time_t *) data);
+            (long)*(clock_time_t *)data);
+    etimer_set(&delay, *(clock_time_t *)data);
     PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER);
   }
 
@@ -1102,7 +1106,7 @@ PROCESS_THREAD(resolv_process, ev, data)
             size_t len;
 
             LOG_DBG("Announcing that we are \"%s\"\n",
-                   resolv_hostname);
+                    resolv_hostname);
 
             memset(uip_appdata, 0, sizeof(struct dns_hdr));
 
@@ -1148,7 +1152,8 @@ init(void)
 /*---------------------------------------------------------------------------*/
 #if RESOLV_AUTO_REMOVE_TRAILING_DOTS
 static const char *
-remove_trailing_dots(const char *name) {
+remove_trailing_dots(const char *name)
+{
   static char dns_name_without_dots[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
   size_t len = strlen(name);
 
@@ -1188,9 +1193,9 @@ resolv_query(const char *name)
     }
     if((nameptr->state == STATE_UNUSED)
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
-      || (nameptr->state == STATE_DONE && clock_seconds() > nameptr->expiration)
+       || (nameptr->state == STATE_DONE && clock_seconds() > nameptr->expiration)
 #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
-    ) {
+       ) {
       lseqi = i;
       lseq = 255;
     } else if(seqno - nameptr->seqno > lseq) {
@@ -1220,7 +1225,8 @@ resolv_query(const char *name)
     const char local_suffix[] = "local";
 
     if((name_len > (sizeof(local_suffix) - 1)) &&
-       (0 == strcasecmp(name + name_len - (sizeof(local_suffix) - 1), local_suffix))) {
+       (0 == strcasecmp(name + name_len - (sizeof(local_suffix) - 1),
+                        local_suffix))) {
       LOG_DBG("Using MDNS to look up \"%s\"\n", name);
       nameptr->is_mdns = 1;
     } else {
@@ -1228,7 +1234,7 @@ resolv_query(const char *name)
     }
   }
   nameptr->is_probe = (mdns_state == MDNS_STATE_PROBING) &&
-                      (0 == strcmp(nameptr->name, resolv_hostname));
+    (0 == strcmp(nameptr->name, resolv_hostname));
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
 
   /* Force check_entires() to run on our process. */
@@ -1245,7 +1251,7 @@ resolv_query(const char *name)
  *
  */
 resolv_status_t
-resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
+resolv_lookup(const char *name, uip_ipaddr_t **ipaddr)
 {
   resolv_status_t ret = RESOLV_STATUS_UNCACHED;
 
@@ -1269,7 +1275,7 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
     struct namemap *nameptr = &names[i];
 
     if(strcasecmp(name, nameptr->name) == 0) {
-      switch (nameptr->state) {
+      switch(nameptr->state) {
       case STATE_DONE:
         ret = RESOLV_STATUS_CACHED;
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
@@ -1303,7 +1309,7 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
   }
 
 #if LOG_LEVEL == LOG_LEVEL_DBG
-  switch (ret) {
+  switch(ret) {
   case RESOLV_STATUS_CACHED:
     if(ipaddr) {
       LOG_DBG("Found \"%s\" in cache => ", name);
@@ -1326,7 +1332,7 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
  *
  */
 static void
-resolv_found(char *name, uip_ipaddr_t * ipaddr)
+resolv_found(char *name, uip_ipaddr_t *ipaddr)
 {
 #if RESOLV_CONF_SUPPORTS_MDNS
   if(strncasecmp(resolv_hostname, name, strlen(resolv_hostname)) == 0 &&
@@ -1353,12 +1359,14 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
         append_str[2] = (((val & 0xF) > 9) ? 'a' : '0') + (val & 0xF);
         val >>= 4;
         append_str[1] = (((val & 0xF) > 9) ? 'a' : '0') + (val & 0xF);
+        /* -1 in order to fit the terminating null byte. */
         strncat(resolv_hostname, append_str,
-                sizeof(resolv_hostname) - strlen(resolv_hostname) - 1); /* -1 in order to fit the terminating null byte. */
+                sizeof(resolv_hostname) - strlen(resolv_hostname) - 1);
       }
 
       /* Re-add the .local suffix */
-      strncat(resolv_hostname, ".local", RESOLV_CONF_MAX_DOMAIN_NAME_SIZE - strlen(resolv_hostname));
+      strncat(resolv_hostname, ".local",
+              RESOLV_CONF_MAX_DOMAIN_NAME_SIZE - strlen(resolv_hostname));
 
       start_name_collision_check(CLOCK_SECOND * 5);
     } else if(mdns_state == MDNS_STATE_READY) {
@@ -1369,16 +1377,15 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
       LOG_DBG("Possible name collision, probing...\n");
       start_name_collision_check(0);
     }
-
   } else
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
-    if(ipaddr) {
-      LOG_DBG("Found address for \"%s\" => ", name);
-      LOG_DBG_6ADDR(ipaddr);
-      LOG_DBG_("\n");
-    } else {
-      LOG_DBG("Unable to retrieve address for \"%s\"\n", name);
-    }
+  if(ipaddr) {
+    LOG_DBG("Found address for \"%s\" => ", name);
+    LOG_DBG_6ADDR(ipaddr);
+    LOG_DBG_("\n");
+  } else {
+    LOG_DBG("Unable to retrieve address for \"%s\"\n", name);
+  }
   process_post(PROCESS_BROADCAST, resolv_event_found, name);
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/resolv/resolv.c
+++ b/os/services/resolv/resolv.c
@@ -67,16 +67,17 @@
 #include "net/ipv6/uip-nameserver.h"
 #include "lib/random.h"
 #include "resolv.h"
+#include <inttypes.h>
 
 #if UIP_UDP
+#include <string.h>
+#if RESOLV_CONF_SUPPORTS_MDNS
+#include <ctype.h>
+#endif /* RESOLV_CONF_SUPPORTS_MDNS */
 
 #include "sys/log.h"
 #define LOG_MODULE "Resolv"
 #define LOG_LEVEL LOG_LEVEL_NONE
-
-#include <string.h>
-#include <stdio.h>
-#include <ctype.h>
 
 int strcasecmp(const char *s1, const char *s2);
 int strncasecmp(const char *s1, const char *s2, size_t n);
@@ -231,13 +232,9 @@ struct namemap {
 #endif /* UIP_CONF_RESOLV_ENTRIES */
 
 static struct namemap names[RESOLV_ENTRIES];
-
 static uint8_t seqno;
-
 static struct uip_udp_conn *resolv_conn = NULL;
-
 static struct etimer retry;
-
 process_event_t resolv_event_found;
 
 PROCESS(resolv_process, "DNS resolver");
@@ -272,7 +269,7 @@ PROCESS(mdns_probe_process, "mDNS probe");
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
 
 /*---------------------------------------------------------------------------*/
-#if RESOLV_VERIFY_ANSWER_NAMES || VERBOSE_DEBUG
+#if RESOLV_VERIFY_ANSWER_NAMES || (LOG_LEVEL == LOG_LEVEL_DBG)
 /** \internal
  * \brief Decodes a DNS name from the DNS format into the given string.
  * \return 1 upon success, 0 if the size of the name would be too large.
@@ -285,7 +282,6 @@ decode_name(const unsigned char *query, char *dest,
             const unsigned char *packet)
 {
   int len = RESOLV_CONF_MAX_DOMAIN_NAME_SIZE;
-
   unsigned char n = *query++;
 
   LOG_DBG("decoding name: \"");
@@ -294,7 +290,7 @@ decode_name(const unsigned char *query, char *dest,
     if(n & 0xc0) {
       const uint16_t offset = query[0] + ((n & ~0xC0) << 8);
 
-      LOG_DBG("<skip-to-%d>",offset);
+      LOG_DBG_("<skip-to-%d>",offset);
       query = packet + offset;
       n = *query++;
     }
@@ -303,12 +299,13 @@ decode_name(const unsigned char *query, char *dest,
       break;
 
     for(; n; --n) {
-      LOG_DBG("%c",*query);
+      LOG_DBG_("%c",*query);
 
       *dest++ = *query++;
 
       if(!--len) {
         *dest = 0;
+        LOG_DBG_("\"\n");
         return 0;
       }
     }
@@ -316,19 +313,20 @@ decode_name(const unsigned char *query, char *dest,
     n = *query++;
 
     if(n) {
-      LOG_DBG(".");
+      LOG_DBG_(".");
       *dest++ = '.';
       --len;
     }
   }
 
-  LOG_DBG("\"\n");
+  LOG_DBG_("\"\n");
   *dest = 0;
   return len != 0;
 }
 /*---------------------------------------------------------------------------*/
 /** \internal
  */
+#if RESOLV_CONF_SUPPORTS_MDNS
 static uint8_t
 dns_name_isequal(const unsigned char *queryptr, const char *name,
                  const unsigned char *packet)
@@ -366,6 +364,7 @@ dns_name_isequal(const unsigned char *queryptr, const char *name,
 
   return name[0] == 0;
 }
+#endif /* RESOLV_CONF_SUPPORTS_MDNS */
 #endif /* RESOLV_VERIFY_ANSWER_NAMES */
 /*---------------------------------------------------------------------------*/
 /** \internal
@@ -373,14 +372,12 @@ dns_name_isequal(const unsigned char *queryptr, const char *name,
 static unsigned char *
 skip_name(unsigned char *query)
 {
-  unsigned char n;
-
   LOG_DBG("skip name: ");
 
   do {
-    n = *query;
+    unsigned char n = *query;
     if(n & 0xc0) {
-      LOG_DBG("<skip-to-%d>", query[0] + ((n & ~0xC0) << 8));
+      LOG_DBG_("<skip-to-%d>", query[0] + ((n & ~0xC0) << 8));
       ++query;
       break;
     }
@@ -403,15 +400,13 @@ skip_name(unsigned char *query)
 static unsigned char *
 encode_name(unsigned char *query, const char *nameptr)
 {
-  char *nptr;
-
   --nameptr;
   /* Convert hostname into suitable query format. */
   do {
     uint8_t n = 0;
 
     ++nameptr;
-    nptr = (char *)query;
+    char *nptr = (char *)query;
     ++query;
     for(n = 0; *nameptr != '.' && *nameptr != 0; ++nameptr) {
       *query = *nameptr;
@@ -450,9 +445,7 @@ start_name_collision_check(clock_time_t after)
 static unsigned char *
 mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
 {
-  uint8_t i;
-
-  for(i = 0; i < UIP_DS6_ADDR_NB; ++i) {
+  for(uint8_t i = 0; i < UIP_DS6_ADDR_NB; ++i) {
     if(uip_ds6_if.addr_list[i].isused
 #if !RESOLV_CONF_MDNS_INCLUDE_GLOBAL_V6_ADDRS
        && uip_is_addr_linklocal(&uip_ds6_if.addr_list[i].ipaddr)
@@ -520,10 +513,6 @@ mdns_prep_host_announce_packet(void)
     }
   };
 
-  unsigned char *queryptr;
-
-  uint8_t total_answers = 0;
-
   /* Be aware that, unless `ARCH_DOESNT_NEED_ALIGNED_STRUCTS` is set,
    * writing directly to the uint16_t members of this struct is an error. */
   struct dns_hdr *hdr = (struct dns_hdr *)uip_appdata;
@@ -533,8 +522,9 @@ mdns_prep_host_announce_packet(void)
 
   hdr->flags1 |= DNS_FLAG1_RESPONSE | DNS_FLAG1_AUTHORATIVE;
 
-  queryptr = (unsigned char *)uip_appdata + sizeof(*hdr);
+  unsigned char *queryptr = (unsigned char *)uip_appdata + sizeof(*hdr);
 
+  uint8_t total_answers = 0;
   queryptr = mdns_write_announce_records(queryptr, &total_answers);
 
   /* We now need to add an NSEC record to indicate
@@ -564,14 +554,15 @@ mdns_prep_host_announce_packet(void)
 static char
 try_next_server(struct namemap *namemapptr)
 {
-#if VERBOSE_DEBUG
-  printf("server %d\n", namemapptr->server);
-#endif
   namemapptr->server++;
   if(uip_nameserver_get(namemapptr->server) != NULL) {
+    LOG_DBG("Using server ");
+    LOG_DBG_6ADDR(uip_nameserver_get(namemapptr->server));
+    LOG_DBG_(", num %u\n", namemapptr->server);
     namemapptr->retries = 0;
     return 1;
   }
+  LOG_DBG("No nameserver, num %u\n", namemapptr->server);
   namemapptr->server = 0;
   return 0;
 }
@@ -583,16 +574,8 @@ try_next_server(struct namemap *namemapptr)
 static void
 check_entries(void)
 {
-  volatile uint8_t i;
-
-  uint8_t *query;
-
-  register struct dns_hdr *hdr;
-
-  register struct namemap *namemapptr;
-
-  for(i = 0; i < RESOLV_ENTRIES; ++i) {
-    namemapptr = &names[i];
+  for(uint8_t i = 0; i < RESOLV_ENTRIES; ++i) {
+    struct namemap *namemapptr = &names[i];
     if(namemapptr->state == STATE_NEW || namemapptr->state == STATE_ASKING) {
       etimer_set(&retry, CLOCK_SECOND / 4);
       if(namemapptr->state == STATE_ASKING) {
@@ -639,7 +622,7 @@ check_entries(void)
         namemapptr->tmr = 1;
         namemapptr->retries = 0;
       }
-      hdr = (struct dns_hdr *)uip_appdata;
+      struct dns_hdr *hdr = (struct dns_hdr *)uip_appdata;
       memset(hdr, 0, sizeof(struct dns_hdr));
       hdr->id = random_rand();
       namemapptr->id = hdr->id;
@@ -654,7 +637,7 @@ check_entries(void)
       hdr->flags1 = DNS_FLAG1_RD;
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
       hdr->numquestions = UIP_HTONS(1);
-      query = (unsigned char *)uip_appdata + sizeof(*hdr);
+      uint8_t *query = (unsigned char *)uip_appdata + sizeof(*hdr);
       query = encode_name(query, namemapptr->name);
 #if RESOLV_CONF_SUPPORTS_MDNS
       if(namemapptr->is_probe) {
@@ -685,7 +668,7 @@ check_entries(void)
                               (query - (uint8_t *) uip_appdata),
                               &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
 
-        LOG_DBG("(i=%d) Sent MDNS %s for \"%s\".\n", i,
+        LOG_DBG("(i=%d) Sent MDNS %s for \"%s\"\n", i,
                namemapptr->is_probe?"probe":"request",namemapptr->name);
       } else {
         uip_udp_packet_sendto(resolv_conn, uip_appdata,
@@ -694,7 +677,7 @@ check_entries(void)
                                 uip_nameserver_get(namemapptr->server),
                               UIP_HTONS(DNS_PORT));
 
-        LOG_DBG("(i=%d) Sent DNS request for \"%s\".\n", i,
+        LOG_DBG("(i=%d) Sent DNS request for \"%s\"\n", i,
                namemapptr->name);
       }
 #else /* RESOLV_CONF_SUPPORTS_MDNS */
@@ -702,7 +685,7 @@ check_entries(void)
                             (query - (uint8_t *) uip_appdata),
                             uip_nameserver_get(namemapptr->server),
                             UIP_HTONS(DNS_PORT));
-      LOG_DBG("(i=%d) Sent DNS request for \"%s\".\n", i,
+      LOG_DBG("(i=%d) Sent DNS request for \"%s\"\n", i,
              namemapptr->name);
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
       break;
@@ -716,25 +699,16 @@ check_entries(void)
 static void
 newdata(void)
 {
-  uint8_t nquestions, nanswers;
-
-  int8_t i;
-
-  register struct namemap *namemapptr = NULL;
-
-  struct dns_answer *ans;
-
-  register struct dns_hdr const *hdr = (struct dns_hdr *)uip_appdata;
-
+  int8_t i = 0;
+  struct dns_hdr const *hdr = (struct dns_hdr *)uip_appdata;
   unsigned char *queryptr = (unsigned char *)hdr + sizeof(*hdr);
-
   const uint8_t is_request = ((hdr->flags1 & ~1) == 0) && (hdr->flags2 == 0);
 
   /* We only care about the question(s) and the answers. The authrr
    * and the extrarr are simply discarded.
    */
-  nquestions = (uint8_t) uip_ntohs(hdr->numquestions);
-  nanswers = (uint8_t) uip_ntohs(hdr->numanswers);
+  uint8_t nquestions = (uint8_t)uip_ntohs(hdr->numquestions);
+  uint8_t nanswers = (uint8_t)uip_ntohs(hdr->numanswers);
 
   queryptr = (unsigned char *)hdr + sizeof(*hdr);
   i = 0;
@@ -746,7 +720,7 @@ newdata(void)
 
   if(is_request && (nquestions == 0)) {
     /* Skip requests with no questions. */
-    LOG_DBG("Skipping request with no questions.\n");
+    LOG_DBG("Skipping request with no questions\n");
     return;
   }
 
@@ -832,6 +806,8 @@ newdata(void)
     return;
   }
 
+  struct namemap *namemapptr = NULL;
+
 #if RESOLV_CONF_SUPPORTS_MDNS
   if(UIP_UDP_BUF->srcport == UIP_HTONS(MDNS_PORT) &&
      hdr->id == 0) {
@@ -853,11 +829,11 @@ newdata(void)
     }
 
     if(i >= RESOLV_ENTRIES || i < 0 || namemapptr->state != STATE_ASKING) {
-      LOG_DBG("DNS response has bad ID (%04X) \n", uip_ntohs(hdr->id));
+      LOG_DBG("DNS response has bad ID (%04X)\n", uip_ntohs(hdr->id));
       return;
     }
 
-    LOG_DBG("Incoming response for \"%s\".\n", namemapptr->name);
+    LOG_DBG("Incoming response for \"%s\"\n", namemapptr->name);
 
     /* We'll change this to DONE when we find the record. */
     namemapptr->state = STATE_ERROR;
@@ -881,7 +857,7 @@ newdata(void)
 
   /* Answer parsing loop */
   while(nanswers > 0) {
-    ans = (struct dns_answer *)skip_name(queryptr);
+    struct dns_answer *ans = (struct dns_answer *)skip_name(queryptr);
 
 #if !ARCH_DOESNT_NEED_ALIGNED_STRUCTS
     {
@@ -891,15 +867,15 @@ newdata(void)
     }
 #endif /* !ARCH_DOESNT_NEED_ALIGNED_STRUCTS */
 
-#if VERBOSE_DEBUG
+#if LOG_LEVEL == LOG_LEVEL_DBG
     char debug_name[40];
     decode_name(queryptr, debug_name, uip_appdata);
-    LOG_DBG("Answer %d: \"%s\", type %d, class %d, ttl %d, length %d\n",
+    LOG_DBG("Answer %d: \"%s\", type %d, class %d, ttl %"PRIu32", length %d\n",
                  ++i, debug_name, uip_ntohs(ans->type),
                  uip_ntohs(ans->class) & 0x7FFF,
-                 (int)((uint32_t) uip_ntohs(ans->ttl[0]) << 16) | (uint32_t)
+                 (uint32_t)((uint32_t) uip_ntohs(ans->ttl[0]) << 16) | (uint32_t)
                  uip_ntohs(ans->ttl[1]), uip_ntohs(ans->len));
-#endif /* VERBOSE_DEBUG */
+#endif /* LOG_LEVEL == LOG_LEVEL_DBG */
 
     /* Check the class and length of the answer to make sure
      * it matches what we are expecting
@@ -948,7 +924,7 @@ newdata(void)
       }
       if(i == RESOLV_ENTRIES) {
         LOG_DBG
-          ("Not enough room to keep track of unsolicited MDNS answer.\n");
+          ("Not enough room to keep track of unsolicited MDNS answer\n");
 
         if(dns_name_isequal(queryptr, resolv_hostname, uip_appdata)) {
           /* Oh snap, they say they are us! We had better report them... */
@@ -981,7 +957,7 @@ newdata(void)
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
     namemapptr->expiration = (uint32_t) uip_ntohs(ans->ttl[0]) << 16 |
         (uint32_t) uip_ntohs(ans->ttl[1]);
-    LOG_DBG("Expires in %lu seconds\n", namemapptr->expiration); 
+    LOG_DBG("Expires in %"PRIu32" seconds\n", namemapptr->expiration);
 
     namemapptr->expiration += clock_seconds();
 #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
@@ -1054,11 +1030,11 @@ PROCESS_THREAD(mdns_probe_process, ev, data)
   PROCESS_BEGIN();
   mdns_state = MDNS_STATE_WAIT_BEFORE_PROBE;
 
-  LOG_DBG("mdns-probe: Process (re)started.\n");
+  LOG_DBG("mdns-probe: Process (re)started\n");
 
   /* Wait extra time if specified in data */
   if(NULL != data) {
-    LOG_DBG("mdns-probe: Probing will begin in %ld clocks.\n",
+    LOG_DBG("mdns-probe: Probing will begin in %ld clocks\n",
            (long)*(clock_time_t *) data);
     etimer_set(&delay, *(clock_time_t *) data);
     PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER);
@@ -1080,7 +1056,7 @@ PROCESS_THREAD(mdns_probe_process, ev, data)
   mdns_state = MDNS_STATE_READY;
   mdns_announce_requested();
 
-  LOG_DBG("mdns-probe: Finished probing.\n");
+  LOG_DBG("mdns-probe: Finished probing\n");
 
   PROCESS_END();
 }
@@ -1097,12 +1073,12 @@ PROCESS_THREAD(resolv_process, ev, data)
 
   resolv_event_found = process_alloc_event();
 
-  LOG_DBG("Process started.\n");
+  LOG_DBG("Process started\n");
 
   resolv_conn = udp_new(NULL, 0, NULL);
 
 #if RESOLV_CONF_SUPPORTS_MDNS
-  LOG_DBG("Supports MDNS.\n");
+  LOG_DBG("Supports MDNS\n");
   uip_udp_bind(resolv_conn, UIP_HTONS(MDNS_PORT));
 
   uip_ds6_maddr_add(&resolv_mdns_addr);
@@ -1125,7 +1101,7 @@ PROCESS_THREAD(resolv_process, ev, data)
           if(mdns_needs_host_announce) {
             size_t len;
 
-            LOG_DBG("Announcing that we are \"%s\".\n",
+            LOG_DBG("Announcing that we are \"%s\"\n",
                    resolv_hostname);
 
             memset(uip_appdata, 0, sizeof(struct dns_hdr));
@@ -1197,15 +1173,10 @@ remove_trailing_dots(const char *name) {
 void
 resolv_query(const char *name)
 {
-  uint8_t i;
-
-  uint8_t lseq, lseqi;
-
-  register struct namemap *nameptr = 0;
+  uint8_t lseqi = 0, lseq = 0, i = 0;
+  struct namemap *nameptr = 0;
 
   init();
-
-  lseq = lseqi = 0;
 
   /* Remove trailing dots, if present. */
   name = remove_trailing_dots(name);
@@ -1233,7 +1204,7 @@ resolv_query(const char *name)
     nameptr = &names[i];
   }
 
-  LOG_DBG("Starting query for \"%s\".\n", name);
+  LOG_DBG("Starting query for \"%s\"\n", name);
 
   memset(nameptr, 0, sizeof(*nameptr));
 
@@ -1250,7 +1221,7 @@ resolv_query(const char *name)
 
     if((name_len > (sizeof(local_suffix) - 1)) &&
        (0 == strcasecmp(name + name_len - (sizeof(local_suffix) - 1), local_suffix))) {
-      LOG_DBG("Using MDNS to look up \"%s\".\n", name);
+      LOG_DBG("Using MDNS to look up \"%s\"\n", name);
       nameptr->is_mdns = 1;
     } else {
       nameptr->is_mdns = 0;
@@ -1278,10 +1249,6 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
 {
   resolv_status_t ret = RESOLV_STATUS_UNCACHED;
 
-  uint8_t i;
-
-  struct namemap *nameptr;
-
   /* Remove trailing dots, if present. */
   name = remove_trailing_dots(name);
 
@@ -1298,8 +1265,8 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
 #endif /* UIP_CONF_LOOPBACK_INTERFACE */
 
   /* Walk through the list to see if the name is in there. */
-  for(i = 0; i < RESOLV_ENTRIES; ++i) {
-    nameptr = &names[i];
+  for(uint8_t i = 0; i < RESOLV_ENTRIES; ++i) {
+    struct namemap *nameptr = &names[i];
 
     if(strcasecmp(name, nameptr->name) == 0) {
       switch (nameptr->state) {
@@ -1339,14 +1306,14 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
   switch (ret) {
   case RESOLV_STATUS_CACHED:
     if(ipaddr) {
-      LOG_DBG("Found \"%s\" in cache. => ", name);
+      LOG_DBG("Found \"%s\" in cache => ", name);
       const uip_ipaddr_t *addr = *ipaddr;
       LOG_DBG_6ADDR(addr);
       LOG_DBG_("\n");
       break;
     }
   default:
-    LOG_DBG("\"%s\" is NOT cached.\n", name);
+    LOG_DBG("\"%s\" is NOT cached\n", name);
     break;
   }
 #endif /* LOG_LEVEL == LOG_LEVEL_DBG */
@@ -1372,7 +1339,7 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
       /* We found this new name while probing.
        * We must now rename ourselves.
        */
-      LOG_DBG("Name collision detected for \"%s\".\n", name);
+      LOG_DBG("Name collision detected for \"%s\"\n", name);
 
       /* Remove the ".local" suffix. */
       resolv_hostname[strlen(resolv_hostname) - 6] = 0;
@@ -1410,7 +1377,7 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
       LOG_DBG_6ADDR(ipaddr);
       LOG_DBG_("\n");
     } else {
-      LOG_DBG("Unable to retrieve address for \"%s\".\n", name);
+      LOG_DBG("Unable to retrieve address for \"%s\"\n", name);
     }
   process_post(PROCESS_BROADCAST, resolv_event_found, name);
 }

--- a/os/services/resolv/resolv.h
+++ b/os/services/resolv/resolv.h
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2002-2003, Adam Dunkels.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met: 
- * 1. Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
- * 2. Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in the 
- *    documentation and/or other materials provided with the distribution. 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  * 3. The name of the author may not be used to endorse or promote
  *    products derived from this software without specific prior
- *    written permission.  
+ *    written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -24,7 +24,7 @@
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This file is part of the uIP TCP/IP stack.
  *
@@ -91,7 +91,7 @@ enum {
 typedef uint8_t resolv_status_t;
 
 /* Functions. */
-resolv_status_t resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr);
+resolv_status_t resolv_lookup(const char *name, uip_ipaddr_t **ipaddr);
 
 void resolv_query(const char *name);
 


### PR DESCRIPTION
This PR
* ~~Fixes a bug in resolv where when switching to next nameserver, the query would not be sent until `255 * retry-time` (set to 250 ms).~~
    * Separated into #1676 
* Cleans up the debug-logging (removed ad-hoc `VERBOSE_DEBUG` concept) and other related fixes to make debug-logging compile
* Cleanup (afaik) unnecessary `volatile`, `register` and large variable scopes
* Minor clean-up of the log output
* ~~Some fixes to code style~~
* Run uncrustify-fix-style on resolv.c/.h