### PR TITLE
tests/examples: fix TARGET for clean and add -j

### DIFF
--- a/examples/6tisch/6p-packet/6p-packet.csc
+++ b/examples/6tisch/6p-packet/6p-packet.csc
@@ -24,7 +24,7 @@
       <identifier>mtype639</identifier>
       <description>6P node</description>
       <source>[CONTIKI_DIR]/examples/6tisch/6p-packet/sixp-node.c</source>
-      <commands>make sixp-node.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) sixp-node.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/6tisch/custom-schedule/cooja.csc
+++ b/examples/6tisch/custom-schedule/cooja.csc
@@ -24,7 +24,7 @@
       <identifier>mtype778</identifier>
       <description>TSCH Schedule Node</description>
       <source>[CONTIKI_DIR]/examples/6tisch/custom-schedule/node.c</source>
-      <commands>make node.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) node.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/6tisch/etsi-plugtest-2017/test-with-cooja-mote.csc
+++ b/examples/6tisch/etsi-plugtest-2017/test-with-cooja-mote.csc
@@ -26,7 +26,7 @@
       <description>RPL/TSCH Node</description>
       <source>[CONTIKI_DIR]/examples/6tisch/etsi-plugtest-2017/node.c</source>
       <commands>make TARGET=cooja clean
-      make TARGET=cooja MAKE_WITH_SIXTOP=1 node.cooja</commands>
+      make -j$(CPUS) TARGET=cooja MAKE_WITH_SIXTOP=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/6tisch/simple-node/rpl-tsch-cooja.csc
+++ b/examples/6tisch/simple-node/rpl-tsch-cooja.csc
@@ -25,7 +25,7 @@
       <description>RPL/TSCH Node</description>
       <source>[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
       <commands>make TARGET=cooja clean
-      make TARGET=cooja node.cooja</commands>
+      make -j$(CPUS) TARGET=cooja node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/6tisch/sixtop/rpl-tsch-sixtop-cooja.csc
+++ b/examples/6tisch/sixtop/rpl-tsch-sixtop-cooja.csc
@@ -24,7 +24,7 @@
       <identifier>mtype204</identifier>
       <description>node</description>
       <source>[CONTIKI_DIR]/examples/6tisch/sixtop/node-sixtop.c</source>
-      <commands>make node-sixtop.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) node-sixtop.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/benchmarks/result-visualization/cooja.csc
+++ b/examples/benchmarks/result-visualization/cooja.csc
@@ -19,7 +19,8 @@
       <identifier>mtype660</identifier>
       <description>RPL/TSCH Node</description>
       <source>[CONFIG_DIR]/node.c</source>
-      <commands>make TARGET=cooja node.cooja</commands>
+      <commands>make TARGET=cooja clean
+make -j$(CPUS) TARGET=cooja node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/benchmarks/rpl-req-resp/sim.csc
+++ b/examples/benchmarks/rpl-req-resp/sim.csc
@@ -24,7 +24,7 @@
       <identifier>mtype90</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/examples/benchmarks/rpl-req-resp/node.c</source>
-      <commands>make node.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) node.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/libs/deployment/sim.csc
+++ b/examples/libs/deployment/sim.csc
@@ -24,7 +24,7 @@
       <identifier>mtype90</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/examples/libs/deployment/node.c</source>
-      <commands>make node.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) node.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/libs/ipv6-uipbuf/ipv6-uipbuf-cooja.csc
+++ b/examples/libs/ipv6-uipbuf/ipv6-uipbuf-cooja.csc
@@ -24,7 +24,7 @@
       <identifier>mtype829</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/examples/libs/ipv6-uipbuf/udp-server.c</source>
-      <commands>make udp-server.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) udp-server.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
@@ -49,7 +49,7 @@
       <identifier>mtype405</identifier>
       <description>Cooja Mote Type #2</description>
       <source>[CONTIKI_DIR]/examples/libs/ipv6-uipbuf/udp-client.c</source>
