### PR TITLE
tests: add more missing cleans

### DIFF
--- a/tests/06-script-base/code-result-visualization/00-result-visualization.csc
+++ b/tests/06-script-base/code-result-visualization/00-result-visualization.csc
@@ -19,7 +19,8 @@
       <identifier>mtype660</identifier>
       <description>RPL/TSCH Node</description>
       <source>[CONTIKI_DIR]/examples/benchmarks/result-visualization/node.c</source>
-      <commands>make TARGET=cooja node.cooja</commands>
+      <commands>make clean TARGET=cooja
+make TARGET=cooja node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/13-ieee802154/01-panid-handling.csc
+++ b/tests/13-ieee802154/01-panid-handling.csc
@@ -25,7 +25,8 @@
       <identifier>mtype740</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONFIG_DIR]/code-panid-handling/test-panid-handling.c</source>
-      <commands>make -j test-panid-handling.cooja TARGET=cooja</commands>
+      <commands>make clean TARGET=cooja
+make -j test-panid-handling.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/13-ieee802154/02-tsch-flush-nbr-queue.csc
+++ b/tests/13-ieee802154/02-tsch-flush-nbr-queue.csc
@@ -24,7 +24,8 @@
       <identifier>mtype476</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONFIG_DIR]/code-flush-nbr-queue/test-flush-nbr-queue.c</source>
-      <commands>make -j test-flush-nbr-queue.cooja TARGET=cooja</commands>
+      <commands>make clean TARGET=cooja
+make -j test-flush-nbr-queue.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/14-rpl-lite/10-rpl-resetting-dio-timer-by-dis.csc
+++ b/tests/14-rpl-lite/10-rpl-resetting-dio-timer-by-dis.csc
@@ -24,7 +24,8 @@
       <identifier>mtype325</identifier>
       <description>root</description>
       <source>[CONTIKI_DIR]/tests/14-rpl-lite/code/root-node.c</source>
-      <commands>make root-node.cooja TARGET=cooja</commands>
+      <commands>make clean TARGET=cooja
+make root-node.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/15-rpl-classic/10-rpl-multi-dodag.csc
+++ b/tests/15-rpl-classic/10-rpl-multi-dodag.csc
@@ -26,7 +26,8 @@
       <identifier>mtype301</identifier>
       <description>Sender</description>
       <source>[CONFIG_DIR]/code/sender-node.c</source>
-      <commands>make -j sender-node.cooja TARGET=cooja</commands>
+      <commands>make clean TARGET=cooja
+make -j sender-node.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/15-rpl-classic/11-rpl-resetting-dio-timer-by-dis.csc
+++ b/tests/15-rpl-classic/11-rpl-resetting-dio-timer-by-dis.csc
@@ -24,7 +24,8 @@
       <identifier>mtype325</identifier>
       <description>root</description>
       <source>[CONTIKI_DIR]/tests/15-rpl-classic/code/root-node.c</source>
-      <commands>make root-node.cooja TARGET=cooja</commands>
+      <commands>make clean TARGET=cooja
+make root-node.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>


### PR DESCRIPTION
This fixes more non-reproducible failures
in Cooja simulations.

This is a sibling to commit 82af502b98e.