### PR TITLE
Makefile: move objectfiles down

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -92,9 +92,6 @@ $(1) \
 }}}}
 endef
 
-CONTIKI_OBJECTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(CONTIKI_SOURCEFILES)}}
-PROJECT_OBJECTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(PROJECT_SOURCEFILES)}}
-
 uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 
 ### Include target makefile (TODO Unsafe?)
@@ -336,6 +333,9 @@ endif
 ### Harmonize filename of a .map file, if the platform's build system wants
 ### to create one
 CONTIKI_NG_PROJECT_MAP = $(BUILD_DIR_BOARD)/$(basename $(notdir $@)).map
+
+CONTIKI_OBJECTFILES += ${addprefix $(OBJECTDIR)/,${call oname, $(CONTIKI_SOURCEFILES)}}
+PROJECT_OBJECTFILES += ${addprefix $(OBJECTDIR)/,${call oname, $(PROJECT_SOURCEFILES)}}
 
 .PHONY: all clean distclean usage help targets boards savetarget savedefines viewconf
 


### PR DESCRIPTION
This is preparation for only building
files that are required for the configuration.

The output from:

env RELSTR=test make NUMCORES=1 Q=''

for 01-compile-base, 02-compile-arm-ports,
and 04-compile-nxp-ports is identical
before/after this patch.