### PR TITLE
Orchestra: optimize channel offsets of unicast slotframes

### DIFF
--- a/os/services/orchestra/orchestra-conf.h
+++ b/os/services/orchestra/orchestra-conf.h
@@ -126,18 +126,11 @@
 #define ORCHESTRA_COLLISION_FREE_HASH             0 /* Set to 1 if ORCHESTRA_LINKADDR_HASH returns unique hashes */
 #endif /* ORCHESTRA_CONF_COLLISION_FREE_HASH */
 
-/* Channel offset for the EB rule, default 0 */
-#ifdef ORCHESTRA_CONF_EB_CHANNEL_OFFSET
-#define ORCHESTRA_EB_CHANNEL_OFFSET               ORCHESTRA_CONF_EB_CHANNEL_OFFSET
-#else
-#define ORCHESTRA_EB_CHANNEL_OFFSET               0
-#endif
-
-/* Channel offset for the default common rule, default 1 */
+/* Channel offset for the default common rule, default 0 */
 #ifdef ORCHESTRA_CONF_DEFAULT_COMMON_CHANNEL_OFFSET
 #define ORCHESTRA_DEFAULT_COMMON_CHANNEL_OFFSET   ORCHESTRA_CONF_DEFAULT_COMMON_CHANNEL_OFFSET
 #else
-#define ORCHESTRA_DEFAULT_COMMON_CHANNEL_OFFSET   1
+#define ORCHESTRA_DEFAULT_COMMON_CHANNEL_OFFSET   0
 #endif
 
 /* Min channel offset for the unicast rules; the default min/max range is [2, sizeof(HS)-2].

--- a/os/services/orchestra/orchestra-conf.h
+++ b/os/services/orchestra/orchestra-conf.h
@@ -140,18 +140,34 @@
 #define ORCHESTRA_DEFAULT_COMMON_CHANNEL_OFFSET   1
 #endif
 
-/* Min channel offset for the unicast rules; the default min/max range is [2, 255] */
+/* Min channel offset for the unicast rules; the default min/max range is [2, sizeof(HS)-2].
+   If the HS has less then 3 channels [1, 1] is used instead.
+*/
 #ifdef ORCHESTRA_CONF_UNICAST_MIN_CHANNEL_OFFSET
 #define ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET       ORCHESTRA_CONF_UNICAST_MIN_CHANNEL_OFFSET
 #else
-#define ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET       2
+#define ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET       (sizeof(TSCH_DEFAULT_HOPPING_SEQUENCE) > 2 ? 2 : 1)
 #endif
 
 /* Max channel offset for the unicast rules */
 #ifdef ORCHESTRA_CONF_UNICAST_MAX_CHANNEL_OFFSET
 #define ORCHESTRA_UNICAST_MAX_CHANNEL_OFFSET       ORCHESTRA_CONF_UNICAST_MAX_CHANNEL_OFFSET
 #else
-#define ORCHESTRA_UNICAST_MAX_CHANNEL_OFFSET       255
+#define ORCHESTRA_UNICAST_MAX_CHANNEL_OFFSET       \
+  (MAX(ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET, sizeof(TSCH_DEFAULT_HOPPING_SEQUENCE) - 1))
+#endif
+
+/* Channel offsets for the EB rule, default: 1 */
+#ifdef ORCHESTRA_CONF_EB_MIN_CHANNEL_OFFSET
+#define ORCHESTRA_EB_MIN_CHANNEL_OFFSET ORCHESTRA_CONF_EB_MIN_CHANNEL_OFFSET
+#else
+#define ORCHESTRA_EB_MIN_CHANNEL_OFFSET 1
+#endif
+
+#ifdef ORCHESTRA_CONF_EB_MAX_CHANNEL_OFFSET
+#define ORCHESTRA_EB_MAX_CHANNEL_OFFSET ORCHESTRA_CONF_EB_MAX_CHANNEL_OFFSET
+#else
+#define ORCHESTRA_EB_MAX_CHANNEL_OFFSET 1
 #endif
 
 #endif /* __ORCHESTRA_CONF_H__ */

