### PR TITLE
native: do not create a map file

### DIFF
--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -48,11 +48,11 @@ endif
 ifeq ($(HOST_OS),Darwin)
 AROPTS = -rc
 LDFLAGS_WERROR := -Wl,-fatal_warnings
-LDFLAGS += -Wl,-flat_namespace,-map,$(CONTIKI_NG_PROJECT_MAP)
+LDFLAGS += -Wl,-flat_namespace
 CFLAGS += -DHAVE_SNPRINTF=1 -U__ASSERT_USE_STDERR
 else
 ifeq ($(HOST_OS),Linux)
-LDFLAGS += -Wl,-Map=$(CONTIKI_NG_PROJECT_MAP),-export-dynamic
+LDFLAGS += -Wl,-export-dynamic
 endif
 endif
 


### PR DESCRIPTION
Cooja is currently the user of map files
on the native platform, but that build configuration
resides in Cooja.