### PR TITLE
tests: reduce output in Cooja tests

### DIFF
--- a/tests/Makefile.simulation-test
+++ b/tests/Makefile.simulation-test
@@ -37,6 +37,9 @@ RUNCOUNT ?= 1
 
 CONTIKI ?= ../..
 
+Q ?= @
+
+.PHONY: all clean cooja tests
 tests: $(TESTLOGS)
 
 summary: clean
@@ -57,4 +60,5 @@ clean:
 
 cooja: $(CONTIKI)/tools/cooja/dist/cooja.jar
 $(CONTIKI)/tools/cooja/dist/cooja.jar:
-	cd $(CONTIKI)/tools/cooja && ant jar
+	@echo "Building Cooja"
+	$(Q)ant -f $(CONTIKI)/tools/cooja/build.xml -silent jar

--- a/tests/simexec.sh
+++ b/tests/simexec.sh
@@ -25,8 +25,6 @@ declare -i OKCOUNT=0
 FAILSEEDS=
 
 for (( SEED=$BASESEED; SEED<$(($BASESEED+$RUNCOUNT)); SEED++ )); do
-  echo "Running test $BASENAME with random seed $SEED"
-
   if java -Xshare:on -Dnashorn.args=--no-deprecation-warning -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$CSC -contiki=$CONTIKI -random-seed=$SEED; then
     OKCOUNT+=1
   else


### PR DESCRIPTION
IMPORTANT: Merge after #1852.

Cooja now prints the simulation so remove
the echo from simexec.sh and run ant in
silent mode so only errors and warnings
are printed.

Also add a $(Q) definition and .PHONY directive
to Makefile.simulation-test while changing it.