### PR TITLE
dbg-io: add format attribute to format_str_v

### DIFF
--- a/os/lib/dbg-io/strformat.h
+++ b/os/lib/dbg-io/strformat.h
@@ -55,7 +55,8 @@ int format_str(const strformat_context_t *ctxt, const char *format, ...)
      __attribute__ ((__format__ (__printf__, 2,3)));
 
 int
-format_str_v(const strformat_context_t *ctxt, const char *format, va_list ap);
+format_str_v(const strformat_context_t *ctxt, const char *format, va_list ap)
+     __attribute__ ((__format__ (__printf__, 2, 0)));
 /*---------------------------------------------------------------------------*/
 #endif /* STRFORMAT_H_ */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The format_str function declared just before
this function has the attribute so add it
to format_str_v for consistency. The GCC
documentation explicitly mentions using 0
as the third argument to the format attribute
for va_list functions such as vprintf.

The attribute does not change code generation,
it just informs the compiler that -Wformat checking
should be applied to the arguments of the function.