### PR TITLE
Makefile: stop when rm fails

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -355,9 +355,9 @@ CONTIKI_NG_PROJECT_MAP = $(BUILD_DIR_BOARD)/$(basename $(notdir $@)).map
 .PHONY: all clean distclean usage help targets boards savetarget savedefines viewconf
 
 clean:
-	-$(Q)rm -f *.d *.e *.o $(CLEAN)
-	-$(Q)rm -rf $(BUILD_DIR_TARGET)
-	-$(Q)rm -f $(addsuffix .$(TARGET), $(CONTIKI_PROJECT))
+	$(Q)rm -f *.d *.e *.o $(CLEAN) \
+		$(addsuffix .$(TARGET), $(CONTIKI_PROJECT))
+	$(Q)rm -rf $(BUILD_DIR_TARGET)
 	@echo Target $(TARGET) cleaned
 
 distclean:
@@ -365,7 +365,7 @@ distclean:
 		echo Running: $(MAKE) TARGET=$$TARG clean; \
 		$(MAKE) TARGET=$$TARG clean; \
 	done
-	-$(Q)rm -rf $(BUILD_DIR)
+	$(Q)rm -rf $(BUILD_DIR)
 
 -include $(CONTIKI_NG_RELOC_PLATFORM_DIR)/$(TARGET)/Makefile.customrules-$(TARGET)
 
@@ -490,7 +490,7 @@ else
 endif
 
 savetarget:
-	-@rm -f Makefile.target
+	@rm -f Makefile.target
 	@echo "saving Makefile.target"
 	@echo >Makefile.target "TARGET = $(TARGET)"
 ifneq ($(BOARD),)
@@ -498,7 +498,7 @@ ifneq ($(BOARD),)
 endif
 
 savedefines:
-	-@rm -f Makefile.$(TARGET).defines
+	@rm -f Makefile.$(TARGET).defines
 	@echo "saving Makefile.$(TARGET).defines"
 	@echo >Makefile.$(TARGET).defines "DEFINES = $(DEFINES)"
 


### PR DESCRIPTION
The current behavior of "make clean" and
several other targets that use rm is to proceed
even if the removal failed, and eventually
return 0. This patch makes make fail and return
a non-zero exit code when rm fails, for example
if the user doesn't have permissions to remove
files/directories:

examples/hello-world$ make clean
TARGET not defined, using target 'native'
rm: cannot remove 'build/native/hello-world.native': Permission denied
rm: cannot remove 'build/native/contiki-ng-native.a': Permission denied
rm: cannot remove 'build/native/obj': Permission denied
make: *** [../../Makefile.include:358: clean] Error 1
examples/hello-world$ echo $?
2

Stopping on failure is important for reproducible
regression tests.