### PR TITLE
Makefile: autodetect $(CONTIKI)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,8 +1,7 @@
 # -*- makefile -*-
 
-ifndef CONTIKI
-  ${error CONTIKI not defined! You must specify where Contiki resides}
-endif
+# Set CONTIKI to the directory where Makefile.include resides.
+CONTIKI := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
 ### Include a helper Makefile that creates variables for all Contiki-NG path
 ### locations.


### PR DESCRIPTION
The build system only verifies that
CONTIKI is set, there is no sanity
check on what it is pointing to. Set
CONTIKI to the directory where
Makefile.include resides.

This eliminates the possibility of standing
in a Contiki-NG v4.7 source tree and pointing
CONTIKI to a v4.6 source tree to use that
build system instead.