### PR TITLE
sky-sensors: use ADC12MCTL from SDK

### DIFF
--- a/arch/platform/sky/dev/sky-sensors.c
+++ b/arch/platform/sky/dev/sky-sensors.c
@@ -39,7 +39,7 @@
 #include "contiki.h"
 #include "lib/sensors.h"
 
-#define ADC12MCTL_NO(adcno) ((unsigned char *) ADC12MCTL0_)[adcno]
+#define ADC12MCTL_NO(adcno) ADC12MCTL[adcno]
 
 static uint16_t adc_on;
 static uint16_t ready;

--- a/arch/platform/z1/dev/sky-sensors.c
+++ b/arch/platform/z1/dev/sky-sensors.c
@@ -39,7 +39,7 @@
 #include "contiki.h"
 #include "lib/sensors.h"
 
-#define ADC12MCTL_NO(adcno) ((unsigned char *) ADC12MCTL0_)[adcno]
+#define ADC12MCTL_NO(adcno) ADC12MCTL[adcno]
 
 static uint16_t adc_on;
 static uint16_t ready;


### PR DESCRIPTION
This definition exists in the header files in both gcc 4.7.2 and gcc 9.3.1. Additionally, the definition in the header files is volatile.