### PR TITLE
tests: clean before other targets

### DIFF
--- a/tests/00-documentation/Makefile
+++ b/tests/00-documentation/Makefile
@@ -39,7 +39,8 @@ READTHEDOCS_ERR = $(RAEDTHEDOCS).err
 CLEAN_TARGETS += $(DOXYGEN_LOG) $(DOXYGEN_ERR)
 CLEAN_TARGETS += $(READTHEDOCS_LOG) $(READTHEDOCS_ERR)
 
-all: clean summary
+all: clean
+	@$(MAKE) summary
 
 doxygen:
 	-@$(MAKE) -C $(DOXYGEN_DIR) 2> $(DOXYGEN_ERR) > /dev/null

--- a/tests/05-compile-tools/Makefile
+++ b/tests/05-compile-tools/Makefile
@@ -29,7 +29,8 @@ TOOLS=tools/serial-io
 BASEDIR=../../
 TESTLOGS=$(subst /,__,$(patsubst %,%.testlog, $(TOOLS)))
 
-all: clean summary
+all: clean
+	@$(MAKE) summary
 
 %.testlog:
 	@echo -n Building tool: $(basename $@)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,7 +30,8 @@ SUMMARIES=$(foreach test,$(TESTS),$(test)/summary)
 
 CONTIKI=..
 
-run: clean summary
+run: clean
+	@$(MAKE) summary
 
 summary: $(SUMMARIES)
 	@cat $(SUMMARIES) > $@

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -25,7 +25,8 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-all: clean summary
+all: clean
+	@$(MAKE) summary
 
 # The stuff below is some GNU make magic to automatically make make
 # give each compile test a number, prefixed with a 0 if the number is

--- a/tests/Makefile.script-test
+++ b/tests/Makefile.script-test
@@ -3,7 +3,8 @@ TESTLOGS=$(sort $(patsubst %.sh,%.testlog,$(TESTS)))
 
 CONTIKI=../..
 
-all: clean summary
+all: clean
+	@$(MAKE) summary
 
 summary: $(TESTLOGS)
 	@cat *.testlog > summary

--- a/tests/Makefile.simulation-test
+++ b/tests/Makefile.simulation-test
@@ -39,7 +39,8 @@ CONTIKI ?= ../..
 
 tests: $(TESTLOGS)
 
-summary: clean tests
+summary: clean
+	@$(MAKE) tests
 ifeq ($(TESTS),)
 	@echo No tests > summary
 else


### PR DESCRIPTION
Simultaneously doing clean and build in
parallel might cause failures that are
difficult to reproduce. Make the targets
that run clean finish cleaning before
starting a build.