-      <commands>make udp-client.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) udp-client.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/libs/ipv6-uipbuf/ipv6-uipbuf-sky.csc
+++ b/examples/libs/ipv6-uipbuf/ipv6-uipbuf-sky.csc
@@ -24,7 +24,7 @@
       <identifier>sky1</identifier>
       <description>Sky Mote Type #sky1</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/libs/ipv6-uipbuf/udp-server.c</source>
-      <commands EXPORT="discard">make udp-server.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make -j$(CPUS) udp-server.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/libs/ipv6-uipbuf/udp-server.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
@@ -47,7 +47,7 @@
       <identifier>sky2</identifier>
       <description>Sky Mote Type #sky2</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/libs/ipv6-uipbuf/udp-client.c</source>
-      <commands EXPORT="discard">make udp-client.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make -j$(CPUS) udp-client.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/libs/ipv6-uipbuf/udp-client.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>

--- a/examples/libs/stack-check/example-sky.csc
+++ b/examples/libs/stack-check/example-sky.csc
@@ -24,7 +24,7 @@
       <identifier>node</identifier>
       <description>RPL Root</description>
       <source EXPORT="discard">[CONFIG_DIR]/example-stack-check.c</source>
-      <commands EXPORT="discard">make example-stack-check.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make -j$(CPUS) example-stack-check.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONFIG_DIR]/example-stack-check.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>

--- a/examples/libs/trickle-library/trickle-library.csc
+++ b/examples/libs/trickle-library/trickle-library.csc
@@ -25,7 +25,7 @@
       <identifier>sky1</identifier>
       <description>trickle-tester</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/libs/trickle-library/trickle-library.c</source>
-      <commands EXPORT="discard">make trickle-library.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make -j$(CPUS) trickle-library.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/libs/trickle-library/trickle-library.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>

--- a/examples/nullnet/nullnet-broadcast.csc
+++ b/examples/nullnet/nullnet-broadcast.csc
@@ -24,7 +24,7 @@
       <identifier>mtype928</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/examples/nullnet/nullnet-broadcast.c</source>
-      <commands>make nullnet-broadcast.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) nullnet-broadcast.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/nullnet/nullnet-unicast.csc
+++ b/examples/nullnet/nullnet-unicast.csc
@@ -24,7 +24,7 @@
       <identifier>mtype634</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/examples/nullnet/nullnet-unicast.c</source>
-      <commands>make nullnet-unicast.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) nullnet-unicast.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/rpl-udp/rpl-udp-cooja.csc
+++ b/examples/rpl-udp/rpl-udp-cooja.csc
@@ -24,7 +24,7 @@
       <identifier>mtype829</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/examples/rpl-udp/udp-server.c</source>
-      <commands>make udp-server.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) udp-server.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
@@ -49,7 +49,7 @@
       <identifier>mtype405</identifier>
       <description>Cooja Mote Type #2</description>
       <source>[CONTIKI_DIR]/examples/rpl-udp/udp-client.c</source>
-      <commands>make udp-client.cooja TARGET=cooja</commands>
+      <commands>make -j$(CPUS) udp-client.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/examples/rpl-udp/rpl-udp-sky.csc
+++ b/examples/rpl-udp/rpl-udp-sky.csc
@@ -24,7 +24,7 @@
       <identifier>sky1</identifier>
       <description>Sky Mote Type #sky1</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/rpl-udp/udp-server.c</source>
-      <commands EXPORT="discard">make udp-server.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make -j$(CPUS) udp-server.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/rpl-udp/udp-server.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
@@ -47,7 +47,7 @@
       <identifier>sky2</identifier>
       <description>Sky Mote Type #sky2</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/rpl-udp/udp-client.c</source>
-      <commands EXPORT="discard">make udp-client.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make -j$(CPUS) udp-client.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/rpl-udp/udp-client.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>

--- a/tests/06-script-base/code-result-visualization/00-result-visualization.csc
+++ b/tests/06-script-base/code-result-visualization/00-result-visualization.csc
@@ -20,7 +20,7 @@
       <description>RPL/TSCH Node</description>
       <source>[CONTIKI_DIR]/examples/benchmarks/result-visualization/node.c</source>
       <commands>make clean TARGET=cooja
