### PR TITLE
tests: display cooja output

### DIFF
--- a/tests/06-script-base/04-test-result-visualization.sh
+++ b/tests/06-script-base/04-test-result-visualization.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+TESTNAME=04-test-result-visualization
+
 CONTIKI=../..
 
 TEST_CODE_DIR=code-result-visualization
@@ -7,18 +9,20 @@ TEST_CODE_DIR=code-result-visualization
 make -C ${TEST_CODE_DIR} clean
 make -C ${TEST_CODE_DIR}
 
-${CONTIKI}/examples/benchmarks/result-visualization/run-analysis.py ${TEST_CODE_DIR}/00-result-visualization.1.scriptlog > analysis.log || exit 1
+${CONTIKI}/examples/benchmarks/result-visualization/run-analysis.py ${TEST_CODE_DIR}/COOJA.testlog > analysis.log || exit 1
 
 # check that some packets were sent and all were received
-grep "PDR=100" analysis.log || exit 1
+grep "PDR=100" analysis.log > /dev/null || exit 1
 
 # check that PDF files are created
-ls plot_charge.pdf || exit 1
-ls plot_duty_cycle_joined.pdf || exit 1
-ls plot_duty_cycle.pdf || exit 1
-ls plot_par.pdf || exit 1
-ls plot_pdr.pdf || exit 1
-ls plot_rpl_switches.pdf || exit 1
+[ -f plot_charge.pdf ] || exit 1
+[ -f plot_duty_cycle_joined.pdf ] || exit 1
+[ -f plot_duty_cycle.pdf ] || exit 1
+[ -f plot_par.pdf ] || exit 1
+[ -f plot_pdr.pdf ] || exit 1
+[ -f plot_rpl_switches.pdf ] || exit 1
+
+echo "${TESTNAME} TEST OK" > ${TESTNAME}.testlog
 
 # success
 exit 0

--- a/tests/simexec.sh
+++ b/tests/simexec.sh
@@ -25,45 +25,14 @@ declare -i OKCOUNT=0
 FAILSEEDS=
 
 for (( SEED=$BASESEED; SEED<$(($BASESEED+$RUNCOUNT)); SEED++ )); do
-	echo -n "Running test $BASENAME with random Seed $SEED"
+  echo "Running test $BASENAME with random seed $SEED"
 
-	# run simulation
-	java -Xshare:on -Dnashorn.args=--no-deprecation-warning -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$CSC -contiki=$CONTIKI -random-seed=$SEED > $BASENAME.$SEED.coojalog &
-	JPID=$!
-
-	# Copy the log and only print "." if it changed
-	touch progress.log
-	while kill -0 $JPID 2> /dev/null
-	do
-		sleep 1
-		diff $BASENAME.$SEED.coojalog progress.log > /dev/null
-		if [ $? -ne 0 ]
-		then
-		  echo -n "."
-		  cp $BASENAME.$SEED.coojalog progress.log
-		fi
-	done
-	rm progress.log
-
-  # wait for end of simulation
-	wait $JPID
-	JRV=$?
-
-	# Save testlog
-	touch COOJA.testlog;
-	mv COOJA.testlog $BASENAME.$SEED.scriptlog
-	rm COOJA.log
-
+  if java -Xshare:on -Dnashorn.args=--no-deprecation-warning -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$CSC -contiki=$CONTIKI -random-seed=$SEED; then
+    OKCOUNT+=1
+  else
+    FAILSEEDS+=" $BASESEED"
+  fi
   TESTCOUNT+=1
-	if [ $JRV -eq 0 ] ; then
-		OKCOUNT+=1
-		echo " OK"
-	else
-		FAILSEEDS+=" $BASESEED"
-		echo " FAIL"
-		echo "==== $BASENAME.$SEED.coojalog ====" ; cat $BASENAME.$SEED.coojalog;
-		echo "==== $BASENAME.$SEED.scriptlog ====" ; cat $BASENAME.$SEED.scriptlog;
-	fi
 done
 
 if [ $TESTCOUNT -ne $OKCOUNT ] ; then


### PR DESCRIPTION
Let the Cooja output echo to stdout in
the tests. This simplifies simexec.sh
and also gives a slight speedup since
the removed polling loop always slept
for 1 second per iteration.