### PR TITLE
cooja: only build used modules

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -246,7 +246,7 @@ endif
 MODULEDIRS = $(MODULES_REL) ${addprefix $(CONTIKI)/, $(MODULES)}
 UNIQUEMODULES = $(call uniq,$(MODULEDIRS))
 MODULES_SOURCES = ${foreach d, $(UNIQUEMODULES), ${subst ${d}/,,${wildcard $(d)/*.c}}}
-CONTIKI_SOURCEFILES += $(MODULES_SOURCES)
+CONTIKI_SOURCEFILES += $(filter-out $(MODULES_SOURCES_EXCLUDES), $(MODULES_SOURCES))
 
 # Include module-specific makefiles
 MODULES_INCLUDES = ${wildcard ${foreach d, $(UNIQUEMODULES), $(d)/Makefile.${notdir $(d)}}}

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -61,13 +61,18 @@ MAIN_OBJ = $(BUILD_DIR_BOARD)/$(LIBNAME).o
 JNILIB = $(BUILD_DIR_BOARD)/$(LIBNAME).$(TARGET)
 CONTIKI_APP_OBJ = $(CONTIKI_APP).o
 
+# No stack end symbol available, code does not work on 64-bit architectures.
+MODULES_SOURCES_EXCLUDES += stack-check.c
+# No Serial Peripheral Interface in Cooja.
+MODULES_SOURCES_EXCLUDES += spi.c
+
 ### COOJA platform sources
 CONTIKI_TARGET_DIRS = . dev lib sys cfs
 
 # (COOJA_SOURCEDIRS contains additional sources dirs set from simulator)
 vpath %.c $(COOJA_SOURCEDIRS)
 
-COOJA_BASE	= simEnvChange.c cooja_mt.c cooja_mtarch.c rtimer-arch.c slip.c watchdog.c int-master.c
+COOJA_BASE	= simEnvChange.c cooja_mt.c cooja_mtarch.c rtimer-arch.c watchdog.c int-master.c
 
 COOJA_INTFS	= beep.c ip.c leds-arch.c moteid.c \
 		    pir-sensor.c rs232.c vib-sensor.c \


### PR DESCRIPTION
Filter out files that do not work
on the platform.

This discovered that slip.c is added
by Makefile.cooja and Makefile.include
so remove it from Makefile.cooja.