### PR TITLE
cortex-m: remove mapfile leftovers

### DIFF
--- a/arch/cpu/arm/cortex-m/Makefile.cortex-m
+++ b/arch/cpu/arm/cortex-m/Makefile.cortex-m
@@ -19,7 +19,9 @@ MODULES += os/lib/newlib
 
 LDFLAGS += -T $(LDSCRIPT)
 LDFLAGS += -Wl,--gc-sections,--sort-section=alignment
-LDFLAGS += -Wl,--cref,--no-warn-mismatch
+# The next line might be trying to avoid
+# https://sourceware.org/bugzilla/show_bug.cgi?id=28910
+LDFLAGS += -Wl,--no-warn-mismatch
 
 OBJCOPY_FLAGS += --gap-fill 0xff
 


### PR DESCRIPTION
The linker parameter --cref prints things
to the map file if that is generated. Remove
the flag now since it goes to stdout without
mapfile.

This change belonged in commit db8c04e6c85d.