### PR TITLE
examples: fix identify target include

### DIFF
--- a/examples/mqtt-client/Makefile
+++ b/examples/mqtt-client/Makefile
@@ -6,7 +6,7 @@ CONTIKI = ../..
 include $(CONTIKI)/Makefile.dir-variables
 MODULES += $(CONTIKI_NG_APP_LAYER_DIR)/mqtt
 
--include $(CONTIKI)/Makefile.identify-target
+include $(CONTIKI)/Makefile.identify-target
 
 MODULES_REL += arch/platform/$(TARGET)
 

--- a/examples/platform-specific/cc26x0-cc13x0/base-demo/Makefile
+++ b/examples/platform-specific/cc26x0-cc13x0/base-demo/Makefile
@@ -1,6 +1,7 @@
 CONTIKI_PROJECT = base-demo
 
--include $(CONTIKI)/Makefile.identify-target
+CONTIKI = ../../../..
+include $(CONTIKI)/Makefile.identify-target
 
 MODULES_REL += $(TARGET)
 
@@ -8,5 +9,4 @@ PLATFORMS_ONLY = cc26x0-cc13x0 simplelink
 
 all: $(CONTIKI_PROJECT)
 
-CONTIKI = ../../../..
 include $(CONTIKI)/Makefile.include


### PR DESCRIPTION
This file should always exist, require
the include to succeed.