### PR TITLE
Avoid out-of-bounds access in cfs-coffee

### DIFF
--- a/os/storage/cfs/cfs-coffee.c
+++ b/os/storage/cfs/cfs-coffee.c
@@ -1253,8 +1253,10 @@ cfs_readdir(struct cfs_dir *dir, struct cfs_dirent *record)
   while(page < COFFEE_PAGE_COUNT) {
     read_header(&hdr, page);
     if(HDR_ACTIVE(hdr) && !HDR_LOG(hdr)) {
-      memcpy(record->name, hdr.name, sizeof(record->name));
-      record->name[sizeof(record->name) - 1] = '\0';
+      memcpy(record->name,
+             hdr.name,
+             MIN(sizeof(record->name), sizeof(hdr.name)));
+      record->name[MIN(sizeof(record->name), sizeof(hdr.name)) - 1] = '\0';
       record->size = file_end(page);
 
       next_page = next_file(page, &hdr);

--- a/os/storage/cfs/cfs.h
+++ b/os/storage/cfs/cfs.h
@@ -67,6 +67,9 @@ typedef int cfs_offset_t;
 typedef CFS_CONF_OFFSET_TYPE cfs_offset_t;
 #endif
 
+/**< CFS directory entry name length */
+#define CFS_DIR_ENTRY_NAME_LENGTH   32
+
 struct cfs_dir {
   /* Iteration state, which is implementation-defined and should not be
      accessed externally. */
@@ -74,7 +77,7 @@ struct cfs_dir {
 };
 
 struct cfs_dirent {
-  char name[32];
+  char name[CFS_DIR_ENTRY_NAME_LENGTH];
   cfs_offset_t size;
 };
 


### PR DESCRIPTION
Fixes a potential out-of-bounds access in cfs-coffee. Firstly suggested in https://github.com/contiki-ng/contiki-ng/pull/1502, and discussed in https://github.com/contiki-ng/contiki-ng/pull/1502#discussion_r645089921.