### PR TITLE
doxygen: turn on quiet mode

### DIFF
--- a/tests/00-documentation/Makefile
+++ b/tests/00-documentation/Makefile
@@ -43,7 +43,7 @@ all: clean
 	@$(MAKE) summary
 
 doxygen:
-	-@$(MAKE) -C $(DOXYGEN_DIR) 2> $(DOXYGEN_ERR) > /dev/null
+	-@$(MAKE) -C $(DOXYGEN_DIR) 2> $(DOXYGEN_ERR)
 
 readthedocs:
 	-@$(MAKE) -C $(READTHEDOCS_DIR) 2> $(READTHEDOCS_ERR) > /dev/null

--- a/tools/doxygen/Doxyfile
+++ b/tools/doxygen/Doxyfile
@@ -714,7 +714,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/tools/doxygen/Doxyfile
+++ b/tools/doxygen/Doxyfile
@@ -1672,7 +1672,7 @@ COMPACT_LATEX          = YES
 # The default value is: a4.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 
 # The EXTRA_PACKAGES tag can be used to specify one or more LaTeX package names
 # that should be included in the LaTeX output. The package can be specified just


### PR DESCRIPTION
Tell doxygen to be quiet instead of piping
output to /dev/null.