### PR TITLE
cooja: add a JNI_OnLoad function

### DIFF
--- a/arch/platform/cooja/platform.c
+++ b/arch/platform/cooja/platform.c
@@ -221,6 +221,24 @@ process_run_thread_loop(void *data)
   /* Then call common Contiki-NG main function */
   main();
 }
+
+/**
+ * \brief           Callback on load of library.
+ * \param vm        unused
+ * \param reserved  unused
+ *
+ * This function is required to return at least the JNI version for
+ * the functions we use.
+ *
+ * Java 11 is the oldest supported Java version so the function returns
+ * JNI_VERSION_10 for now.
+ */
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+  return JNI_VERSION_10;
+}
+
 /*---------------------------------------------------------------------------*/
 /**
  * \brief      Initialize a mote by starting processes etc.


### PR DESCRIPTION
This function is required to return
the JNI version for the functions we
use, and we use some that are later
than 1.1. Without the function, the JVM assumes
JNI Version 1.1.

Java 11 is the oldest supported Java version
so make the function return JNI_VERSION_10.