### PR TITLE
uip6: disable doxygen for disabled function

### DIFF
--- a/os/net/ipv6/uip.h
+++ b/os/net/ipv6/uip.h
@@ -1478,7 +1478,7 @@ extern uint8_t uip_flags;
                                too many retransmissions. */
 
 
-/**
+/*
  * \brief process the options within a hop by hop or destination option header
  * \retval 0: nothing to send,
  * \retval 1: drop pkt


### PR DESCRIPTION
The doxygen documents a commented out function,
so turn the documentation into a regular comment.