### PR TITLE
TSCH_CONF_ASSOCIATION_POLL_FREQUENCY revert change

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-def.h
+++ b/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-def.h
@@ -133,9 +133,9 @@
 #define TSCH_CONF_CHANNEL_SCAN_DURATION (CLOCK_SECOND / 10)
 #endif
 
-/* Tweak to improve TSCH association speed on this platform */
+/* Increase this from the default 100 to improve TSCH association speed on this platform */
 #ifndef TSCH_CONF_ASSOCIATION_POLL_FREQUENCY
-#define TSCH_CONF_ASSOCIATION_POLL_FREQUENCY 10
+#define TSCH_CONF_ASSOCIATION_POLL_FREQUENCY 1000
 #endif
 
 /* Slightly reduce the TSCH guard time (from 2200 usec to 1800 usec) to make sure


### PR DESCRIPTION
Prior to version 4.7, the TSCH_CONF_ASSOCIATION_POLL_FREQUENCY for the CC26xx/CC13xx was 1000.
Version 4.7 changed it to 10 with the attempt to improve the association performance (PR #1515).
After user complains on actually reduced performance the PR reverts this change.