### PR TITLE
cooja: fix include guard names

### DIFF
--- a/arch/platform/cooja/dev/pir-sensor.h
+++ b/arch/platform/cooja/dev/pir-sensor.h
@@ -28,8 +28,8 @@
  *
  */
 
-#ifndef PIR_H_
-#define PIR_H_
+#ifndef PIR_SENSOR_H_
+#define PIR_SENSOR_H_
 
 #include "lib/sensors.h"
 
@@ -37,4 +37,4 @@ extern const struct sensors_sensor pir_sensor;
 
 #define PIR_SENSOR "PIR"
 
-#endif /* PIR_H_ */
+#endif /* PIR_SENSOR_H_ */

--- a/arch/platform/cooja/dev/vib-sensor.h
+++ b/arch/platform/cooja/dev/vib-sensor.h
@@ -28,8 +28,8 @@
  *
  */
 
-#ifndef VIB_H_
-#define VIB_H_
+#ifndef VIB_SENSOR_H_
+#define VIB_SENSOR_H_
 
 #include "lib/sensors.h"
 
@@ -37,4 +37,4 @@ extern const struct sensors_sensor vib_sensor;
 
 #define VIB_SENSOR "Vibration"
 
-#endif /* VIB_H_ */
+#endif /* VIB_SENSOR_H_ */


### PR DESCRIPTION
Name the guards according to the filename.