--- a/os/services/orchestra/orchestra-rule-eb-per-time-source.c
+++ b/os/services/orchestra/orchestra-rule-eb-per-time-source.c
@@ -29,11 +29,11 @@
  */
 /**
  * \file
-
  *         Orchestra: a slotframe dedicated to transmission of EBs.
  *         Nodes transmit at a timeslot defined as hash(MAC) % ORCHESTRA_EBSF_PERIOD
  *         Nodes listen at a timeslot defined as hash(time_source.MAC) % ORCHESTRA_EBSF_PERIOD
  * \author Simon Duquennoy <simonduq@sics.se>
+ *         Atis Elsts <atis.elsts@edi.lv>
  */
 
 #include "contiki.h"
@@ -43,6 +43,7 @@
 static uint16_t slotframe_handle = 0;
 static uint16_t channel_offset = 0;
 static struct tsch_slotframe *sf_eb;
+static struct tsch_link *timesource_link;
 
 /*---------------------------------------------------------------------------*/
 static uint16_t
@@ -50,6 +51,23 @@ get_node_timeslot(const linkaddr_t *addr)
 {
 #if ORCHESTRA_EBSF_PERIOD > 0
   return ORCHESTRA_LINKADDR_HASH(addr) % ORCHESTRA_EBSF_PERIOD;
+#else
+  return 0xffff;
+#endif
+}
+/*---------------------------------------------------------------------------*/
+static uint16_t
+get_node_channel_offset(const linkaddr_t *addr)
+{
+#if ORCHESTRA_EBSF_PERIOD > 0
+  if(ORCHESTRA_EB_MAX_CHANNEL_OFFSET >= ORCHESTRA_EB_MIN_CHANNEL_OFFSET) {
+    return ORCHESTRA_LINKADDR_HASH(addr) %
+        (ORCHESTRA_EB_MAX_CHANNEL_OFFSET - ORCHESTRA_EB_MIN_CHANNEL_OFFSET + 1)
+        + ORCHESTRA_EB_MIN_CHANNEL_OFFSET;
+  } else {
+    /* ORCHESTRA_EB_MIN_CHANNEL_OFFSET configure larger than max offset, this is an error */
+    return 0xffff;
+  }
 #else
   return 0xffff;
 #endif
@@ -66,6 +84,7 @@ select_packet(uint16_t *slotframe, uint16_t *timeslot, uint16_t *channel_offset)
     if(timeslot != NULL) {
       *timeslot = get_node_timeslot(&linkaddr_node_addr);
     }
+    /* no need to set the channel offset: it's taken automatically from the link */
     return 1;
   }
   return 0;
