### PR TITLE
Dockerfile: update to renode 1.13.0

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -133,7 +133,7 @@ COPY --chown=user:user files/cooja ${HOME}/.local/bin/cooja
 # Download, build and install Renode
 RUN git clone --quiet https://github.com/renode/renode.git \
   && cd ${HOME}/renode \
-  && git checkout v1.3 \
+  && git checkout v1.13.0 \
   && ./build.sh
 ENV PATH="${HOME}/renode:${PATH}"
 


### PR DESCRIPTION
This is required for upgrading to Ubuntu 20.