### PR TITLE
Fix Cooja warning in tests/examples

### DIFF
--- a/examples/6tisch/etsi-plugtest-2017/test-with-cooja-mote.csc
+++ b/examples/6tisch/etsi-plugtest-2017/test-with-cooja-mote.csc
@@ -5,7 +5,6 @@
   <project EXPORT="discard">[APPS_DIR]/avrora</project>
   <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
-  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
   <simulation>
     <title>ETSI Plugtest 2017 with Cooja Mote</title>
     <speedlimit>1.0</speedlimit>

--- a/examples/6tisch/simple-node/rpl-tsch-cooja.csc
+++ b/examples/6tisch/simple-node/rpl-tsch-cooja.csc
@@ -5,7 +5,6 @@
   <project EXPORT="discard">[APPS_DIR]/avrora</project>
   <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
-  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
   <simulation>
     <title>RPL+TSCH</title>
     <randomseed>123456</randomseed>

--- a/tests/07-simulation-base/02-ringbufindex.csc
+++ b/tests/07-simulation-base/02-ringbufindex.csc
@@ -5,7 +5,6 @@
   <project EXPORT="discard">[APPS_DIR]/avrora</project>
   <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
-  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
   <simulation>
     <title>Test ringbufindex</title>
     <randomseed>123456</randomseed>

--- a/tests/07-simulation-base/26-cooja-rpl-tsch-orchestra-perfect-link.csc
+++ b/tests/07-simulation-base/26-cooja-rpl-tsch-orchestra-perfect-link.csc
@@ -5,7 +5,6 @@
   <project EXPORT="discard">[APPS_DIR]/avrora</project>
   <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
-  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
   <simulation>
     <title>RPL+TSCH</title>
     <randomseed>123456</randomseed>

--- a/tests/13-ieee802154/01-panid-handling.csc
+++ b/tests/13-ieee802154/01-panid-handling.csc
@@ -5,7 +5,6 @@
   <project EXPORT="discard">[APPS_DIR]/avrora</project>
   <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
-  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
   <simulation>
     <title>My simulation</title>
     <randomseed>123456</randomseed>

--- a/tests/15-rpl-classic/10-rpl-multi-dodag.csc
+++ b/tests/15-rpl-classic/10-rpl-multi-dodag.csc
@@ -6,7 +6,6 @@
   <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
   <project EXPORT="discard">[APPS_DIR]/serial2pty</project>
-  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
   <simulation>
     <title>My simulation</title>
     <randomseed>123456</randomseed>


### PR DESCRIPTION
Cooja currently prints:

 WARN [main] (Cooja.java:4314) - Replaced [APPS_DIR]/radiologger-headless with /home/user/contiki-ng/tools/cooja/apps/radiologger-headless (default: /home/user/contiki-ng/tools/cooja/apps), but could not find it. This does not have to be an error, as the file might be created later.
 WARN [main] (Cooja.java:3678) - Loaded simulation may depend on not found  extension: '/home/user/contiki-ng/tools/cooja/apps/radiologger-headless'

in the regression tests. Remove the references
to the third-party module radiologger-headless
to avoid these warnings.