### PR TITLE
tests: build Cooja first in tun-rpl-br

### DIFF
--- a/tests/17-tun-rpl-br/Makefile
+++ b/tests/17-tun-rpl-br/Makefile
@@ -1,10 +1,9 @@
 CONTIKI=../..
 
-all: cooja
+.PHONY: start
 
-cooja: $(CONTIKI)/tools/cooja/dist/cooja.jar
-
-$(CONTIKI)/tools/cooja/dist/cooja.jar:
-	cd $(CONTIKI)/tools/cooja && ant jar
+start:
+	@ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $(CONTIKI)/tools/cooja/build.xml jar
+	@$(MAKE) all
 
 include ../Makefile.script-test


### PR DESCRIPTION
The tests depend on cooja.jar so make
sure the file is built before starting
the tests.

This should not be the root cause of the
intermittently failing CI tests, but
this patch removes one source of
non-determinism.