### PR TITLE
Fix cooja windows closing after few minutes #1497

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -128,8 +128,8 @@ ENV                     LC_ALL=C.UTF-8
 ENV                     LANG=C.UTF-8
 WORKDIR                 ${HOME}
 
-# Create Cooja shortcut
-RUN echo "#!/bin/bash\nant -Dbasedir=${COOJA} -f ${COOJA}/build.xml run" > ${HOME}/cooja && \
+# Create Cooja shortcut  
+RUN echo "#!/bin/bash\n\n# Periodically print an invisible character to keep Windows docker from\n# terminating the session for inactivity.\n/bin/bash -c "while sleep 120; do printf '\33[0n'; done" &\nPID=$!\ntrap exit_cleanup INT\n\nfunction exit_cleanup() {\n  kill $PID\n}\n\nant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $HOME/contiki-ng/tools/cooja/build.xml run_bigmem\n\nexit_cleanup" > ${HOME}/cooja && \
   chmod +x ${HOME}/cooja
 
 # Download, build and install Renode

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -129,8 +129,8 @@ ENV                     LANG=C.UTF-8
 WORKDIR                 ${HOME}
 
 # Create Cooja shortcut  
-RUN echo "#!/bin/bash\n\n# Periodically print an invisible character to keep Windows docker from\n# terminating the session for inactivity.\n/bin/bash -c "while sleep 120; do printf '\33[0n'; done" &\nPID=$!\ntrap exit_cleanup INT\n\nfunction exit_cleanup() {\n  kill $PID\n}\n\nant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $HOME/contiki-ng/tools/cooja/build.xml run_bigmem\n\nexit_cleanup" > ${HOME}/cooja && \
-  chmod +x ${HOME}/cooja
+COPY files/* ${HOME}/
+RUN sudo chmod +x ${HOME}/cooja
 
 # Download, build and install Renode
 RUN git clone --quiet https://github.com/renode/renode.git \

--- a/tools/docker/files/cooja
+++ b/tools/docker/files/cooja
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Periodically print an invisible character to keep Windows docker from
+# terminating the session for inactivity.
+/bin/bash -c "while sleep 120; do printf '\33[0n'; done" &
+PID=$!
+
+trap exit_cleanup INT
+
+function exit_cleanup() {
+  kill $PID
+}
+
+ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $HOME/contiki-ng/tools/cooja/build.xml run_bigmem
+
+exit_cleanup


### PR DESCRIPTION
as per discussion in issue #1497 and contribution from @pjonsson :

- new version of cooja script which periodically prints an invisible character to keep windows docker from terminating the session for inactivity
- script copied from docker file to avoid echo'ing ~500 characters