### PR TITLE
cooja: detect missing Makefile.customrules-cooja

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -360,7 +360,8 @@ distclean:
 	done
 	$(Q)rm -rf $(BUILD_DIR)
 
--include $(CONTIKI_NG_RELOC_PLATFORM_DIR)/$(TARGET)/Makefile.customrules-$(TARGET)
+# Include custom build rule Makefiles specified by platforms/CPUs.
+include $(MAKEFILES_CUSTOMRULES)
 
 ### See http://make.paulandlesley.org/autodep.html#advanced
 

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -11,6 +11,8 @@ endif
 
 COOJA_DIR = $(CONTIKI_NG_TOOLS_DIR)/cooja
 
+MAKEFILES_CUSTOMRULES += $(CONTIKI_NG_RELOC_PLATFORM_DIR)/cooja/Makefile.customrules-cooja
+
 # Use dbg-io for IO functions like printf()
 MODULES += os/lib/dbg-io
 


### PR DESCRIPTION
Allow the platforms to specify makefiles that
should be included and give an error message when
the include fails.