### PR TITLE
cortex-m: align build with Makefile.include

### DIFF
--- a/arch/cpu/arm/cortex-m/Makefile.cortex-m
+++ b/arch/cpu/arm/cortex-m/Makefile.cortex-m
@@ -28,8 +28,4 @@ LDFLAGS += -Wl,--no-warn-mismatch
 
 OBJCOPY_FLAGS += --gap-fill 0xff
 
-### Resolve any potential circular dependencies between the linked libraries
-### See: https://stackoverflow.com/questions/5651869/gcc-what-are-the-start-group-and-end-group-command-line-options/5651895
-TARGET_LIBFLAGS := $(LD_START_GROUP) $(TARGET_LIBFILES) $(LD_END_GROUP)
-
 include $(CONTIKI)/$(CONTIKI_NG_ARM_DIR)/Makefile.arm

--- a/arch/cpu/arm/cortex-m/Makefile.customrules-cortex-m
+++ b/arch/cpu/arm/cortex-m/Makefile.customrules-cortex-m
@@ -1,5 +1,11 @@
 CUSTOM_RULE_LINK = 1
 
+# Targets can define LD_START_GROUP and LD_END_GROUP to resolve circular
+# dependencies between linked libraries, see:
+# https://stackoverflow.com/questions/5651869/gcc-what-are-the-start-group-and-end-group-command-line-options/5651895
+# These are not defined by default since it has a significant performance cost.
+TARGET_LIBEXTRAS = $(LD_START_GROUP) $(TARGET_LIBFILES) $(LD_END_GROUP)
+
 $(OUT_ELF): $(CONTIKI_OBJECTFILES) $(OBJECTDIR)/%.o $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(LDSCRIPT) $(TARGET_LIBS)
 	$(TRACE_LD)
-	$(Q)$(LD) $(LDFLAGS) ${filter-out $(LDSCRIPT) %.a,$^} ${filter %.a,$^} $(TARGET_LIBFLAGS) -o $@
+	$(Q)$(LD) $(LDFLAGS) ${filter-out $(LDSCRIPT) %.a,$^} ${filter %.a,$^} $(TARGET_LIBEXTRAS) -o $@


### PR DESCRIPTION
Move definitions to align the customrules for
cortex-m with the rules in Makefile.include.
This is preparation for making cortex-m-based
platforms be able to link without custom rules.

The compiler invocations are identical before/after
this commit.