### PR TITLE
rpl-border-router: fix GCC 8 warnings

### DIFF
--- a/examples/rpl-border-router/webserver/httpd-simple.c
+++ b/examples/rpl-border-router/webserver/httpd-simple.c
@@ -175,7 +175,8 @@ PT_THREAD(handle_input(struct httpd_state *s))
     s->filename[sizeof(s->filename) - 1] = '\0';
   } else {
     s->inputbuf[PSOCK_DATALEN(&s->sin) - 1] = 0;
-    strncpy(s->filename, s->inputbuf, sizeof(s->filename));
+    strncpy(s->filename, s->inputbuf, sizeof(s->filename) - 1);
+    s->filename[sizeof(s->filename) - 1] = '\0';
   }
 #endif /* URLCONV */
 

--- a/os/services/rpl-border-router/native/slip-config.c
+++ b/os/services/rpl-border-router/native/slip-config.c
@@ -97,10 +97,11 @@ slip_config_handle_arguments(int argc, char **argv)
 
     case 't':
       if(strncmp("/dev/", optarg, 5) == 0) {
-        strncpy(slip_config_tundev, optarg + 5, sizeof(slip_config_tundev));
+        strncpy(slip_config_tundev, optarg + 5, sizeof(slip_config_tundev) - 1);
       } else {
-        strncpy(slip_config_tundev, optarg, sizeof(slip_config_tundev));
+        strncpy(slip_config_tundev, optarg, sizeof(slip_config_tundev) - 1);
       }
+      slip_config_tundev[sizeof(slip_config_tundev) - 1] = '\0';
       break;
 
     case 'a':

--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -165,7 +165,7 @@ tun_alloc(char *dev)
    */
   ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
   if(*dev != 0) {
-    strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+    strncpy(ifr.ifr_name, dev, IFNAMSIZ - 1);
   }
 
   if((err = ioctl(fd, TUNSETIFF, (void *)&ifr)) < 0) {


### PR DESCRIPTION
GCC 8 added the -Wstringop-truncation warning
which makes the regression tests fail on recent
versions of Ubuntu. Silence the compiler by
copying one character less, and add an explicit
null termination afterwards when required.