### PR TITLE
Add consts suggested by cppcheck

### DIFF
--- a/os/lib/circular-list.c
+++ b/os/lib/circular-list.c
@@ -56,13 +56,13 @@ circular_list_init(circular_list_t cl)
 }
 /*---------------------------------------------------------------------------*/
 void *
-circular_list_head(circular_list_t cl)
+circular_list_head(const circular_list_t cl)
 {
   return *cl;
 }
 /*---------------------------------------------------------------------------*/
 void *
-circular_list_tail(circular_list_t cl)
+circular_list_tail(const circular_list_t cl)
 {
   struct cl *this;
 
@@ -76,7 +76,7 @@ circular_list_tail(circular_list_t cl)
 }
 /*---------------------------------------------------------------------------*/
 void
-circular_list_remove(circular_list_t cl, void *element)
+circular_list_remove(circular_list_t cl, const void *element)
 {
   struct cl *this, *previous;
 
@@ -132,7 +132,7 @@ circular_list_add(circular_list_t cl, void *element)
 }
 /*---------------------------------------------------------------------------*/
 unsigned long
-circular_list_length(circular_list_t cl)
+circular_list_length(const circular_list_t cl)
 {
   unsigned long len = 1;
   struct cl *this;
@@ -149,7 +149,7 @@ circular_list_length(circular_list_t cl)
 }
 /*---------------------------------------------------------------------------*/
 bool
-circular_list_is_empty(circular_list_t cl)
+circular_list_is_empty(const circular_list_t cl)
 {
   return *cl == NULL ? true : false;
 }

--- a/os/lib/circular-list.h
+++ b/os/lib/circular-list.h
@@ -94,14 +94,14 @@ void circular_list_init(circular_list_t cl);
  * \param cl The circular, singly-linked list.
  * \return A pointer to the list's head, or NULL if the list is empty
  */
-void *circular_list_head(circular_list_t cl);
+void *circular_list_head(const circular_list_t cl);
 
 /**
  * \brief Return the tail of a circular, singly-linked list.
  * \param cl The circular, singly-linked list.
  * \return A pointer to the list's tail, or NULL if the list is empty
  */
-void *circular_list_tail(circular_list_t cl);
+void *circular_list_tail(const circular_list_t cl);
 
 /**
  * \brief Add an element to a circular, singly-linked list.
@@ -132,14 +132,14 @@ void circular_list_add(circular_list_t cl, void *element);
  * call this function as part of a list traversal, it is advised to stop
  * traversing after this function returns.
  */
-void circular_list_remove(circular_list_t cl, void *element);
+void circular_list_remove(circular_list_t cl, const void *element);
 
 /**
  * \brief Get the length of a circular, singly-linked list.
  * \param cl The circular, singly-linked list.
  * \return The number of elements in the list
  */
-unsigned long circular_list_length(circular_list_t cl);
+unsigned long circular_list_length(const circular_list_t cl);
 
 /**
  * \brief Determine whether a circular, singly-linked list is empty.
@@ -147,7 +147,7 @@ unsigned long circular_list_length(circular_list_t cl);
  * \retval true The list is empty
  * \retval false The list is not empty
  */
-bool circular_list_is_empty(circular_list_t cl);
+bool circular_list_is_empty(const circular_list_t cl);
 /*---------------------------------------------------------------------------*/
 #endif /* CIRCULAR_LIST_H_ */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbl-circ-list.c
+++ b/os/lib/dbl-circ-list.c
@@ -57,13 +57,13 @@ dbl_circ_list_init(dbl_circ_list_t dblcl)
 }
 /*---------------------------------------------------------------------------*/
 void *
-dbl_circ_list_head(dbl_circ_list_t dblcl)
+dbl_circ_list_head(const dbl_circ_list_t dblcl)
 {
   return *dblcl;
 }
 /*---------------------------------------------------------------------------*/
 void *
-dbl_circ_list_tail(dbl_circ_list_t dblcl)
+dbl_circ_list_tail(const dbl_circ_list_t dblcl)
 {
   struct dblcl *this;
 
@@ -77,7 +77,7 @@ dbl_circ_list_tail(dbl_circ_list_t dblcl)
 }
 /*---------------------------------------------------------------------------*/
 void
-dbl_circ_list_remove(dbl_circ_list_t dblcl, void *element)
+dbl_circ_list_remove(dbl_circ_list_t dblcl, const void *element)
 {
   struct dblcl *this;
 
@@ -202,7 +202,7 @@ dbl_circ_list_add_before(dbl_circ_list_t dblcl, void *existing, void *element)
 }
 /*---------------------------------------------------------------------------*/
 unsigned long
-dbl_circ_list_length(dbl_circ_list_t dblcl)
+dbl_circ_list_length(const dbl_circ_list_t dblcl)
 {
   unsigned long len = 1;
   struct dblcl *this;
@@ -219,7 +219,7 @@ dbl_circ_list_length(dbl_circ_list_t dblcl)
 }
 /*---------------------------------------------------------------------------*/
 bool
-dbl_circ_list_is_empty(dbl_circ_list_t dblcl)
+dbl_circ_list_is_empty(const dbl_circ_list_t dblcl)
 {
   return *dblcl == NULL ? true : false;
 }

--- a/os/lib/dbl-circ-list.h
+++ b/os/lib/dbl-circ-list.h
@@ -96,14 +96,14 @@ void dbl_circ_list_init(dbl_circ_list_t dblcl);
  * \param dblcl The circular, doubly-linked list.
  * \return A pointer to the list's head, or NULL if the list is empty
  */
-void *dbl_circ_list_head(dbl_circ_list_t dblcl);
+void *dbl_circ_list_head(const dbl_circ_list_t dblcl);
 
 /**
  * \brief Return the tail of a circular, doubly-linked list.
  * \param dblcl The circular, doubly-linked list.
  * \return A pointer to the list's tail, or NULL if the list is empty
  */
