### PR TITLE
Immediately try to resolve when switching DNS server

### DIFF
--- a/os/services/resolv/resolv.c
+++ b/os/services/resolv/resolv.c
@@ -596,7 +596,7 @@ check_entries(void)
     if(namemapptr->state == STATE_NEW || namemapptr->state == STATE_ASKING) {
       etimer_set(&retry, CLOCK_SECOND / 4);
       if(namemapptr->state == STATE_ASKING) {
-        if(--namemapptr->tmr == 0) {
+        if(namemapptr->tmr == 0 || --namemapptr->tmr == 0) {
 #if RESOLV_CONF_SUPPORTS_MDNS
           if(++namemapptr->retries ==
              (namemapptr->is_mdns ? RESOLV_CONF_MAX_MDNS_RETRIES :


### PR DESCRIPTION
This PR fixes a bug in resolv where when switching to next nameserver, the query would not be sent until 255 * `retry` (set to 250 ms).

This happens because `try_next_server()` sets `retries` to 0. Thus, `tmr` will be set to 0 at https://github.com/contiki-ng/contiki-ng/blob/develop/os/services/resolv/resolv.c#L623. At next call to `check_entries()`, the 0 in `tmr` will be decremented and wrap to 255 at https://github.com/contiki-ng/contiki-ng/blob/develop/os/services/resolv/resolv.c#L599. With this PR the wrap is avoided and next server queried at the first opportunity after switching to it.