### PR TITLE
Fix -Wempty-body warning

### DIFF
--- a/arch/cpu/cc2538/lpm.c
+++ b/arch/cpu/cc2538/lpm.c
@@ -70,8 +70,8 @@ rtimer_clock_t lpm_stats[3];
   do { memset(lpm_stats, 0, sizeof(lpm_stats)); } while(0)
 #define LPM_STATS_ADD(pm, val)   do { lpm_stats[pm] += val; } while(0)
 #else
-#define LPM_STATS_INIT()
-#define LPM_STATS_ADD(stat, val)
+#define LPM_STATS_INIT() do {} while (0)
+#define LPM_STATS_ADD(stat, val) do {} while (0)
 #endif
 /*---------------------------------------------------------------------------*/
 /*

--- a/arch/cpu/cc26x0-cc13x0/rf-core/rf-switch.h
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/rf-switch.h
@@ -90,10 +90,10 @@ void rf_switch_power_down(void);
  */
 void rf_switch_select_path(uint8_t path);
 #else
-#define rf_switch_init()
-#define rf_switch_power_up()
-#define rf_switch_power_down()
-#define rf_switch_select_path(p)
+#define rf_switch_init() do {} while (0)
+#define rf_switch_power_up() do {} while (0)
+#define rf_switch_power_down() do {} while (0)
+#define rf_switch_select_path(p) do {} while (0)
 #endif /* RF_SWITCH_ENABLE */
 /*---------------------------------------------------------------------------*/
 #endif /* RF_SWITCH_H_ */


### PR DESCRIPTION
Clang with -Wall gives a -Wempty-body
warning in these places, add a newline
to make it obvious that the loop does
nothing.

Uncrustify does not change this formatting.