### PR TITLE
cc26x0-web-demo: increase buffer size

### DIFF
--- a/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/cc26x0-web-demo.h
+++ b/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/cc26x0-web-demo.h
@@ -167,7 +167,7 @@ extern process_event_t cc26xx_web_demo_load_config_defaults;
 #define CC26XX_WEB_DEMO_UNIT_GYRO     "deg per sec"
 /*---------------------------------------------------------------------------*/
 /* A data type for sensor readings, internally stored in a linked list */
-#define CC26XX_WEB_DEMO_CONVERTED_LEN        12
+#define CC26XX_WEB_DEMO_CONVERTED_LEN        16
 
 typedef struct cc26xx_web_demo_sensor_reading {
   struct cc26xx_web_demo_sensor_reading *next;


### PR DESCRIPTION
This ensures the snprinted values fit
in the buffer.