### PR TITLE
Fix coffee-manager build srcdir

### DIFF
--- a/tools/coffee-manager/build.xml
+++ b/tools/coffee-manager/build.xml
@@ -7,7 +7,7 @@
 
   <target name="compile" depends="init">
     <mkdir dir="build"/>
-    <javac srcdir="org/contikios/coffee" destdir="build" includeantruntime="false" debug="true" />
+    <javac srcdir="." destdir="build" includeantruntime="false" debug="true" />
   </target>
 
   <target name="clean" depends="init">


### PR DESCRIPTION
The jar target depends on the compile target, but
the faulty srcdir on the compile target makes
the jar target infer the files it needs and recompiles
them.