### PR TITLE
arm: catch undefined syms in object files

### DIFF
--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -34,6 +34,9 @@ ASFLAGS += -c
 
 LDFLAGS += -mthumb -mabi=aapcs -mlittle-endian
 
+# Disallow undefined symbols in object files.
+LDFLAGS += -Wl,-zdefs
+
 OBJDUMP_FLAGS += --disassemble --source --disassembler-options=force-thumb
 
 ### Caller can override the default compiler optimization levels


### PR DESCRIPTION
Add -Wl,-zdefs to the linker flags.