### PR TITLE
6tisch/simple-node: disable LOG_CONF_LEVEL_FRAMER

### DIFF
--- a/examples/6tisch/simple-node/project-conf.h
+++ b/examples/6tisch/simple-node/project-conf.h
@@ -75,7 +75,11 @@
 #define LOG_CONF_LEVEL_IPV6                        LOG_LEVEL_WARN
 #define LOG_CONF_LEVEL_6LOWPAN                     LOG_LEVEL_WARN
 #define LOG_CONF_LEVEL_MAC                         LOG_LEVEL_INFO
+/* Do not enable LOG_CONF_LEVEL_FRAMER on SimpleLink,
+   that will cause it to print from an interrupt context. */
+#ifndef CONTIKI_TARGET_SIMPLELINK
 #define LOG_CONF_LEVEL_FRAMER                      LOG_LEVEL_WARN
+#endif
 #define TSCH_LOG_CONF_PER_SLOT                     1
 
 #endif /* PROJECT_CONF_H_ */


### PR DESCRIPTION
SimpleLink CC13xx/CC26xx prints a message in the regression
tests that it disables LOG_CONF_LEVEL_FRAMER. Stop
defining LOG_CONF_LEVEL_FRAMER for those configurations.