### PR TITLE
msp430: add nop in splhigh_()

### DIFF
--- a/arch/cpu/msp430/f1xxx/msp430.c
+++ b/arch/cpu/msp430/f1xxx/msp430.c
@@ -278,6 +278,9 @@ splhigh_(void)
 #else
   asmv("mov r2, %0" : "=r" (sr));
   asmv("bic %0, r2" : : "i" (GIE));
+  /* GCC 9 warns about risk of incorrect execution without nop after
+     interrupt state changes. */
+  asmv("nop");
 #endif
   return sr & GIE;		/* Ignore other sr bits. */
 }

--- a/arch/cpu/msp430/f2xxx/msp430.c
+++ b/arch/cpu/msp430/f2xxx/msp430.c
@@ -215,6 +215,9 @@ splhigh_(void)
 #else
   asmv("mov r2, %0" : "=r" (sr));
   asmv("bic %0, r2" : : "i" (GIE));
+  /* GCC 9 warns about risk of incorrect execution without nop after
+     interrupt state changes. */
+  asmv("nop");
 #endif
   return sr & GIE;    /* Ignore other sr bits. */
 }

--- a/arch/cpu/msp430/f5xxx/msp430.c
+++ b/arch/cpu/msp430/f5xxx/msp430.c
@@ -217,6 +217,9 @@ splhigh_(void)
 #else
   asmv("mov r2, %0" : "=r" (sr));
   asmv("bic %0, r2" : : "i" (GIE));
+  /* GCC 9 warns about risk of incorrect execution without nop after
+     interrupt state changes. */
+  asmv("nop");
 #endif
   return sr & GIE;		/* Ignore other sr bits. */
 }


### PR DESCRIPTION
The assembler in GCC 9 complains about
a missing nop after interrupt state
changes. Add the nop.