-make TARGET=cooja node.cooja</commands>
+make -j$(CPUS) TARGET=cooja node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/01-ping-lla-csma-w-rpl.csc
+++ b/tests/09-ipv6/01-ping-lla-csma-w-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_CSMA=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_CSMA=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/02-ping-ula-csma-w-rpl.csc
+++ b/tests/09-ipv6/02-ping-ula-csma-w-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_ULA=1 WITH_CSMA=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_ULA=1 WITH_CSMA=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/03-ping-lla-tsch-w-rpl.csc
+++ b/tests/09-ipv6/03-ping-lla-tsch-w-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_TSCH=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_TSCH=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/04-ping-ula-tsch-w-rpl.csc
+++ b/tests/09-ipv6/04-ping-ula-tsch-w-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_ULA=1 WITH_TSCH=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_ULA=1 WITH_TSCH=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/05-ping-lla-csma-wo-rpl.csc
+++ b/tests/09-ipv6/05-ping-lla-csma-wo-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_CSMA=1 WITHOUT_RPL=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_CSMA=1 WITHOUT_RPL=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/06-ping-ula-csma-wo-rpl.csc
+++ b/tests/09-ipv6/06-ping-ula-csma-wo-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_ULA=1 WITH_CSMA=1 WITHOUT_RPL=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_ULA=1 WITH_CSMA=1 WITHOUT_RPL=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/07-ping-lla-tsch-wo-rpl.csc
+++ b/tests/09-ipv6/07-ping-lla-tsch-wo-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_TSCH=1 WITHOUT_RPL=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_TSCH=1 WITHOUT_RPL=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/08-ping-ula-tsch-wo-rpl.csc
+++ b/tests/09-ipv6/08-ping-ula-tsch-wo-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_ULA=1 WITH_TSCH=1 WITHOUT_RPL=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_ULA=1 WITH_TSCH=1 WITHOUT_RPL=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/09-ping-lla-ula-csma-w-rpl.csc
+++ b/tests/09-ipv6/09-ping-lla-ula-csma-w-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_ULA=1 WITH_CSMA=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_ULA=1 WITH_CSMA=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/10-ping-lla-ula-tsch-w-rpl.csc
+++ b/tests/09-ipv6/10-ping-lla-ula-tsch-w-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_ULA=1 WITH_TSCH=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_ULA=1 WITH_TSCH=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/11-ping-lla-ula-csma-wo-rpl.csc
+++ b/tests/09-ipv6/11-ping-lla-ula-csma-wo-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_NBR_MULTI_IPV6_ADDRS=1 WITH_ULA=1 WITH_CSMA=1 WITHOUT_RPL=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_NBR_MULTI_IPV6_ADDRS=1 WITH_ULA=1 WITH_CSMA=1 WITHOUT_RPL=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/09-ipv6/12-ping-lla-ula-tsch-wo-rpl.csc
+++ b/tests/09-ipv6/12-ping-lla-ula-tsch-wo-rpl.csc
@@ -25,8 +25,8 @@
       <identifier>mtype787</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/tests/09-ipv6/code/node.c</source>
-      <commands>make clean
-      make WITH_NBR_MULTI_IPV6_ADDRS=1 WITH_ULA=1 WITH_TSCH=1 WITHOUT_RPL=1 node.cooja</commands>
+      <commands>make TARGET=cooja clean
+      make -j$(CPUS) WITH_NBR_MULTI_IPV6_ADDRS=1 WITH_ULA=1 WITH_TSCH=1 WITHOUT_RPL=1 node.cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>


### PR DESCRIPTION
Add -j$(CPUS) to the Cooja make commands to speed up
builds.

Discovered that some tests clean for the wrong
TARGET while changing these files, so fix that
at the same time.

The tests all make clean to ensure there is nothing
laying around in the build tree from earlier tests,
and the example result-visualization is used by
the tests so add a make clean in that file.