### PR TITLE
nrf52832: remove $(NRFLIB)

### DIFF
--- a/arch/cpu/nrf52832/Makefile.nrf52832
+++ b/arch/cpu/nrf52832/Makefile.nrf52832
@@ -159,8 +159,8 @@ ASMFLAGS += -DCONFIG_GPIO_AS_PINRESET
 ASMFLAGS += -DBLE_STACK_SUPPORT_REQD
 
 C_SOURCE_FILE_NAMES = $(notdir $(C_SOURCE_FILES))
+CONTIKI_SOURCEFILES += $(C_SOURCE_FILE_NAMES)
 C_PATHS = $(call remduplicates, $(dir $(C_SOURCE_FILES) ) )
-C_OBJECTS = $(addprefix $(OBJECT_DIRECTORY)/, $(C_SOURCE_FILE_NAMES:.c=.o) )
 
 ASM_SOURCE_FILE_NAMES = $(notdir $(ASM_SOURCE_FILES))
 ASM_PATHS = $(call remduplicates, $(dir $(ASM_SOURCE_FILES) ))
@@ -169,15 +169,7 @@ ASM_OBJECTS = $(addprefix $(OBJECT_DIRECTORY)/, $(ASM_SOURCE_FILE_NAMES:.s=.o) )
 vpath %.c $(C_PATHS)
 vpath %.s $(ASM_PATHS)
 
-OBJECTS = $(C_OBJECTS) $(ASM_OBJECTS)
-
-NRFLIB = $(BUILD_DIR_BOARD)/nrf52832.a
-
-TARGET_LIBS = $(NRFLIB) $(NRF52_SDK_ROOT)/components/iot/ble_6lowpan/lib/ble_6lowpan.a
-
-$(NRFLIB): $(OBJECTS)
-	$(TRACE_AR)
-	$(Q)$(AR) $(AROPTS) $@ $^
+TARGET_LIBS = $(ASM_OBJECTS) $(NRF52_SDK_ROOT)/components/iot/ble_6lowpan/lib/ble_6lowpan.a
 
 # Assemble files
 $(OBJECT_DIRECTORY)/%.o: %.s


### PR DESCRIPTION
Targets that have their own way of constructing
the list of object files to be built cause issues
with completing the dependency management in
the build system.

Since all files are compiled with the same flags,
there is no strong reason to "partition" the build
and hamper build parallelism. Add the source files
from the SDK to CONTIKI_SOURCEFILES instead of
constructing something special for this architecture.

All object files are still built with the same flags
as before this patch, the only thing that has changed
is that the object files are passed directly to the linker
instead of first making a library that is passed to the linker.