### PR TITLE
nrf: fail when missing $(NRFJPROG)

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -86,7 +86,7 @@ endif
 
 %.upload: $(OUT_HEX)
 ifeq (, $(shell which $(NRFJPROG)))
-	@echo "ERROR: Could not find nrfjprog, please install it first"
+	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
 else
 	$(NRFJPROG) $(NRFJPROG_OPTIONS) $(NRFJPROG_FLAGS) --sectorerase --program $<
 	$(NRFJPROG) $(NRFJPROG_OPTIONS) $(NRFJPROG_FLAGS) --reset
@@ -114,7 +114,7 @@ nrf-upload-sequence: $(foreach SNR, $(NRF_SNRS), nrf-upload-snr.$(SNR))
 
 %.upload-all: $(OUT_HEX)
 ifeq (, $(shell which $(NRFJPROG)))
-	@echo "ERROR: Could not find nrfjprog, please install it first"
+	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
 else
 	$(MAKE) HEX_FILE=$< -j $(NUMPAR) nrf-upload-sequence
 endif

--- a/arch/cpu/nrf52840/Makefile.nrf52840
+++ b/arch/cpu/nrf52840/Makefile.nrf52840
@@ -122,7 +122,7 @@ endif
 
 %.upload: $(OUT_HEX)
 ifeq (, $(shell which $(NRFJPROG)))
-	@echo "ERROR: Could not find nrfjprog, please install it first"
+	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
 else
 	$(NRFJPROG) -f nrf52 $(NRFJPROG_FLAGS) --sectorerase --program $<
 	$(NRFJPROG) -f nrf52 $(NRFJPROG_FLAGS) --reset
@@ -150,7 +150,7 @@ nrf-upload-sequence: $(foreach SNR, $(NRF_SNRS), nrf-upload-snr.$(SNR))
 
 %.upload-all: $(OUT_HEX)
 ifeq (, $(shell which $(NRFJPROG)))
-	@echo "ERROR: Could not find nrfjprog, please install it first"
+	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
 else
 	$(MAKE) HEX_FILE=$< -j $(NUMPAR) nrf-upload-sequence
 endif


### PR DESCRIPTION
Replace the echo "ERROR: .." with
a call to $(error) to ensure make
fails with a non-zero return value.