### PR TITLE
jn516x: add a customrules file

### DIFF
--- a/arch/platform/jn516x/Makefile.customrules-jn516x
+++ b/arch/platform/jn516x/Makefile.customrules-jn516x
@@ -1,0 +1,22 @@
+CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
+	$(TRACE_CC)
+	$(Q)$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
+
+CUSTOM_RULE_LINK = 1
+ALLLIBS = $(addprefix -l,$(LDLIBS)) $(addprefix -l,$(LDSTACKLIBS)) $(addprefix -l,$(LDMYLIBS))
+ABS_APPLIBS = $(addsuffix _$(JENNIC_CHIP_FAMILY).a,$(addprefix $(COMPONENTS_BASE_DIR)/Library/lib,$(APPLIBS)))
+
+ifneq ($(wildcard $(SDK_BASE_DIR)/Components/Library/*),)
+# The SDK is fully installed, proceed to linking
+$(BUILD_DIR_BOARD)/%.$(TARGET): %.o $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(CONTIKI_NG_TARGET_LIB) $(ABS_APPLIBS)
+	@echo  ${filter %.a,$^}
+	$(Q)$(CC) -Wl,--gc-sections $(LDFLAGS) -T$(LINKCMD) -o $@ -Wl,--start-group \
+	  ${filter-out %.a,$^} ${filter %.a,$^} \
+	  $(ALLLIBS) -Wl,--end-group
+else
+# The SDK does not include libraries, only build objects and libraries, skip linking
+$(BUILD_DIR_BOARD)/%.$(TARGET): %.o $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(CONTIKI_NG_TARGET_LIB)
+	@echo Creating empty $@
+	touch $@
+endif

--- a/arch/platform/jn516x/Makefile.jn516x
+++ b/arch/platform/jn516x/Makefile.jn516x
@@ -199,6 +199,8 @@ endif
 endif
 DEV_PORT = $(USBDEVBASENAME)$(MOTE)
 
+MAKEFILES_CUSTOMRULES += $(CONTIKI_NG_RELOC_PLATFORM_DIR)/jn516x/Makefile.customrules-jn516x
+
 #### make targets
 
 ########################################################################
@@ -215,29 +217,6 @@ DEV_PORT = $(USBDEVBASENAME)$(MOTE)
 
 %.dmp: %.$(TARGET)
 	$(Q)$(OBJDUMP) -d $< > $@
-
-CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
-$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
-	$(TRACE_CC)
-	$(Q)$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
-
-CUSTOM_RULE_LINK = 1
-ALLLIBS = $(addprefix -l,$(LDLIBS)) $(addprefix -l,$(LDSTACKLIBS)) $(addprefix -l,$(LDMYLIBS))
-ABS_APPLIBS = $(addsuffix _$(JENNIC_CHIP_FAMILY).a,$(addprefix $(COMPONENTS_BASE_DIR)/Library/lib,$(APPLIBS)))
-
-ifneq ($(wildcard $(SDK_BASE_DIR)/Components/Library/*),)
-# The SDK is fully installed, proceed to linking
-$(BUILD_DIR_BOARD)/%.$(TARGET): %.o $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(CONTIKI_NG_TARGET_LIB) $(ABS_APPLIBS)
-	@echo  ${filter %.a,$^}
-	$(Q)$(CC) -Wl,--gc-sections $(LDFLAGS) -T$(LINKCMD) -o $@ -Wl,--start-group \
-	  ${filter-out %.a,$^} ${filter %.a,$^} \
-	  $(ALLLIBS) -Wl,--end-group
-else
-# The SDK does not include libraries, only build objects and libraries, skip linking
-$(BUILD_DIR_BOARD)/%.$(TARGET): %.o $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(CONTIKI_NG_TARGET_LIB)
-	@echo Creating empty $@
-	touch $@
-endif
 
 $(BUILD_DIR_BOARD)/%.$(TARGET).bin: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	$(TRACE_OBJCOPY)


### PR DESCRIPTION
The platform specific rules should be
defined at the stage of the customrules
inclusion, not at the target makefile
inclusion.

The output of:

env RELSTR=test make NUMCORES=1 Q=''

in 04-compile-nxp-ports is identical
before/after this patch.