### PR TITLE
doxygen: remove cygwin support

### DIFF
--- a/tools/doxygen/Makefile
+++ b/tools/doxygen/Makefile
@@ -1,21 +1,6 @@
-contiking 	:= ../..
-empty		:=
-space		:= $(empty) $(empty)
-pwd			:= $(shell cd $(contiking); pwd)
-
 # Doxyfile configuration variables
-export docdir	:= .
 export doclatex	:= NO
-export docroot	:= $(contiking)
-
-# Get appropriate root for doxygen path cutoff
-ifeq ($(HOST_OS),Windows)
-  # on windows need to convert cygwin path to windows path for doxygen
-  ifneq (,$(findstring cygdrive,$(pwd)))
-    cygroot = $(subst /,$(space),$(patsubst /cygdrive/%,%,$(pwd)))
-    export docroot = $(firstword $(cygroot)):/$(subst $(space),/,$(wordlist 2,$(words $(cygroot)),$(cygroot)))
-  endif
-endif
+export docroot	:= ../..
 
 .PHONY: clean html
 
@@ -24,6 +9,4 @@ html: clean
 
 clean:
 	@echo "> Cleaning Documentation"
-	@$(RM) -r "$(docdir)/html"
-	@$(RM) -r "doxygen.log"
-	@echo " done."
+	@$(RM) -r html doxygen.log


### PR DESCRIPTION
Only doclatex and docroot are used
by Doxyfile, remove the other variables.
The generated html is identical before/after
this commit.