### PR TITLE
simpelink: fix doxygen warnings

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/CC1350STK.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc1350/CC1350STK.h
@@ -29,7 +29,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-/** ============================================================================
+/**
  *  @file       CC1350STK.h
  *
  *  @brief      CC1350 SensorTag Board Specific header file.
@@ -39,7 +39,6 @@
  *  @code
  *  #include "CC1350STK.h"
  *  @endcode
- *  ============================================================================
  */
 #ifndef __CC1350STK_BOARD_H__
 #define __CC1350STK_BOARD_H__

--- a/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/CC2650STK.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/sensortag/cc2650/CC2650STK.h
@@ -29,7 +29,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-/** ============================================================================
+/**
  *  @file       CC2650STK.h
  *
  *  @brief      CC2650 SensorTag Board Specific header file.
@@ -39,7 +39,6 @@
  *  @code
  *  #include "CC2650STK.h"
  *  @endcode
- *  ============================================================================
  */
 #ifndef __CC2650STK_BOARD_H__
 #define __CC2650STK_BOARD_H__


### PR DESCRIPTION
The "===" makes Doxygen believe it is
in a header. The section looks fine
in the HTML without the delimiter,
so remove it.