### PR TITLE
Remove unused map flags

### DIFF
--- a/arch/cpu/arm/cortex-m/Makefile.cortex-m
+++ b/arch/cpu/arm/cortex-m/Makefile.cortex-m
@@ -14,7 +14,7 @@ MODULES += os/lib/newlib
 
 LDFLAGS += -T $(LDSCRIPT)
 LDFLAGS += -Wl,--gc-sections,--sort-section=alignment
-LDFLAGS += -Wl,-Map=$(CONTIKI_NG_PROJECT_MAP),--cref,--no-warn-mismatch
+LDFLAGS += -Wl,--cref,--no-warn-mismatch
 
 OBJCOPY_FLAGS += --gap-fill 0xff
 

--- a/arch/cpu/nrf52832/Makefile.nrf52832
+++ b/arch/cpu/nrf52832/Makefile.nrf52832
@@ -139,7 +139,6 @@ CFLAGS += -ggdb
 CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 # keep every function in separate section. This will allow linker to dump unused functions
-LDFLAGS += -Xlinker -Map=$(CONTIKI_NG_PROJECT_MAP)
 LDFLAGS += -mabi=aapcs -L $(TEMPLATE_PATH)
 LDFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 # let linker to dump unused sections

--- a/arch/platform/jn516x/Makefile.jn516x
+++ b/arch/platform/jn516x/Makefile.jn516x
@@ -231,7 +231,7 @@ $(BUILD_DIR_BOARD)/%.$(TARGET): %.o $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) 
 	@echo  ${filter %.a,$^}
 	$(Q)$(CC) -Wl,--gc-sections $(LDFLAGS) -T$(LINKCMD) -o $@ -Wl,--start-group \
 	  ${filter-out %.a,$^} ${filter %.a,$^} \
-	  $(ALLLIBS) -Wl,--end-group -Wl,-Map,$(CONTIKI_NG_PROJECT_MAP)
+	  $(ALLLIBS) -Wl,--end-group
 else
 # The SDK does not include libraries, only build objects and libraries, skip linking
 $(BUILD_DIR_BOARD)/%.$(TARGET): %.o $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(CONTIKI_NG_TARGET_LIB)


### PR DESCRIPTION
The mapfile is only used by Cooja and MSPSim in Contiki-NG nowadays.