### PR TITLE
Use default mirror in docker build

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -8,7 +8,6 @@ USER root
 # Tools
 RUN apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install ca-certificates > /dev/null && \
-    sed -i -e 's#http://archive.ubuntu.com/ubuntu/#mirror://mirrors.ubuntu.com/mirrors.txt#' /etc/apt/sources.list && \
     apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install gnupg software-properties-common > /dev/null
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -7,9 +7,10 @@ USER root
 
 # Tools
 RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install ca-certificates > /dev/null && \
-    apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common > /dev/null
+    apt-get -qq -y --no-install-recommends install \
+      ca-certificates \
+      gnupg \
+      software-properties-common > /dev/null
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
   echo "deb http://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-xamarin.list && \


### PR DESCRIPTION
As we can see on #1845, the mirror://mirrors.ubuntu.com/mirrors.txt is not working.
I tried locally and it also does not work.
@pjonsson I can see that you added it. Is it okay to revert it? 