### PR TITLE
cc2538dk: fix test flags for 6tisch/simple-node

### DIFF
--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -3,7 +3,7 @@ TOOLSDIR=../../tools
 
 EXAMPLES = \
 6tisch/6p-packet/zoul \
-6tisch/simple-node/cc2538dk:MAKE_WITH_SECURITY=1,MAKE_WITH_ORCHESTRA=1 \
+6tisch/simple-node/cc2538dk:MAKE_WITH_SECURITY=1:MAKE_WITH_ORCHESTRA=1 \
 6tisch/simple-node/simplelink:DEFINES=TSCH_CONF_AUTOSELECT_TIME_SOURCE=1 \
 6tisch/simple-node/nrf:BOARD=nrf52840/dk \
 6tisch/simple-node/nrf:BOARD=nrf52840/dongle \


### PR DESCRIPTION
The current simple-node test is built with
MAKE_WITH_SECURITY=0 and MAKE_WITH_ORCHESTRA=0
which was probably not the intention. Adjust
the test to build with MAKE_WITH_SECURITY=1
and MAKE_WITH_ORCHESTRA=1.