### PR TITLE
cooja: disable slip-arch with NULLNET

### DIFF
--- a/arch/platform/cooja/slip-arch.c
+++ b/arch/platform/cooja/slip-arch.c
@@ -28,6 +28,8 @@
  *
  */
 
+#if !defined(NETSTACK_CONF_WITH_NULLNET) || !NETSTACK_CONF_WITH_NULLNET
+
 #include "dev/slip.h"
 #include "dev/rs232.h"
 
@@ -37,3 +39,4 @@ slip_arch_init()
   rs232_set_input(slip_input_byte);
 }
 
+#endif


### PR DESCRIPTION
The file uses slip_input_byte which resides
in slip. Slip uses the rxbuf from uIP, and
that is not available with NULLNET.