### PR TITLE
tests: stop directing output to /dev/null

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -351,11 +351,9 @@ clean:
 	$(Q)rm -f *.d *.e *.o $(CLEAN) \
 		$(addsuffix .$(TARGET), $(CONTIKI_PROJECT))
 	$(Q)rm -rf $(BUILD_DIR_TARGET)
-	@echo Target $(TARGET) cleaned
 
 distclean:
-	@for TARG in `ls $(CONTIKI_NG_RELOC_PLATFORM_DIR) $(TARGETDIRS)`; do \
-		echo Running: $(MAKE) TARGET=$$TARG clean; \
+	$(Q)for TARG in `ls $(CONTIKI_NG_RELOC_PLATFORM_DIR) $(TARGETDIRS)`; do \
 		$(MAKE) TARGET=$$TARG clean; \
 	done
 	$(Q)rm -rf $(BUILD_DIR)

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -39,6 +39,15 @@ else
   CPUS := 8
 endif
 
+# Make tests quiet unless running in CI or user specifies something else.
+ifndef CI
+  V ?= 1
+  Q ?= @
+  MAKEOPTIONS ?= V=$(V) Q=$(Q)
+endif
+PRINT_DIR ?= --no-print-directory
+MAKEOPTIONS += $(PRINT_DIR) WERROR=1
+
 # The stuff below is some GNU make magic to automatically make make
 # give each compile test a number, prefixed with a 0 if the number is
 # < 10, to match the way the simulation tests output works.
@@ -52,8 +61,8 @@ get_target_vars = $(wordlist 2,15,$(subst :, ,$1))
 define dooneexample
 @echo -n Building example $(3): $(1) $(4) for target $(2)
 @((cd $(EXAMPLESDIR)/$(1) && \
- $(MAKE) $(4) TARGET=$(2) clean && make -j$(CPUS) $(4) TARGET=$(2) WERROR=1) > \
-      /dev/null 2>make.err && \
+   $(MAKE) $(4) TARGET=$(2) $(MAKEOPTIONS) clean && \
+   make -j$(CPUS) $(4) TARGET=$(2) $(MAKEOPTIONS)) 2>make.err && \
  (echo " -> OK" && printf "%-75s %-40s %-20s TEST OK\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog) || \
  (echo " -> FAIL" && printf "%-75s %-40s %-20s TEST FAIL\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog ; cat make.err))
 @rm -f make.err


### PR DESCRIPTION
This patch toggles the build system to work
in terse mode instead of working in verbose
mode and immediately redirect all output
to /dev/null.

This patch also removes an echo in distclean
and instead makes that rule use $(Q) to decide
whether commands are shown.

Despite this, make still insists on printing
"rm testfile.o" after each test which is caused
by testfile.o being produced by chained rules.
Fixing that requires tweaking the rules in Makefile.include
so I have left the printout.

After this patch, it is possible to see the compiler
and linker invocations for compilation tests
by starting them with:

make Q=''