### PR TITLE
list: put const in right place

### DIFF
--- a/os/lib/list.c
+++ b/os/lib/list.c
@@ -79,7 +79,7 @@ list_init(list_t list)
  * \sa list_tail()
  */
 void *
-list_head(const list_t list)
+list_head(const_list_t list)
 {
   return *list;
 }
@@ -97,7 +97,7 @@ list_head(const list_t list)
  * \param src The source list.
  */
 void
-list_copy(list_t dest, const list_t src)
+list_copy(list_t dest, const_list_t src)
 {
   *dest = *src;
 }
@@ -114,7 +114,7 @@ list_copy(list_t dest, const list_t src)
  * \sa list_head()
  */
 void *
-list_tail(const list_t list)
+list_tail(const_list_t list)
 {
   struct list *l;
 
@@ -269,7 +269,7 @@ list_remove(list_t list, const void *item)
  */
 /*---------------------------------------------------------------------------*/
 int
-list_length(const list_t list)
+list_length(const_list_t list)
 {
   struct list *l;
   int n = 0;
@@ -335,7 +335,7 @@ list_item_next(const void *item)
  *			   is present in the list.
  */
 bool
-list_contains(const list_t list, const void *item)
+list_contains(const_list_t list, const void *item)
 {
   struct list *l;
   for(l = *list; l != NULL; l = l->next) {

--- a/os/lib/list.h
+++ b/os/lib/list.h
@@ -135,9 +135,14 @@
  */
 typedef void ** list_t;
 
+/**
+ * The non-modifiable linked list type.
+ */
+typedef void *const *const_list_t;
+
 void   list_init(list_t list);
-void * list_head(const list_t list);
-void * list_tail(const list_t list);
+void * list_head(const_list_t list);
+void * list_tail(const_list_t list);
 void * list_pop (list_t list);
 void   list_push(list_t list, void *item);
 
@@ -146,15 +151,15 @@ void * list_chop(list_t list);
 void   list_add(list_t list, void *item);
 void   list_remove(list_t list, const void *item);
 
-int    list_length(const list_t list);
+int    list_length(const_list_t list);
 
-void   list_copy(list_t dest, const list_t src);
+void   list_copy(list_t dest, const_list_t src);
 
 void   list_insert(list_t list, void *previtem, void *newitem);
 
 void * list_item_next(const void *item);
 
-bool list_contains(const list_t list, const void *item);
+bool list_contains(const_list_t list, const void *item);
 
 #endif /* LIST_H_ */
 


### PR DESCRIPTION
The intention of the const on the parameters
of the list functions is that they do not
modify that argument. Putting const on the list_t
type makes the type void **const rather than
the intended void *const *.