### PR TITLE
tests: ensure cd is successful

### DIFF
--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -39,7 +39,7 @@ get_target_vars = $(wordlist 2,15,$(subst :, ,$1))
 
 define dooneexample
 @echo -n Building example $(3): $(1) $(4) for target $(2)
-@((cd $(EXAMPLESDIR)/$(1); \
+@((cd $(EXAMPLESDIR)/$(1) && \
  $(MAKE) $(4) TARGET=$(2) clean && make -j $(4) TARGET=$(2) WERROR=1) > \
       /dev/null 2>make.err && \
  (echo " -> OK" && printf "%-75s %-40s %-20s TEST OK\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog) || \
@@ -53,16 +53,23 @@ $(call dooneexample,$(dir $(call get_target,${1})),$(notdir $(call get_target,${
 endef
 #end of GNU make magic
 
-examples:
+examples: | $(EXAMPLESDIR)
 	$(foreach ex, $(EXAMPLES), $(call doexample, ${ex}))
+
+$(EXAMPLESDIR):
+	@echo "Could not find examples directory $(EXAMPLESDIR).\n"
+	@echo "If this failure is when running 19-out-of-tree-builds, clone"
+	@echo "https://github.com/contiki-ng/out-of-tree-tests into"
+	@echo "$(EXAMPLESDIR) and run the test again.\n"
+	@false
 
 summary: examples
 	@cat *.testlog > summary
 	@echo "========== Summary =========="
 	@cat summary
 
-clean:
+clean: | $(EXAMPLESDIR)
 	@rm -f *.testlog summary
 	@$(foreach example, $(EXAMPLES), \
            $(foreach target, $(EXAMPLESTARGETS), \
-             (cd $(EXAMPLESDIR)/$(example); $(MAKE) TARGET=$(target) clean);))
+             (cd $(EXAMPLESDIR)/$(example) && $(MAKE) TARGET=$(target) clean);))


### PR DESCRIPTION
Running 19-out-of-tree-build in the Docker
image on my local computer hangs without
output. The reason is that the return value
of cd is ignored in the Makefile, replacing
";" with "&&" gives us a proper failure.
The clean rule has a similar problem.

Getting the message that make could not cd
into /home/user/out-of-tree-tests can still
be confusing, so add an explanation for
the failure by adding a dependency on the directory
and make the rule for that directory echo
the expected action and then fail.

The reason this test works in the Github CI
is that build.yml ensures /home/user/out-of-tree-tests
is populated before starting docker.