### PR TITLE
Small improvements found while working on the Silabs port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,15 @@ jobs:
     steps:
 
     # Checks out the repo with full history
-    - uses: actions/checkout@v2
+    - name: Checkout github repo (+ download lfs dependencies)
+      uses: actions/checkout@v2
       with:
           fetch-depth: '0'
           submodules: 'recursive'
           persist-credentials: false
+          lfs: true
+    - name: Checkout LFS objects
+      run: git lfs checkout
 
     # Construct the correct docker container image tag corresponding to this build
     - name: Figure out correct docker image tag

--- a/arch/cpu/arm/cortex-m/Makefile.cortex-m
+++ b/arch/cpu/arm/cortex-m/Makefile.cortex-m
@@ -1,13 +1,16 @@
-CMSIS_PATH = CMSIS/CMSIS
+ifndef CMSIS_PATH
+    CMSIS_PATH = CMSIS/CMSIS
 
-CMSIS_ROOT = $(CONTIKI)/$(CONTIKI_NG_ARM_DIR)/$(CMSIS_PATH)
-ifeq (,$(wildcard $(CMSIS_ROOT)/*))
-    $(warning $(CMSIS_ROOT) does not exist or is empty.)
-    $(warning Did you run 'git submodule update --init' ?)
-    $(error "")
+    CMSIS_ROOT = $(CONTIKI)/$(CONTIKI_NG_ARM_DIR)/$(CMSIS_PATH)
+    ifeq (,$(wildcard $(CMSIS_ROOT)/*))
+        $(warning $(CMSIS_ROOT) does not exist or is empty.)
+        $(warning Did you run 'git submodule update --init' ?)
+        $(error "")
+    endif
+    CONTIKI_ARM_DIRS += $(CMSIS_PATH)/Core/Include
 endif
 
-CONTIKI_ARM_DIRS += cortex-m $(CMSIS_PATH)/Core/Include
+CONTIKI_ARM_DIRS += cortex-m
 
 ### Build syscalls for newlib
 MODULES += os/lib/newlib

--- a/tools/doxygen/Makefile
+++ b/tools/doxygen/Makefile
@@ -18,7 +18,7 @@ ifeq ($(HOST_OS),Windows)
   endif
 endif
 
-export docdirs = $(sort $(foreach dir,$(basedirs),${shell find $(contiking)/${dir} -type d}))
+export docdirs = $(sort $(foreach dir,$(basedirs),${shell find $(contiking)/${dir} -maxdepth 7 -type d}))
 export docsrc = $(docdirs) $(foreach dir,$(docdirs) .,${shell find $(dir) -type f -name "doxygen*.txt"})
 
 .PHONY: clean html


### PR DESCRIPTION
1. Doxygen script fails when there is a folder with empty space.
2. CMSIS cannot be overwritten forcing the usage of the CMSIS provided by contiki-ng
3. In our actions we are not checking out the lfs dependencies.

This PR contains the commits needed by #1845 which are stand alone and can be considered general improvements to the code.