### PR TITLE
Remove unused CC_CONF_*

### DIFF
--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -99,7 +99,6 @@
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
 #define CC_CONF_REGISTER_ARGS          1
-#define CC_CONF_FUNCTION_POINTER_ARGS  1
 #define CC_CONF_VA_ARGS                1
 #define CC_CONF_INLINE inline
 

--- a/arch/platform/jn516x/jn516x-def.h
+++ b/arch/platform/jn516x/jn516x-def.h
@@ -215,7 +215,6 @@
  */
 
 #define CC_CONF_REGISTER_ARGS          1
-#define CC_CONF_FUNCTION_POINTER_ARGS  1
 #define CC_CONF_VA_ARGS                1
 #define CC_CONF_INLINE                 inline
 

--- a/arch/platform/native/contiki-conf.h
+++ b/arch/platform/native/contiki-conf.h
@@ -52,7 +52,6 @@ struct select_callback {
 int select_set_callback(int fd, const struct select_callback *callback);
 
 #define CC_CONF_REGISTER_ARGS          1
-#define CC_CONF_FUNCTION_POINTER_ARGS  1
 #define CC_CONF_VA_ARGS                1
 /*#define CC_CONF_INLINE                 inline*/
 

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -58,43 +58,6 @@
 #define CC_REGISTER_ARG
 #endif /* CC_CONF_REGISTER_ARGS */
 
-/**
- * Configure if the C compiler supports the arguments for function
- * pointers.
- */
-#if CC_CONF_FUNCTION_POINTER_ARGS
-#define CC_FUNCTION_POINTER_ARGS 1
-#else /* CC_CONF_FUNCTION_POINTER_ARGS */
-#define CC_FUNCTION_POINTER_ARGS 0
-#endif /* CC_CONF_FUNCTION_POINTER_ARGS */
-
-/**
- * Configure if the C compiler have problems with const function pointers
- */
-#ifdef CC_CONF_CONST_FUNCTION_BUG
-#define CC_CONST_FUNCTION
-#else /* CC_CONF_CONST_FUNCTION_BUG */
-#define CC_CONST_FUNCTION const
-#endif /* CC_CONF_CONST_FUNCTION_BUG */
-
-/**
- * Configure work-around for unsigned char bugs with sdcc.
- */
-#if CC_CONF_UNSIGNED_CHAR_BUGS
-#define CC_UNSIGNED_CHAR_BUGS 1
-#else /* CC_CONF_UNSIGNED_CHAR_BUGS */
-#define CC_UNSIGNED_CHAR_BUGS 0
-#endif /* CC_CONF_UNSIGNED_CHAR_BUGS */
-
-/**
- * Configure if C compiler supports double hash marks in C macros.
- */
-#if CC_CONF_DOUBLE_HASH
-#define CC_DOUBLE_HASH 1
-#else /* CC_CONF_DOUBLE_HASH */
-#define CC_DOUBLE_HASH 0
-#endif /* CC_CONF_DOUBLE_HASH */
-
 #ifdef CC_CONF_INLINE
 #define CC_INLINE CC_CONF_INLINE
 #else /* CC_CONF_INLINE */
@@ -124,15 +87,6 @@
 #else
 #define CC_DEPRECATED(msg)
 #endif /* CC_CONF_DEPRECATED */
-
-/**
- * Configure if the C compiler supports the assignment of struct value.
- */
-#ifdef CC_CONF_ASSIGN_AGGREGATE
-#define CC_ASSIGN_AGGREGATE(dest, src)	CC_CONF_ASSIGN_AGGREGATE(dest, src)
-#else /* CC_CONF_ASSIGN_AGGREGATE */
-#define CC_ASSIGN_AGGREGATE(dest, src)	*dest = *src
-#endif /* CC_CONF_ASSIGN_AGGREGATE */
 
 #if CC_CONF_NO_VA_ARGS
 #define CC_NO_VA_ARGS CC_CONF_VA_ARGS

--- a/tools/doxygen/Doxyfile
+++ b/tools/doxygen/Doxyfile
@@ -1959,8 +1959,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = CC_FUNCTION_POINTER_ARGS:=1 \
-                         NETSTACK_CONF_WITH_IPV6:=1 \
+PREDEFINED             = NETSTACK_CONF_WITH_IPV6:=1 \
                          UIP_TCP:=1 \
                          UIP_UDP:=1 \
                          UIP_CONF_ICMP6:=1 \


### PR DESCRIPTION
The defined macros are not used in Contiki-NG
so remove the ifdefs.