### PR TITLE
TSCH scanning: limit the etimer frequency to 1/CLOCK_SECOND to reduce CPU usage during the scanning

### DIFF
--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -786,7 +786,7 @@ PT_THREAD(tsch_scan(struct pt *pt))
 
   TSCH_ASN_INIT(tsch_current_asn, 0, 0);
 
-  etimer_set(&scan_timer, CLOCK_SECOND / TSCH_ASSOCIATION_POLL_FREQUENCY);
+  etimer_set(&scan_timer, MAX(1, CLOCK_SECOND / TSCH_ASSOCIATION_POLL_FREQUENCY));
   current_channel_since = clock_time();
 
   while(!tsch_is_associated && !tsch_is_coordinator) {
@@ -851,7 +851,7 @@ PT_THREAD(tsch_scan(struct pt *pt))
       NETSTACK_RADIO.off();
     } else if(!tsch_is_coordinator) {
       /* Go back to scanning */
-      etimer_reset(&scan_timer);
+      etimer_restart(&scan_timer);
       PT_WAIT_UNTIL(pt, etimer_expired(&scan_timer));
     }
   }


### PR DESCRIPTION
The problem is that not only the scanning consumes 100% radio at the moment, but also 100% CPU because timers can be added with zero timeout on some platforms, and also potentially in the past (due to `etimer_reset` behavior). This PR aims to reduce that.