### PR TITLE
lwm2m-ipso-objects: do not build unused file

### DIFF
--- a/examples/lwm2m-ipso-objects/Makefile
+++ b/examples/lwm2m-ipso-objects/Makefile
@@ -1,6 +1,6 @@
 CONTIKI_PROJECT = example-ipso-objects
 
-CONTIKI_SOURCEFILES += serial-protocol.c example-ipso-temperature.c
+CONTIKI_SOURCEFILES += example-ipso-temperature.c
 
 PLATFORMS_EXCLUDE = sky z1
 


### PR DESCRIPTION
The serial-protocol.c contains functionality
that is used by example-server.c in the same
directory.