### PR TITLE
Improvements of the unit test library

### DIFF
--- a/examples/libs/unit-tests/code-unittests/test-examples.c
+++ b/examples/libs/unit-tests/code-unittests/test-examples.c
@@ -41,7 +41,7 @@ void
 print_test_report(const unit_test_t *utp)
 {
   printf("[=check-me=] %s... ", utp->descr);
-  if(utp->result == unit_test_failure) {
+  if(utp->passed == false) {
     printf("FAILED at line %u\n", utp->exit_line);
   } else {
     printf("SUCCEEDED\n");

--- a/os/services/unit-test/unit-test.c
+++ b/os/services/unit-test/unit-test.c
@@ -29,11 +29,12 @@
 
 /**
  * \file
- *	A tool for unit testing Contiki software.
+ *	Default print function for unit tests.
  * \author
- * 	Nicolas Tsiftes <nvt@sics.se>
+ * 	Nicolas Tsiftes <nicolas.tsiftes@ri.se>
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 
 #include "unit-test.h"
@@ -48,12 +49,12 @@ void
 unit_test_print_report(const unit_test_t *utp)
 {
   printf("\nUnit test: %s\n", utp->descr);
-  printf("Result: %s\n", utp->result == unit_test_failure ?
-                         "failure" : "success");
-  printf("Exit point: %s:%u\n", utp->test_file, (unsigned)utp->exit_line);
-  printf("Start: %u\n", (unsigned)utp->start);
-  printf("End: %u\n", (unsigned)utp->end);
-  printf("Duration: %u\n", (unsigned)(utp->end - utp->start));
-  printf("Ticks per second: %u\n", (unsigned)RTIMER_SECOND);
+  printf("Result: %s\n", utp->passed ? "success" : "failure");
+  printf("Exit point: %s:%u\n", utp->test_file, utp->exit_line);
+  printf("Assertions executed: %"PRIu32"\n", utp->assertions);
+  printf("Start: %"PRIu64"\n", (uint64_t)utp->start);
+  printf("End: %"PRIu64"\n", (uint64_t)utp->end);
+  printf("Duration: %"PRId64" ticks\n", (int64_t)(utp->end - utp->start));
+  printf("Ticks per second: %u\n", (unsigned)CLOCK_SECOND);
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/unit-test/unit-test.h
+++ b/os/services/unit-test/unit-test.h
@@ -29,73 +29,84 @@
 
 /**
  * \file
- *	A tool for unit testing Contiki software.
+ *	A tool for unit testing Contiki-NG software.
  * \author
- * 	Nicolas Tsiftes <nvt@sics.se>
+ * 	Nicolas Tsiftes <nicolas.tsiftes@ri.se>
  */
 
 #ifndef UNIT_TEST_H
 #define UNIT_TEST_H
 
-#include "sys/rtimer.h"
+#include <stdbool.h>
+#include <stdint.h>
 
-typedef enum unit_test_result {
-  unit_test_failure = 0,
-  unit_test_success = 1
-} unit_test_result_t;
+#include <sys/clock.h>
 
 /**
- * The unit_test structure describes the results of a unit test. Each 
+ * The unit_test structure describes the results of a unit test. Each
  * registered unit test statically allocates an object of this type.
  */
 typedef struct unit_test {
   const char * const descr;
   const char * const test_file;
-  unit_test_result_t result;
+  uint32_t assertions;
+  bool passed;
   unsigned exit_line;
-  rtimer_clock_t start;
-  rtimer_clock_t end;
+  clock_time_t start;
+  clock_time_t end;
 } unit_test_t;
+
+typedef void (*unit_test_report_function_t)(const unit_test_t *);
 
 /**
  * Register a unit test.
  *
- * This macro allocates unit test descriptor, which is a structure of 
- * type unit_test_t. The descriptor contains information about a unit 
+ * This macro allocates unit test descriptor, which is a structure of
+ * type unit_test_t. The descriptor contains information about a unit
  * test, and the results from the last execution of the test.
  *
  * \param name The name of the unit test.
- * \param descr A string that briefly describes the unit test.
+ * \param description A string that briefly describes the unit test.
  */
-#define UNIT_TEST_REGISTER(name, descr) static unit_test_t unit_test_##name = {descr, __FILE__, unit_test_success, 0, 0, 0}
+#define UNIT_TEST_REGISTER(name, description) \
+  static unit_test_t unit_test_##name =	      \
+    {.descr = (description),   		      \
+     .test_file = __FILE__,                   \
+     .assertions = 0,                         \
+     .passed = false,                         \
+     .exit_line = 0,                          \
+     .start = 0,                              \
+     .end = 0                                 \
+    }
 
 /**
  * Define a unit test.
  *
- * This macro defines the function that will be executed when conducting 
- * a unit test. The name that is passed as a parameter must have been 
- * registered with the UNIT_TEST_REGISTER() macro.
+ * This macro defines the function that will be executed when
+ * conducting a unit test. The name that is passed as a parameter must
+ * have been registered with the UNIT_TEST_REGISTER() macro.
  *
  * The function defined by this macro must start with a call to the
- * UNIT_TEST_BEGIN() macro, and end with a call to the UNIT_TEST_END() 
+ * UNIT_TEST_BEGIN() macro, and end with a call to the UNIT_TEST_END()
  * macro.
  *
- * The standard test function template produced by this macro will 
- * ensure that the unit test keeps track of the result, the time taken to 
- * execute (in rtimer ticks), and the exit point of the test. The 
- * latter corresponds to the line number at which the test was 
+ * The standard test function template produced by this macro will
+ * ensure that the unit test keeps track of the result, the time taken
+ * to execute it (in clock ticks), and the exit point of the test. The
+ * latter corresponds to the line number at which the test was
  * determined to be a success or failure.
  *
  * \param name The name of the unit test.
  */
-#define UNIT_TEST(name) static void unit_test_function_##name(unit_test_t *utp)
+#define UNIT_TEST(name) static void unit_test_function_##name(unit_test_t *unit_test_ptr)
 
 /**
  * Mark the starting point of the unit test function.
  */
-#define UNIT_TEST_BEGIN() do {                                                \
-                            utp->start = RTIMER_NOW();                        \
-                            utp->result = unit_test_success;                  \
+#define UNIT_TEST_BEGIN() do {                                                 \
+                            unit_test_ptr->start = clock_time();               \
+                            unit_test_ptr->assertions = 0;                     \
+                            unit_test_ptr->passed = true;                      \
                           } while(0)
 
 /**
@@ -103,12 +114,12 @@ typedef struct unit_test {
  */
 #define UNIT_TEST_END() UNIT_TEST_SUCCEED();                                  \
                         unit_test_end:                                        \
-                          utp->end = RTIMER_NOW()
+                          unit_test_ptr->end = clock_time()
 
 /*
- * The test result is printed with a function that is selected by 
+ * The test result is printed with a function that is selected by
  * defining UNIT_TEST_PRINT_FUNCTION, which must be of the type
- * "void (*)(const unit_test_t *)". The default selection is 
+ * unit_test_report_function_t. The default selection is
  * unit_test_print_report, which is available in unit-test.c.
  */
 #ifndef UNIT_TEST_PRINT_FUNCTION
@@ -135,39 +146,39 @@ typedef struct unit_test {
 /**
  * Report that a unit test succeeded.
  *
- * This macro is useful for writing tests that can succeed earlier than 
- * the last execution point of the test, which is specified by a call to 
- * the UNIT_TEST_END() macro.
+ * This macro is useful for writing tests that can succeed earlier
+ * than the last execution point of the test, which is specified by a
+ * call to the UNIT_TEST_END() macro.
  *
- * Tests can usually be written without calls to UNIT_TEST_SUCCEED(), 
- * since it is implicitly called at the end of the test---unless 
+ * Tests can usually be written without calls to UNIT_TEST_SUCCEED(),
+ * since it is implicitly called at the end of the test -- unless
  * UNIT_TEST_FAIL() has been called.
- * 
  */
 #define UNIT_TEST_SUCCEED() do {                                              \
-                              utp->exit_line = __LINE__;                      \
+                              unit_test_ptr->exit_line = __LINE__;            \
                               goto unit_test_end;                             \
                             } while(0)
 
 /**
  * Report that a unit test failed.
  *
- * This macro is used to signal that a unit test failed to execute. The 
- * line number at which this macro was called is stored in the unit test 
+ * This macro is used to signal that a unit test failed to execute. The
+ * line number at which this macro was called is stored in the unit test
  * descriptor.
  */
 #define UNIT_TEST_FAIL() do {                                                 \
-                           utp->exit_line = __LINE__;                         \
-                           utp->result = unit_test_failure;                   \
+                           unit_test_ptr->exit_line = __LINE__;               \
+                           unit_test_ptr->passed = false;                     \
                            goto unit_test_end;                                \
                          } while(0)
 
 /**
- * Report failure if an expression is false.
+ * Assert an expression, and report a failure if the expression is false.
  *
  * \param expr The expression to evaluate.
  */
 #define UNIT_TEST_ASSERT(expr) do {                                           \
+                                 unit_test_ptr->assertions++;                 \
                                  if(!(expr)) {                                \
                                    UNIT_TEST_FAIL();                          \
                                  }                                            \
@@ -176,15 +187,16 @@ typedef struct unit_test {
 /**
  * Obtain the result of a certain unit test.
  *
- * If the unit test has not yet been executed, this macro returns 
- * unit_test_failed. Otherwise it returns the result of the last
+ * If the unit test has not yet been executed, this macro returns
+ * false. Otherwise it returns the result of the last
  * execution of the unit test.
  *
  * \param name The name of the unit test.
+ * \return A boolean that tells whether the unit test has passed.
  */
-#define UNIT_TEST_RESULT(name) (unit_test_##name.result)
+#define UNIT_TEST_PASSED(name) (unit_test_##name.passed)
 
 /* The print function. */
-void UNIT_TEST_PRINT_FUNCTION(const unit_test_t *utp);
+void UNIT_TEST_PRINT_FUNCTION(const unit_test_t *unit_test_ptr);
 
 #endif /* !UNIT_TEST_H */

--- a/tests/07-simulation-base/code-data-structures/test-data-structures.c
+++ b/tests/07-simulation-base/code-data-structures/test-data-structures.c
@@ -59,7 +59,7 @@ void
 print_test_report(const unit_test_t *utp)
 {
   printf("=check-me= ");
-  if(utp->result == unit_test_failure) {
+  if(utp->passed == false) {
     printf("FAILED   - %s: exit at L%u\n", utp->descr, utp->exit_line);
   } else {
     printf("SUCCEEDED - %s\n", utp->descr);

--- a/tests/07-simulation-base/code-ringbufindex/test-ringbufindex.c
+++ b/tests/07-simulation-base/code-ringbufindex/test-ringbufindex.c
@@ -46,7 +46,7 @@ void
 test_print_report(const unit_test_t *utp)
 {
   printf("=check-me= ");
-  if(utp->result == unit_test_failure) {
+  if(utp->passed == false) {
     printf("FAILED   - %s: exit at L%u\n", utp->descr, utp->exit_line);
   } else {
     printf("SUCCEEDED - %s\n", utp->descr);

--- a/tests/08-native-runs/12-heapmem/test-heapmem.c
+++ b/tests/08-native-runs/12-heapmem/test-heapmem.c
@@ -207,10 +207,10 @@ PROCESS_THREAD(test_heapmem_process, ev, data)
   UNIT_TEST_RUN(invalid_freeing);
   UNIT_TEST_RUN(stats_check);
 
-  if(UNIT_TEST_RESULT(do_many_allocations) == unit_test_failure ||
-     UNIT_TEST_RESULT(max_alloc)           == unit_test_failure ||
-     UNIT_TEST_RESULT(invalid_freeing)     == unit_test_failure ||
-     UNIT_TEST_RESULT(stats_check)         == unit_test_failure) {
+  if(!UNIT_TEST_PASSED(do_many_allocations) ||
+     !UNIT_TEST_PASSED(max_alloc) ||
+     !UNIT_TEST_PASSED(invalid_freeing) ||
+     !UNIT_TEST_PASSED(stats_check)) {
     printf("=check-me= FAILED\n");
     printf("---\n");
   }

--- a/tests/10-ipv6-nbr/nbr-multi-addrs/test.c
+++ b/tests/10-ipv6-nbr/nbr-multi-addrs/test.c
@@ -56,7 +56,7 @@ void
 my_test_print(const unit_test_t *utp)
 {
   unit_test_print_report(utp);
-  if(utp->result == unit_test_failure) {
+  if(utp->passed == false) {
     printf("\nTEST FAILED\n");
     exit(1); /* exit by failure */
   }

--- a/tests/13-ieee802154/code-6tisch/common.c
+++ b/tests/13-ieee802154/code-6tisch/common.c
@@ -57,7 +57,7 @@ void
 test_print_report(const unit_test_t *utp)
 {
   printf("=check-me= ");
-  if(utp->result == unit_test_failure) {
+  if(utp->passed == false) {
     printf("FAILED   - %s: exit at L%u\n", utp->descr, utp->exit_line);
   } else {
     printf("SUCCEEDED - %s\n", utp->descr);

--- a/tests/13-ieee802154/code-flush-nbr-queue/common.c
+++ b/tests/13-ieee802154/code-flush-nbr-queue/common.c
@@ -42,7 +42,7 @@ void
 test_print_report(const unit_test_t *utp)
 {
   printf("=check-me= ");
-  if(utp->result == unit_test_failure) {
+  if(utp->passed == false) {
     printf("FAILED   - %s: exit at L%u\n", utp->descr, utp->exit_line);
   } else {
     printf("SUCCEEDED - %s\n", utp->descr);

--- a/tests/13-ieee802154/code-panid-handling/test-panid-handling.c
+++ b/tests/13-ieee802154/code-panid-handling/test-panid-handling.c
@@ -115,7 +115,7 @@ void
 test_print_report(const unit_test_t *utp)
 {
   printf("=check-me= ");
-  if(utp->result == unit_test_failure) {
+  if(utp->passed == false) {
     printf("FAILED   - %s: at test index %d\n", utp->descr, utp->exit_line);
   } else {
     printf("SUCEEDED - %s\n", utp->descr);
@@ -268,7 +268,7 @@ UNIT_TEST(panid_frame_ver_0b00)
                    num_of_tests);
 
   UNIT_TEST_END();
-  utp->exit_line = index;
+  unit_test_ptr->exit_line = index;
 }
 
 UNIT_TEST(panid_frame_ver_0b01)
@@ -284,7 +284,7 @@ UNIT_TEST(panid_frame_ver_0b01)
                    num_of_tests);
 
   UNIT_TEST_END();
-  utp->exit_line = index;
+  unit_test_ptr->exit_line = index;
 }
 
 UNIT_TEST(panid_frame_ver_0b10)
@@ -300,7 +300,7 @@ UNIT_TEST(panid_frame_ver_0b10)
                    num_of_tests);
 
   UNIT_TEST_END();
-  utp->exit_line = index;
+  unit_test_ptr->exit_line = index;
 }
 
 PROCESS_THREAD(test_process, ev, data)


### PR DESCRIPTION
A few minor changes of the unit test module, including

1. Update the comments.
2. Switch unit test result type to boolean.
3. Switch timer to clock_t to avoid wrapping rtimer values.
4. Report the number of assertions executed in a unit test.