### PR TITLE
Makefile: detect $(JAVA_HOME)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -45,6 +45,8 @@ ifneq (, $(shell which ccache))
   CCACHE ?= ccache
 endif
 
+JAVA = java
+
 BUILD_DIR = build
 BUILD_DIR_TARGET = $(BUILD_DIR)/$(TARGET)
 BUILD_DIR_TARGET_BOARD = $(BUILD_DIR_TARGET)/$(BOARD)

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -150,7 +150,7 @@ $(COOJA_PATH)/mspsim/mspsim.jar: $(COOJA_PATH)/mspsim/build.xml
 	cd $(COOJA_PATH)/mspsim && ant jar
 
 %.mspsim:	%.${TARGET} ${COOJA_PATH}/mspsim/mspsim.jar
-	java -jar ${COOJA_PATH}/mspsim/mspsim.jar -platform=${TARGET} $<
+	$(JAVA) -jar ${COOJA_PATH}/mspsim/mspsim.jar -platform=${TARGET} $<
 
 %.mspsim-maptable: %.$(TARGET)
-	java -classpath ${COOJA_PATH}/mspsim/mspsim.jar se.sics.mspsim.util.MapTable $(CONTIKI_NG_PROJECT_MAP)
+	$(JAVA) -classpath ${COOJA_PATH}/mspsim/mspsim.jar se.sics.mspsim.util.MapTable $(CONTIKI_NG_PROJECT_MAP)

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -16,6 +16,24 @@ COOJA_DIR = $(CONTIKI_NG_TOOLS_DIR)/cooja
 # Use dbg-io for IO functions like printf()
 MODULES += os/lib/dbg-io
 
+JAVA_INCDIR := $(shell $(JAVA) -XshowSettings:properties -version 2>&1 | grep java.home | awk -F"= " '{print $$2}')
+ifneq ($(MAKECMDGOALS),clean)
+  ifeq ($(JAVA_INCDIR),)
+    $(error No java.home found from "$(JAVA) -XshowSettings:properties -version")
+  endif
+endif
+ifeq ($(HOST_OS),Windows)
+  JAVA_OS_NAME = win32
+else
+  ifeq ($(HOST_OS),Linux)
+    JAVA_OS_NAME = linux
+  else
+    JAVA_OS_NAME = darwin
+  endif
+endif
+
+JAVA_CFLAGS = -I"$(JAVA_INCDIR)/include" -I"$(JAVA_INCDIR)/include/$(JAVA_OS_NAME)"
+
 ### Assuming simulator quickstart if no JNI library name set from Cooja
 ifndef LIBNAME
 QUICKSTART=1
@@ -34,7 +52,7 @@ ifneq ($(MAKECMDGOALS),clean)
 .PHONY: $(MAKECMDGOALS)
 .PRECIOUS: $(MAKECMDGOALS)
 $(MAKECMDGOALS): $(COOJA_DIR)/dist/cooja.jar
-	 java -mx512m -jar $< -quickstart='$(firstword $(MAKECMDGOALS))' -contiki='$(CONTIKI)'
+	 $(JAVA) -mx512m -jar $< -quickstart='$(firstword $(MAKECMDGOALS))' -contiki='$(CONTIKI)'
 endif
 
 endif ## QUICKSTART
@@ -72,7 +90,7 @@ CLEAN += COOJA.log
 
 ### Compiler arguments
 #CC = gcc
-CFLAGSNO = $(EXTRA_CC_ARGS) -Wall -g -I/usr/local/include -DCLASSNAME=$(CLASSNAME)
+CFLAGSNO = $(JAVA_CFLAGS) $(EXTRA_CC_ARGS) -Wall -g -I/usr/local/include -DCLASSNAME=$(CLASSNAME)
 ifeq ($(WERROR),1)
 CFLAGSNO += -Werror
 endif


### PR DESCRIPTION
Add detection of $(JAVA_HOME) in
the build system so Cooja does not
need to know about Contiki-NG
build-internal details.

Since this requires the build system
to know about $(JAVA), also update
platforms that use the plain string
"java" to use the new variable.