### PR TITLE
tests: fix intermittent 17-tun-rpl tests

### DIFF
--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -21,7 +21,7 @@ CURDIR=$(pwd)
 # Start simulation
 ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" &
 JPID=$!
-sleep 20
+sleep 30
 
 # Connect to the simulation
 echo "Starting tunslip6"

--- a/tests/17-tun-rpl-br/test-border-router.sh
+++ b/tests/17-tun-rpl-br/test-border-router.sh
@@ -27,7 +27,7 @@ CURDIR=$(pwd)
 # Start simulation
 ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" &
 JPID=$!
-sleep 20
+sleep 30
 
 # Connect to the simulation
 echo "Starting tunslip6"

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -27,7 +27,7 @@ CURDIR=$(pwd)
 # Start simulation
 ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $CONTIKI/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$CURDIR/$BASENAME.csc -contiki=$CONTIKI -logdir=$CURDIR" &
 JPID=$!
-sleep 20
+sleep 30
 
 # Connect to the simulation
 echo "Starting native border-router"


### PR DESCRIPTION
The tests try to establish a connection with
tunslip6 before Cooja starts listening, increase
the delay from 20 to 30 seconds.