### PR TITLE
tunslip6: print connection error info

### DIFF
--- a/tools/serial-io/tunslip6.c
+++ b/tools/serial-io/tunslip6.c
@@ -1044,8 +1044,8 @@ exit(1);
       }
 
       if(connect(slipfd, p->ai_addr, p->ai_addrlen) == -1) {
-        close(slipfd);
         perror("client: connect");
+        close(slipfd);
         continue;
       }
       break;


### PR DESCRIPTION
Print the errno relating to the failed
connect rather than the (potential) errno
from close. If close succeeded, errno is
undefined.