@@ -74,39 +93,44 @@ select_packet(uint16_t *slotframe, uint16_t *timeslot, uint16_t *channel_offset)
 static void
 new_time_source(const struct tsch_neighbor *old, const struct tsch_neighbor *new)
 {
-  uint16_t old_ts = old != NULL ? get_node_timeslot(tsch_queue_get_nbr_address(old)) : 0xffff;
-  uint16_t new_ts = new != NULL ? get_node_timeslot(tsch_queue_get_nbr_address(new)) : 0xffff;
+  uint16_t old_ts = 0xffff;
+  uint16_t new_ts = 0xffff;
+  uint16_t old_channel_offset = 0xffff;
+  uint16_t new_channel_offset = 0xffff;
 
-  if(new_ts == old_ts) {
+  if(old != NULL) {
+    const linkaddr_t *addr = tsch_queue_get_nbr_address(old);
+    old_ts = get_node_timeslot(addr);
+    old_channel_offset = get_node_channel_offset(addr);
+  }
+
+  if(new != NULL) {
+    const linkaddr_t *addr = tsch_queue_get_nbr_address(new);
+    new_ts = get_node_timeslot(addr);
+    new_channel_offset = get_node_channel_offset(addr);
+  }
+
+  if(new_ts == old_ts && old_channel_offset == new_channel_offset) {
     return;
   }
 
-  if(old_ts != 0xffff) {
+  if(timesource_link != NULL) {
     /* Stop listening to the old time source's EBs */
-    if(old_ts == get_node_timeslot(&linkaddr_node_addr)) {
-      /* This was the same timeslot as slot. Reset original link options */
-      tsch_schedule_add_link(sf_eb, LINK_OPTION_TX, LINK_TYPE_ADVERTISING_ONLY,
-        &tsch_broadcast_address, old_ts, ORCHESTRA_EB_CHANNEL_OFFSET, 1);
-    } else {
-      /* Remove slot */
-      tsch_schedule_remove_link_by_timeslot(sf_eb, old_ts, ORCHESTRA_EB_CHANNEL_OFFSET);
-    }
+    tsch_schedule_remove_link(sf_eb, timesource_link);
+    timesource_link = NULL;
   }
   if(new_ts != 0xffff) {
-    uint8_t link_options = LINK_OPTION_RX;
-    if(new_ts == get_node_timeslot(&linkaddr_node_addr)) {
-      /* This is also our timeslot, add necessary flags */
-      link_options |= LINK_OPTION_TX;
-    }
     /* Listen to the time source's EBs */
-    tsch_schedule_add_link(sf_eb, link_options, LINK_TYPE_ADVERTISING_ONLY,
-      &tsch_broadcast_address, new_ts, ORCHESTRA_EB_CHANNEL_OFFSET, 1);
+    timesource_link = tsch_schedule_add_link(sf_eb, LINK_OPTION_RX, LINK_TYPE_ADVERTISING_ONLY,
+        &tsch_broadcast_address, new_ts, new_channel_offset, 0);
   }
 }
 /*---------------------------------------------------------------------------*/
 static void
 init(uint16_t sf_handle)
 {
+  const uint16_t local_ts = get_node_timeslot(&linkaddr_node_addr);
+  const uint16_t local_channel_offset = get_node_channel_offset(&linkaddr_node_addr);
   slotframe_handle = sf_handle;
   channel_offset = sf_handle;
   sf_eb = tsch_schedule_add_slotframe(slotframe_handle, ORCHESTRA_EBSF_PERIOD);
@@ -114,7 +138,7 @@ init(uint16_t sf_handle)
   tsch_schedule_add_link(sf_eb,
                          LINK_OPTION_TX,
                          LINK_TYPE_ADVERTISING_ONLY, &tsch_broadcast_address,
-                         get_node_timeslot(&linkaddr_node_addr), ORCHESTRA_EB_CHANNEL_OFFSET, 1);
+                         local_ts, local_channel_offset, 0);
 }
 /*---------------------------------------------------------------------------*/
 struct orchestra_rule eb_per_time_source = {

--- a/tests/07-simulation-base/26-cooja-rpl-tsch-orchestra-perfect-link.csc
+++ b/tests/07-simulation-base/26-cooja-rpl-tsch-orchestra-perfect-link.csc
@@ -24,7 +24,7 @@
       <description>RPL/TSCH Node</description>
       <source>[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
       <commands EXPORT="discard">make TARGET=cooja clean
-make -j$(CPUS) node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=1 MAKE_WITH_STORING_ROUTING=1 MAKE_WITH_LINK_BASED_ORCHESTRA=1 DEFINES=LINK_STATS_CONF_PACKET_COUNTERS=1,TSCH_CONF_KEEPALIVE_TIMEOUT=1024,TSCH_CONF_MAX_KEEPALIVE_TIMEOUT=1024</commands>
+make -j$(CPUS) node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=1 MAKE_WITH_STORING_ROUTING=1 MAKE_WITH_LINK_BASED_ORCHESTRA=1 DEFINES=LINK_STATS_CONF_PACKET_COUNTERS=1,TSCH_CONF_KEEPALIVE_TIMEOUT=1024,TSCH_CONF_MAX_KEEPALIVE_TIMEOUT=1024,ORCHESTRA_CONF_UNICAST_MIN_CHANNEL_OFFSET=2,ORCHESTRA_CONF_EB_MIN_CHANNEL_OFFSET=1,ORCHESTRA_CONF_EB_MAX_CHANNEL_OFFSET=1</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>


### PR DESCRIPTION
**The problem:** there is an intention to logically separate the channel offsets that are used for EB packets, for broadcast packets, and for unicast packets. However, the max unicast channel offset is set to 255. The real channel is calculated as `offset % hopping_sequence_size`. As typical hopping sequences are much shorter than 256 elements, in many cases unicast packet are going to use the same physical channels as EB and broadcast packets, leading to potential collisions between these types of packets.

**The solution:** the PR makes the range of channel offsets dependent on the hopping sequence size. This will not work as intended if the hopping sequence is changed at the runtime to have a smaller number of channels. However, this is not typical for most networks.

Of course, keeping the three groups of packets is separate channels is not possible if the number of channels is less than 3. In that special case we set `ORCHESTRA_UNICAST_MIN_CHANNEL_OFFSET` to 0 and allow the ranges to overlap.

The practical impact of this is very small for most networks, however, it makes it easier to reason about the causes of the collisions in the networks.

This is based on work done with Cysca Technologies.