### PR TITLE
Fix the return type of uipbuf_get_attr(UIPBUF_ATTR_RSSI) calls

### DIFF
--- a/examples/6tisch/timesync-demo/node.c
+++ b/examples/6tisch/timesync-demo/node.c
@@ -79,7 +79,7 @@ udp_rx_callback(struct simple_udp_connection *c,
               (unsigned long)remote_time_clock_ticks,
               (unsigned long)local_time_clock_ticks,
               (unsigned long)(local_time_clock_ticks - remote_time_clock_ticks),
-              (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI),
+              (int16_t)uipbuf_get_attr(UIPBUF_ATTR_RSSI),
               uipbuf_get_attr(UIPBUF_ATTR_LINK_QUALITY));
   }
 }

--- a/examples/mqtt-client/mqtt-client.c
+++ b/examples/mqtt-client/mqtt-client.c
@@ -306,7 +306,7 @@ echo_reply_handler(uip_ipaddr_t *source, uint8_t ttl, uint8_t *data,
                    uint16_t datalen)
 {
   if(uip_ip6addr_cmp(source, uip_ds6_defrt_choose())) {
-    def_rt_rssi = (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
+    def_rt_rssi = (int16_t)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/cc26x0-web-demo.c
+++ b/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/cc26x0-web-demo.c
@@ -434,7 +434,7 @@ echo_reply_handler(uip_ipaddr_t *source, uint8_t ttl, uint8_t *data,
                    uint16_t datalen)
 {
   if(uip_ip6addr_cmp(source, uip_ds6_defrt_choose())) {
-    def_rt_rssi = (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
+    def_rt_rssi = (int16_t)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/nrf52dk/mqtt-demo/mqtt-demo.c
+++ b/examples/platform-specific/nrf52dk/mqtt-demo/mqtt-demo.c
@@ -234,7 +234,7 @@ echo_reply_handler(uip_ipaddr_t *source, uint8_t ttl, uint8_t *data,
                    uint16_t datalen)
 {
   if(uip_ip6addr_cmp(source, uip_ds6_defrt_choose())) {
-    def_rt_rssi = (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
+    def_rt_rssi = (int16_t)uipbuf_get_attr(UIPBUF_ATTR_RSSI);
   }
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR fixes the following problem reported by @jsolderitsch on Gitter:

I see that a modification was made to mqtt-client.c about 5 months ago. In line 309:

    def_rt_rssi = sicslowpan_get_last_rssi();

was replaced by

    def_rt_rssi = (int)uipbuf_get_attr(UIPBUF_ATTR_RSSI);

When I build the mqtt-client for TARGET= simplelink and BOARD=sensortag/cc1352r1 the rssi as reported to my broker is wrong:

```
{"d":{"Platform":"simplelink","Board":"sensortag/cc1352r1","Seq #":1,"Uptime (sec)":18,"Def Route":"fe80::212:4b00:1ca7:7b7c","RSSI (dBm)":65508}}
{"d":{"Platform":"simplelink","Board":"sensortag/cc1352r1","Seq #":2,"Uptime (sec)":48,"Def Route":"fe80::212:4b00:1ca7:7b7c","RSSI (dBm)":65508}}
{"d":{"Platform":"simplelink","Board":"sensortag/cc1352r1","Seq #":3,"Uptime (sec)":78,"Def Route":"fe80::212:4b00:1ca7:7b7c","RSSI (dBm)":65504}}
```

If I revert to the older version, suppress the Warnings are Errors setting, then the reported RSSI's seem right:

```
{"d":{"Platform":"simplelink","Board":"sensortag/cc1352r1","Seq #":1,"Uptime (sec)":29,"Def Route":"fe80::212:4b00:1ca7:7b7c","RSSI (dBm)":-27}}
{"d":{"Platform":"simplelink","Board":"sensortag/cc1352r1","Seq #":2,"Uptime (sec)":59,"Def Route":"fe80::212:4b00:1ca7:7b7c","RSSI (dBm)":-27}}
{"d":{"Platform":"simplelink","Board":"sensortag/cc1352r1","Seq #":3,"Uptime (sec)":89,"Def Route":"fe80::212:4b00:1ca7:7b7c","RSSI (dBm)":-32}}
```