### PR TITLE
tests: use the existing hashbang

### DIFF
--- a/tests/17-tun-rpl-br/01-border-router-cooja.sh
+++ b/tests/17-tun-rpl-br/01-border-router-cooja.sh
@@ -6,4 +6,4 @@ CONTIKI=$1
 # Simulation file
 BASENAME=$(basename $0 .sh)
 
-bash test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60
+./test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60

--- a/tests/17-tun-rpl-br/02-border-router-cooja-tsch.sh
+++ b/tests/17-tun-rpl-br/02-border-router-cooja-tsch.sh
@@ -7,4 +7,4 @@ CONTIKI=$1
 BASENAME=$(basename $0 .sh)
 
 # Add a little extra initial time to account for TSCH association time
-bash test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 120
+./test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 120

--- a/tests/17-tun-rpl-br/03-border-router-sky.sh
+++ b/tests/17-tun-rpl-br/03-border-router-sky.sh
@@ -6,4 +6,4 @@ CONTIKI=$1
 # Simulation file
 BASENAME=$(basename $0 .sh)
 
-bash test-border-router.sh $CONTIKI $BASENAME fd00::0212:7404:0004:0404 60
+./test-border-router.sh $CONTIKI $BASENAME fd00::0212:7404:0004:0404 60

--- a/tests/17-tun-rpl-br/07-native-border-router-cooja.sh
+++ b/tests/17-tun-rpl-br/07-native-border-router-cooja.sh
@@ -6,4 +6,4 @@ CONTIKI=$1
 # Simulation file
 BASENAME=$(basename $0 .sh)
 
-bash test-native-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60
+./test-native-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60

--- a/tests/17-tun-rpl-br/08-border-router-cooja-frag.sh
+++ b/tests/17-tun-rpl-br/08-border-router-cooja-frag.sh
@@ -6,4 +6,4 @@ CONTIKI=$1
 # Simulation file
 BASENAME=$(basename $0 .sh)
 
-bash test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60 1200 4
+./test-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60 1200 4

--- a/tests/17-tun-rpl-br/09-native-border-router-cooja-frag.sh
+++ b/tests/17-tun-rpl-br/09-native-border-router-cooja-frag.sh
@@ -6,4 +6,4 @@ CONTIKI=$1
 # Simulation file
 BASENAME=$(basename $0 .sh)
 
-bash test-native-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60 1200 4
+./test-native-border-router.sh $CONTIKI $BASENAME fd00::204:4:4:4 60 1200 4


### PR DESCRIPTION
Execute scripts directly so they use
the specified interpreter + parameters
in the first line.

This is a sibling to commit 183df607ee5bf9.