### PR TITLE
tests: use Cooja build file

### DIFF
--- a/examples/benchmarks/result-visualization/README.md
+++ b/examples/benchmarks/result-visualization/README.md
@@ -25,11 +25,8 @@ extract metrics from that log file, and plot the metrics.
 The steps are automated in the script `run-cooja.py`.
 The script requires Python 3 and assumes that Cooja has lareayd been build.
 
-When the `run-cooja.py` script is executed, it performs the following steps:
-
-1. Checks if Cooja has been built.
-2. Execute a Cooja simulation using the simulation file `cooja.csc`
-   and control file `coojalogger.js`.
+When the `run-cooja.py` script is executed, it executes a Cooja simulation
+using the simulation file `cooja.csc` and control file `coojalogger.js`.
 
 The results are saved in the log file called `COOJA.testlog`.
 

--- a/examples/benchmarks/result-visualization/run-cooja.py
+++ b/examples/benchmarks/result-visualization/run-cooja.py
@@ -9,7 +9,7 @@ SELF_PATH = os.path.dirname(os.path.abspath(__file__))
 # move three levels up
 CONTIKI_PATH = os.path.dirname(os.path.dirname(os.path.dirname(SELF_PATH)))
 
-cooja_jar = os.path.normpath(os.path.join(CONTIKI_PATH, "tools", "cooja", "dist", "cooja.jar"))
+build_xml = os.path.normpath(os.path.join(CONTIKI_PATH, "tools", "cooja", "build.xml"))
 cooja_input = 'cooja.csc'
 cooja_output = 'COOJA.testlog'
 
@@ -51,7 +51,7 @@ def execute_test(cooja_file):
         return False
 
     filename = os.path.join(SELF_PATH, cooja_file)
-    args = " ".join(["java -Djava.awt.headless=true -jar ", cooja_jar, "-nogui=" + filename, "-contiki=" + CONTIKI_PATH])
+    args = " ".join(["ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f", build_xml, "run_bigmem -Dargs='-nogui=" + filename, "-contiki=" + CONTIKI_PATH, "-logdir=" + SELF_PATH + "'"])
     sys.stdout.write("  Running Cooja, args={}\n".format(args))
 
     (retcode, output) = run_subprocess(args, '')
@@ -82,10 +82,6 @@ def execute_test(cooja_file):
 # Run the application
 
 def main():
-    if not os.access(cooja_jar, os.R_OK):
-        print('The file "{}" does not exist, did you build Cooja?'.format(cooja_jar))
-        exit(-1)
-
     input_file = cooja_input
     if len(sys.argv) > 1:
         # change from the default

