### PR TITLE
native: configure according to $(CC)

### DIFF
--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -25,15 +25,15 @@ CFLAGS  += $(CFLAGSNO)
 SMALL ?= 0
 
 # The optimizations on native platform cannot be enabled in GCC (not Clang) versions less than 7.2
-GCC_IS_CLANG := $(shell gcc --version 2> /dev/null | grep clang)
+GCC_IS_CLANG := $(shell $(CC) --version 2> /dev/null | grep clang)
 ifneq ($(GCC_IS_CLANG),)
   NATIVE_CAN_OPTIIMIZE = 1
 else
-  GCC_VERSION := $(shell gcc -dumpfullversion -dumpversion | cut -b1-3)
+  GCC_VERSION := $(shell $(CC) -dumpfullversion -dumpversion | cut -b1-3)
   ifeq ($(shell expr $(GCC_VERSION) \>= 7.2), 1)
-  	NATIVE_CAN_OPTIIMIZE = 1
+    NATIVE_CAN_OPTIIMIZE = 1
   else
-  	NATIVE_CAN_OPTIIMIZE = 0
+    NATIVE_CAN_OPTIIMIZE = 0
   endif
 endif
 


### PR DESCRIPTION
The checks for how to compile should
be with respect to the compiler used
for the build.