### PR TITLE
lwm2m: fix GCC 12 truncation warning

### DIFF
--- a/os/services/lwm2m/lwm2m-engine.c
+++ b/os/services/lwm2m/lwm2m-engine.c
@@ -285,7 +285,7 @@ get_method_as_string(coap_resource_flags_t method)
 static const char *
 get_status_as_string(lwm2m_status_t status)
 {
-  static char buffer[8];
+  static char buffer[14];
   switch(status) {
   case LWM2M_STATUS_OK:
     return "OK";


### PR DESCRIPTION
The size of an enum is not fixed, so
GCC 12 complains that the snprintf might
truncate the value written into the buffer.
Increase the size of the buffer so
the regression tests compile without warnings
on Ubuntu 22.