### PR TITLE
cortex-m: do not add LD_*_GROUP by default

### DIFF
--- a/arch/cpu/arm/cortex-m/Makefile.cortex-m
+++ b/arch/cpu/arm/cortex-m/Makefile.cortex-m
@@ -17,9 +17,6 @@ CONTIKI_ARM_DIRS += cortex-m
 ### Build syscalls for newlib
 MODULES += os/lib/newlib
 
-LD_START_GROUP = -Wl,--start-group
-LD_END_GROUP = -Wl,--end-group
-
 LDFLAGS += -T $(LDSCRIPT)
 LDFLAGS += -Wl,--gc-sections,--sort-section=alignment
 # The next line might be trying to avoid

--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -121,6 +121,9 @@ LDSCRIPT ?= $(CONTIKI_CPU)/$(SUBFAMILY)/$(SUBFAMILY).lds
 # Globally linked libraries
 TARGET_LIBFILES += -lc -lgcc -lnosys -lm
 
+LD_START_GROUP = -Wl,--start-group
+LD_END_GROUP = -Wl,--end-group
+
 ################################################################################
 ### Specialized build targets
 


### PR DESCRIPTION
There is a performance penalty of forcing
the linker to resolve circular dependencies
so only enable it on platforms that needs
the support.