-void *dbl_circ_list_tail(dbl_circ_list_t dblcl);
+void *dbl_circ_list_tail(const dbl_circ_list_t dblcl);
 
 /**
  * \brief Add an element to the head of a circular, doubly-linked list.
@@ -128,7 +128,7 @@ void dbl_circ_list_add_head(dbl_circ_list_t dblcl, void *element);
 void dbl_circ_list_add_tail(dbl_circ_list_t dblcl, void *element);
 
 /**
- * \brief Add an element to a circular, doubly linked list after an existing element.
+ * \brief Add element to a circular, doubly-linked list after existing element.
  * \param dblcl The circular, doubly-linked list.
  * \param existing A pointer to the existing element.
  * \param element A pointer to the element to be added.
@@ -145,7 +145,7 @@ void dbl_circ_list_add_after(dbl_circ_list_t dblcl, void *existing,
                              void *element);
 
 /**
- * \brief Add an element to a circular, doubly linked list before an existing element.
+ * \brief Add element to a circular, doubly-linked list before existing element.
  * \param dblcl The circular, doubly-linked list.
  * \param existing A pointer to the existing element.
  * \param element A pointer to the element to be added.
@@ -170,14 +170,14 @@ void dbl_circ_list_add_before(dbl_circ_list_t dblcl, void *existing,
  * call this function as part of a list traversal, it is advised to stop
  * traversing after this function returns.
  */
-void dbl_circ_list_remove(dbl_circ_list_t dblcl, void *element);
+void dbl_circ_list_remove(dbl_circ_list_t dblcl, const void *element);
 
 /**
  * \brief Get the length of a circular, doubly-linked list.
  * \param dblcl The circular, doubly-linked list.
  * \return The number of elements in the list
  */
-unsigned long dbl_circ_list_length(dbl_circ_list_t dblcl);
+unsigned long dbl_circ_list_length(const dbl_circ_list_t dblcl);
 
 /**
  * \brief Determine whether a circular, doubly-linked list is empty.
@@ -185,7 +185,7 @@ unsigned long dbl_circ_list_length(dbl_circ_list_t dblcl);
  * \retval true The list is empty
  * \retval false The list is not empty
  */
-bool dbl_circ_list_is_empty(dbl_circ_list_t dblcl);
+bool dbl_circ_list_is_empty(const dbl_circ_list_t dblcl);
 /*---------------------------------------------------------------------------*/
 #endif /* DBL_CIRC_LIST_H_ */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbl-list.c
+++ b/os/lib/dbl-list.c
@@ -57,13 +57,13 @@ dbl_list_init(dbl_list_t dll)
 }
 /*---------------------------------------------------------------------------*/
 void *
-dbl_list_head(dbl_list_t dll)
+dbl_list_head(const dbl_list_t dll)
 {
   return *dll;
 }
 /*---------------------------------------------------------------------------*/
 void *
-dbl_list_tail(dbl_list_t dll)
+dbl_list_tail(const dbl_list_t dll)
 {
   struct dll *this;
 
@@ -77,7 +77,7 @@ dbl_list_tail(dbl_list_t dll)
 }
 /*---------------------------------------------------------------------------*/
 void
-dbl_list_remove(dbl_list_t dll, void *element)
+dbl_list_remove(dbl_list_t dll, const void *element)
 {
   struct dll *this, *previous, *next;
 
@@ -201,7 +201,7 @@ dbl_list_add_before(dbl_list_t dll, void *existing, void *element)
 }
 /*---------------------------------------------------------------------------*/
 unsigned long
-dbl_list_length(dbl_list_t dll)
+dbl_list_length(const dbl_list_t dll)
 {
   unsigned long len = 0;
   struct dll *this;
@@ -218,7 +218,7 @@ dbl_list_length(dbl_list_t dll)
 }
 /*---------------------------------------------------------------------------*/
 bool
-dbl_list_is_empty(dbl_list_t dll)
+dbl_list_is_empty(const dbl_list_t dll)
 {
   return *dll == NULL ? true : false;
 }

--- a/os/lib/dbl-list.h
+++ b/os/lib/dbl-list.h
@@ -96,14 +96,14 @@ void dbl_list_init(dbl_list_t dll);
  * \param dll The doubly-linked list.
  * \return A pointer to the list's head, or NULL if the list is empty
  */
-void *dbl_list_head(dbl_list_t dll);
+void *dbl_list_head(const dbl_list_t dll);
 
 /**
  * \brief Return the tail of a doubly-linked list.
  * \param dll The doubly-linked list.
  * \return A pointer to the list's tail, or NULL if the list is empty
  */
-void *dbl_list_tail(dbl_list_t dll);
+void *dbl_list_tail(const dbl_list_t dll);
 
 /**
  * \brief Add an element to the head of a doubly-linked list.
@@ -168,14 +168,14 @@ void dbl_list_add_before(dbl_list_t dll, void *existing, void *element);
  * call this function as part of a list traversal, it is advised to stop
  * traversing after this function returns.
  */
-void dbl_list_remove(dbl_list_t dll, void *element);
+void dbl_list_remove(dbl_list_t dll, const void *element);
 
 /**
  * \brief Get the length of a doubly-linked list.
  * \param dll The doubly-linked list.
  * \return The number of elements in the list
  */
-unsigned long dbl_list_length(dbl_list_t dll);
+unsigned long dbl_list_length(const dbl_list_t dll);
 
 /**
  * \brief Determine whether a doubly-linked list is empty.
@@ -183,7 +183,7 @@ unsigned long dbl_list_length(dbl_list_t dll);
  * \retval true The list is empty
  * \retval false The list is not empty
  */
-bool dbl_list_is_empty(dbl_list_t dll);
+bool dbl_list_is_empty(const dbl_list_t dll);
 /*---------------------------------------------------------------------------*/
 #endif /* DBL_LIST_H_ */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/list.c
+++ b/os/lib/list.c
@@ -79,7 +79,7 @@ list_init(list_t list)
  * \sa list_tail()
  */
 void *
-list_head(list_t list)
+list_head(const list_t list)
 {
   return *list;
 }
