### PR TITLE
CI: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "develop"


### PR DESCRIPTION
IMPORTANT: This PR requires repository configuration described by https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates

Dependabot can provide automatic pull requests
for things in the repository that should
be updated.

Example PR from dependabot against a repo owned
by the github organization:

https://github.com/github/opensource.guide/pull/2248

Documentation:

https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates