### PR TITLE
tests: sleep less

### DIFF
--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -14,11 +14,11 @@ make -C $CONTIKI/examples/lwm2m-ipso-objects clean >/dev/null
 make -C $CONTIKI/examples/lwm2m-ipso-objects > make.log 2> make.err
 sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native > node.log 2> node.err &
 CPID=$!
-sleep 10
 
 echo "Downloading leshan"
 LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
 wget -nv -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
+sleep 10
 echo "Starting leshan server"
 java -jar $LESHAN_JAR >leshan.log 2>leshan.err &
 LESHID=$!
@@ -33,11 +33,10 @@ while [ $COUNTER -gt 0 ]; do
 done
 
 echo "Closing native node"
-sleep 1
 kill_bg $CPID
 
-echo "Closing leshan"
 sleep 1
+echo "Closing leshan"
 kill_bg $LESHID
 
 
@@ -56,12 +55,7 @@ else
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 
-rm make.log
-rm make.err
-rm node.log
-rm node.err
-rm leshan.log
-rm leshan.err
+rm make.log make.err node.log node.err leshan.log leshan.err
 
 # We do not want Make to stop -> Return 0
 # The Makefile will check if a log contains FAIL at the end

--- a/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
+++ b/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
@@ -34,11 +34,10 @@ while [ $COUNTER -gt 0 ]; do
 done
 
 echo "Closing standalone example"
-sleep 1
 kill_bg $CPID
 
-echo "Closing leshan"
 sleep 1
+echo "Closing leshan"
 kill_bg $LESHID
 
 
@@ -57,12 +56,7 @@ else
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 
-rm make.log
-rm make.err
-rm node.log
-rm node.err
-rm leshan.log
-rm leshan.err
+rm make.log make.err node.log node.err leshan.log leshan.err
 
 # We do not want Make to stop -> Return 0
 # The Makefile will check if a log contains FAIL at the end

--- a/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
+++ b/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
@@ -13,11 +13,11 @@ make -C $CONTIKI/examples/lwm2m-ipso-objects clean >/dev/null
 make -C $CONTIKI/examples/lwm2m-ipso-objects DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 > make.log 2> make.err
 sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native > node.log 2> node.err &
 CPID=$!
-sleep 10
 
 echo "Downloading leshan with Q-Mode support"
 LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
 wget -nv -nc https://carlosgp143.github.io/resources/$LESHAN_JAR
+sleep 10
 echo "Starting leshan server with Q-Mode enabled"
 java -jar $LESHAN_JAR >leshan.log 2>leshan.err &
 LESHID=$!
@@ -33,11 +33,10 @@ while [ $COUNTER -gt 0 ]; do
 done
 
 echo "Closing native node"
-sleep 1
 pgrep ipso | sudo xargs kill -9
 
-echo "Closing leshan"
 sleep 1
+echo "Closing leshan"
 pgrep java | sudo xargs kill -9
 
 #Two OKs needed: awake and sleeping
@@ -58,12 +57,7 @@ else
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 
-rm make.log
-rm make.err
-rm node.log
-rm node.err
-rm leshan.log
-rm leshan.err
+rm make.log make.err node.log node.err leshan.log leshan.err
 
 # We do not want Make to stop -> Return 0
 # The Makefile will check if a log contains FAIL at the end

--- a/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
+++ b/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
@@ -33,11 +33,10 @@ while [ $COUNTER -gt 0 ]; do
 done
 
 echo "Closing standalone example"
-sleep 1
 pgrep lwm2m-example | sudo xargs kill -9
 
-echo "Closing leshan"
 sleep 1
+echo "Closing leshan"
 pgrep java | sudo xargs kill -9
 
 aux=$(grep -c 'OK' leshan.err)


### PR DESCRIPTION
Put sleep statements on the line before
the thing that needs a delay to happen.
This uncovered a couple of sleep statements
that were not needed.

Also consolidate the separate calls to rm into
a single call to shorten the test scripts and
avoid some forking.