### PR TITLE
nrf52840: configure serial-line (and shell) for USB when native USB is enabled

### DIFF
--- a/arch/platform/nrf52840/platform.c
+++ b/arch/platform/nrf52840/platform.c
@@ -113,6 +113,10 @@ platform_init_stage_two(void)
 
 #if NRF52840_NATIVE_USB
   usb_serial_init();
+  serial_line_init();
+#if BUILD_WITH_SHELL
+  usb_serial_set_input(serial_line_input_byte);
+#endif
 #endif
 
 #if NRF52840_USB_DFU_TRIGGER


### PR DESCRIPTION
Configure serial-line to use USB instead of UART0 when native USB is enabled. dbg-io is already configured to output via USB when native USB is enabled.