### PR TITLE
cooja: do not override archive lib rule

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -1,5 +1,3 @@
-# $Id: Makefile.cooja,v 1.42 2010/11/10 13:11:43 fros4943 Exp $
-
 ## The COOJA Simulator Contiki platform Makefile
 ##
 ## This makefile should normally never be called directly, but
@@ -57,9 +55,7 @@ endif
 
 endif ## QUICKSTART
 
-#MAIN_SRC = $(BUILD_DIR_BOARD)/$(LIBNAME).c
 MAIN_OBJ = $(BUILD_DIR_BOARD)/$(LIBNAME).o
-ARCHIVE = $(BUILD_DIR_BOARD)/$(LIBNAME).a
 JNILIB = $(BUILD_DIR_BOARD)/$(LIBNAME).$(TARGET)
 CONTIKI_APP_OBJ = $(CONTIKI_APP).o
 
@@ -89,7 +85,6 @@ CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 CLEAN += COOJA.log
 
 ### Compiler arguments
-#CC = gcc
 CFLAGSNO = $(JAVA_CFLAGS) $(EXTRA_CC_ARGS) -Wall -g -I/usr/local/include -DCLASSNAME=$(CLASSNAME)
 ifeq ($(WERROR),1)
 CFLAGSNO += -Werror

--- a/arch/platform/cooja/Makefile.customrules-cooja
+++ b/arch/platform/cooja/Makefile.customrules-cooja
@@ -1,26 +1,12 @@
 ### Define custom targets
 
-CUSTOM_RULE_C_TO_CE=1
-#CUSTOM_RULE_C_TO_OBJECTDIR_O=1
 CUSTOM_RULE_S_TO_OBJECTDIR_O=1
-#CUSTOM_RULE_C_TO_O=1
-#CUSTOM_RULE_C_TO_CO=1
-CUSTOM_RULE_ALLOBJS_TO_TARGETLIB=1
 CUSTOM_RULE_LINK=1
 
-REDEF_PRINTF=1 # Redefine functions to enable printf()s inside Cooja
-
-# NB: Assumes ARCHIVE was not overridden and is in $(BUILD_DIR_BOARD)
-$(ARCHIVE): $(CONTIKI_OBJECTFILES) | $(OBJECTDIR)
-	$(Q)$(AR_COMMAND_1) $^ $(AR_COMMAND_2)
-
 # NB: Assumes JNILIB was not overridden and is in $(BUILD_DIR_BOARD)
-$(JNILIB): $(CONTIKI_APP_OBJ) $(MAIN_OBJ) $(PROJECT_OBJECTFILES) $(ARCHIVE) | $(OBJECTDIR)
-
-ifdef REDEF_PRINTF
+$(JNILIB): $(CONTIKI_APP_OBJ) $(MAIN_OBJ) $(PROJECT_OBJECTFILES) $(CONTIKI_NG_TARGET_LIB) | $(OBJECTDIR)
 	@echo Redefining printf,sprintf,vsnprintf,etc.
 	-$(Q)$(foreach OBJ,$^, $(OBJCOPY) --redefine-syms $(CONTIKI)/arch/platform/cooja/redefine.syms $(OBJ); )
-endif ## REDEF_PRINTF
 	@echo Linking $(JNILIB)
 	$(Q)$(LINK_COMMAND_1) $^ $(LINK_COMMAND_2)
 


### PR DESCRIPTION
IMPORTANT: Merge after #1857 to preserve behavior on OS X.

The build commands executed by Cooja are
identical to the build commands executed
by the native platform. Stop overriding
the target library rule and use the existing
rule instead.

Also remove some dead, commented out, and
always true defines.