### PR TITLE
cooja: remove -fno-builtin-printf

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -64,8 +64,6 @@ LD = $(CC)
 CP = true
 OBJCOPY ?= objcopy
 
-CFLAGS += -fno-builtin-printf
-
 JAVA_CFLAGS = -I"$(JAVA_INCDIR)/include" -I"$(JAVA_INCDIR)/include/$(JAVA_OS_NAME)"
 
 REDEFINE_PRINTF = 1


### PR DESCRIPTION
The original motivation to add the flag was
probably to prevent compiler optimizations
that replace calls to printf with other
functions, for example puts.

Since the Cooja platform now uses dbg-io,
the concern about compiler optimizations
is no longer an issue so remove the flag
so we get -Wformat warnings from the compiler.