### PR TITLE
tests: add missing clean

### DIFF
--- a/tests/07-simulation-base/01-hello-world-sky.csc
+++ b/tests/07-simulation-base/01-hello-world-sky.csc
@@ -19,7 +19,8 @@
       <identifier>sky1</identifier>
       <description>Sky Mote Type #1</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/hello-world/hello-world.c</source>
-      <commands EXPORT="discard">make -j hello-world.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make TARGET=sky clean
+make -j hello-world.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/hello-world/hello-world.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>

--- a/tests/07-simulation-base/02-ringbufindex.csc
+++ b/tests/07-simulation-base/02-ringbufindex.csc
@@ -25,7 +25,8 @@
       <identifier>mtype297</identifier>
       <description>ringbufindex testee</description>
       <source>[CONFIG_DIR]/code-ringbufindex/test-ringbufindex.c</source>
-      <commands>make test-ringbufindex.cooja TARGET=cooja</commands>
+      <commands>make TARGET=cooja clean
+make test-ringbufindex.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/07-simulation-base/07-hello-world-z1.csc
+++ b/tests/07-simulation-base/07-hello-world-z1.csc
@@ -19,7 +19,8 @@
       <identifier>z11</identifier>
       <description>Z1 Mote Type #z11</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/hello-world/hello-world.c</source>
-      <commands EXPORT="discard">make hello-world.z1 TARGET=z1</commands>
+      <commands EXPORT="discard">make TARGET=z1 clean
+make hello-world.z1 TARGET=z1</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/hello-world/hello-world.z1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>

--- a/tests/07-simulation-base/22-stack-guard-sky.csc
+++ b/tests/07-simulation-base/22-stack-guard-sky.csc
@@ -19,7 +19,8 @@
       <identifier>sky1</identifier>
       <description>Sky Mote Type #1</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/libs/stack-check/example-stack-check.c</source>
-      <commands EXPORT="discard">make -j example-stack-check.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make TARGET=sky clean
+make -j example-stack-check.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/libs/stack-check/example-stack-check.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>


### PR DESCRIPTION
This fixes a link failure in 02-ringbufindex
because of mismatched object types when running
tests in the 32 bit docker and a 64-bit host
using the same source tree.

Add the make clean for the sky/z1 tests as well
to reduce the risk that future cut&paste based
on existing tests reintroduces this issue.