### PR TITLE
native/cooja: enable motelist-all target

### DIFF
--- a/Makefile.embedded
+++ b/Makefile.embedded
@@ -34,14 +34,3 @@ serialview: $(SERIAL_DUMP_BIN)
 
 login: $(SERIAL_DUMP_BIN)
 	$(SERIALDUMP) -b$(BAUDRATE) $(PORT)
-
-###
-### Targets using tools/motelist
-###
-CONTIKI_NG_MOTELIST_DIR = $(CONTIKI_NG_TOOLS_DIR)/motelist
-CONTIKI_NG_MOTELIST = $(CONTIKI_NG_MOTELIST_DIR)/motelist.py
-
-.PHONY: motelist-all
-
-motelist-all:
-	$(CONTIKI_NG_MOTELIST)

--- a/Makefile.include
+++ b/Makefile.include
@@ -520,6 +520,17 @@ endif
 	@echo "To view more Make variables, edit $(CONTIKI)/Makefile.include, rule 'viewconf'"
 	@echo "To view more C variables, edit $(VIEWCONF)"
 
+###
+### Targets using tools/motelist
+###
+CONTIKI_NG_MOTELIST_DIR = $(CONTIKI_NG_TOOLS_DIR)/motelist
+CONTIKI_NG_MOTELIST = $(CONTIKI_NG_MOTELIST_DIR)/motelist.py
+
+.PHONY: motelist-all
+
+motelist-all:
+	$(Q)$(CONTIKI_NG_MOTELIST)
+
 ### Include Makefile.embedded for relevant platforms, in order to pull in
 ### rules for login, serialview etc
 ifeq ($(findstring $(TARGET),native cooja),)


### PR DESCRIPTION
The build system defaults to TARGET=native so
typing "make motelist-all" gives:

TARGET not defined, using target 'native'
make: *** No rule to make target 'motelist-all'.  Stop.

Move the diagnostic motelist-all target to
Makefile.include so the user can get a listing
of the devices connected to the computer regardless
of TARGET.