### PR TITLE
antelope: use aql_status_t return value

### DIFF
--- a/os/storage/antelope/aql-parser.c
+++ b/os/storage/antelope/aql-parser.c
@@ -721,7 +721,7 @@ PARSER_ARG(domain, char *name)
     element_size = 2;
     break;
   default:
-    return NONE;
+    return PLE_ERROR;
   }
 
   AQL_ADD_ATTRIBUTE(adt, name, domain, element_size);


### PR DESCRIPTION
NONE is an enum value from token, but
PARSER_ARG returns an aql_status_t value.
Use the PLE_ERROR return value instead
since that is the right type and will still
give a failure with AQL_ERROR().