### PR TITLE
Dockerfile: clean after first apt-get round

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install \
       ca-certificates \
       gnupg \
-      software-properties-common > /dev/null
+      software-properties-common > /dev/null && \
+    apt-get -qq clean
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
   echo "deb http://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \


### PR DESCRIPTION
This reduces the size of the image.