### PR TITLE
native: do not use ?= for make predefines

### DIFF
--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -4,17 +4,17 @@ CONTIKI_SOURCEFILES += rtimer-arch.c watchdog.c eeprom.c int-master.c
 CONTIKI_SOURCEFILES += gpio-hal-arch.c
 
 ### Compiler definitions
-CC       ?= gcc
-CXX      ?= g++
+CC       = gcc
+CXX      = g++
 ifdef LD_OVERRIDE
   LD     = $(LD_OVERRIDE)
 else
   LD     = gcc
 endif
-AS       ?= as
-NM       ?= nm
-OBJCOPY  ?= objcopy
-STRIP    ?= strip
+AS       = as
+NM       = nm
+OBJCOPY  = objcopy
+STRIP    = strip
 ifeq ($(WERROR),1)
 CFLAGSWERROR=-Werror
 endif

--- a/tests/06-script-base/code-test-lc/Makefile
+++ b/tests/06-script-base/code-test-lc/Makefile
@@ -1,6 +1,6 @@
 CONTIKI = ../../..
 
-CC ?= gcc
+CC = gcc
 CFLAGS += -Wall -g -I/user/local/include
 CFLAGS += -I$(CONTIKI)/os
 

--- a/tests/06-script-base/code-test-memb/Makefile
+++ b/tests/06-script-base/code-test-memb/Makefile
@@ -1,6 +1,6 @@
 CONTIKI = ../../..
 
-CC ?= gcc
+CC = gcc
 CFLAGS += -Wall -g
 CFLAGS += -I.
 CFLAGS += -I/user/local/include


### PR DESCRIPTION
Make predefines variables such as CC, CXX,
AS and so on, so using ?= to define
them in a Makefile will have no effect.
Switch the Makefiles to using = instead.