### PR TITLE
Makefile: add support for --start/end-group

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -458,6 +458,12 @@ ifndef LD
 endif
 
 ifndef CUSTOM_RULE_LINK
+# Targets can define LD_START_GROUP and LD_END_GROUP to resolve circular
+# dependencies between linked libraries, see:
+# https://stackoverflow.com/questions/5651869/gcc-what-are-the-start-group-and-end-group-command-line-options/5651895
+# These are not defined by default since it has a significant performance cost.
+TARGET_LIBEXTRAS = $(LD_START_GROUP) $(TARGET_LIBFILES) $(LD_END_GROUP)
+
 # Cooja passes LIBNAME through the environment and all .csc files contain
 # calls to make with a target that is *not* what Cooja needs. Add
 # a compatibility line for link rule so we can have a single rule that
@@ -470,7 +476,7 @@ ifdef REDEFINE_PRINTF
 endif
 	$(TRACE_LD)
 	$(Q)$(LD) $(LDFLAGS) $(TARGET_STARTFILES) ${filter-out %.a,$^} \
-	    ${filter %.a,$^} $(TARGET_LIBFILES) -o $(LIBNAME)
+	    ${filter %.a,$^} $(TARGET_LIBEXTRAS) -o $(LIBNAME)
 endif
 
 %.$(TARGET): $(BUILD_DIR_BOARD)/%.$(TARGET)

--- a/arch/cpu/arm/cortex-m/Makefile.cortex-m
+++ b/arch/cpu/arm/cortex-m/Makefile.cortex-m
@@ -17,6 +17,9 @@ CONTIKI_ARM_DIRS += cortex-m
 ### Build syscalls for newlib
 MODULES += os/lib/newlib
 
+LD_START_GROUP = -Wl,--start-group
+LD_END_GROUP = -Wl,--end-group
+
 LDFLAGS += -T $(LDSCRIPT)
 LDFLAGS += -Wl,--gc-sections,--sort-section=alignment
 # The next line might be trying to avoid
@@ -29,6 +32,6 @@ CPU_STARTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(CPU_START_SOURCEFILES
 
 ### Resolve any potential circular dependencies between the linked libraries
 ### See: https://stackoverflow.com/questions/5651869/gcc-what-are-the-start-group-and-end-group-command-line-options/5651895
-TARGET_LIBFLAGS := -Wl,--start-group $(TARGET_LIBFILES) -Wl,--end-group
+TARGET_LIBFLAGS := $(LD_START_GROUP) $(TARGET_LIBFILES) $(LD_END_GROUP)
 
 include $(CONTIKI)/$(CONTIKI_NG_ARM_DIR)/Makefile.arm


### PR DESCRIPTION
This is preparation for making cortex-m use
the link rule in Makefile.include.

The output from

env RELSTR=test make NUMCORES=1 Q=''

on 02-compile-arm-ports is identical before/after
this patch.