### PR TITLE
Add missing include in simple-energest

### DIFF
--- a/os/services/simple-energest/simple-energest.c
+++ b/os/services/simple-energest/simple-energest.c
@@ -46,6 +46,7 @@
 #include "simple-energest.h"
 #include <stdio.h>
 #include <limits.h>
+#include <inttypes.h>
 
 /* Log configuration */
 #include "sys/log.h"


### PR DESCRIPTION
As in title - fixes compilation failure for at least simplelink platform.