@@ -97,7 +97,7 @@ list_head(list_t list)
  * \param src The source list.
  */
 void
-list_copy(list_t dest, list_t src)
+list_copy(list_t dest, const list_t src)
 {
   *dest = *src;
 }
@@ -114,7 +114,7 @@ list_copy(list_t dest, list_t src)
  * \sa list_head()
  */
 void *
-list_tail(list_t list)
+list_tail(const list_t list)
 {
   struct list *l;
 
@@ -234,7 +234,7 @@ list_pop(list_t list)
  */
 /*---------------------------------------------------------------------------*/
 void
-list_remove(list_t list, void *item)
+list_remove(list_t list, const void *item)
 {
   struct list *l, *r;
 
@@ -269,7 +269,7 @@ list_remove(list_t list, void *item)
  */
 /*---------------------------------------------------------------------------*/
 int
-list_length(list_t list)
+list_length(const list_t list)
 {
   struct list *l;
   int n = 0;
@@ -319,7 +319,7 @@ list_insert(list_t list, void *previtem, void *newitem)
  *             lists.
  */
 void *
-list_item_next(void *item)
+list_item_next(const void *item)
 {
   return item == NULL ? NULL : ((struct list *)item)->next;
 }
@@ -335,7 +335,7 @@ list_item_next(void *item)
  *			   is present in the list.
  */
 bool
-list_contains(list_t list, void *item)
+list_contains(const list_t list, const void *item)
 {
   struct list *l;
   for(l = *list; l != NULL; l = l->next) {

--- a/os/lib/list.h
+++ b/os/lib/list.h
@@ -136,25 +136,25 @@
 typedef void ** list_t;
 
 void   list_init(list_t list);
-void * list_head(list_t list);
-void * list_tail(list_t list);
+void * list_head(const list_t list);
+void * list_tail(const list_t list);
 void * list_pop (list_t list);
 void   list_push(list_t list, void *item);
 
 void * list_chop(list_t list);
 
 void   list_add(list_t list, void *item);
-void   list_remove(list_t list, void *item);
+void   list_remove(list_t list, const void *item);
 
-int    list_length(list_t list);
+int    list_length(const list_t list);
 
-void   list_copy(list_t dest, list_t src);
+void   list_copy(list_t dest, const list_t src);
 
 void   list_insert(list_t list, void *previtem, void *newitem);
 
-void * list_item_next(void *item);
+void * list_item_next(const void *item);
 
-bool list_contains(list_t list, void *item);
+bool list_contains(const list_t list, const void *item);
 
 #endif /* LIST_H_ */
 

--- a/os/net/app-layer/coap/coap-observe.c
+++ b/os/net/app-layer/coap/coap-observe.c
@@ -307,7 +307,7 @@ coap_notify_observers_sub(coap_resource_t *resource, const char *subpath)
 }
 /*---------------------------------------------------------------------------*/
 void
-coap_observe_handler(coap_resource_t *resource, coap_message_t *coap_req,
+coap_observe_handler(const coap_resource_t *resource, coap_message_t *coap_req,
                      coap_message_t *coap_res)
 {
   const coap_endpoint_t *src_ep;

--- a/os/net/app-layer/coap/coap-observe.h
+++ b/os/net/app-layer/coap/coap-observe.h
@@ -75,7 +75,8 @@ int coap_remove_observer_by_mid(const coap_endpoint_t *ep,
 void coap_notify_observers(coap_resource_t *resource);
 void coap_notify_observers_sub(coap_resource_t *resource, const char *subpath);
 
-void coap_observe_handler(coap_resource_t *resource, coap_message_t *request,
+void coap_observe_handler(const coap_resource_t *resource,
+                          coap_message_t *request,
                           coap_message_t *response);
 
 uint8_t coap_has_observers(char *path);

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -83,7 +83,7 @@ coap_log_2(uint16_t value)
 }
 /*---------------------------------------------------------------------------*/
 static uint32_t
-coap_parse_int_option(uint8_t *bytes, size_t length)
+coap_parse_int_option(const uint8_t *bytes, size_t length)
 {
   uint32_t var = 0;
   int i = 0;

--- a/os/net/ipv6/udp-socket.c
+++ b/os/net/ipv6/udp-socket.c
@@ -100,7 +100,7 @@ udp_socket_bind(struct udp_socket *c,
 /*---------------------------------------------------------------------------*/
 int
 udp_socket_connect(struct udp_socket *c,
-                   uip_ipaddr_t *remote_addr,
+                   const uip_ipaddr_t *remote_addr,
                    uint16_t remote_port)
 {
   if(c == NULL || c->udp_conn == NULL) {

--- a/os/net/ipv6/udp-socket.h
+++ b/os/net/ipv6/udp-socket.h
@@ -138,7 +138,7 @@ int udp_socket_bind(struct udp_socket *c,
  *
  */
 int udp_socket_connect(struct udp_socket *c,
-                       uip_ipaddr_t *remote_addr,
+                       const uip_ipaddr_t *remote_addr,
                        uint16_t remote_port);
 /**
  * \brief      Send data on a UDP socket

--- a/os/net/ipv6/uip-nd6.c
+++ b/os/net/ipv6/uip-nd6.c
@@ -364,7 +364,8 @@ discard:
 /*------------------------------------------------------------------*/
 #if UIP_ND6_SEND_NS
 void
-uip_nd6_ns_output(uip_ipaddr_t * src, uip_ipaddr_t * dest, uip_ipaddr_t * tgt)
+uip_nd6_ns_output(const uip_ipaddr_t * src, const uip_ipaddr_t * dest,
+                  uip_ipaddr_t * tgt)
 {
   uipbuf_clear();
   UIP_IP_BUF->vtc = 0x60;
@@ -702,7 +703,7 @@ discard:
 
 /*---------------------------------------------------------------------------*/
 void
-uip_nd6_ra_output(uip_ipaddr_t * dest)
+uip_nd6_ra_output(const uip_ipaddr_t * dest)
 {
 
   UIP_IP_BUF->vtc = 0x60;

--- a/os/net/ipv6/uip-nd6.h
+++ b/os/net/ipv6/uip-nd6.h
@@ -388,7 +388,8 @@ typedef struct uip_nd6_opt_redirected_hdr {
  *   a SLLAO option, otherwise no.
  */
 void
-uip_nd6_ns_output(uip_ipaddr_t *src, uip_ipaddr_t *dest, uip_ipaddr_t *tgt);
+uip_nd6_ns_output(const uip_ipaddr_t *src, const uip_ipaddr_t *dest,
+                  uip_ipaddr_t *tgt);
 
 #if UIP_CONF_ROUTER
 #if UIP_ND6_SEND_RA
@@ -397,7 +398,7 @@ uip_nd6_ns_output(uip_ipaddr_t *src, uip_ipaddr_t *dest, uip_ipaddr_t *tgt);
  *
  * Only for router, for periodic as well as sollicited RA
  */
-void uip_nd6_ra_output(uip_ipaddr_t *dest);
+void uip_nd6_ra_output(const uip_ipaddr_t *dest);
 #endif /* UIP_ND6_SEND_RA */
 #endif /*UIP_CONF_ROUTER*/
 

--- a/os/net/ipv6/uip-sr.c
+++ b/os/net/ipv6/uip-sr.c
@@ -66,7 +66,8 @@ uip_sr_num_nodes(void)
 }
 /*---------------------------------------------------------------------------*/
 static int
-node_matches_address(void *graph, const uip_sr_node_t *node, const uip_ipaddr_t *addr)
+node_matches_address(const void *graph, const uip_sr_node_t *node,
+                     const uip_ipaddr_t *addr)
 {
   if(node == NULL || addr == NULL || graph != node->graph) {
     return 0;
@@ -78,7 +79,7 @@ node_matches_address(void *graph, const uip_sr_node_t *node, const uip_ipaddr_t 
 }
 /*---------------------------------------------------------------------------*/
 uip_sr_node_t *
-uip_sr_get_node(void *graph, const uip_ipaddr_t *addr)
+uip_sr_get_node(const void *graph, const uip_ipaddr_t *addr)
 {
   uip_sr_node_t *l;
   for(l = list_head(nodelist); l != NULL; l = list_item_next(l)) {
@@ -91,7 +92,7 @@ uip_sr_get_node(void *graph, const uip_ipaddr_t *addr)
 }
 /*---------------------------------------------------------------------------*/
 int
-uip_sr_is_addr_reachable(void *graph, const uip_ipaddr_t *addr)
+uip_sr_is_addr_reachable(const void *graph, const uip_ipaddr_t *addr)
 {
   int max_depth = UIP_SR_LINK_NUM;
   uip_ipaddr_t root_ipaddr;
@@ -110,7 +111,8 @@ uip_sr_is_addr_reachable(void *graph, const uip_ipaddr_t *addr)
 }
 /*---------------------------------------------------------------------------*/
 void
-uip_sr_expire_parent(void *graph, const uip_ipaddr_t *child, const uip_ipaddr_t *parent)
+uip_sr_expire_parent(const void *graph, const uip_ipaddr_t *child,
+                     const uip_ipaddr_t *parent)
 {
   uip_sr_node_t *l = uip_sr_get_node(graph, child);
   /* Check if parent matches */
@@ -120,7 +122,8 @@ uip_sr_expire_parent(void *graph, const uip_ipaddr_t *child, const uip_ipaddr_t 
 }
 /*---------------------------------------------------------------------------*/
 uip_sr_node_t *
-uip_sr_update_node(void *graph, const uip_ipaddr_t *child, const uip_ipaddr_t *parent, uint32_t lifetime)
+uip_sr_update_node(void *graph, const uip_ipaddr_t *child,
+                   const uip_ipaddr_t *parent, uint32_t lifetime)
 {
   uip_sr_node_t *child_node = uip_sr_get_node(graph, child);
   uip_sr_node_t *parent_node = uip_sr_get_node(graph, parent);
@@ -197,7 +200,7 @@ uip_sr_node_head(void)
 }
 /*---------------------------------------------------------------------------*/
 uip_sr_node_t *
-uip_sr_node_next(uip_sr_node_t *item)
+uip_sr_node_next(const uip_sr_node_t *item)
 {
   return list_item_next(item);
 }
@@ -249,7 +252,7 @@ uip_sr_free_all(void)
 }
 /*---------------------------------------------------------------------------*/
 int
-uip_sr_link_snprint(char *buf, int buflen, uip_sr_node_t *link)
+uip_sr_link_snprint(char *buf, int buflen, const uip_sr_node_t *link)
 {
   int index = 0;
   uip_ipaddr_t child_ipaddr;

--- a/os/net/ipv6/uip-sr.h
+++ b/os/net/ipv6/uip-sr.h
@@ -116,7 +116,8 @@ int uip_sr_num_nodes(void);
  * \param child The IPv6 address of the child
  * \param parent The IPv6 address of the parent
 */
-void uip_sr_expire_parent(void *graph, const uip_ipaddr_t *child, const uip_ipaddr_t *parent);
+void uip_sr_expire_parent(const void *graph, const uip_ipaddr_t *child,
+                          const uip_ipaddr_t *parent);
 
 /**
  * Updates a child-parent link
@@ -126,7 +127,9 @@ void uip_sr_expire_parent(void *graph, const uip_ipaddr_t *child, const uip_ipad
  * \param parent The IPv6 address of the parent
  * \param lifetime The link lifetime in seconds
 */
-uip_sr_node_t *uip_sr_update_node(void *graph, const uip_ipaddr_t *child, const uip_ipaddr_t *parent, uint32_t lifetime);
+uip_sr_node_t *uip_sr_update_node(void *graph, const uip_ipaddr_t *child,
+                                  const uip_ipaddr_t *parent,
+                                  uint32_t lifetime);
 
 /**
  * Returns the head of the non-storing node list
@@ -141,7 +144,7 @@ uip_sr_node_t *uip_sr_node_head(void);
  * \param item The current element in the list
  * \return The next element of the list
 */
-uip_sr_node_t *uip_sr_node_next(uip_sr_node_t *item);
+uip_sr_node_t *uip_sr_node_next(const uip_sr_node_t *item);
 
 /**
  * Looks up for a source routing node from its IPv6 global address
@@ -150,7 +153,7 @@ uip_sr_node_t *uip_sr_node_next(uip_sr_node_t *item);
  * \param addr The target address
  * \return A pointer to the node
 */
-uip_sr_node_t *uip_sr_get_node(void *graph, const uip_ipaddr_t *addr);
+uip_sr_node_t *uip_sr_get_node(const void *graph, const uip_ipaddr_t *addr);
 
 /**
  * Telle whether an address is reachable, i.e. if there exists a path from
@@ -160,7 +163,7 @@ uip_sr_node_t *uip_sr_get_node(void *graph, const uip_ipaddr_t *addr);
  * \param addr The target IPv6 global address
  * \return 1 if the node is reachable, 0 otherwise
 */
-int uip_sr_is_addr_reachable(void *graph, const uip_ipaddr_t *addr);
+int uip_sr_is_addr_reachable(const void *graph, const uip_ipaddr_t *addr);
 
 /**
  * A function called periodically. Used to age the links (decrease lifetime
@@ -189,7 +192,7 @@ void uip_sr_free_all(void);
 * \return Identical to snprintf: number of bytes written excluding ending null
 * byte. A value >= buflen if the buffer was too small.
 */
-int uip_sr_link_snprint(char *buf, int buflen, uip_sr_node_t *link);
+int uip_sr_link_snprint(char *buf, int buflen, const uip_sr_node_t *link);
 
  /** @} */
 

--- a/os/net/mac/framer/frame802154.c
+++ b/os/net/mac/framer/frame802154.c
@@ -222,7 +222,7 @@ frame802154_check_dest_panid(frame802154_t *frame)
 /*---------------------------------------------------------------------------*/
 /* Check is the address is a broadcast address, whatever its size */
 int
-frame802154_is_broadcast_addr(uint8_t mode, uint8_t *addr)
+frame802154_is_broadcast_addr(uint8_t mode, const uint8_t *addr)
 {
   int i = mode == FRAME802154_SHORTADDRMODE ? 2 : 8;
   while(i-- > 0) {
@@ -466,7 +466,7 @@ frame802154_create(frame802154_t *p, uint8_t *buf)
 }
 
 void
-frame802154_parse_fcf(uint8_t *data, frame802154_fcf_t *pfcf)
+frame802154_parse_fcf(const uint8_t *data, frame802154_fcf_t *pfcf)
 {
   frame802154_fcf_t fcf;
 

--- a/os/net/mac/framer/frame802154.h
+++ b/os/net/mac/framer/frame802154.h
@@ -216,7 +216,7 @@ int frame802154_hdrlen(frame802154_t *p);
 void frame802154_create_fcf(frame802154_fcf_t *fcf, uint8_t *buf);
 int frame802154_create(frame802154_t *p, uint8_t *buf);
 int frame802154_parse(uint8_t *data, int length, frame802154_t *pf);
-void frame802154_parse_fcf(uint8_t *data, frame802154_fcf_t *pfcf);
+void frame802154_parse_fcf(const uint8_t *data, frame802154_fcf_t *pfcf);
 
 /* Get current PAN ID */
 uint16_t frame802154_get_pan_id(void);
@@ -228,7 +228,7 @@ void frame802154_has_panid(frame802154_fcf_t *fcf, int *has_src_pan_id, int *has
 /* Check if the destination PAN ID, if any, matches ours */
 int frame802154_check_dest_panid(frame802154_t *frame);
 /* Check is the address is a broadcast address, whatever its size */
-int frame802154_is_broadcast_addr(uint8_t mode, uint8_t *addr);
+int frame802154_is_broadcast_addr(uint8_t mode, const uint8_t *addr);
 /* Check and extract source and destination linkaddr from frame */
 int frame802154_extract_linkaddr(frame802154_t *frame, linkaddr_t *source_address, linkaddr_t *dest_address);
 

--- a/os/net/mac/framer/frame802154e-ie.c
+++ b/os/net/mac/framer/frame802154e-ie.c
@@ -160,7 +160,7 @@ frame80215e_create_ie_header_ack_nack_time_correction(uint8_t *buf, int len,
  * followed by payload IEs) */
 int
 frame80215e_create_ie_header_list_termination_1(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   int ie_len = 0;
   if(len >= 2 + ie_len && ies != NULL) {
@@ -175,7 +175,7 @@ frame80215e_create_ie_header_list_termination_1(uint8_t *buf, int len,
  * followed by an unformatted payload) */
 int
 frame80215e_create_ie_header_list_termination_2(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   int ie_len = 0;
   if(len >= 2 + ie_len && ies != NULL) {
@@ -189,7 +189,7 @@ frame80215e_create_ie_header_list_termination_2(uint8_t *buf, int len,
 /* Payload IE. List termination */
 int
 frame80215e_create_ie_payload_list_termination(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   int ie_len = 0;
   if(len >= 2 + ie_len && ies != NULL) {

--- a/os/net/mac/framer/frame802154e-ie.h
+++ b/os/net/mac/framer/frame802154e-ie.h
@@ -99,14 +99,14 @@ int frame80215e_create_ie_header_ack_nack_time_correction(uint8_t *buf, int len,
 /* Header IE. List termination 1 (Signals the end of the Header IEs when
  * followed by payload IEs) */
 int frame80215e_create_ie_header_list_termination_1(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 /* Header IE. List termination 2 (Signals the end of the Header IEs when
  * followed by an unformatted payload) */
 int frame80215e_create_ie_header_list_termination_2(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 /* Payload IE. List termination */
 int frame80215e_create_ie_payload_list_termination(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 #if TSCH_WITH_SIXTOP
 /* Payload IE. 6top. Used to nest sub-IEs */
 int frame80215e_create_ie_ietf(uint8_t *buf, int len,

--- a/os/net/mac/framer/nullframer.c
+++ b/os/net/mac/framer/nullframer.c
@@ -47,7 +47,7 @@
 
 /*---------------------------------------------------------------------------*/
 static int
-is_broadcast_addr(uint8_t mode, uint8_t *addr)
+is_broadcast_addr(uint8_t mode, const uint8_t *addr)
 {
   int i = mode == FRAME802154_SHORTADDRMODE ? 2 : 8;
   while(i-- > 0) {

--- a/os/net/nbr-table.c
+++ b/os/net/nbr-table.c
@@ -82,35 +82,35 @@ key_from_index(int index)
 /*---------------------------------------------------------------------------*/
 /* Get an item from its neighbor index */
 static nbr_table_item_t *
-item_from_index(nbr_table_t *table, int index)
+item_from_index(const nbr_table_t *table, int index)
 {
   return table != NULL && index != -1 ? (char *)table->data + index * table->item_size : NULL;
 }
 /*---------------------------------------------------------------------------*/
 /* Get the neighbor index of an item */
 static int
-index_from_key(nbr_table_key_t *key)
+index_from_key(const nbr_table_key_t *key)
 {
   return key != NULL ? key - (nbr_table_key_t *)neighbor_addr_mem.mem : -1;
 }
 /*---------------------------------------------------------------------------*/
 /* Get the neighbor index of an item */
 static int
-index_from_item(nbr_table_t *table, const nbr_table_item_t *item)
+index_from_item(const nbr_table_t *table, const nbr_table_item_t *item)
 {
   return table != NULL && item != NULL ? ((int)((char *)item - (char *)table->data)) / table->item_size : -1;
 }
 /*---------------------------------------------------------------------------*/
 /* Get an item from its key */
 static nbr_table_item_t *
-item_from_key(nbr_table_t *table, nbr_table_key_t *key)
+item_from_key(const nbr_table_t *table, const nbr_table_key_t *key)
 {
   return item_from_index(table, index_from_key(key));
 }
 /*---------------------------------------------------------------------------*/
 /* Get the key af an item */
 static nbr_table_key_t *
-key_from_item(nbr_table_t *table, const nbr_table_item_t *item)
+key_from_item(const nbr_table_t *table, const nbr_table_item_t *item)
 {
   return key_from_index(index_from_item(table, item));
 }
@@ -137,7 +137,8 @@ index_from_lladdr(const linkaddr_t *lladdr)
 /*---------------------------------------------------------------------------*/
 /* Get bit from "used" or "locked" bitmap */
 static int
-nbr_get_bit(uint8_t *bitmap, nbr_table_t *table, nbr_table_item_t *item)
+nbr_get_bit(const uint8_t *bitmap, const nbr_table_t *table,
+            const nbr_table_item_t *item)
 {
   int item_index = index_from_item(table, item);
   if(table != NULL && item_index != -1) {
@@ -150,7 +151,8 @@ nbr_get_bit(uint8_t *bitmap, nbr_table_t *table, nbr_table_item_t *item)
 /*---------------------------------------------------------------------------*/
 /* Set bit in "used" or "locked" bitmap */
 static int
-nbr_set_bit(uint8_t *bitmap, nbr_table_t *table, nbr_table_item_t *item, int value)
+nbr_set_bit(uint8_t *bitmap, const nbr_table_t *table,
+            const nbr_table_item_t *item, int value)
 {
   int item_index = index_from_item(table, item);
 
@@ -229,15 +231,17 @@ nbr_table_gc_get_worst(const linkaddr_t *lladdr1, const linkaddr_t *lladdr2)
 }
 /*---------------------------------------------------------------------------*/
 bool
-nbr_table_can_accept_new(const linkaddr_t *new, const linkaddr_t *candidate_for_removal,
-                         nbr_table_reason_t reason, void *data)
+nbr_table_can_accept_new(const linkaddr_t *new,
+                         const linkaddr_t *candidate_for_removal,
+                         nbr_table_reason_t reason, const void *data)
 {
   /* Default behavior: if full, always replace worst entry. */
   return true;
 }
 /*---------------------------------------------------------------------------*/
 static const linkaddr_t *
-select_for_removal(const linkaddr_t *new, nbr_table_reason_t reason, void *data)
+select_for_removal(const linkaddr_t *new, nbr_table_reason_t reason,
+                   const void *data)
 {
   nbr_table_key_t *k;
   const linkaddr_t *worst_lladdr = NULL;
@@ -265,8 +269,8 @@ select_for_removal(const linkaddr_t *new, nbr_table_reason_t reason, void *data)
 }
 /*---------------------------------------------------------------------------*/
 static bool
-entry_is_allowed(nbr_table_t *table, const linkaddr_t *lladdr,
-                 nbr_table_reason_t reason, void *data,
+entry_is_allowed(const nbr_table_t *table, const linkaddr_t *lladdr,
+                 nbr_table_reason_t reason, const void *data,
                  const linkaddr_t **to_be_removed_ptr)
 {
   bool ret;
@@ -292,14 +296,15 @@ entry_is_allowed(nbr_table_t *table, const linkaddr_t *lladdr,
 }
 /*---------------------------------------------------------------------------*/
 bool
-nbr_table_entry_is_allowed(nbr_table_t *table, const linkaddr_t *lladdr,
-                           nbr_table_reason_t reason, void *data)
+nbr_table_entry_is_allowed(const nbr_table_t *table, const linkaddr_t *lladdr,
+                           nbr_table_reason_t reason, const void *data)
 {
   return entry_is_allowed(table, lladdr, reason, data, NULL);
 }
 /*---------------------------------------------------------------------------*/
 static nbr_table_key_t *
-nbr_table_allocate(nbr_table_reason_t reason, void *data, const linkaddr_t *to_be_removed_lladdr)
+nbr_table_allocate(nbr_table_reason_t reason, const void *data,
+                   const linkaddr_t *to_be_removed_lladdr)
 {
   nbr_table_key_t *new = memb_alloc(&neighbor_addr_mem);
   if(new != NULL) {
@@ -349,7 +354,7 @@ nbr_table_register(nbr_table_t *table, nbr_table_callback *callback)
 /*---------------------------------------------------------------------------*/
 /* Test whether a specified table has been registered or not */
 int
-nbr_table_is_registered(nbr_table_t *table)
+nbr_table_is_registered(const nbr_table_t *table)
 {
   if(table != NULL && table->index >= 0 && table->index < MAX_NUM_TABLES
                    && all_tables[table->index] == table) {
@@ -360,7 +365,7 @@ nbr_table_is_registered(nbr_table_t *table)
 /*---------------------------------------------------------------------------*/
 /* Returns the first item of the current table */
 nbr_table_item_t *
-nbr_table_head(nbr_table_t *table)
+nbr_table_head(const nbr_table_t *table)
 {
   /* Get item from first key */
   nbr_table_item_t *item = item_from_key(table, list_head(nbr_table_keys));
@@ -374,7 +379,7 @@ nbr_table_head(nbr_table_t *table)
 /*---------------------------------------------------------------------------*/
 /* Iterates over the current table */
 nbr_table_item_t *
-nbr_table_next(nbr_table_t *table, nbr_table_item_t *item)
+nbr_table_next(const nbr_table_t *table, nbr_table_item_t *item)
 {
   do {
     void *key = key_from_item(table, item);
@@ -387,7 +392,8 @@ nbr_table_next(nbr_table_t *table, nbr_table_item_t *item)
 /*---------------------------------------------------------------------------*/
 /* Add a neighbor indexed with its link-layer address */
 nbr_table_item_t *
-nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr, nbr_table_reason_t reason, void *data)
+nbr_table_add_lladdr(const nbr_table_t *table, const linkaddr_t *lladdr,
+                     nbr_table_reason_t reason, const void *data)
 {
   int index;
   nbr_table_item_t *item;
@@ -443,7 +449,7 @@ nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr, nbr_table_rea
 /*---------------------------------------------------------------------------*/
 /* Get an item from its link-layer address */
 void *
-nbr_table_get_from_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
+nbr_table_get_from_lladdr(const nbr_table_t *table, const linkaddr_t *lladdr)
 {
   void *item = item_from_index(table, index_from_lladdr(lladdr));
   return nbr_get_bit(used_map, table, item) ? item : NULL;
@@ -451,7 +457,7 @@ nbr_table_get_from_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
 /*---------------------------------------------------------------------------*/
 /* Removes a neighbor from the current table (unset "used" bit) */
 int
-nbr_table_remove(nbr_table_t *table, void *item)
+nbr_table_remove(const nbr_table_t *table, const void *item)
 {
   int ret = nbr_set_bit(used_map, table, item, 0);
   nbr_set_bit(locked_map, table, item, 0);
@@ -460,7 +466,7 @@ nbr_table_remove(nbr_table_t *table, void *item)
 /*---------------------------------------------------------------------------*/
 /* Lock a neighbor for the current table (set "locked" bit) */
 int
-nbr_table_lock(nbr_table_t *table, void *item)
+nbr_table_lock(const nbr_table_t *table, const void *item)
 {
 #if DEBUG
   int i = index_from_item(table, item);
@@ -471,7 +477,7 @@ nbr_table_lock(nbr_table_t *table, void *item)
 /*---------------------------------------------------------------------------*/
 /* Release the lock on a neighbor for the current table (unset "locked" bit) */
 int
-nbr_table_unlock(nbr_table_t *table, void *item)
+nbr_table_unlock(const nbr_table_t *table, const void *item)
 {
 #if DEBUG
   int i = index_from_item(table, item);
@@ -482,7 +488,7 @@ nbr_table_unlock(nbr_table_t *table, void *item)
 /*---------------------------------------------------------------------------*/
 /* Get link-layer address of an item */
 linkaddr_t *
-nbr_table_get_lladdr(nbr_table_t *table, const void *item)
+nbr_table_get_lladdr(const nbr_table_t *table, const void *item)
 {
   nbr_table_key_t *key = key_from_item(table, item);
   return key != NULL ? &key->lladdr : NULL;
@@ -505,7 +511,7 @@ nbr_table_key_head(void)
 }
 /*---------------------------------------------------------------------------*/
 nbr_table_key_t *
-nbr_table_key_next(nbr_table_key_t *key)
+nbr_table_key_next(const nbr_table_key_t *key)
 {
   return list_item_next(key);
 }

--- a/os/net/nbr-table.h
+++ b/os/net/nbr-table.h
@@ -67,9 +67,11 @@ typedef enum {
 #define NBR_TABLE_CAN_ACCEPT_NEW nbr_table_can_accept_new
 #endif /* NBR_TABLE_CONF_CAN_ACCEPT_NEW */
 
-const linkaddr_t *NBR_TABLE_GC_GET_WORST(const linkaddr_t *lladdr1, const linkaddr_t *lladdr2);
-bool NBR_TABLE_CAN_ACCEPT_NEW(const linkaddr_t *new, const linkaddr_t *candidate_for_removal,
-                              nbr_table_reason_t reason, void *data);
+const linkaddr_t *NBR_TABLE_GC_GET_WORST(const linkaddr_t *lladdr1,
+                                         const linkaddr_t *lladdr2);
+bool NBR_TABLE_CAN_ACCEPT_NEW(const linkaddr_t *new,
+                              const linkaddr_t *candidate_for_removal,
+                              nbr_table_reason_t reason, const void *data);
 
 /* An item in a neighbor table */
 typedef void nbr_table_item_t;
@@ -109,36 +111,43 @@ typedef struct nbr_table_key {
 /** \name Neighbor tables: register and loop through table elements */
 /** @{ */
 int nbr_table_register(nbr_table_t *table, nbr_table_callback *callback);
-int nbr_table_is_registered(nbr_table_t *table);
-nbr_table_item_t *nbr_table_head(nbr_table_t *table);
-nbr_table_item_t *nbr_table_next(nbr_table_t *table, nbr_table_item_t *item);
+int nbr_table_is_registered(const nbr_table_t *table);
+nbr_table_item_t *nbr_table_head(const nbr_table_t *table);
+nbr_table_item_t *nbr_table_next(const nbr_table_t *table,
+                                 nbr_table_item_t *item);
 /** @} */
 
 /** \name Neighbor tables: add and get data */
 /** @{ */
-nbr_table_item_t *nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr, nbr_table_reason_t reason, void *data);
-nbr_table_item_t *nbr_table_get_from_lladdr(nbr_table_t *table, const linkaddr_t *lladdr);
+nbr_table_item_t *nbr_table_add_lladdr(const nbr_table_t *table,
+                                       const linkaddr_t *lladdr,
+                                       nbr_table_reason_t reason,
+                                       const void *data);
+nbr_table_item_t *nbr_table_get_from_lladdr(const nbr_table_t *table,
+                                            const linkaddr_t *lladdr);
 /** @} */
 
 /** \name Neighbor tables: set flags (unused, locked, unlocked) */
 /** @{ */
-int nbr_table_remove(nbr_table_t *table, nbr_table_item_t *item);
-int nbr_table_lock(nbr_table_t *table, nbr_table_item_t *item);
-int nbr_table_unlock(nbr_table_t *table, nbr_table_item_t *item);
+int nbr_table_remove(const nbr_table_t *table, const nbr_table_item_t *item);
+int nbr_table_lock(const nbr_table_t *table, const nbr_table_item_t *item);
+int nbr_table_unlock(const nbr_table_t *table, const nbr_table_item_t *item);
 /** @} */
 
 /** \name Neighbor tables: address manipulation */
 /** @{ */
-linkaddr_t *nbr_table_get_lladdr(nbr_table_t *table, const nbr_table_item_t *item);
+linkaddr_t *nbr_table_get_lladdr(const nbr_table_t *table,
+                                 const nbr_table_item_t *item);
 /** @} */
 
 /** \name Neighbor tables: other */
 /** @{ */
 void nbr_table_clear(void);
-bool nbr_table_entry_is_allowed(nbr_table_t *table, const linkaddr_t *lladdr,
-                                nbr_table_reason_t reason, void *data);
+bool nbr_table_entry_is_allowed(const nbr_table_t *table,
+                                const linkaddr_t *lladdr,
+                                nbr_table_reason_t reason, const void *data);
 nbr_table_key_t *nbr_table_key_head(void);
-nbr_table_key_t *nbr_table_key_next(nbr_table_key_t *key);
+nbr_table_key_t *nbr_table_key_next(const nbr_table_key_t *key);
 int nbr_table_count_entries(void);
 
 /** @} */

--- a/os/net/routing/rpl-classic/rpl-nbr-policy.c
+++ b/os/net/routing/rpl-classic/rpl-nbr-policy.c
@@ -98,7 +98,7 @@ can_accept_new_parent(const linkaddr_t *candidate_for_removal, rpl_dio_t *dio)
 /*---------------------------------------------------------------------------*/
 bool
 rpl_nbr_can_accept_new(const linkaddr_t *new, const linkaddr_t *candidate_for_removal,
-                       nbr_table_reason_t reason, void *data)
+                       nbr_table_reason_t reason, const void *data)
 {
   bool accept;
   switch(reason) {

--- a/os/sys/process.c
+++ b/os/sys/process.c
@@ -121,7 +121,7 @@ process_start(struct process *p, process_data_t data)
 }
 /*---------------------------------------------------------------------------*/
 static void
-exit_process(struct process *p, struct process *fromprocess)
+exit_process(struct process *p, const struct process *fromprocess)
 {
   register struct process *q;
   struct process *old_current = process_current;

--- a/tests/10-ipv6-nbr/nbr-multi-addrs/test.c
+++ b/tests/10-ipv6-nbr/nbr-multi-addrs/test.c
@@ -65,7 +65,7 @@ my_test_print(const unit_test_t *utp)
 /* NBR_TABLE_CONF_CAN_ACCEPT_NEW is set to rpl_nbr_can_accept_new() */
 bool
 reject_if_full(const linkaddr_t *new, const linkaddr_t *candidate_for_removal,
-                       nbr_table_reason_t reason, void *data)
+                       nbr_table_reason_t reason, const void *data)
 {
   return candidate_for_removal == NULL;
 }

--- a/tests/13-ieee802154/code-6tisch/common.c
+++ b/tests/13-ieee802154/code-6tisch/common.c
@@ -48,7 +48,7 @@ static void *mac_sent_callback_arg;
 /* NBR_TABLE_CONF_CAN_ACCEPT_NEW is set to rpl_nbr_can_accept_new() */
 bool
 reject_if_full(const linkaddr_t *new, const linkaddr_t *candidate_for_removal,
-                       nbr_table_reason_t reason, void *data)
+                       nbr_table_reason_t reason, const void *data)
 {
   return candidate_for_removal == NULL;
 }


### PR DESCRIPTION
Latest version of cppcheck added some additional checks for missing consts, which this PR corrects.

* I noticed all the list libraries consistently avoid the suggested consts, so maybe there is a rationale I am missing
* I put nbr-table in a separate commit because 1) The semantic of several functions might become confusing: E.g. functions to lock, unlock, remove, etc. now take _only_ const parameters, 2) I am not sure if the `data` parameter in misc. nbr-table functions are intended to allow for modification, and 3) I myself added some missing consts not found by cppcheck
* Added commit 4e07c47f20057827bec40a916a49584027e2e161 from https://github.com/contiki-ng/contiki-ng/pull/1502 since that commit is ready, while the rest of the PR needs some more attention.

A quick test reveals a handful of bytes are saved on code-size