### PR TITLE
Enable nvmc flash storage for target nrf52840

### DIFF
--- a/arch/cpu/nrf52840/Makefile.nrf52840
+++ b/arch/cpu/nrf52840/Makefile.nrf52840
@@ -58,6 +58,20 @@ LDFLAGS += -mabi=aapcs -mfloat-abi=hard -mfpu=fpv4-sp-d16
 LDFLAGS += --specs=nano.specs -lc -lnosys
 LDFLAGS += -L $(NRF5_SDK_ROOT)/modules/nrfx/mdk
 
+# enable nvmc flash driver for nrf52840
+ifeq ($(NRF52840_USE_NVMC_FLASH),1)
+  CFLAGS += -DNRF_FSTORAGE_ENABLED=1
+  CFLAGS += -DNRF_FSTORAGE_PARAM_CHECK_DISABLED=0
+  
+  NRF52_SDK_C_SRCS += components/libraries/fstorage/nrf_fstorage.c \
+  components/libraries/fstorage/nrf_fstorage_nvmc.c \
+  components/libraries/atomic/nrf_atomic.c \
+  modules/nrfx/hal/nrf_nvmc.c
+  
+  NRF52_SDK_INC_PATHS += components/libraries/fstorage
+  NRF52_SDK_INC_PATHS += components/libraries/atomic
+endif
+
 # nRF52 SDK sources
 NRF52_SDK_C_SRCS += components/boards/boards.c \
   components/libraries/util/app_error.c \

--- a/examples/platform-specific/nrf52840/nvmc_flash/Makefile
+++ b/examples/platform-specific/nrf52840/nvmc_flash/Makefile
@@ -1,0 +1,13 @@
+
+ifndef TARGET
+	TARGET=nrf52840
+	BOARD=dk
+	NRF52840_USE_NVMC_FLASH=1
+endif
+
+CONTIKI_PROJECT = nrf52840_nvmc_flash
+all: $(CONTIKI_PROJECT)
+upload: $(CONTIKI_PROJECT).upload
+
+CONTIKI = ../../../..
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/nrf52840/nvmc_flash/README.md
+++ b/examples/platform-specific/nrf52840/nvmc_flash/README.md
@@ -1,0 +1,19 @@
+A minimal Contiki-NG example, simple printing out "Hello, world".
+This example runs a full IPv6 stack with 6LoWPAN and RPL.
+It is possible, for example to ping such a node:
+
+```
+make TARGET=native && sudo ./hello-world.native
+```
+
+Look for the node's global IPv6, e.g.:
+```
+[INFO: Native    ] Added global IPv6 address fd00::302:304:506:708
+```
+
+And ping it (over the tun interface):
+```
+$ ping6 fd00::302:304:506:708
+PING fd00::302:304:506:708(fd00::302:304:506:708) 56 data bytes
+64 bytes from fd00::302:304:506:708: icmp_seq=1 ttl=64 time=0.289 ms
+```

--- a/examples/platform-specific/nrf52840/nvmc_flash/README.md
+++ b/examples/platform-specific/nrf52840/nvmc_flash/README.md
@@ -1,19 +1,24 @@
-A minimal Contiki-NG example, simple printing out "Hello, world".
-This example runs a full IPv6 stack with 6LoWPAN and RPL.
-It is possible, for example to ping such a node:
+NVMC Flash Example
+===================
+This examples shows how you can use the flash memory from the nrf52840 chip.
+The chip allows to use the flash memory either via the softdevice or via nvmc (non volatile memory controller).
+We have focused on the second approach, hence this example does not use the softdevice at all.
 
-```
-make TARGET=native && sudo ./hello-world.native
+It will initialize the flash memory modules and write with an successive read an increasing counter at address 0xFD000.
+There will be an 10 second break between each read/write cycle.
+
+The example requires one DK and it doesn't use SoftDevice. To compile and flash the
+example run:
+
+```bash
+# compile
+make TARGET=nrf52840 BOARD=dk NRF52840_USE_NVMC_FLASH=1 all
+# flash
+make TARGET=nrf52840 BOARD=dk NRF52840_USE_NVMC_FLASH=1 all
 ```
 
-Look for the node's global IPv6, e.g.:
-```
-[INFO: Native    ] Added global IPv6 address fd00::302:304:506:708
-```
-
-And ping it (over the tun interface):
-```
-$ ping6 fd00::302:304:506:708
-PING fd00::302:304:506:708(fd00::302:304:506:708) 56 data bytes
-64 bytes from fd00::302:304:506:708: icmp_seq=1 ttl=64 time=0.289 ms
+The makefile will source the properties TARGET,BOARD and NRF52840_USE_NVMC_FLASH automatically, so feel free also to use the shortcut:
+```bash
+make all
+make upload
 ```

