### PR TITLE
feat: radio test mode for cc2650 launchpad

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/rf-core/rf-core.h
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/rf-core.h
@@ -316,6 +316,8 @@ typedef struct rf_core_primary_mode_s {
 /* How long to wait for the RF to finish TX of a packet or an ACK */
 #define RF_CORE_TX_FINISH_TIMEOUT (RTIMER_SECOND >> 7)
 
+/* How long to wait for the RF to set up test mode: around 0.1 msec */
+#define RF_CORE_TEST_MODE_TIMEOUT (RTIMER_SECOND >> 14)
 /*---------------------------------------------------------------------------*/
 /* Make the main driver process visible to mode drivers */
 PROCESS_NAME(rf_core_process);

--- a/examples/platform-specific/cc26x0-cc13x0/radio-test-mode/Makefile
+++ b/examples/platform-specific/cc26x0-cc13x0/radio-test-mode/Makefile
@@ -1,0 +1,15 @@
+CONTIKI_PROJECT = radio-test-mode
+
+-include $(CONTIKI)/Makefile.identify-target
+
+MODULES_REL += $(TARGET)
+
+MAKE_MAC = MAKE_MAC_NULLMAC
+MAKE_NET = MAKE_NET_NULLNET
+
+PLATFORMS_ONLY = cc26x0-cc13x0
+
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../../..
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/cc26x0-cc13x0/radio-test-mode/project-conf.h
+++ b/examples/platform-specific/cc26x0-cc13x0/radio-test-mode/project-conf.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+/*---------------------------------------------------------------------------*/
+/* Enable the ROM bootloader */
+#define CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE   1
+/*---------------------------------------------------------------------------*/
+/* Change to match your configuration */
+#define IEEE802154_CONF_PANID            0xABCD
+#define IEEE802154_CONF_DEFAULT_CHANNEL      25
+#define RF_BLE_CONF_ENABLED                   1
+
+#define LOG_CONF_LEVEL_MAC        LOG_LEVEL_DBG
+/*---------------------------------------------------------------------------*/
+#endif /* PROJECT_CONF_H_ */
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/cc26x0-cc13x0/radio-test-mode/radio-test-mode.c
+++ b/examples/platform-specific/cc26x0-cc13x0/radio-test-mode/radio-test-mode.c
@@ -1,0 +1,61 @@
+#include "contiki.h"
+#include "dev/leds.h"
+#include "net/netstack.h"
+#include "packetbuf.h"
+#include "sys/log.h"
+#include <string.h>
+#include <stdio.h>
+
+#define LOG_MODULE "TEST-MODE"
+
+#define SEND_INTERVAL CLOCK_SECOND
+
+PROCESS(radio_test_mode, "CC2650 Radio Test Mode");
+AUTOSTART_PROCESSES(&radio_test_mode);
+
+PROCESS_THREAD(radio_test_mode, ev, data)
+{
+  static struct etimer periodic_timer;
+
+  PROCESS_BEGIN();
+
+  static int configuration[3];
+  configuration[0] = 25; // Channel
+  configuration[1] = 0;  // Power [0(5 dBm) - 12(-21 dBm)]
+  configuration[2] = 0;  // Modulated carrier or not
+
+  etimer_set(&periodic_timer, SEND_INTERVAL);
+  static bool carrier_on = true;
+  static int power_level = 0;
+
+  while(1) {
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&periodic_timer));
+    radio_result_t response;
+    if (carrier_on) {
+      configuration[1] = power_level;
+      response = NETSTACK_CONF_RADIO.set_object(RADIO_POWER_MODE_CARRIER_ON, configuration, 3);
+      if (response == RADIO_RESULT_OK) {
+        leds_on(LEDS_GREEN);
+        leds_off(LEDS_RED);
+      } else if (response == RADIO_RESULT_INVALID_VALUE || response == RADIO_RESULT_ERROR) {
+        leds_on(LEDS_RED);
+        leds_off(LEDS_GREEN);
+      }
+      power_level++;
+      if (power_level > 12) power_level = 0;
+    } else {
+      response = NETSTACK_CONF_RADIO.set_object(RADIO_POWER_MODE_CARRIER_OFF, configuration, 3);
+      if (response == RADIO_RESULT_OK) {
+        leds_off(LEDS_RED);
+      } else if (response == RADIO_RESULT_INVALID_VALUE || response == RADIO_RESULT_ERROR) {
+        leds_on(LEDS_RED);
+      }
+      leds_off(LEDS_GREEN);
+    }
+    carrier_on = !carrier_on;
+    etimer_reset(&periodic_timer);
+  }
+
+  PROCESS_END();
+}
+


### PR DESCRIPTION
This PR introduces radio test mode option to CC2650 LaunchPad devices.

Along with the functionality implemented in `ieee-mode.c`, an example sketch is made available in the directory `examples/platform-specific/cc26x0-cc13x0/radio-test-mode`. Following figure shows the signal capture from Texas Instruments SmartRF Studio of a periodic test-mode generator using the example sketch.

Parameters used in this source code is influenced from the code export feature in Smart RF Studio.

<img width="1197" alt="Signal capture from SmartRF Studio" src="https://user-images.githubusercontent.com/14261304/155730529-906d4ec5-153c-4862-893a-eb3e921c949f.png">
