### PR TITLE
Makefile: allow overriding $(Q)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -273,7 +273,7 @@ ifeq ($(V),1)
   TRACE_OBJDUMP  =
   TRACE_MKDIR =
   TRACE_CP =
-  Q=
+  Q ?=
 else
   TRACE_CC = @echo "  CC       " $<
   TRACE_CXX = @echo "  CXX      " $<
@@ -284,7 +284,7 @@ else
   TRACE_OBJDUMP  = @echo "  OBJDUMP  " $< "-->" $@
   TRACE_MKDIR = @echo "  MKDIR    " $@
   TRACE_CP       = @echo "  CP       " $< "-->" $@
-  Q=@
+  Q ?= @
 endif
 
 ### Forward comma-separated list of arbitrary defines to the compiler


### PR DESCRIPTION
Allow the user to call make with
a specific Q on the command line.

This enables the user to see all
the calls to the tools by specifying
Q="" when calling make. It also enables
a really quiet mode if the user combines
V=1 and Q=@.