### PR TITLE
Fix for buffer overflow in BLE L2CAP

### DIFF
--- a/os/net/mac/ble/ble-l2cap.c
+++ b/os/net/mac/ble/ble-l2cap.c
@@ -439,7 +439,7 @@ input_l2cap_frame_flow_channel(l2cap_channel_t *channel, uint8_t *data, uint16_t
     memcpy(&frame_len, &data[0], 2);
     payload_len = frame_len;
     
-    if(channel->rx_buffer.current_index + payload_len > BLE_L2CAP_NODE_MTU) {
+    if(payload_len > BLE_L2CAP_NODE_MTU - channel->rx_buffer.current_index) {
     	LOG_WARN("l2cap_frame: illegal L2CAP frame payload_len: %d\n", payload_len);
     	/* the current index plus the payload length may not be larger than 
 	 * the destination buffer */


### PR DESCRIPTION
This PR fixes a buffer overflow in the BLE L2CAP credit-based flow control.  

The overflow occurs in the `input_l2cap_frame_flow_channel` function, as an adversary is able to control the amount of data copied by memcpy ([source](https://github.com/contiki-ng/contiki-ng/blob/release/v4.4/os/net/mac/ble/ble-l2cap.c#L424)).

To fix this issue I suggest to:

- Add a condition for the first fragment that checks, whether the received `payload_len` is larger than `BLE_L2CAP_NODE_MTU`, which is the length of the destination array.
- Add an integer overflow resistant condition for the subsequent fragments that checks, whether the sum of the received `payload_len` of the current fragment and the `current_index` of the `rx_buffer` is larger than `BLE_L2CAP_NODE_MTU`, which is the length of the destination array.

In both cases illegal frames are simply dropped.
