### PR TITLE
fix cooja-radio RADIO_PARAM_LAST_RSSI and RADIO_PARAM_LAST_LQI

### DIFF
--- a/arch/platform/cooja/dev/cooja-radio.c
+++ b/arch/platform/cooja/dev/cooja-radio.c
@@ -58,9 +58,23 @@
 
 const struct simInterface radio_interface;
 
+
+
+/* There radio driver can provide cooja it's nosignal value.
+ * But at present, cooja ignore and override it.
+ * */
 enum {
-    RSSI_NO_SIGNAL = -120,
-    LQI_NO_SIGNAL  = 120,
+    /*
+     * Tmote Sky (with CC2420 radio) give value -100dB
+     * CC1310 gives value about -110dB
+    */
+    RSSI_NO_SIGNAL = -110 ,
+
+    /*
+     * Tmote Sky (with CC2420 radio) give value 105
+     * CC1310 gives value about 100?
+    */
+    LQI_NO_SIGNAL  = 100 ,
 };
 
 /* COOJA */
@@ -71,11 +85,11 @@ rtimer_clock_t simLastPacketTimestamp = 0;
 char simOutDataBuffer[COOJA_RADIO_BUFSIZE];
 int simOutSize = 0;
 char simRadioHWOn = 1;
-int simSignalStrength = -100;
-int simLastSignalStrength = -100;
+int simSignalStrength       = RSSI_NO_SIGNAL;
+int simLastSignalStrength   = RSSI_NO_SIGNAL;
 char simPower = 100;
 int simRadioChannel = 26;
-int simLQI = 105;
+int simLQI      = LQI_NO_SIGNAL;
 int simLastLQI  = LQI_NO_SIGNAL;
 
 

--- a/arch/platform/cooja/dev/cooja-radio.c
+++ b/arch/platform/cooja/dev/cooja-radio.c
@@ -58,6 +58,11 @@
 
 const struct simInterface radio_interface;
 
+enum {
+    RSSI_NO_SIGNAL = -120,
+    LQI_NO_SIGNAL  = 120,
+};
+
 /* COOJA */
 char simReceiving = 0;
 char simInDataBuffer[COOJA_RADIO_BUFSIZE];
@@ -71,6 +76,9 @@ int simLastSignalStrength = -100;
 char simPower = 100;
 int simRadioChannel = 26;
 int simLQI = 105;
+int simLastLQI  = LQI_NO_SIGNAL;
+
+
 
 static const void *pending_data;
 
@@ -136,6 +144,13 @@ radio_LQI(void)
 {
   return simLQI;
 }
+
+static
+int radio_LQI_last(void)
+{
+  return simLastLQI;
+}
+
 /*---------------------------------------------------------------------------*/
 static int
 radio_on(void)
@@ -162,6 +177,7 @@ doInterfaceActionsBeforeTick(void)
   }
   if(simReceiving) {
     simLastSignalStrength = simSignalStrength;
+    simLastLQI              = simLQI;
     return;
   }
 
@@ -191,8 +207,8 @@ radio_read(void *buf, unsigned short bufsize)
   memcpy(buf, simInDataBuffer, simInSize);
   simInSize = 0;
   if(!poll_mode) {
-    packetbuf_set_attr(PACKETBUF_ATTR_RSSI, simSignalStrength);
-    packetbuf_set_attr(PACKETBUF_ATTR_LINK_QUALITY, simLQI);
+    packetbuf_set_attr(PACKETBUF_ATTR_RSSI, radio_signal_strength_last());
+    packetbuf_set_attr(PACKETBUF_ATTR_LINK_QUALITY, radio_LQI_last() );
   }
 
   return tmp;
@@ -351,15 +367,17 @@ get_value(radio_param_t param, radio_value_t *value)
     }
     return RADIO_RESULT_OK;
   case RADIO_PARAM_LAST_RSSI:
-    *value = simSignalStrength;
+      *value = radio_signal_strength_last();
     return RADIO_RESULT_OK;
+
   case RADIO_PARAM_LAST_LINK_QUALITY:
-    *value = simLQI;
+    *value = radio_LQI_last();
     return RADIO_RESULT_OK;
+
   case RADIO_PARAM_RSSI:
-    /* return a fixed value depending on the channel */
-    *value = -90 + simRadioChannel - 11;
+    *value = radio_signal_strength_current();
     return RADIO_RESULT_OK;
+
   case RADIO_CONST_MAX_PAYLOAD_LEN:
     *value = (radio_value_t)COOJA_RADIO_BUFSIZE;
     return RADIO_RESULT_OK;
@@ -399,7 +417,8 @@ set_value(radio_param_t param, radio_value_t value)
     set_send_on_cca((value & RADIO_TX_MODE_SEND_ON_CCA) != 0);
     return RADIO_RESULT_OK;
   case RADIO_PARAM_CHANNEL:
-    if(value < 11 || value > 26) {
+      // for <0 cooja think that it noises at all chanels
+    if(value < 0) {
       return RADIO_RESULT_INVALID_VALUE;
     }
     radio_set_channel(value);

--- a/arch/platform/cooja/dev/cooja-radio.c
+++ b/arch/platform/cooja/dev/cooja-radio.c
@@ -146,7 +146,7 @@ radio_LQI(void)
 }
 
 static
-int radio_LQI_last(void)
+int radio_lqi_last(void)
 {
   return simLastLQI;
 }
@@ -208,7 +208,7 @@ radio_read(void *buf, unsigned short bufsize)
   simInSize = 0;
   if(!poll_mode) {
     packetbuf_set_attr(PACKETBUF_ATTR_RSSI, radio_signal_strength_last());
-    packetbuf_set_attr(PACKETBUF_ATTR_LINK_QUALITY, radio_LQI_last() );
+    packetbuf_set_attr(PACKETBUF_ATTR_LINK_QUALITY, radio_lqi_last() );
   }
 
   return tmp;
@@ -367,11 +367,11 @@ get_value(radio_param_t param, radio_value_t *value)
     }
     return RADIO_RESULT_OK;
   case RADIO_PARAM_LAST_RSSI:
-      *value = radio_signal_strength_last();
+    *value = radio_signal_strength_last();
     return RADIO_RESULT_OK;
 
   case RADIO_PARAM_LAST_LINK_QUALITY:
-    *value = radio_LQI_last();
+    *value = radio_lqi_last();
     return RADIO_RESULT_OK;
 
   case RADIO_PARAM_RSSI:
@@ -417,10 +417,12 @@ set_value(radio_param_t param, radio_value_t value)
     set_send_on_cca((value & RADIO_TX_MODE_SEND_ON_CCA) != 0);
     return RADIO_RESULT_OK;
   case RADIO_PARAM_CHANNEL:
-      // for <0 cooja think that it noises at all chanels
-    if(value < 0) {
-      return RADIO_RESULT_INVALID_VALUE;
-    }
+    /* with chanels <0 cooja mutches with any chanels:
+     *  - sent packets on negative chanekl -> to any receivers chanels.
+     *  - receiver on negative chanel <- gots any sender chcnels.
+     * So, negative chanel useful for wide-band noise generation.
+     * Or sniff wide-band air.
+     * */
     radio_set_channel(value);
     return RADIO_RESULT_OK;
   default:


### PR DESCRIPTION
here fixed cooja-radio RADIO_PARAM_LAST_RSSI and RADIO_PARAM_LAST_LINK_QUALITY - now it reports rssi and lqi captured at packet start.

* there was used current rssi(cca) for last packet, but accidentaly, cooja updates it right after packet end, and if mote code not luck, it miss rssi at packet end, and got current strength (after packet) on air.