### PR TITLE
Fixes to simplelink GPIO HAL

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.c
@@ -54,6 +54,26 @@ static PIN_Config pin_config[] = { PIN_TERMINATE };
 static PIN_State pin_state;
 static PIN_Handle pin_handle;
 /*---------------------------------------------------------------------------*/
+/**< PIN standard input configuration mimicking IOC_STD_INPUT */
+#define GPIO_HAL_PIN_STD_INPUT      (PIN_INPUT_EN | PIN_GPIO_OUTPUT_DIS | \
+                                     PIN_NOPULL | PIN_DRVSTR_MIN | PIN_IRQ_DIS)
+
+/**< PIN standard input configuration bitmask */
+#define GPIO_HAL_PIN_STD_INPUT_BM   (PIN_BM_INPUT_EN | PIN_BM_GPIO_OUTPUT_EN | \
+                                     PIN_BM_PULLING | PIN_BM_INV_INOUT | \
+                                     PIN_BM_DRVSTR | PIN_BM_SLEWCTRL | \
+                                     PIN_BM_HYSTERESIS | PIN_BM_IRQ)
+
+/**< PIN standard input configuration mimicking IOC_STD_OUTPUT */
+#define GPIO_HAL_PIN_STD_OUTPUT     (PIN_INPUT_DIS | PIN_GPIO_OUTPUT_EN | \
+                                     PIN_NOPULL | PIN_DRVSTR_MIN | PIN_IRQ_DIS)
+
+/**< PIN standard output configuration bitmask */
+#define GPIO_HAL_PIN_STD_OUTPUT_BM  (PIN_BM_INPUT_EN | PIN_BM_GPIO_OUTPUT_EN | \
+                                     PIN_BM_PULLING | PIN_BM_INV_INOUT | \
+                                     PIN_BM_DRVSTR | PIN_BM_SLEWCTRL | \
+                                     PIN_BM_HYSTERESIS | PIN_BM_IRQ)
+/*---------------------------------------------------------------------------*/
 static void
 from_hal_cfg(gpio_hal_pin_cfg_t cfg, PIN_Config *pin_cfg, PIN_Config *pin_mask)
 {
@@ -146,9 +166,37 @@ gpio_hal_arch_init(void)
   PIN_registerIntCb(pin_handle, gpio_int_cb);
 }
 /*---------------------------------------------------------------------------*/
