### PR TITLE
tests: disable the unit-test example

### DIFF
--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -55,7 +55,6 @@ libs/shell/openmote \
 libs/simple-energest/openmote \
 libs/timers/zoul \
 libs/trickle-library/zoul \
-libs/unit-tests/zoul \
 lwm2m-ipso-objects/zoul:DEFINES=LWM2M_Q_MODE_CONF_ENABLED=1,LWM2M_Q_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1\
 lwm2m-ipso-objects/zoul:MAKE_WITH_DTLS=1 \
 mqtt-client/simplelink:BOARD=sensortag/cc2650:DEFINES=BOARD_CONF_SENSORS_DISABLE=1,TI_SPI_CONF_ENABLE=0 \


### PR DESCRIPTION
Having the test in the compilation suite
results in multiple ant invocations that
create cooja.jar at the same time. This
gives strange error messages about truncated
zip files and manifests.

Remove the test from the arm compilation testsuite
for now, simulation tests should be in 07-simulation-base.