### PR TITLE
z1: add newlib printf support

### DIFF
--- a/arch/cpu/msp430/dev/uart0-putchar.c
+++ b/arch/cpu/msp430/dev/uart0-putchar.c
@@ -36,4 +36,19 @@ putchar(int c)
 #endif /* SLIP_ARCH_CONF_ENABLED */
   return c;
 }
+
+#if defined(__GNUC__) && (__GNUC__ >= 9)
+/* The printf() in newlib in GCC 9 from Texas Instruments uses the
+ * "TI C I/O" protocol which is not implemented in GDB. The user manual
+ * suggests overriding write() to redirect printf() output. */
+int
+write(int fd, const char *buf, int len)
+{
+  int i = 0;
+  for(; i < len && buf[i]; i++) {
+    putchar(buf[i]);
+  }
+  return i;
+}
+#endif
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This makes 07-hello-world-z1.csc pass
when using GCC 9.