### PR TITLE
examples/benchmarks/rpl-req-resp: enable building for Simplelink

### DIFF
--- a/examples/benchmarks/rpl-req-resp/Makefile
+++ b/examples/benchmarks/rpl-req-resp/Makefile
@@ -1,8 +1,8 @@
 CONTIKI_PROJECT = node
 all: $(CONTIKI_PROJECT)
 
-PLATFORMS_EXCLUDE = sky z1 nrf52dk native simplelink
-BOARDS_EXCLUDE = srf06/cc13x0 launchpad/cc1310 launchpad/cc1350 sensortag/cc2650 sensortag/cc1350
+PLATFORMS_EXCLUDE = sky z1 nrf52dk native
+BOARDS_EXCLUDE = launchpad/cc1350-4 launchpad/cc2640r2
 
 MODULES_REL += ../testbeds
 

--- a/examples/benchmarks/rpl-req-resp/node.c
+++ b/examples/benchmarks/rpl-req-resp/node.c
@@ -52,6 +52,19 @@
 #define UDP_PORT 8214
 #define SEND_INTERVAL (CLOCK_SECOND)
 
+/* Builds that are known to be failing */
+#if CONTIKI_TARGET_SIMPLELINK
+#if CONTIKI_BOARD_LAUNCHPAD_CC1310 \
+  || CONTIKI_BOARD_LAUNCHPAD_CC1350 \
+  || CONTIKI_BOARD_LAUNCHPAD_CC2650 \
+  || CONTIKI_BOARD_SENSORTAG_CC1350 \
+  || CONTIKI_BOARD_SENSORTAG_CC2650 \
+  || CONTIKI_BOARD_SRF06_CC13X0 \
+  || CONTIKI_BOARD_SRF06_CC26X0
+#error "This board and target combination cannot be built due to size limitations"
+#endif
+#endif
+
 static struct simple_udp_connection udp_conn;
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR enabled building the `rpl-req-resp` benchmark example on Simplelink by removing it from the PLATFORMS_EXCLUDE list.