### PR TITLE
zoul: remove faulty doxygen return doc

### DIFF
--- a/arch/platform/zoul/dev/antenna-sw.h
+++ b/arch/platform/zoul/dev/antenna-sw.h
@@ -57,8 +57,6 @@
  * RF interface of the CC2538, or the Sub-1GHz RF interface of the CC1200.
  * The function is set to enable the Sub-1GHz as default,
  * it should be called from the contiki-main initialization process.
- *
- * \return ignored
  */
 void antenna_sw_config(void);
 

--- a/arch/platform/zoul/dev/led-strip.h
+++ b/arch/platform/zoul/dev/led-strip.h
@@ -59,8 +59,6 @@
  * LEDs 3VDC-powered per strip
  * The function is set to power OFF the LEDs as default,
  * it should be called from the contiki-main initialization process.
- *
- * \return ignored
  */
 void led_strip_config(void);
 


### PR DESCRIPTION
These functions do not return anything,
so remove the return tag.