### PR TITLE
tests: show output in 17-tun-rpl

### DIFF
--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -19,14 +19,13 @@ TARGETHOPS=4
 CURDIR=$(pwd)
 
 # Start simulation
-echo "Starting Cooja simulation $BASENAME.csc"
-ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" > $BASENAME.coojalog &
+ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" &
 JPID=$!
 sleep 20
 
 # Connect to the simulation
 echo "Starting tunslip6"
-make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=zoul >> $BASENAME.tunslip6.log 2>&1 &
+make -C $CONTIKI/examples/rpl-border-router connect-router-cooja TARGET=zoul &
 MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME
@@ -48,10 +47,6 @@ rm -f COOJA.testlog COOJA.log
 if [ $STATUS -eq 0 ] && [ $HOPS -eq $TARGETHOPS ] ; then
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
 else
-  echo "==== $BASENAME.coojalog ====" ; cat $BASENAME.coojalog;
-  echo "==== $BASENAME.tunslip6.log ====" ; cat $BASENAME.tunslip6.log;
-  echo "==== $BASENAME.scriptlog ====" ; cat $BASENAME.scriptlog;
-
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 

--- a/tests/17-tun-rpl-br/test-border-router.sh
+++ b/tests/17-tun-rpl-br/test-border-router.sh
@@ -21,30 +21,24 @@ PING_DELAY=${6:-1}
 
 # ICMP request-reply count
 COUNT=5
-# Test OK of COUNT_TARGET ok out of COUNT
-COUNT_TARGET=3
 
 CURDIR=$(pwd)
 
 # Start simulation
-echo "Starting Cooja simulation $BASENAME.csc"
-ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" > $BASENAME.coojalog &
+ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" &
 JPID=$!
 sleep 20
 
 # Connect to the simulation
 echo "Starting tunslip6"
-make -C $CONTIKI/examples/rpl-border-router/ connect-router-cooja TARGET=zoul >> $BASENAME.tunslip6.log 2>&1 &
+make -C $CONTIKI/examples/rpl-border-router connect-router-cooja TARGET=zoul &
 MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME
 
 # Do ping
-echo "Pinging"
-ping6 $IPADDR -c $COUNT -s $PING_SIZE -i $PING_DELAY | tee $BASENAME.scriptlog
-# Fetch ping6 status code (not $? because this is piped)
-STATUS=${PIPESTATUS[0]}
-REPLIES=`grep -c 'icmp_seq=' $BASENAME.scriptlog`
+ping6 $IPADDR -c $COUNT -s $PING_SIZE -i $PING_DELAY
+STATUS=$?
 
 echo "Closing simulation and tunslip6"
 sleep 1
@@ -53,13 +47,9 @@ kill_bg $MPID 15
 sleep 1
 rm -f COOJA.testlog COOJA.log
 
-if [ $STATUS -eq 0 ] && [ $REPLIES -ge $COUNT_TARGET ] ; then
+if [ $STATUS -eq 0 ]; then
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
 else
-  echo "==== $BASENAME.coojalog ====" ; cat $BASENAME.coojalog;
-  echo "==== $BASENAME.tunslip6.log ====" ; cat $BASENAME.tunslip6.log;
-  echo "==== $BASENAME.scriptlog ====" ; cat $BASENAME.scriptlog;
-
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -21,30 +21,24 @@ PING_DELAY=${6:-1}
 
 # ICMP request-reply count
 COUNT=5
-# Test OK of COUNT_TARGET ok out of COUNT
-COUNT_TARGET=3
 
 CURDIR=$(pwd)
 
 # Start simulation
-echo "Starting Cooja simulation $BASENAME.csc"
-ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" > $BASENAME.coojalog &
+ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" &
 JPID=$!
 sleep 20
 
 # Connect to the simulation
 echo "Starting native border-router"
-nohup make -C $CONTIKI/examples/rpl-border-router/ -B connect-router-cooja TARGET=native >> $BASENAME.nbr.log 2>&1 &
+make -C $CONTIKI/examples/rpl-border-router -B connect-router-cooja TARGET=native &
 MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME
 
 # Do ping
-echo "Pinging"
-ping6 $IPADDR -c $COUNT -s $PING_SIZE -i $PING_DELAY | tee $BASENAME.scriptlog
-# Fetch ping6 status code (not $? because this is piped)
-STATUS=${PIPESTATUS[0]}
-REPLIES=`grep -c 'icmp_seq=' $BASENAME.scriptlog`
+ping6 $IPADDR -c $COUNT -s $PING_SIZE -i $PING_DELAY
+STATUS=$?
 
 echo "Closing simulation and nbr"
 sleep 1
@@ -53,13 +47,9 @@ kill_bg $MPID 15
 sleep 1
 rm -f COOJA.testlog COOJA.log
 
-if [ $STATUS -eq 0 ] && [ $REPLIES -ge $COUNT_TARGET ] ; then
+if [ $STATUS -eq 0 ]; then
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
 else
-  echo "==== $BASENAME.coojalog ====" ; cat $BASENAME.coojalog;
-  echo "==== $BASENAME.nbr.log ====" ; cat $BASENAME.nbr.log;
-  echo "==== $BASENAME.scriptlog ====" ; cat $BASENAME.scriptlog;
-
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
 fi
 


### PR DESCRIPTION
The intermittent CI failures of 17-tun-rpl
are difficult to debug without relative ordering
of events. Stop writing output to a file that
is shown on failure so we can use
"Show timestamps" in CI to understand the order
of events.

I cannot find any CI logs where only
some pings go through, so remove that
logic as well to eliminate other sources
of errors.