### PR TITLE
Fix RPL classic border router prefix

### DIFF
--- a/os/net/routing/rpl-classic/rpl-dag-root.c
+++ b/os/net/routing/rpl-classic/rpl-dag-root.c
@@ -119,11 +119,9 @@ rpl_dag_root_start(void)
     if(root_if != NULL) {
       rpl_dag_t *dag;
       uip_ipaddr_t prefix;
-      const uip_ipaddr_t *default_prefix;
 
       rpl_set_root(RPL_DEFAULT_INSTANCE, ipaddr);
       dag = rpl_get_any_dag();
-      default_prefix = uip_ds6_default_prefix();
 
       /* If there are routes in this dag, we remove them all as we are
          from now on the new dag root and the old routes are wrong */
@@ -135,7 +133,7 @@ rpl_dag_root_start(void)
         dag->instance->def_route = NULL;
       }
 
-      uip_ip6addr_copy(&prefix, default_prefix);
+      uip_ip6addr_copy(&prefix, ipaddr);
       rpl_set_prefix(dag, &prefix, 64);
       LOG_INFO("root_set_prefix: created a new RPL dag\n");
       return 0;


### PR DESCRIPTION
Fix for #1568. Tested with standalone RPL root and RPL border border.