### PR TITLE
Makefile: add support for ccache

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -41,6 +41,12 @@ ifdef CI
   endif
 endif
 
+ifndef IAR
+  ifneq (, $(shell which ccache))
+    CCACHE ?= ccache
+  endif
+endif
+
 BUILD_DIR = build
 BUILD_DIR_TARGET = $(BUILD_DIR)/$(TARGET)
 BUILD_DIR_TARGET_BOARD = $(BUILD_DIR_TARGET)/$(BOARD)
@@ -363,14 +369,14 @@ distclean:
 ifndef CUSTOM_RULE_C_TO_OBJECTDIR_O
 $(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(TRACE_CC)
-	$(Q)$(CC) $(CFLAGS) -MMD -c $< -o $@
+	$(Q)$(CCACHE) $(CC) $(CFLAGS) -MMD -c $< -o $@
 	@$(FINALIZE_DEPENDENCY)
 endif
 
 ifndef CUSTOM_RULE_CPP_TO_OBJECTDIR_O
 $(OBJECTDIR)/%.o: %.cpp | $(OBJECTDIR)
 	$(TRACE_CXX)
-	$(Q)$(CXX) $(CXXFLAGS) -MMD -c $< -o $@
+	$(Q)$(CCACHE) $(CXX) $(CXXFLAGS) -MMD -c $< -o $@
 	@$(FINALIZE_DEPENDENCY)
 endif
 
@@ -386,55 +392,55 @@ endif
 ifndef CUSTOM_RULE_C_TO_OBJECTDIR_S
 $(OBJECTDIR)/%.s: %.c | $(OBJECTDIR)
 	$(TRACE_CC)
-	$(Q)$(CC) $(CFLAGS) -S $< -o $@
+	$(Q)$(CCACHE) $(CC) $(CFLAGS) -S $< -o $@
 endif
 
 ifndef CUSTOM_RULE_CPP_TO_OBJECTDIR_S
 $(OBJECTDIR)/%.s: %.cpp | $(OBJECTDIR)
 	$(TRACE_CXX)
-	$(Q)$(CXX) $(CXXFLAGS) -S $< -o $@
+	$(Q)$(CCACHE) $(CXX) $(CXXFLAGS) -S $< -o $@
 endif
 
 ifndef CUSTOM_RULE_C_TO_OBJECTDIR_E
 $(OBJECTDIR)/%.e: %.c | $(OBJECTDIR)
 	$(TRACE_CC)
-	$(Q)$(CC) $(CFLAGS) -E $< -o $@
+	$(Q)$(CCACHE) $(CC) $(CFLAGS) -E $< -o $@
 endif
 
 ifndef CUSTOM_RULE_CPP_TO_OBJECTDIR_E
 $(OBJECTDIR)/%.e: %.cpp | $(OBJECTDIR)
 	$(TRACE_CXX)
-	$(Q)$(CXX) $(CXXFLAGS) -E $< -o $@
+	$(Q)$(CCACHE) $(CXX) $(CXXFLAGS) -E $< -o $@
 endif
 
 ifndef CUSTOM_RULE_C_TO_O
 %.o: %.c
 	$(TRACE_CC)
-	$(Q)$(CC) $(CFLAGS) -c $< -o $@
+	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
 endif
 
 ifndef CUSTOM_RULE_CPP_TO_O
 %.o: %.cpp
 	$(TRACE_CXX)
-	$(Q)$(CXX) $(CXXFLAGS) -c $< -o $@
+	$(Q)$(CCACHE) $(CXX) $(CXXFLAGS) -c $< -o $@
 endif
 
 ifndef CUSTOM_RULE_C_TO_S
 %.s: %.c
 	$(TRACE_CC)
-	$(Q)$(CC) $(CFLAGS) -S $< -o $@
+	$(Q)$(CCACHE) $(CC) $(CFLAGS) -S $< -o $@
 endif
 
 ifndef CUSTOM_RULE_C_TO_E
 %.e: %.c
 	$(TRACE_CC)
-	$(Q)$(CC) $(CFLAGS) -E $< -o $@
+	$(Q)$(CCACHE) $(CC) $(CFLAGS) -E $< -o $@
 endif
 
 ifndef CUSTOM_RULE_CPP_TO_E
 %.e: %.cpp
 	$(TRACE_CXX)
-	$(Q)$(CXX) $(CXXFLAGS) -E $< -o $@
+	$(Q)$(CCACHE) $(CXX) $(CXXFLAGS) -E $< -o $@
 endif
 
 ifndef AROPTS


### PR DESCRIPTION
This improves build times when source files
are unchanged. On a warm cache, my machine
gets a 98% hitrate for tests/01-compile-base:

cache hit (direct)                  1621
cache hit (preprocessed)               0
cache miss                            33
cache hit rate                     98.00 %
compile failed                         4
couldn't find the compiler             9
cleanups performed                     0

The 9 "couldn't find the compiler" are caused by
not having msp430-gcc installed on my machine,
and the failed compilations are caused by
compiler warnings.