### PR TITLE
msp430: gcc 9 compilation fixes

### DIFF
--- a/arch/cpu/msp430/isr_compat.h
+++ b/arch/cpu/msp430/isr_compat.h
@@ -58,7 +58,9 @@
 /* A tricky #define to stringify _Pragma parameters */
 #define __PRAGMA__(x) _Pragma(#x)
 
-#if defined(__GNUC__)  &&  defined(__MSP430__)
+#if defined(__GNUC__) && (__GNUC__ >= 9)
+#define ISR(a,b) __attribute__((interrupt(a ## _VECTOR))) void b(void)
+#elif defined(__GNUC__)  &&  defined(__MSP430__)
     /* This is the MSPGCC compiler */
 #define ISR(a,b) interrupt(a ## _VECTOR) b(void)
 #elif defined(__AQCOMPILER__)

--- a/arch/cpu/msp430/msp430-def.h
+++ b/arch/cpu/msp430/msp430-def.h
@@ -41,7 +41,12 @@
 
 #else /* __IAR_SYSTEMS_ICC__ */
 
-#ifdef __MSPGCC__
+#if defined(__GNUC__) && (__GNUC__ >= 9)
+#include <msp430.h>
+#define nop() _no_operation()
+#define eint()  __eint()
+#define dint()  __dint()
+#elif defined(__MSPGCC__)
 #include <msp430.h>
 #include <legacymsp430.h>
 #else /* __MSPGCC__ */


### PR DESCRIPTION
This makes the msp430 header files compile
with gcc 9 from Texas Instruments.