### PR TITLE
Align ble_addr_to_eui64 implementations

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/ble-addr.c
+++ b/arch/cpu/cc26x0-cc13x0/ble-addr.c
@@ -54,13 +54,19 @@ ble_addr_cpy_to(uint8_t *dst)
   }
 }
 /*---------------------------------------------------------------------------*/
-void
+int
 ble_addr_to_eui64(uint8_t *dst, uint8_t *src)
 {
+  if(!dst || !src) {
+    return -1;
+  }
+
   memcpy(dst, src, 3);
   dst[3] = 0xFF;
   dst[4] = 0xFE;
   memcpy(&dst[5], &src[3], 3);
+
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/cpu/cc26x0-cc13x0/ble-addr.h
+++ b/arch/cpu/cc26x0-cc13x0/ble-addr.h
@@ -64,8 +64,10 @@ void ble_addr_cpy_to(uint8_t *dst);
  * \param dst A pointer to the destination area where the EUI64 address is to be
  *            written
  * \param src A pointer to the BLE address that is to be copied
+ * \return  0 : Returned successfully
+ *         -1 : Returned with error
  */
-void ble_addr_to_eui64(uint8_t *dst, uint8_t *src);
+int ble_addr_to_eui64(uint8_t *dst, uint8_t *src);
 
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
There are multiple definitions of ble_addr_to_eui64
in the tree. Align the implementations so
cc26x0-cc13x0 implementation behaves the same way
as the simplelink-cc13xx-cc26xx implementation.