### PR TITLE
tests: return error from make for compile tests

### DIFF
--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -62,10 +62,8 @@ define dooneexample
 @echo -n Building example $(3): $(1) $(4) for target $(2)
 @((cd $(EXAMPLESDIR)/$(1) && \
    $(MAKE) $(4) TARGET=$(2) $(MAKEOPTIONS) clean && \
-   make -j$(CPUS) $(4) TARGET=$(2) $(MAKEOPTIONS)) 2>make.err && \
- (echo " -> OK" && printf "%-75s %-40s %-20s TEST OK\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog) || \
- (echo " -> FAIL" && printf "%-75s %-40s %-20s TEST FAIL\n" "$(1)" "$(4)" "$(2)" > $(3)-$(subst /,-,$(1))$(2).testlog ; cat make.err))
-@rm -f make.err
+   make -j$(CPUS) $(4) TARGET=$(2) $(MAKEOPTIONS)) || \
+  printf "%-75s %-40s %-20s TEST FAIL\n" "$(1)" "$(4)" "$(2)" >> summary)
 endef
 
 define doexample
@@ -75,6 +73,7 @@ endef
 #end of GNU make magic
 
 examples: | $(EXAMPLESDIR)
+	@rm -f summary
 	$(foreach ex, $(EXAMPLES), $(call doexample, ${ex}))
 
 $(EXAMPLESDIR):
@@ -85,12 +84,12 @@ $(EXAMPLESDIR):
 	@false
 
 summary: examples
-	@cat *.testlog > summary
 	@echo "========== Summary =========="
-	@cat summary
+	@([ ! -f summary ] && echo "All tests OK" && touch summary) || \
+          (echo "Failures:" && cat summary && false)
 
 clean: | $(EXAMPLESDIR)
-	@rm -f *.testlog summary
+	@rm -f summary
 	@$(foreach example, $(EXAMPLES), \
            $(foreach target, $(EXAMPLESTARGETS), \
              (cd $(EXAMPLESDIR)/$(example) && $(MAKE) TARGET=$(target) clean);))


### PR DESCRIPTION
Mirror the logic from Makefile.simulation-test
so make exits with an error upon failure. This
also removes the output per test when it passes,
this is convenient for the 100 tests in
02-compile-arm-ports.