### PR TITLE
Renamed get and remove tsch link functions

### DIFF
--- a/examples/6tisch/etsi-plugtest-2017/sf-plugtest.c
+++ b/examples/6tisch/etsi-plugtest-2017/sf-plugtest.c
@@ -247,7 +247,7 @@ delete_cell(const linkaddr_t *peer_addr, const sf_plugtest_cell_t *cell)
   channel_offset = cell->channel_offset[0] + (cell->channel_offset[1] << 8);
 
   if((slotframe = tsch_schedule_get_slotframe_by_handle(0)) == NULL ||
-     tsch_schedule_remove_link_by_timeslot(slotframe, timeslot, channel_offset) == 0) {
+     tsch_schedule_remove_link_by_offsets(slotframe, timeslot, channel_offset) == 0) {
     LOG_ERR("cannot delete a cell\n");
     return -1;
   }
@@ -324,7 +324,7 @@ add_req_handler(const linkaddr_t *peer_addr,
   channel_offset = pending_cell.channel_offset[0] + (pending_cell.channel_offset[1] << 8);
 
   if((slotframe = tsch_schedule_get_slotframe_by_handle(0)) == NULL ||
-     tsch_schedule_get_link_by_timeslot(slotframe, timeslot, channel_offset) != NULL ||
+     tsch_schedule_get_link_by_offsets(slotframe, timeslot, channel_offset) != NULL ||
      reserve_cell(peer_addr, &pending_cell) < 0) {
     LOG_ERR("Failed to add a cell [slot:%u]\n", timeslot);
     sixp_output(SIXP_PKT_TYPE_RESPONSE,
@@ -366,7 +366,7 @@ add_res_handler(const linkaddr_t *peer_addr, sixp_pkt_rc_t rc,
   }
 
   if((slotframe = tsch_schedule_get_slotframe_by_handle(0)) == NULL ||
-     tsch_schedule_get_link_by_timeslot(slotframe, timeslot, channel_offset) != NULL ||
+     tsch_schedule_get_link_by_offsets(slotframe, timeslot, channel_offset) != NULL ||
      add_cell(peer_addr, (sf_plugtest_cell_t *)cell, LINK_OPTION_TX) < 0) {
     LOG_ERR("Failed to add a cell [slot:%u]\n", timeslot);
   }
@@ -412,7 +412,7 @@ delete_req_handler(const linkaddr_t *peer_addr,
   channel_offset = pending_cell.channel_offset[0] + (pending_cell.channel_offset[1] << 8);
 
   if((slotframe = tsch_schedule_get_slotframe_by_handle(0)) == NULL ||
-     (link = tsch_schedule_get_link_by_timeslot(slotframe, timeslot, channel_offset)) == NULL ||
+     (link = tsch_schedule_get_link_by_offsets(slotframe, timeslot, channel_offset)) == NULL ||
      memcmp(peer_addr, &link->addr, sizeof(linkaddr_t)) != 0) {
     LOG_ERR("Failed to delete a cell [slot:%u]\n", timeslot);
     sixp_output(SIXP_PKT_TYPE_RESPONSE,
@@ -463,7 +463,7 @@ delete_res_handler(const linkaddr_t *peer_addr, sixp_pkt_rc_t rc,
   }
 
   if((slotframe = tsch_schedule_get_slotframe_by_handle(0)) == NULL ||
-     (link = tsch_schedule_get_link_by_timeslot(slotframe, timeslot, channel_offset)) == NULL ||
+     (link = tsch_schedule_get_link_by_offsets(slotframe, timeslot, channel_offset)) == NULL ||
      memcmp(peer_addr, &link->addr, sizeof(linkaddr_t)) != 0 ||
      delete_cell(peer_addr, cell) < 0) {
     LOG_ERR("Failed to delete a cell [slot:%u]\n", timeslot);

--- a/examples/6tisch/sixtop/sf-simple.c
+++ b/examples/6tisch/sixtop/sf-simple.c
@@ -173,9 +173,9 @@ remove_links_to_schedule(const uint8_t *cell_list, uint16_t cell_list_len)
       continue;
     }
 
-    tsch_schedule_remove_link_by_timeslot(slotframe,
-                                          cell.timeslot_offset,
-                                          cell.channel_offset);
+    tsch_schedule_remove_link_by_offsets(slotframe,
+                                         cell.timeslot_offset,
+                                         cell.channel_offset);
   }
 }
 
@@ -273,9 +273,9 @@ add_req_input(const uint8_t *body, uint16_t body_len, const linkaddr_t *peer_add
         i < cell_list_len && feasible_link < num_cells;
         i += sizeof(cell)) {
       read_cell(&cell_list[i], &cell);
-      if(tsch_schedule_get_link_by_timeslot(slotframe,
-                                            cell.timeslot_offset,
-                                            cell.channel_offset) == NULL) {
+      if(tsch_schedule_get_link_by_offsets(slotframe,
+                                           cell.timeslot_offset,
+                                           cell.channel_offset) == NULL) {
         sixp_pkt_set_cell_list(SIXP_PKT_TYPE_RESPONSE,
                                (sixp_pkt_code_t)(uint8_t)SIXP_PKT_RC_SUCCESS,
                                (uint8_t *)&cell, sizeof(cell),
@@ -347,9 +347,9 @@ delete_req_input(const uint8_t *body, uint16_t body_len,
     /* ensure before delete */
     for(i = 0, removed_link = 0; i < cell_list_len; i += sizeof(cell)) {
       read_cell(&cell_list[i], &cell);
-      if(tsch_schedule_get_link_by_timeslot(slotframe,
-                                            cell.timeslot_offset,
-                                            cell.channel_offset) != NULL) {
+      if(tsch_schedule_get_link_by_offsets(slotframe,
+                                           cell.timeslot_offset,
+                                           cell.channel_offset) != NULL) {
         sixp_pkt_set_cell_list(SIXP_PKT_TYPE_RESPONSE,
                                (sixp_pkt_code_t)(uint8_t)SIXP_PKT_RC_SUCCESS,
                                (uint8_t *)&cell, sizeof(cell),
@@ -485,7 +485,7 @@ sf_simple_add_links(linkaddr_t *peer_addr, uint8_t num_links)
     /* Randomly select a slot offset within TSCH_SCHEDULE_DEFAULT_LENGTH */
     random_slot = ((random_rand() & 0xFF)) % TSCH_SCHEDULE_DEFAULT_LENGTH;
 
-    if(tsch_schedule_get_link_by_timeslot(sf, random_slot, 0) == NULL) {
+    if(tsch_schedule_get_link_by_offsets(sf, random_slot, 0) == NULL) {
 
       /* To prevent repeated slots */
       for(i = 0; i < index; i++) {
@@ -575,7 +575,7 @@ sf_simple_remove_links(linkaddr_t *peer_addr)
   assert(peer_addr != NULL && sf != NULL);
 
   for(i = 0; i < TSCH_SCHEDULE_DEFAULT_LENGTH; i++) {
-    l = tsch_schedule_get_link_by_timeslot(sf, i, 0);
+    l = tsch_schedule_get_link_by_offsets(sf, i, 0);
 
     if(l) {
       /* Non-zero value indicates a scheduled link */

--- a/os/net/mac/tsch/tsch-packet.c
+++ b/os/net/mac/tsch/tsch-packet.c
@@ -255,7 +255,7 @@ tsch_packet_create_eb(uint8_t *hdr_len, uint8_t *tsch_sync_ie_offset)
   {
     /* Send slotframe 0 with link at timeslot 0 and channel offset 0 */
     struct tsch_slotframe *sf0 = tsch_schedule_get_slotframe_by_handle(0);
-    struct tsch_link *link0 = tsch_schedule_get_link_by_timeslot(sf0, 0, 0);
+    struct tsch_link *link0 = tsch_schedule_get_link_by_offsets(sf0, 0, 0);
     if(sf0 && link0) {
       ies.ie_tsch_slotframe_and_link.num_slotframes = 1;
       ies.ie_tsch_slotframe_and_link.slotframe_handle = sf0->handle;

--- a/os/net/mac/tsch/tsch-schedule.c
+++ b/os/net/mac/tsch/tsch-schedule.c
@@ -378,6 +378,27 @@ tsch_schedule_get_link_by_offsets(struct tsch_slotframe *slotframe,
   return NULL;
 }
 /*---------------------------------------------------------------------------*/
+/* Looks within a slotframe for a link with a given timeslot */
+struct tsch_link *
+tsch_schedule_get_link_by_timeslot(struct tsch_slotframe *slotframe,
+                                  uint16_t timeslot)
+{
+  if(!tsch_is_locked()) {
+    if(slotframe != NULL) {
+      struct tsch_link *l = list_head(slotframe->links_list);
+      /* Loop over all items. Assume there is max one link per timeslot and channel_offset */
+      while(l != NULL) {
+        if(l->timeslot == timeslot) {
+          return l;
+        }
+        l = list_item_next(l);
+      }
+      return l;
+    }
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
 static struct tsch_link *
 default_tsch_link_comparator(struct tsch_link *a, struct tsch_link *b)
 {

--- a/os/net/mac/tsch/tsch-schedule.c
+++ b/os/net/mac/tsch/tsch-schedule.c
@@ -228,10 +228,15 @@ tsch_schedule_add_link(struct tsch_slotframe *slotframe,
     }
 
     if(do_remove) {
-      /* Start with removing the link currently installed at this timeslot and
-       * channel offset (needed to keep neighbor state in sync with link options
-       * etc.) */
-      tsch_schedule_remove_link_by_offsets(slotframe, timeslot, channel_offset);
+      /* Start with removing any link currently installed at this timeslot
+       * (needed to keep neighbor state in sync with link options etc.). We
+       * don't check for channel offset because only one link per timeslot
+       * is allowed in a given slotframe */
+      l = tsch_schedule_get_link_by_timeslot(slotframe, timeslot);
+      if(l != NULL) {
+        tsch_schedule_remove_link(slotframe, l);
+        l = NULL;
+      }
     }
     if(!tsch_get_lock()) {
       LOG_ERR("! add_link memb_alloc couldn't take lock\n");

--- a/os/net/mac/tsch/tsch-schedule.c
+++ b/os/net/mac/tsch/tsch-schedule.c
@@ -228,9 +228,9 @@ tsch_schedule_add_link(struct tsch_slotframe *slotframe,
     }
 
     if(do_remove) {
-      /* Start with removing the link currently installed at this timeslot (needed
+      /* Start with removing the link currently installed at this timeslot and channel offset (needed
        * to keep neighbor state in sync with link options etc.) */
-      tsch_schedule_remove_link_by_timeslot(slotframe, timeslot, channel_offset);
+      tsch_schedule_remove_link_by_offsets(slotframe, timeslot, channel_offset);
     }
     if(!tsch_get_lock()) {
       LOG_ERR("! add_link memb_alloc couldn't take lock\n");
@@ -333,10 +333,10 @@ tsch_schedule_remove_link(struct tsch_slotframe *slotframe, struct tsch_link *l)
   return 0;
 }
 /*---------------------------------------------------------------------------*/
-/* Removes a link from slotframe and timeslot. Return a 1 if success, 0 if failure */
+/* Removes a link from slotframe and timeslot + channel offset. Return a 1 if success, 0 if failure */
 int
-tsch_schedule_remove_link_by_timeslot(struct tsch_slotframe *slotframe,
-                                      uint16_t timeslot, uint16_t channel_offset)
+tsch_schedule_remove_link_by_offsets(struct tsch_slotframe *slotframe,
+                                     uint16_t timeslot, uint16_t channel_offset)
 {
   int ret = 0;
   if(!tsch_is_locked()) {
@@ -357,10 +357,10 @@ tsch_schedule_remove_link_by_timeslot(struct tsch_slotframe *slotframe,
   return ret;
 }
 /*---------------------------------------------------------------------------*/
-/* Looks within a slotframe for a link with a given timeslot */
+/* Looks within a slotframe for a link with a given timeslot and channel offset */
 struct tsch_link *
-tsch_schedule_get_link_by_timeslot(struct tsch_slotframe *slotframe,
-                                   uint16_t timeslot, uint16_t channel_offset)
+tsch_schedule_get_link_by_offsets(struct tsch_slotframe *slotframe,
+                                  uint16_t timeslot, uint16_t channel_offset)
 {
   if(!tsch_is_locked()) {
     if(slotframe != NULL) {

--- a/os/net/mac/tsch/tsch-schedule.c
+++ b/os/net/mac/tsch/tsch-schedule.c
@@ -228,8 +228,9 @@ tsch_schedule_add_link(struct tsch_slotframe *slotframe,
     }
 
     if(do_remove) {
-      /* Start with removing the link currently installed at this timeslot and channel offset (needed
-       * to keep neighbor state in sync with link options etc.) */
+      /* Start with removing the link currently installed at this timeslot and
+       * channel offset (needed to keep neighbor state in sync with link options
+       * etc.) */
       tsch_schedule_remove_link_by_offsets(slotframe, timeslot, channel_offset);
     }
     if(!tsch_get_lock()) {
@@ -333,7 +334,8 @@ tsch_schedule_remove_link(struct tsch_slotframe *slotframe, struct tsch_link *l)
   return 0;
 }
 /*---------------------------------------------------------------------------*/
-/* Removes a link from slotframe and timeslot + channel offset. Return a 1 if success, 0 if failure */
+/* Removes a link from slotframe and timeslot + channel offset. Return a 1 if
+ * success, 0 if failure */
 int
 tsch_schedule_remove_link_by_offsets(struct tsch_slotframe *slotframe,
                                      uint16_t timeslot, uint16_t channel_offset)
@@ -357,7 +359,8 @@ tsch_schedule_remove_link_by_offsets(struct tsch_slotframe *slotframe,
   return ret;
 }
 /*---------------------------------------------------------------------------*/
-/* Looks within a slotframe for a link with a given timeslot and channel offset */
+/* Looks within a slotframe for a link with a given timeslot and channel
+ * offset */
 struct tsch_link *
 tsch_schedule_get_link_by_offsets(struct tsch_slotframe *slotframe,
                                   uint16_t timeslot, uint16_t channel_offset)
@@ -365,7 +368,8 @@ tsch_schedule_get_link_by_offsets(struct tsch_slotframe *slotframe,
   if(!tsch_is_locked()) {
     if(slotframe != NULL) {
       struct tsch_link *l = list_head(slotframe->links_list);
-      /* Loop over all items. Assume there is max one link per timeslot and channel_offset */
+      /* Loop over all items. Assume there is max one link per timeslot
+         and channel_offset */
       while(l != NULL) {
         if(l->timeslot == timeslot && l->channel_offset == channel_offset) {
           return l;
@@ -386,7 +390,7 @@ tsch_schedule_get_link_by_timeslot(struct tsch_slotframe *slotframe,
   if(!tsch_is_locked()) {
     if(slotframe != NULL) {
       struct tsch_link *l = list_head(slotframe->links_list);
-      /* Loop over all items. Assume there is max one link per timeslot and channel_offset */
+      /* Loop over all items. Assume there is max one link per timeslot */
       while(l != NULL) {
         if(l->timeslot == timeslot) {
           return l;

--- a/os/net/mac/tsch/tsch-schedule.h
+++ b/os/net/mac/tsch/tsch-schedule.h
@@ -122,6 +122,15 @@ struct tsch_link *tsch_schedule_get_link_by_offsets(struct tsch_slotframe *slotf
                                                     uint16_t timeslot, uint16_t channel_offset);
 
 /**
+ * \brief Looks within a slotframe for a link with a given timeslot
+ * \param slotframe The desired slotframe
+ * \param timeslot The desired timeslot
+ * \return The link if found, NULL otherwise
+ */
+struct tsch_link *tsch_schedule_get_link_by_timeslot(struct tsch_slotframe *slotframe,
+                                                     uint16_t timeslot);
+
+/**
  * \brief Removes a link
  * \param slotframe The slotframe the link belongs to
  * \param l The link to be removed

--- a/os/net/mac/tsch/tsch-schedule.h
+++ b/os/net/mac/tsch/tsch-schedule.h
@@ -112,14 +112,14 @@ struct tsch_link *tsch_schedule_add_link(struct tsch_slotframe *slotframe,
 struct tsch_link *tsch_schedule_get_link_by_handle(uint16_t handle);
 
 /**
- * \brief Looks within a slotframe for a link with a given timeslot
+ * \brief Looks within a slotframe for a link with a given timeslot and channel offset
  * \param slotframe The desired slotframe
  * \param timeslot The desired timeslot
  * \param channel_offset The desired channel offset 
  * \return The link if found, NULL otherwise
  */
-struct tsch_link *tsch_schedule_get_link_by_timeslot(struct tsch_slotframe *slotframe,
-                                                     uint16_t timeslot, uint16_t channel_offset);
+struct tsch_link *tsch_schedule_get_link_by_offsets(struct tsch_slotframe *slotframe,
+                                                    uint16_t timeslot, uint16_t channel_offset);
 
 /**
  * \brief Removes a link
@@ -130,14 +130,14 @@ struct tsch_link *tsch_schedule_get_link_by_timeslot(struct tsch_slotframe *slot
 int tsch_schedule_remove_link(struct tsch_slotframe *slotframe, struct tsch_link *l);
 
 /**
- * \brief Removes a link from a slotframe and timeslot
+ * \brief Removes a link from a slotframe and timeslot + channel offset
  * \param slotframe The slotframe where to look for the link
  * \param timeslot The timeslot where to look for the link within the target slotframe
  * \param channel_offset The channel offset where to look for the link within the target slotframe
  * \return 1 if success, 0 if failure
  */
-int tsch_schedule_remove_link_by_timeslot(struct tsch_slotframe *slotframe,
-                                          uint16_t timeslot, uint16_t channel_offset);
+int tsch_schedule_remove_link_by_offsets(struct tsch_slotframe *slotframe,
+                                         uint16_t timeslot, uint16_t channel_offset);
 
 /**
  * \brief Returns the next active link after a given ASN, and a backup link (for the same ASN, with Rx flag)

--- a/os/services/orchestra/orchestra-rule-special-for-root.c
+++ b/os/services/orchestra/orchestra-rule-special-for-root.c
@@ -191,7 +191,7 @@ root_node_updated(const linkaddr_t *root, uint8_t is_added)
         LINK_TYPE_NORMAL, root,
         timeslot_tx, get_node_channel_offset(root), 0);
   } else {
-    tsch_schedule_remove_link_by_timeslot(sf_tx, timeslot_tx, get_node_channel_offset(root));
+    tsch_schedule_remove_link_by_offsets(sf_tx, timeslot_tx, get_node_channel_offset(root));
     tsch_queue_free_packets_to(root);
   }
 }

--- a/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
+++ b/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
@@ -133,7 +133,7 @@ remove_uc_link(const linkaddr_t *linkaddr)
   }
 
   timeslot = get_node_timeslot(linkaddr);
-  l = tsch_schedule_get_link_by_timeslot(sf_unicast, timeslot, local_channel_offset);
+  l = tsch_schedule_get_link_by_offsets(sf_unicast, timeslot, local_channel_offset);
   if(l == NULL) {
     return;
   }


### PR DESCRIPTION
@atiselsts Since there is a legitimate use for a function that checks whether a link exists based solely on slot offset (a.k.a., "timeslot"), it would be better to rename the functions `tsch_schedule_remove_link_by_timeslot` and `tsch_schedule_get_link_by_timeslot` to reflect the changes introduced in #1162 , where these functions were modified to operate on timeslot and channel offset, instead of just timeslot.