### PR TITLE
Dockerfile: use nearby mirrors for packages

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -6,7 +6,8 @@ ENV DEBIAN_FRONTEND noninteractive
 USER root
 
 # Tools
-RUN apt-get -qq update && \
+RUN sed -i -e 's#http://archive.ubuntu.com/ubuntu/#mirror://mirrors.ubuntu.com/mirrors.txt#' /etc/apt/sources.list && \
+    apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install gnupg ca-certificates software-properties-common > /dev/null
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \


### PR DESCRIPTION
Many Contiki-NG users are outside the US,
switch the packages to be downloaded from
a mirror that is closer to the user.