### PR TITLE
Dockerfile: install ccache

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
   apt-get -qq -y --no-install-recommends install \
     ant \
     build-essential \
+    ccache \
     doxygen \
     gdb \
     git \


### PR DESCRIPTION
More detailed numbers below, but ccache
gets a 99.99% hitrate when running the three
first test suites under tests/ with a warm
cache. The high hitrate halves the time it
takes to complete the tests on my computer.

time -p (cd 01-compile-base/ && make && cd ../02-compile-arm-ports/ && make && cd ../04-compile-nxp-ports/ && make)

Time without ccache:

real 157.10
user 820.20
sys 116.13

Time for first run on empty cache:

real 170.16
user 947.49
sys 182.50

Cache statistics after first run:

cache hit (direct)                     1
cache hit (preprocessed)            2682
cache miss                         13575
cache hit rate                     16.50 %
cleanups performed                     0
files in cache                     43371
cache size                         273.1 MB

Time for second run with warm cache:

real 83.28
user 220.47
sys 60.76

Cache statistics for second run:

cache hit (direct)                 10427
cache hit (preprocessed)            5829
cache miss                             2
cache hit rate                     99.99 %
cleanups performed                     0
files in cache                     49135
cache size                         297.5 MB

Aggregated cache statistics after first+second run:

cache hit (direct)                 10575
cache hit (preprocessed)            8364
cache miss                         13577
cache hit rate                     58.25 %
cleanups performed                     0
files in cache                     49059
cache size                         297.2 MB