### PR TITLE
cooja:make build CLASS-specified platform.c so that make can easy check it's fresh

### DIFF
--- a/arch/platform/cooja/Makefile.customrules-cooja
+++ b/arch/platform/cooja/Makefile.customrules-cooja
@@ -28,9 +28,31 @@ endif ## REDEF_PRINTF
 .PHONY: $(CONTIKI_APP).cooja
 $(CONTIKI_APP).cooja: $(JNILIB)
 	cp $(JNILIB) $@
-	rm $(CONTIKI_APP_OBJ)
+ 
+# rm $(CONTIKI_APP_OBJ)
+
+
+ifeq ("$(CLASSNAME)","")
+$(error CLASSNAME not defined!)
+endif
+
+MAINJNI_NAME = platform_$(CLASSNAME)
+JNI_OBJ = $(OBJECTDIR)/$(MAINJNI_NAME).o
+
+# keep intermediate platform.o under name JNI_OBJ, since it can explicit evaluates for claimed CLASSNAME
+#JNI_OBJ: $(OBJECTDIR)/platform.o | $(OBJECTDIR)
+#   cp  $(OBJECTDIR)/platform.o $@ 
+
+$(OBJECTDIR)/$(MAINJNI_NAME).o: platform.c | $(OBJECTDIR)
+	$(TRACE_CC)
+	$(Q)$(CC) $(CFLAGS) -c $< -o $@
+
+
+.PRECIOUS: $(OBJECTDIR)/platform.o
 
 # Trickiness: GNU make matches this against the file base name.
 # Assume that the directory part is the standard location.
-mtype%.o: platform.o | $(OBJECTDIR)
-	mv platform.o $@
+mtype%.o: $(JNI_OBJ) | $(OBJECTDIR)
+	cp $(JNI_OBJ) $@
+
+.PRECIOUS: $(JNI_OBJ)


### PR DESCRIPTION
cooja make now builds JNI_OBJ from platform.c for cooja-specified library CLASSNAME, to allow safe and fast make rebuilds.

* Cooja need compiled version platform.c specified for every library CLASSNAME. So, to allow make can normaly check that this object is obsolete and need rebuild, it should be different files.  So, here provide making JNI_OBJ object wich is now platform_\<CLASSNAME\>.o
        This inermediate keeps with compiled objects, so make can check freshness, and rebuild for new simulation.

* with this patch no more need make clean before simulation build. 
* this should fix [such](https://github.com/contiki-ng/contiki-ng/pull/1661/checks?check_run_id=3957178259) cooja builds failures
