### PR TITLE
Stop truncating names in archive

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -438,7 +438,7 @@ ifndef CUSTOM_RULE_CPP_TO_E
 endif
 
 ifndef AROPTS
-  AROPTS = rcf
+  AROPTS = rc
 endif
 
 ifndef CUSTOM_RULE_ALLOBJS_TO_TARGETLIB


### PR DESCRIPTION
We do not have legacy-ar-implementations
on the supported platforms so stop truncating
long file names for compatibility reasons.