### PR TITLE
tests: make wget non-verbose

### DIFF
--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -18,7 +18,7 @@ sleep 10
 
 echo "Downloading leshan"
 LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-wget -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
+wget -nv -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server"
 java -jar $LESHAN_JAR >leshan.log 2>leshan.err &
 LESHID=$!

--- a/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
+++ b/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
@@ -13,7 +13,7 @@ make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m >make.log 2>mak
 
 echo "Downloading leshan"
 LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-wget -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
+wget -nv -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server"
 java -jar $LESHAN_JAR -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
 LESHID=$!

--- a/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
+++ b/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
@@ -17,7 +17,7 @@ sleep 10
 
 echo "Downloading leshan with Q-Mode support"
 LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
-wget -nc https://carlosgp143.github.io/resources/$LESHAN_JAR
+wget -nv -nc https://carlosgp143.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server with Q-Mode enabled"
 java -jar $LESHAN_JAR >leshan.log 2>leshan.err &
 LESHID=$!

--- a/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
+++ b/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
@@ -12,7 +12,7 @@ make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m DEFINES=LWM2M_Q
 
 echo "Downloading leshan with Q-Mode support"
 LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
-wget -nc https://carlosgp143.github.io/resources/$LESHAN_JAR
+wget -nv -nc https://carlosgp143.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server with Q-Mode enabled"
 java -jar $LESHAN_JAR -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
 LESHID=$!


### PR DESCRIPTION
The files downloaded are 19150-42000K
so the progress indicators are substantial.
Switch wget to non-verbose mode.