### PR TITLE
fixed doxygen comments on rtimer arch code.

### DIFF
--- a/arch/cpu/cc2538/rtimer-arch.c
+++ b/arch/cpu/cc2538/rtimer-arch.c
@@ -61,12 +61,6 @@ rtimer_arch_init(void)
   return;
 }
 /*---------------------------------------------------------------------------*/
-/**
- * \brief Schedules an rtimer task to be triggered at time t
- * \param t The time when the task will need executed. This is an absolute
- *          time, in other words the task will be executed AT time \e t,
- *          not IN \e t ticks
- */
 void
 rtimer_arch_schedule(rtimer_clock_t t)
 {

--- a/arch/cpu/cc26x0-cc13x0/rtimer-arch.c
+++ b/arch/cpu/cc26x0-cc13x0/rtimer-arch.c
@@ -56,12 +56,7 @@ rtimer_arch_init(void)
   return;
 }
 /*---------------------------------------------------------------------------*/
-/**
- * \brief Schedules an rtimer task to be triggered at time t
- * \param t The time when the task will need executed.
- *
- * \e t is an absolute time, in other words the task will be executed AT
- * time \e t, not IN \e t rtimer ticks.
+ /**
  *
  * This function schedules a one-shot event with the AON RTC.
  *

--- a/arch/cpu/nrf52832/rtimer-arch.c
+++ b/arch/cpu/nrf52832/rtimer-arch.c
@@ -79,11 +79,6 @@ rtimer_arch_init(void)
 }
 /*---------------------------------------------------------------------------*/
 /**
- * \brief Schedules an rtimer task to be triggered at time t
- * \param t The time when the task will need executed.
- *
- * \e t is an absolute time, in other words the task will be executed AT
- * time \e t, not IN \e t rtimer ticks.
  *
  * This function schedules a one-shot event with the nRF RTC.
  */

--- a/arch/cpu/nrf52840/rtimer-arch.c
+++ b/arch/cpu/nrf52840/rtimer-arch.c
@@ -63,11 +63,6 @@ rtimer_arch_init(void)
 }
 /*---------------------------------------------------------------------------*/
 /**
- * \brief Schedules an rtimer task to be triggered at time t
- * \param t The time when the task will need executed.
- *
- * \e t is an absolute time, in other words the task will be executed AT
- * time \e t, not IN \e t rtimer ticks.
  *
  * This function schedules a one-shot event with the nRF RTC.
  */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/rtimer-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/rtimer-arch.c
@@ -157,12 +157,7 @@ rtimer_arch_init(void)
 }
 /*---------------------------------------------------------------------------*/
 /**
- * \brief    Schedules an rtimer task to be triggered at time \p t.
- * \param t  The time when the task will need executed.
- *
- *           \p t is an absolute time, in other words the task will be
- *           executed AT time \p t, not IN \p t rtimer ticks.
- *
+
  *           This function schedules a one-shot event with the AON RTC.
  *
  *           This functions converts \p t to a value suitable for the AON RTC.

--- a/os/sys/rtimer.h
+++ b/os/sys/rtimer.h
@@ -243,7 +243,12 @@ void rtimer_run_next(void);
 void rtimer_arch_init(void);
 
 /**
- * Schedule the call to `rtimer_run_next` at the time t.
+ * \brief Schedules an rtimer task to be triggered at time t
+ * \param t The time when the task will need executed.
+ *
+ * \e t is an absolute time, in other words the task will be executed AT
+ * time \e t, not IN \e t rtimer ticks.
+ *
  */
 void rtimer_arch_schedule(rtimer_clock_t t);
 


### PR DESCRIPTION
This moves the doxygen descriptions to the os/sys/rtimer.h file so that the param list is described only once. Seems to remove the doxygen warning on the rtimer codebase.
