### PR TITLE
Stop with error when $(CC) is missing

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -104,6 +104,9 @@ else
     ${error More than one TARGET Makefile found: $(target_makefile)}
   endif
   include $(target_makefile)
+  ifeq (, $(shell which $(CC)))
+    $(error Target "$(TARGET)" compiler "$(CC)" cannot be found)
+  endif
 endif
 
 # Decide whether to build or to skip this target for this platform


### PR DESCRIPTION
Trying to "make login PORT=/dev/ttyACM2"
in the hello-world example for a target
without installed toolchain currently
results in:

make: msp430-gcc: Command not found
make: msp430-gcc: Command not found
make: msp430-gcc: Command not found
/bin/sh: 1: test: -lt: unexpected operator
rlwrap ../../tools/serial-io/serialdump -b115200 /dev/ttyACM2
connecting to /dev/ttyACM2

Add a check that $(CC) can be found after
including Makefile.$(TARGET) to ensure
that make immediately stops even
if the target Makefile is missing
error checks for the toolchain. For sky,
this results in the error message:

make: msp430-gcc: Command not found
make: msp430-gcc: Command not found
./../Makefile.include:108: *** Target "sky" compiler "msp430-gcc" cannot be found.  Stop.