### PR TITLE
native: do not add everything to symtable

### DIFF
--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -50,10 +50,6 @@ AROPTS = -rc
 LDFLAGS_WERROR := -Wl,-fatal_warnings
 LDFLAGS += -Wl,-flat_namespace
 CFLAGS += -DHAVE_SNPRINTF=1 -U__ASSERT_USE_STDERR
-else
-ifeq ($(HOST_OS),Linux)
-LDFLAGS += -Wl,-export-dynamic
-endif
 endif
 
 # Disallow undefined symbols in object files.


### PR DESCRIPTION
The --export-dynamic flag adds all symbols
to the dynamic symbol table. This might be
required when using dlopen like Cooja does,
but the Cooja platform has its own Makefile
and build flags.