### PR TITLE
gitignore: remove Cooja tmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,5 @@ COOJA.testlog
 *.summary
 *.err
 summary
-tests/[0-9][0-9]-*/org/
-examples/libs/unit-tests/org/
 tests/18-coap-lwm2m/Californium.properties
 tests/18-coap-lwm2m/leshan-server-demo*.jar


### PR DESCRIPTION
Cooja now puts these files in the JVM
temporary directory.