### PR TITLE
Fixed multicast IPv6 address handling in MPL

### DIFF
--- a/os/net/ipv6/multicast/mpl.c
+++ b/os/net/ipv6/multicast/mpl.c
@@ -459,7 +459,7 @@ extern uint16_t uip_slen;
  * \brief Modify an ipv6 address to give it link local scope
  * a: uip_ip6addr_t address to modify
  */
-#define UIP_ADDR_MAKE_LINK_LOCAL(a) (((uip_ip6addr_t *)a)->u8[1] = UIP_MCAST6_SCOPE_LINK_LOCAL)
+#define UIP_ADDR_MAKE_LINK_LOCAL(a) (((uip_ip6addr_t *)a)->u8[1] = (((uip_ip6addr_t *)a)->u8[1] & 0xF0) | UIP_MCAST6_SCOPE_LINK_LOCAL)
 /*---------------------------------------------------------------------------*/
 /* Local function prototypes */
 /*---------------------------------------------------------------------------*/
@@ -534,8 +534,8 @@ domain_set_allocate(uip_ip6addr_t *address)
         LOG_DBG("Found higher scoped address in table\n");
         break;
       }
-    } while(data_addr.u8[1] <= 5);
-    if(data_addr.u8[1] > 5) {
+    } while(uip_mcast6_get_address_scope(&data_addr) <= UIP_MCAST6_SCOPE_SITE_LOCAL);
+    if(uip_mcast6_get_address_scope(&data_addr) > UIP_MCAST6_SCOPE_SITE_LOCAL) {
       LOG_ERR("Failed to find MPL domain data address in table\n");
       return NULL;
     }

--- a/os/net/ipv6/multicast/mpl.h
+++ b/os/net/ipv6/multicast/mpl.h
@@ -59,7 +59,7 @@
 /*---------------------------------------------------------------------------*/
 /* Protocol Constants */
 /*---------------------------------------------------------------------------*/
-#define ALL_MPL_FORWARDERS(a, r)   uip_ip6addr(a, 0xFF00 + r,0x00,0x00,0x00,0x00,0x00,0x00,0xFC)
+#define ALL_MPL_FORWARDERS(a, r)   uip_ip6addr(a, 0xFF00 + r, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFC)
 #define HBHO_OPT_TYPE_MPL          0x6D
 #define MPL_IP_HOP_LIMIT           0xFF   /**< Hop limit for ICMP messages */
 #define HBHO_BASE_LEN              8
@@ -145,7 +145,7 @@
 #endif
 /*---------------------------------------------------------------------------*/
 /**
-* Seed ID Low Bits
+ * Seed ID Low Bits
  * If the Seed ID Length setting is 1 or 2, this setting defines the seed
  * id for this seed. If the seed id setting is 3, then this defines the lower
  * 64 bits of the seed id.
@@ -157,7 +157,7 @@
 #endif
 /*---------------------------------------------------------------------------*/
 /**
-* Seed ID High Bits
+ * Seed ID High Bits
  * If the Seed ID Length setting is 3, this setting defines the upper 64 bits
  * for the seed id. Else it's ignored.
  */


### PR DESCRIPTION
This fixes the issue described in #1700 where the multicast address flags are not correctly masked off from the scope when handling MPL domain addresses.

Currently the only multicast addresses that MPL will work with are addresses where the flags are set to zero. These addresses are meant to be reserved for well-known multicast addresses, so it forces users who want to dynamically assign a multicast group, to use an address space that is not intended to be used for dynamically assigned addresses.

Also included are a few code style issues picked up by `uncrustify` when checking the changes for creating this PR.