### PR TITLE
native: remove unused build rule

### DIFF
--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -58,8 +58,3 @@ LDFLAGS += -Wl,-zdefs
 endif
 
 MAKE_MAC ?= MAKE_MAC_NULLMAC
-
-### Compilation rules
-
-%.so: $(OBJECTDIR)/%.o
-	$(Q)$(LD) -shared $(LDFLAGS) -o $@ $^


### PR DESCRIPTION
The rule for building shared libraries
seem to be unused so remove it.

The rule looks like a standard formulation
for shared libraries so it probably belongs
in Makefile.include if we need it.