### PR TITLE
Fix version detection for recent gcc

### DIFF
--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -3,8 +3,9 @@
 # GCC specific definitions and actions
 #
 
-GCC_MAJOR_VERSION := $(shell $(CC) -dumpversion | cut -d "." -f 1)
-GCC_MINOR_VERSION := $(shell $(CC) -dumpversion | cut -d "." -f 2)
+GCC_VERSION := $(shell $(CC) -dumpfullversion -dumpversion)
+GCC_MAJOR_VERSION := $(word 1,$(subst ., ,$(GCC_VERSION)))
+GCC_MINOR_VERSION := $(word 2,$(subst ., ,$(GCC_VERSION)))
 
 # Warn if using version 6.3.x of arm-none-eabi-gcc
 ifeq ("$(CC)","arm-none-eabi-gcc")


### PR DESCRIPTION
GCC 7 in Ubuntu 18 and GCC 9 in Ubuntu 20
only emits the major version when called
with -dumpversion which causes GCC_MINOR_VERSION
to become empty. GCC also has a -dumpfullversion
that will emit the entire version on GCC 7
and later, but msp430-gcc will fail with
an error message because there are no input
files.

Adding both parameters makes both msp430-gcc
and GCC 7/9 on Ubuntu provide the full version
so use that in the GCC version detection.