### PR TITLE
Compile msp430 & jn516x as gnu99 instead of gnu89

### DIFF
--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -165,7 +165,7 @@ endif
 ifndef CFLAGSNO
 CFLAGSNO = -Wall -mmcu=$(CC_MCU) $(CFLAGSWERROR)
 endif
-CFLAGS  += -Os -fno-strict-aliasing
+CFLAGS  += -Os -fno-strict-aliasing -std=gnu99
 LDFLAGS += -mmcu=$(CC_MCU) -Wl,-Map=$(CONTIKI_NG_PROJECT_MAP)
 
 ### These flags can reduce the code size and RAM usage with up to 10%

--- a/arch/platform/jn516x/Makefile.jn516x
+++ b/arch/platform/jn516x/Makefile.jn516x
@@ -61,6 +61,8 @@ LDLIBS := $(subst MiniMac_JN516x, ,$(LDLIBS))
   LDLIBS += JPT_$(JENNIC_CHIP)
 endif
 
+CFLAGS += -std=gnu99
+
 # Enable all warnings
 CFLAGS += -Wall
 # Disable warnings that result many false positives with the Contiki core


### PR DESCRIPTION
This aligns the behavior of these ports with the documentation of C99 in the wiki.

This also fixes the compilation errors in pull request #1761 for me locally.