### PR TITLE
examples: add clean + -j to unit-tests

### DIFF
--- a/examples/libs/unit-tests/00-unit-tests.csc
+++ b/examples/libs/unit-tests/00-unit-tests.csc
@@ -24,7 +24,8 @@
       <identifier>mtype72</identifier>
       <description>Cooja Mote Type #1</description>
       <source>[CONTIKI_DIR]/examples/libs/unit-tests/code-unittests/test-examples.c</source>
-      <commands>make test-examples.cooja TARGET=cooja</commands>
+      <commands>make TARGET=cooja clean
+make -j$(CPUS) test-examples.cooja TARGET=cooja</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>


### PR DESCRIPTION
This example is called from the regression
tests and they need to be reproducible, add
a make clean. Also add -j$(CPUS) to get some
speedup over sequential execution.