### PR TITLE
the type of ringbuf index can be modified.

### DIFF
--- a/os/contiki-default-conf.h
+++ b/os/contiki-default-conf.h
@@ -58,6 +58,16 @@
 #ifndef QUEUEBUF_CONF_NUM
 #define QUEUEBUF_CONF_NUM 8
 #endif /* QUEUEBUF_CONF_NUM */
+
+/* RINGBUF_INDEX_CONF_TYPE defines the default type of ringbuf index. 
+   access to (struct ringbuf *)->get_ptr and ->get_ptr must be atomic. 
+   users cans change to the type which makes access atomically, 
+   but C does not guarantee this.
+ */
+#ifndef RINGBUF_INDEX_CONF_TYPE
+#define RINGBUF_INDEX_CONF_TYPE  uint8_t
+#endif /* RINGBUF_INDEX_CONF_TYPE */
+
 /*---------------------------------------------------------------------------*/
 /* uIPv6 configuration options.
  *

--- a/os/lib/ringbuf.h
+++ b/os/lib/ringbuf.h
@@ -67,10 +67,10 @@
  */
 struct ringbuf {
   uint8_t *data;
-  uint8_t mask;
+  RINGBUF_INDEX_CONF_TYPE mask;
 
   /* XXX these must be 8-bit quantities to avoid race conditions. */
-  uint8_t put_ptr, get_ptr;
+  RINGBUF_INDEX_CONF_TYPE put_ptr, get_ptr;
 };
 
 /**
@@ -87,7 +87,7 @@ struct ringbuf {
  *
  */
 void    ringbuf_init(struct ringbuf *r, uint8_t *a,
-		     uint8_t size_power_of_two);
+		     RINGBUF_INDEX_CONF_TYPE size_power_of_two);
 
 /**
  * \brief      Insert a byte into the ring buffer


### PR DESCRIPTION
The type of ringbuf index can be modified by user, according to the platform.
because of contiki-ng is offen used on 32bit platform, these platform always handle 32bit data atomically.
The size of ringbuf being below 256 can't satisfy the needs of many scenes.
