### PR TITLE
Optimize/tsch neighbor removal

### DIFF
--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -529,6 +529,7 @@ tsch_rx_process_pending()
 static void
 tsch_tx_process_pending(void)
 {
+  uint16_t num_packets_freed = 0;
   int16_t dequeued_index;
   /* Loop on accessing (without removing) a pending input packet */
   while((dequeued_index = ringbufindex_peek_get(&dequeued_ringbuf)) != -1) {
@@ -543,10 +544,14 @@ tsch_tx_process_pending(void)
     mac_call_sent_callback(p->sent, p->ptr, p->ret, p->transmissions);
     /* Free packet queuebuf */
     tsch_queue_free_packet(p);
-    /* Free all unused neighbors */
-    tsch_queue_free_unused_neighbors();
     /* Remove dequeued packet from ringbuf */
     ringbufindex_get(&dequeued_ringbuf);
+    num_packets_freed++;
+  }
+
+  if(num_packets_freed > 0) {
+    /* Free all unused neighbors */
+    tsch_queue_free_unused_neighbors();
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -495,7 +495,7 @@ static void
 tsch_rx_process_pending()
 {
   int16_t input_index;
-  /* Loop on accessing (without removing) a pending input packet */
+  /* Loop on accessing (without removing) a pending output packet */
   while((input_index = ringbufindex_peek_get(&input_ringbuf)) != -1) {
     struct input_packet *current_input = &input_array[input_index];
     frame802154_t frame;


### PR DESCRIPTION
The TSCH function `tsch_tx_process_pending()` currently tries to remove all unused neighbors after processing each packet. This can be done only once, at the end of the function. Alternatively, a periodic callback function could be introduced that performs this only in pre-set intervals, or some other kind of rate-limited processing.