--- a/tests/10-ipv6-nbr/01-test-nbr-multi-addrs.sh
+++ b/tests/10-ipv6-nbr/01-test-nbr-multi-addrs.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/sh -e
 
 TEST_NAME=01-test-nbr-multi-addrs
 
 if [ $# -eq 1 ]; then
-    # a (relative) path to CONTIKI_DIR is supposed to be given as $1
+    # Absolute path to CONTIKI_DIR in $1.
     TEST_DIR=$1/tests/10-ipv6-nbr
 else
     TEST_DIR=.//tests/10-ipv6-nbr
@@ -13,9 +13,9 @@ EXEC_FILE_NAME=test.native
 
 make -C ${SRC_DIR} clean
 
-echo "build the test program"...
+echo "build the test program..."
 make -C ${SRC_DIR} > ${TEST_NAME}.log
 
 echo "run the test..."
-${TEST_DIR}/${SRC_DIR}/${EXEC_FILE_NAME} | tee ${TEST_NAME}.log | \
+${SRC_DIR}/${EXEC_FILE_NAME} | tee ${TEST_NAME}.log | \
     grep -vE '^\[' >> ${TEST_NAME}.testlog

--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -16,9 +16,11 @@ WAIT_TIME=60
 # The expected hop count
 TARGETHOPS=4
 
+CURDIR=$(pwd)
+
 # Start simulation
 echo "Starting Cooja simulation $BASENAME.csc"
-java -Xshare:on -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$BASENAME.csc -contiki=$CONTIKI  > $BASENAME.coojalog &
+ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" > $BASENAME.coojalog &
 JPID=$!
 sleep 20
 
@@ -38,11 +40,10 @@ HOPS=`wc $BASENAME.scriptlog -l | cut -f 1 -d ' '`
 
 echo "Closing simulation and tunslip6"
 sleep 1
-kill_bg $JPID
-kill_bg $MPID
+kill_bg $JPID 15
+kill_bg $MPID 15
 sleep 1
-rm COOJA.testlog
-rm COOJA.log
+rm -f COOJA.testlog COOJA.log
 
 if [ $STATUS -eq 0 ] && [ $HOPS -eq $TARGETHOPS ] ; then
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;

--- a/tests/17-tun-rpl-br/test-border-router.sh
+++ b/tests/17-tun-rpl-br/test-border-router.sh
@@ -24,9 +24,11 @@ COUNT=5
 # Test OK of COUNT_TARGET ok out of COUNT
 COUNT_TARGET=3
 
+CURDIR=$(pwd)
+
 # Start simulation
 echo "Starting Cooja simulation $BASENAME.csc"
-java -Xshare:on -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$BASENAME.csc -contiki=$CONTIKI > $BASENAME.coojalog &
+ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" > $BASENAME.coojalog &
 JPID=$!
 sleep 20
 
@@ -46,11 +48,10 @@ REPLIES=`grep -c 'icmp_seq=' $BASENAME.scriptlog`
 
 echo "Closing simulation and tunslip6"
 sleep 1
-kill_bg $JPID
-kill_bg $MPID
+kill_bg $JPID 15
+kill_bg $MPID 15
 sleep 1
-rm COOJA.testlog
-rm COOJA.log
+rm -f COOJA.testlog COOJA.log
 
 if [ $STATUS -eq 0 ] && [ $REPLIES -ge $COUNT_TARGET ] ; then
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -24,9 +24,11 @@ COUNT=5
 # Test OK of COUNT_TARGET ok out of COUNT
 COUNT_TARGET=3
 
+CURDIR=$(pwd)
+
 # Start simulation
 echo "Starting Cooja simulation $BASENAME.csc"
-java -Xshare:on -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$BASENAME.csc -contiki=$CONTIKI > $BASENAME.coojalog &
+ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" > $BASENAME.coojalog &
 JPID=$!
 sleep 20
 
@@ -46,11 +48,10 @@ REPLIES=`grep -c 'icmp_seq=' $BASENAME.scriptlog`
 
 echo "Closing simulation and nbr"
 sleep 1
-kill_bg $JPID
-kill_bg $MPID
+kill_bg $JPID 15
+kill_bg $MPID 15
 sleep 1
-rm COOJA.testlog
-rm COOJA.log
+rm -f COOJA.testlog COOJA.log
 
 if [ $STATUS -eq 0 ] && [ $REPLIES -ge $COUNT_TARGET ] ; then
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;

--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -55,7 +55,7 @@ else
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 
-rm make.log make.err node.log node.err leshan.log leshan.err
+rm -f make.log make.err node.log node.err leshan.log leshan.err
 
 # We do not want Make to stop -> Return 0
 # The Makefile will check if a log contains FAIL at the end

--- a/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
+++ b/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
@@ -8,8 +8,8 @@ BASENAME=07-lwm2m-standalone-test
 
 # Building standalone posix example
 echo "Compiling standalone posix example"
-make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m clean >/dev/null
-make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m >make.log 2>make.err
+make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m clean >/dev/null
+make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m >make.log 2>make.err
 
 echo "Downloading leshan"
 LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
@@ -56,7 +56,7 @@ else
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 
-rm make.log make.err node.log node.err leshan.log leshan.err
+rm -f make.log make.err node.log node.err leshan.log leshan.err
 
 # We do not want Make to stop -> Return 0
 # The Makefile will check if a log contains FAIL at the end

--- a/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
+++ b/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
@@ -57,7 +57,7 @@ else
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 
-rm make.log make.err node.log node.err leshan.log leshan.err
+rm -f make.log make.err node.log node.err leshan.log leshan.err
 
 # We do not want Make to stop -> Return 0
 # The Makefile will check if a log contains FAIL at the end

--- a/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
+++ b/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
@@ -7,8 +7,8 @@ BASENAME=09-lwm2m-qmode-standalone-test
 
 # Building standalone posix example
 echo "Compiling standalone posix example"
-make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m clean >/dev/null
-make CONTIKI_NG=../../$CONTIKI -C example-lwm2m-standalone/lwm2m DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 >make.log 2>make.err
+make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m clean >/dev/null
+make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 >make.log 2>make.err
 
 echo "Downloading leshan with Q-Mode support"
 LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
@@ -56,12 +56,7 @@ else
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 
-rm make.log
-rm make.err
-rm node.log
-rm node.err
-rm leshan.log
-rm leshan.err
+rm -f make.log make.err node.log node.err leshan.log leshan.err
 
 # We do not want Make to stop -> Return 0
 # The Makefile will check if a log contains FAIL at the end

--- a/tests/Makefile.script-test
+++ b/tests/Makefile.script-test
@@ -13,7 +13,7 @@ summary: $(TESTLOGS)
 
 %.testlog: %.sh
 	@echo "========== Running script test $(basename $@).sh =========="
-	@./"$(basename $@).sh" "$(CONTIKI)"
+	@./"$(basename $@).sh" "$(realpath $(CONTIKI))"
 
 clean:
 	@rm -f *.*log report summary

--- a/tests/Makefile.simulation-test
+++ b/tests/Makefile.simulation-test
@@ -25,7 +25,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-all: cooja summary
+all: summary
 
 TESTS=$(wildcard ??-*.csc)
 TESTLOGS=$(sort $(patsubst %.csc,%.testlog,$(TESTS)))
@@ -39,7 +39,7 @@ CONTIKI ?= ../..
 
 Q ?= @
 
-.PHONY: all clean cooja tests
+.PHONY: all clean tests
 tests: $(TESTLOGS)
 
 summary: clean
@@ -52,13 +52,8 @@ endif
 	@echo "========== Summary =========="
 	@cat summary
 
-%.testlog: %.csc cooja
-	@$(CONTIKI)/tests/simexec.sh "$<" "$(CONTIKI)" "$(basename $@)" $(BASESEED) $(RUNCOUNT)
+%.testlog: %.csc
+	@$(CONTIKI)/tests/simexec.sh "$(realpath $<)" "$(realpath $(CONTIKI))" "$(basename $@)" $(BASESEED) $(RUNCOUNT)
 
 clean:
 	@rm -f *.*log report summary
-
-cooja: $(CONTIKI)/tools/cooja/dist/cooja.jar
-$(CONTIKI)/tools/cooja/dist/cooja.jar:
-	@echo "Building Cooja"
-	$(Q)ant -f $(CONTIKI)/tools/cooja/build.xml -silent jar

--- a/tests/simexec.sh
+++ b/tests/simexec.sh
@@ -24,8 +24,10 @@ declare -i OKCOUNT=0
 # A list of seeds the resulted in failure
 FAILSEEDS=
 
+CURDIR=$(pwd)
+
 for (( SEED=$BASESEED; SEED<$(($BASESEED+$RUNCOUNT)); SEED++ )); do
-  if java -Xshare:on -Dnashorn.args=--no-deprecation-warning -jar $CONTIKI/tools/cooja/dist/cooja.jar -nogui=$CSC -contiki=$CONTIKI -random-seed=$SEED; then
+  if ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CSC -contiki=$CONTIKI -logdir=$CURDIR -random-seed=$SEED"; then
     OKCOUNT+=1
   else
     FAILSEEDS+=" $BASESEED"


### PR DESCRIPTION
This depends on: https://github.com/contiki-ng/cooja/pull/131, https://github.com/contiki-ng/cooja/pull/129 and one more patch on top of those.

Remove the knowledge of Cooja build system
from Contiki-NG and just call ant on the run
target in Cooja instead.

This ensures that Cooja is rebuilt when
the sources have been updated.

Also reduce the number of calls to rm while
I'm touching these files.