### PR TITLE
cooja: add $(Q) to the customrules

### DIFF
--- a/arch/platform/cooja/Makefile.customrules-cooja
+++ b/arch/platform/cooja/Makefile.customrules-cooja
@@ -12,23 +12,24 @@ REDEF_PRINTF=1 # Redefine functions to enable printf()s inside Cooja
 
 # NB: Assumes ARCHIVE was not overridden and is in $(BUILD_DIR_BOARD)
 $(ARCHIVE): $(CONTIKI_OBJECTFILES) | $(OBJECTDIR)
-	$(AR_COMMAND_1) $^ $(AR_COMMAND_2)
+	$(Q)$(AR_COMMAND_1) $^ $(AR_COMMAND_2)
 
 # NB: Assumes JNILIB was not overridden and is in $(BUILD_DIR_BOARD)
 $(JNILIB): $(CONTIKI_APP_OBJ) $(MAIN_OBJ) $(PROJECT_OBJECTFILES) $(ARCHIVE) | $(OBJECTDIR)
 
 ifdef REDEF_PRINTF
 	@echo Redefining printf,sprintf,vsnprintf,etc.
-	-$(foreach OBJ,$^, $(OBJCOPY) --redefine-syms $(CONTIKI)/arch/platform/cooja/redefine.syms $(OBJ); )
+	-$(Q)$(foreach OBJ,$^, $(OBJCOPY) --redefine-syms $(CONTIKI)/arch/platform/cooja/redefine.syms $(OBJ); )
 endif ## REDEF_PRINTF
-	$(LINK_COMMAND_1) $^ $(LINK_COMMAND_2)
+	@echo Linking $(JNILIB)
+	$(Q)$(LINK_COMMAND_1) $^ $(LINK_COMMAND_2)
 
 .PHONY: $(CONTIKI_APP).cooja
 $(CONTIKI_APP).cooja: $(JNILIB)
-	cp $(JNILIB) $@
-	rm $(CONTIKI_APP_OBJ)
+	$(Q)cp $(JNILIB) $@
+	$(Q)rm $(CONTIKI_APP_OBJ)
 
 # Trickiness: GNU make matches this against the file base name.
 # Assume that the directory part is the standard location.
 mtype%.o: platform.o | $(OBJECTDIR)
-	mv platform.o $@
+	$(Q)mv platform.o $@


### PR DESCRIPTION
This reduces the amount of output from
Cooja unless running with V=1.

Add an echo before the final link so
it's possible to diagnose whether the build
step completed when asking for Cooja output
during support requests. Example of error
message from a failing build:

Message:> make test-ringbufindex.cooja TARGET=cooja
Message:  CC        test-ringbufindex.c
...
Message:Redefining printf,sprintf,vsnprintf,etc.
Message:Linking build/cooja/mtype364.cooja
Message:/usr/bin/ld: i386 architecture of input file `build/cooja/mtype364.a(simEnvChange.o)' is incompatible with i386:x86-64 output
...