### PR TITLE
etimer: adapted to use a sorted list

### DIFF
--- a/arch/cpu/arm/arm-def.h
+++ b/arch/cpu/arm/arm-def.h
@@ -50,9 +50,6 @@
  */
 #define CLOCK_CONF_SECOND 128
 
-/* Clock (time) comparison macro */
-#define CLOCK_LT(a, b)  ((signed long)((a) - (b)) < 0)
-
 /* Platform typedefs */
 typedef uint32_t clock_time_t;
 typedef uint32_t uip_stats_t;

--- a/arch/cpu/msp430/f1xxx/clock.c
+++ b/arch/cpu/msp430/f1xxx/clock.c
@@ -41,7 +41,7 @@
 
 #define MAX_TICKS (~((clock_time_t)0) / 2)
 
-#define CLOCK_LT(a, b) ((int16_t)((a)-(b)) < 0)
+#define LESS_THAN(a, b) ((int16_t)((a)-(b)) < 0)
 
 static volatile unsigned long seconds;
 
@@ -73,7 +73,7 @@ ISR(TIMERA1, timera1)
 
     last_tar = read_tar();
     /* Make sure interrupt time is future */
-    while(!CLOCK_LT(last_tar, TACCR1)) {
+    while(!LESS_THAN(last_tar, TACCR1)) {
       TACCR1 += INTERVAL;
       ++count;
 

--- a/arch/cpu/msp430/f5xxx/clock.c
+++ b/arch/cpu/msp430/f5xxx/clock.c
@@ -41,7 +41,7 @@
 
 #define MAX_TICKS (~((clock_time_t)0) / 2)
 
-#define CLOCK_LT(a, b) ((int16_t)((a)-(b)) < 0)
+#define LESS_THAN(a, b) ((int16_t)((a)-(b)) < 0)
 
 static volatile unsigned long seconds;
 
@@ -73,7 +73,7 @@ ISR(TIMER1_A1, timera1)
 
     last_tar = read_tar();
     /* Make sure interrupt time is future */
-    while(!CLOCK_LT(last_tar, TA1CCR1)) {
+    while(!LESS_THAN(last_tar, TA1CCR1)) {
       TA1CCR1 += INTERVAL;
       ++count;
 

--- a/os/sys/clock.h
+++ b/os/sys/clock.h
@@ -82,6 +82,13 @@
 #define CLOCK_SECOND (clock_time_t)32
 #endif
 
+/* Clock (time) comparison macro */
+#define CLOCK_LT(a, b) (sizeof(clock_time_t) == 2 \
+    ? (int16_t)((a) - (b)) < 0 \
+    : (sizeof(clock_time_t) == 4 \
+        ? (int32_t)((a) - (b)) < 0 \
+        : ((int64_t)((a) - (b)) < 0)))
+
 /**
  * Initialize the clock library.
  *

--- a/os/sys/etimer.c
+++ b/os/sys/etimer.c
@@ -49,92 +49,59 @@
 #include "sys/etimer.h"
 #include "sys/process.h"
 
-static struct etimer *timerlist;
-static clock_time_t next_expiration;
-
+static struct etimer *next_etimer;
 PROCESS(etimer_process, "Event timer");
 /*---------------------------------------------------------------------------*/
 static void
-update_time(void)
+remove_etimer_from_list(struct etimer *previous, struct etimer *et)
 {
-  clock_time_t tdist;
-  clock_time_t now;
-  struct etimer *t;
-
-  if(timerlist == NULL) {
-    next_expiration = 0;
+  et->p = PROCESS_NONE;
+  if(previous) {
+    previous->next = et->next;
   } else {
-    now = clock_time();
-    t = timerlist;
-    /* Must calculate distance to next time into account due to wraps */
-    tdist = t->timer.start + t->timer.interval - now;
-    for(t = t->next; t != NULL; t = t->next) {
-      if(t->timer.start + t->timer.interval - now < tdist) {
-        tdist = t->timer.start + t->timer.interval - now;
-      }
-    }
-    next_expiration = now + tdist;
+    next_etimer = et->next;
   }
 }
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(etimer_process, ev, data)
 {
-  struct etimer *t, *u;
+  struct etimer *current;
+  struct etimer *previous;
 
   PROCESS_BEGIN();
 
-  timerlist = NULL;
+  next_etimer = NULL;
 
   while(1) {
     PROCESS_YIELD();
 
+    current = next_etimer;
+    previous = NULL;
+
     if(ev == PROCESS_EVENT_EXITED) {
-      struct process *p = data;
-
-      while(timerlist != NULL && timerlist->p == p) {
-        timerlist = timerlist->next;
-      }
-
-      if(timerlist != NULL) {
-        t = timerlist;
-        while(t->next != NULL) {
-          if(t->next->p == p) {
-            t->next = t->next->next;
-          } else {
-            t = t->next;
-          }
+      while(current) {
+        if(current->p == ((struct process *)data)) {
+          remove_etimer_from_list(previous, current);
+          current = previous ? previous->next : next_etimer;
+          continue;
         }
+        previous = current;
+        current = current->next;
       }
-      continue;
-    } else if(ev != PROCESS_EVENT_POLL) {
-      continue;
-    }
-
-again:
-
-    u = NULL;
-
-    for(t = timerlist; t != NULL; t = t->next) {
-      if(timer_expired(&t->timer)) {
-        if(process_post(t->p, PROCESS_EVENT_TIMER, t) == PROCESS_ERR_OK) {
-
-          /* Reset the process ID of the event timer, to signal that the
-             etimer has expired. This is later checked in the
-             etimer_expired() function. */
-          t->p = PROCESS_NONE;
-          if(u != NULL) {
-            u->next = t->next;
-          } else {
-            timerlist = t->next;
-          }
-          t->next = NULL;
-          update_time();
-          goto again;
+    } else if(ev == PROCESS_EVENT_POLL) {
+      while(current && timer_expired(&current->timer)) {
+        if(process_post(current->p, PROCESS_EVENT_TIMER, current)
+            == PROCESS_ERR_OK) {
+          remove_etimer_from_list(previous, current);
+          current = previous ? previous->next : next_etimer;
+          continue;
         } else {
+          /* retry later */
           etimer_request_poll();
         }
+        previous = current;
+        current = current->next;
       }
-      u = t;
     }
   }
 
@@ -148,29 +115,35 @@ etimer_request_poll(void)
 }
 /*---------------------------------------------------------------------------*/
 static void
-add_timer(struct etimer *timer)
+add_timer(struct etimer *et)
 {
-  struct etimer *t;
+  clock_time_t expiration_time;
+  struct etimer *current;
+  struct etimer *previous;
 
-  etimer_request_poll();
+  /* remove et from the list */
+  etimer_stop(et);
 
-  if(timer->p != PROCESS_NONE) {
-    for(t = timerlist; t != NULL; t = t->next) {
-      if(t == timer) {
-        /* Timer already on list, bail out. */
-        timer->p = PROCESS_CURRENT();
-        update_time();
-        return;
-      }
-    }
+  /* locate insertion point */
+  expiration_time = etimer_expiration_time(et);
+  current = next_etimer;
+  previous = NULL;
+  while(current
+      && CLOCK_LT(etimer_expiration_time(current), expiration_time)) {
+    previous = current;
+    current = current->next;
   }
 
-  /* Timer not on list. */
-  timer->p = PROCESS_CURRENT();
-  timer->next = timerlist;
-  timerlist = timer;
-
-  update_time();
+  /* insert et */
+  et->p = PROCESS_CURRENT();
+  if(previous) {
+    et->next = previous->next;
+    previous->next = et;
+  } else {
+    et->next = next_etimer;
+    next_etimer = et;
+    etimer_request_poll();
+  }
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -206,7 +179,7 @@ void
 etimer_adjust(struct etimer *et, int timediff)
 {
   et->timer.start += timediff;
-  update_time();
+  add_timer(et);
 }
 /*---------------------------------------------------------------------------*/
 int
@@ -230,43 +203,35 @@ etimer_start_time(struct etimer *et)
 int
 etimer_pending(void)
 {
-  return timerlist != NULL;
+  return next_etimer != NULL;
 }
 /*---------------------------------------------------------------------------*/
 clock_time_t
 etimer_next_expiration_time(void)
 {
-  return etimer_pending() ? next_expiration : 0;
+  return next_etimer ? etimer_expiration_time(next_etimer) : 0;
 }
 /*---------------------------------------------------------------------------*/
 void
 etimer_stop(struct etimer *et)
 {
-  struct etimer *t;
+  struct etimer *current;
+  struct etimer *previous;
 
-  /* First check if et is the first event timer on the list. */
-  if(et == timerlist) {
-    timerlist = timerlist->next;
-    update_time();
-  } else {
-    /* Else walk through the list and try to find the item before the
-       et timer. */
-    for(t = timerlist; t != NULL && t->next != et; t = t->next) {
-    }
-
-    if(t != NULL) {
-      /* We've found the item before the event timer that we are about
-         to remove. We point the items next pointer to the event after
-         the removed item. */
-      t->next = et->next;
-
-      update_time();
-    }
+  if(et->p == PROCESS_NONE) {
+    return;
   }
 
-  /* Remove the next pointer from the item to be removed. */
-  et->next = NULL;
-  /* Set the timer as expired */
+  current = next_etimer;
+  previous = NULL;
+  while(current) {
+    if(current == et) {
+      remove_etimer_from_list(previous, current);
+      break;
+    }
+    previous = current;
+    current = current->next;
+  }
   et->p = PROCESS_NONE;
 }
 /*---------------------------------------------------------------------------*/

--- a/os/sys/etimer.c
+++ b/os/sys/etimer.c
@@ -235,4 +235,20 @@ etimer_stop(struct etimer *et)
   et->p = PROCESS_NONE;
 }
 /*---------------------------------------------------------------------------*/
+bool
+etimer_check_ordering(void)
+{
+  struct etimer *current;
+
+  current = next_etimer;
+  while(current && current->next) {
+    if(CLOCK_LT(etimer_expiration_time(current->next),
+        etimer_expiration_time(current))) {
+      return false;
+    }
+    current = current->next;
+  }
+  return true;
+}
+/*---------------------------------------------------------------------------*/
 /** @} */

--- a/os/sys/etimer.h
+++ b/os/sys/etimer.h
@@ -64,6 +64,7 @@
 #define ETIMER_H_
 
 #include "contiki.h"
+#include <stdbool.h>
 
 /**
  * A timer.
@@ -246,6 +247,11 @@ int etimer_pending(void);
  */
 clock_time_t etimer_next_expiration_time(void);
 
+/**
+ * \brief      Check if all etimers are correctly ordered by expiration time.
+ * \return     True if the ordering is correct and false otherwise.
+ */
+bool etimer_check_ordering(void);
 
 /** @} */
 

--- a/tests/08-native-runs/14-etimer.sh
+++ b/tests/08-native-runs/14-etimer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./run-one.sh 14-etimer

--- a/tests/08-native-runs/14-etimer/Makefile
+++ b/tests/08-native-runs/14-etimer/Makefile
@@ -1,0 +1,9 @@
+CONTIKI_PROJECT = test-etimer
+all: $(CONTIKI_PROJECT)
+
+TARGET = native
+
+MODULES += os/services/unit-test
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/14-etimer/test-etimer.c
+++ b/tests/08-native-runs/14-etimer/test-etimer.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, Uppsala universitet.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "contiki.h"
+#include "unit-test.h"
+#include <stdio.h>
+
+PROCESS(test_process, "test");
+AUTOSTART_PROCESSES(&test_process);
+
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(expiration, "expiration");
+UNIT_TEST(expiration)
+{
+  struct etimer et;
+
+  UNIT_TEST_BEGIN();
+
+  etimer_set(&et, CLOCK_SECOND);
+  UNIT_TEST_ASSERT(etimer_pending());
+  UNIT_TEST_ASSERT(
+      etimer_start_time(&et) + CLOCK_SECOND == etimer_expiration_time(&et));
+  etimer_stop(&et);
+  UNIT_TEST_ASSERT(etimer_expired(&et));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(ordering, "ordering");
+UNIT_TEST(ordering)
+{
+  struct etimer et[3];
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT(etimer_check_ordering());
+  etimer_set(&et[0], CLOCK_SECOND);
+  etimer_set(&et[1], 3 * CLOCK_SECOND);
+  etimer_set(&et[2], 2 * CLOCK_SECOND);
+  UNIT_TEST_ASSERT(etimer_check_ordering());
+  etimer_stop(&et[0]);
+  etimer_stop(&et[2]);
+  UNIT_TEST_ASSERT(etimer_check_ordering());
+  etimer_reset(&et[0]);
+  etimer_restart(&et[2]);
+  UNIT_TEST_ASSERT(etimer_check_ordering());
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(test_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(expiration);
+  UNIT_TEST_RUN(ordering);
+
+  if(!UNIT_TEST_PASSED(expiration)
+      || !UNIT_TEST_PASSED(ordering)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
+  printf("=check-me= DONE\n");
+  printf("---\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Presently, the etimer implementation maintains a list of etimers without leveraging the existing list API. This PR fixes this and also adds a function for updating the `next_expiration` variable more efficiently.