### PR TITLE
arm: remove -fno-builtin

### DIFF
--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -22,7 +22,7 @@ CFLAGS += -mthumb -mabi=aapcs -mlittle-endian
 CFLAGS += -Wall
 CFLAGS += -std=c99
 CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
-CFLAGS += -fshort-enums -fomit-frame-pointer -fno-builtin
+CFLAGS += -fshort-enums -fomit-frame-pointer
 ifeq ($(WERROR),1)
   CFLAGS += -Werror
 endif

--- a/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/Makefile
+++ b/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/Makefile
@@ -18,4 +18,7 @@ CONTIKI=../../../..
 include $(CONTIKI)/Makefile.dir-variables
 MODULES += $(CONTIKI_NG_APP_LAYER_DIR)/mqtt $(CONTIKI_NG_APP_LAYER_DIR)/coap
 
+# FIXME: Fix the code and remove the next line.
+CFLAGS += -Wno-stringop-truncation
+
 include $(CONTIKI)/Makefile.include


### PR DESCRIPTION
The flag entered the repository through
the nrf52832 port. Why that flag was added
to the nRF5 SDK in the first place is unclear:

https://devzone.nordicsemi.com/f/nordic-q-a/53021/reason-for--fno-builtin-introduced-in-sdk-7

The flag is a sledgehammer, -fno-builtin-printf
disables -Wformat warnings, and optimizations
for general purpose functions such as strcmp/memcmp,
general purpose floating point functions,
and typical bit operation functions such as
clz/ctz/popcount.