### PR TITLE
ipv6: conditionalize tcp-socket on UIP_TCP

### DIFF
--- a/os/net/ipv6/tcp-socket.c
+++ b/os/net/ipv6/tcp-socket.c
@@ -40,6 +40,8 @@
 
 #include "tcp-socket.h"
 
+#if UIP_TCP
+
 #include <string.h>
 
 static void relisten(struct tcp_socket *s);
@@ -407,3 +409,4 @@ tcp_socket_queuelen(struct tcp_socket *s)
   return s->output_data_len;
 }
 /*---------------------------------------------------------------------------*/
+#endif /* UIP_TCP */


### PR DESCRIPTION
The functions in tcpip.c are conditionalized
on UIP_TCP, so the symbols used by tcp-socket.c
cannot be taken for granted.

The build system does not offer conditional
builds based on configuration, so add an #if
around the contents of tcp-socket.c for now.