--- a/examples/platform-specific/nrf52840/nvmc_flash/nrf52840_nvmc_flash.c
+++ b/examples/platform-specific/nrf52840/nvmc_flash/nrf52840_nvmc_flash.c
@@ -1,0 +1,161 @@
+/**
+ * \file
+ *         Simple contiki-ng program, which writes and reads data from the
+ *         nrf52840 flash memory via nvmc (non volatile memory controller)
+ *         Example based on: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fsdk_nrf5_v16.0.0%2Flib_fstorage.html
+ *
+ *         This example will always update the same memory location, thus
+ *         we need to erase the flash page everytime before we update the
+ *         memory location.
+ *
+ * \author
+ *         Andreas Karner <andreas.karner[at]student.tugraz.at
+ */
+
+#include "contiki.h"
+#include <stdio.h>
+
+// makefile will source them if NRF52840_USE_NVMC_FLASH is set
+#include <nrf_fstorage.h>
+#include "nrf_drv_clock.h"
+#include "nrf_fstorage_nvmc.h"
+
+/*---------------------------------------------------------------------------*/
+PROCESS(simple_nrf52840_nvmc_flash, "Simple nvmc flash example on nrf52840");
+AUTOSTART_PROCESSES(&simple_nrf52840_nvmc_flash);
+/*---------------------------------------------------------------------------*/
+
+/*
+ * Define callbacks for fstorage events
+ */
+static void flash_callback(nrf_fstorage_evt_t *p_evt)
+{
+  if (p_evt->result != NRF_SUCCESS)
+  {
+    printf("Flash storage operation failed\n");
+    return;
+  }
+
+  switch (p_evt->id)
+  {
+  case NRF_FSTORAGE_EVT_WRITE_RESULT:
+  {
+    printf("Event received: wrote %ld bytes at address 0x%lx.\n",
+           p_evt->len, p_evt->addr);
+  }
+  break;
+
+  case NRF_FSTORAGE_EVT_ERASE_RESULT:
+  {
+    printf("Event received: erased %ld page from address 0x%lx.\n",
+           p_evt->len, p_evt->addr);
+  }
+  // unused event
+  // case NRF_FSTORAGE_EVT_READ_RESULT:
+  break;
+
+  default:
+    break;
+  }
+}
+
+/*
+ * The erase size for the chip nrf52840 is set to 4096 for nvmc
+ * So we can assume a page is exactly 4096 bytes big
+ * Because we will only write and update always the same
+ * value, let's request a single page.
+ */
+NRF_FSTORAGE_DEF(nrf_fstorage_t flash_instance) =
+    {
+        .evt_handler = flash_callback,
+        .start_addr = 0xFD000,
+        .end_addr = 0xFE000,
+};
+
+/*
+ * This is the address in flash were data will be written.
+ */
+#define FLASH_ADDR 0xFD000
+
+static struct etimer timer;
+static uint32_t write_num = 10;
+static uint32_t read_num = 0;
+static ret_code_t flash_ret = 0;
+
+PROCESS_THREAD(simple_nrf52840_nvmc_flash, ev, data)
+{
+
+  PROCESS_BEGIN();
+
+  printf("Simple nrf52840 nvmc flash example started\n");
+  printf("It will write every 10 seconds a new value\n");
+
+  // init fstorage properly
+  nrf_fstorage_init(
+      &flash_instance,    /* You fstorage instance, previously defined. */
+      &nrf_fstorage_nvmc, /* Name of the backend. -> we use nvmc*/
+      NULL                /* Optional parameter, backend-dependant. */
+  );
+
+  etimer_set(&timer, CLOCK_SECOND * 10);
+
+  while (1)
+  {
+    // because we always update the same value postion in flash,
+    // we need to erase it first
+    // if you do not need to update the value, no erase is needed
+    flash_ret = nrf_fstorage_erase(
+        &flash_instance, /* The instance to use. */
+        FLASH_ADDR,      /* The address to start erasing*/
+        1,               /* Number of pages to erase */
+        NULL             /* Optional parameter, backend-dependend.*/
+    );
+    if (NRF_SUCCESS == flash_ret)
+    {
+      printf("Erased page successfully, start writting stuff\n");
+
+      // four bytes (uint32_t) is the smallest unit which can be written with this lib
+      flash_ret = nrf_fstorage_write(
+          &flash_instance,   /* The instance to use. */
+          FLASH_ADDR,        /* The address in flash where to store the data. */
+          &write_num,        /* A pointer to the data. */
+          sizeof(write_num), /* Length of the data, in bytes. */
+          NULL               /* Optional parameter, backend-dependent. */
+      );
+      if (NRF_SUCCESS == flash_ret)
+      {
+        printf("Written value %ld successfully to flash memory\n", write_num++);
+
+        // four bytes (uint32_t) is the smallest unit which can be read with this lib
+        flash_ret = nrf_fstorage_read(
+            &flash_instance, /* The instance to use. */
+            FLASH_ADDR,      /* The address in flash where to read data from. */
+            &read_num,       /* A buffer to copy the data into. */
+            sizeof(read_num) /* Length of the data, in bytes. */
+        );
+        if (NRF_SUCCESS == flash_ret)
+        {
+          printf("Successfully read value: %ld\n", read_num);
+        }
+        else
+        {
+          printf("Failed to read value from flash memory\n");
+        }
+      }
+      else
+      {
+        printf("Failed to write value to flash memory\n");
+      }
+    }
+    else
+    {
+      printf("Failed to erase page\n");
+    }
+
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+    etimer_reset(&timer);
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/rssi_classifier
+++ b/examples/rssi_classifier
@@ -1,1 +1,0 @@
-/home/akarner/tulocal/prj_andreas_karner/workspace/rssi_classifier

--- a/examples/rssi_classifier
+++ b/examples/rssi_classifier
@@ -1,0 +1,1 @@
+/home/akarner/tulocal/prj_andreas_karner/workspace/rssi_classifier


### PR DESCRIPTION
Adjusted makefile to include nvmc flash storage files for target nrf52840 if the value NRF52840_USE_NVMC_FLASH is set in the local project makefile. In addition, I have added an example to ./examples/platform-specific/nrf52840/nvmc_flash/ directory.