+
+void
+gpio_hal_arch_no_port_pin_set_input(gpio_hal_pin_t pin)
+{
+  PIN_add(pin_handle, PIN_getConfig(pin));
+
+  /* Configure pin as standard input */
+  PIN_Config pin_cfg = GPIO_HAL_PIN_STD_INPUT | pin;
+  PIN_Config pin_mask = GPIO_HAL_PIN_STD_INPUT_BM;
+
+  PIN_setConfig(pin_handle, pin_mask, pin_cfg);
+}
+/*---------------------------------------------------------------------------*/
+void gpio_hal_arch_no_port_pin_set_output(gpio_hal_pin_t pin)
+{
+  PIN_add(pin_handle, PIN_getConfig(pin));
+
+  /* Configure pin as standard output */
+  PIN_Config pin_cfg = GPIO_HAL_PIN_STD_OUTPUT | pin;
+  PIN_Config pin_mask = GPIO_HAL_PIN_STD_OUTPUT_BM;
+  PIN_setConfig(pin_handle, pin_mask, pin_cfg);
+}
+/*---------------------------------------------------------------------------*/
 void
 gpio_hal_arch_no_port_interrupt_enable(gpio_hal_pin_t pin)
 {
+  /*
+   * This requires pin cfg already set with GPIO_HAL_PIN_CFG_INT_ENABLE,
+   * i.e. enabled interrupts, thus making this function redundant.
+   * Might be fixed if switching to GPIO or GPIO++ lib. instead of PIN.
+   */
   PIN_Config pin_cfg;
   PIN_Config irq_cfg;
 
@@ -164,6 +212,10 @@ gpio_hal_arch_no_port_interrupt_disable(gpio_hal_pin_t pin)
 {
   PIN_add(pin_handle, PIN_getConfig(pin));
 
+  /*
+   * This removes all IRQ config., thus pin cfg must be set again to
+   * re-enable interrupts.
+   */
   PIN_setInterrupt(pin_handle, pin | PIN_IRQ_DIS);
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.c
@@ -101,7 +101,7 @@ to_hal_cfg(PIN_Config pin_cfg, gpio_hal_pin_cfg_t *cfg)
     }
 
     /* Pulling config */
-    switch(pin_cfg & PIN_BM_PULLING) {
+    switch(pin_cfg & (PIN_GEN | PIN_BM_PULLING)) {
     case PIN_NOPULL:   *cfg |= GPIO_HAL_PIN_CFG_PULL_NONE; break;
     case PIN_PULLUP:   *cfg |= GPIO_HAL_PIN_CFG_PULL_UP;   break;
     case PIN_PULLDOWN: *cfg |= GPIO_HAL_PIN_CFG_PULL_DOWN; break;
@@ -111,7 +111,7 @@ to_hal_cfg(PIN_Config pin_cfg, gpio_hal_pin_cfg_t *cfg)
   /* Interrupt config */
   if(pin_cfg & PIN_BM_IRQ) {
     /* Interrupt edge config */
-    switch(pin_cfg & PIN_BM_IRQ) {
+    switch(pin_cfg & (PIN_GEN | PIN_BM_IRQ)) {
     case PIN_IRQ_DIS:       *cfg |= GPIO_HAL_PIN_CFG_EDGE_NONE;
                             *cfg |= GPIO_HAL_PIN_CFG_INT_DISABLE;
                             break;

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.h
@@ -53,9 +53,6 @@
 
 #include <ti/drivers/pin/PINCC26XX.h>
 /*---------------------------------------------------------------------------*/
-#define gpio_hal_arch_pin_set_input(port, pin)  PINCC26XX_setOutputEnable(pin, false)
-#define gpio_hal_arch_pin_set_output(port, pin) PINCC26XX_setOutputEnable(pin, true)
-
 #define gpio_hal_arch_set_pin(port, pin)        PINCC26XX_setOutputValue(pin, 1)
 #define gpio_hal_arch_clear_pin(port, pin)      PINCC26XX_setOutputValue(pin, 0)
 #define gpio_hal_arch_toggle_pin(port, pin)     PINCC26XX_setOutputValue(pin, \

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/rtimer-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/rtimer-arch.c
@@ -72,7 +72,7 @@ rtimer_clock_stub(uintptr_t unused)
  * \brief  The Man-in-the-Middle ISR hook for the HWI dispatch ISR. This
  *         will be the ISR dispatched when INT_AON_RTC_COMB is triggered,
  *         and will either dispatch the interrupt to the rtimer driver or
- *         the HWI driver, depening on which event triggered the interrupt.
+ *         the HWI driver, depending on which event triggered the interrupt.
  */
 static void
 rtimer_isr_hook(void)
@@ -150,7 +150,7 @@ rtimer_arch_init(void)
   IntRegister(INT_AON_RTC_COMB, rtimer_isr_hook);
   IntPrioritySet(INT_AON_RTC_COMB, INT_PRI_LEVEL7);
 
-  AONEventMcuWakeUpSet(AON_EVENT_MCU_WU1, AON_EVENT_RTC_CH1);
+  AONEventMcuWakeUpSet(AON_EVENT_MCU_WU3, AON_EVENT_RTC_CH1);
   AONRTCCombinedEventConfig(HWIP_RTC_CH | RTIMER_RTC_CH);
 
   HwiP_restore(key);


### PR DESCRIPTION
Some bug-fixes and improvements to the GPIO HAL:
1. Fixed a bug where the MCU does not wakeup from standby on DIO edges, and thus interrupts may be lost.
    * The PIN driver does indeed configure wakeup on DIO edges [here](https://github.com/contiki-ng/coresdk_cc13xx_cc26xx/blob/master/source/ti/drivers/pin/PINCC26XX.c#L350), but the same wakeup-selector WU1 is re-purposed to RTC_CH1 in [rtimer-arch.c:153](https://github.com/contiki-ng/contiki-ng/blob/develop/arch/cpu/simplelink-cc13xx-cc26xx/dev/rtimer-arch.c#L153). This PR switches the wake-up for RTC_CH1 to WU3 (WU2 is used by BATMON). Happy to hear any comments on this solution.
2. Fixed a bug in the PIN-to-HAL config conversion which caused IRQ and pull-config not to be included.
3. cc13xx/cc26xx pins have independent output and input buffers which should both be configured when switching a pin between input and output. The current implementation only manipulated the output config, causing e.g. interrupts to work only if the PIN had its input enabled either manually or via the PIN init table. This PR sets both output and input config, mimicking cc13xx-cc26xx platform, and newer TI GPIO drivers.
4. Added some comments about the Simplelink GPIO HAL quirks on interrupt enable/disable (fixing them requires some more work).