### PR TITLE
Makefile: move FORCE to Makefile.include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -107,6 +107,10 @@ endef
 
 uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 
+# Rule to force rebuilds.
+.PHONY: FORCE
+FORCE:
+
 # Identify if the target makefile is in-tree, or from $(TARGETDIRS).
 target_makefile := $(wildcard $(CONTIKI_NG_RELOC_PLATFORM_DIR)/$(TARGET)/Makefile.$(TARGET) \
                    $(foreach TDIR, $(TARGETDIRS), $(TDIR)/$(TARGET)/Makefile.$(TARGET)))

--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -34,8 +34,6 @@ USB_SOURCEFILES += usb-core.c cdc-acm.c usb-arch.c usb-serial.c cdc-acm-descript
 CONTIKI_SOURCEFILES += $(CONTIKI_CPU_SOURCEFILES) $(USB_SOURCEFILES)
 
 ### Always re-build ieee-addr.o in case the command line passes a new NODEID
-FORCE:
-
 $(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(OBJECTDIR)
 	$(TRACE_CC)
 	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@

--- a/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -58,8 +58,6 @@ endif
 BSL = $(CONTIKI_NG_TOOLS_DIR)/cc2538-bsl/cc2538-bsl.py
 
 ### Always re-build ieee-addr.o in case the command line passes a new NODEID
-FORCE:
-
 $(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(OBJECTDIR)
 	$(TRACE_CC)
 	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@

--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -124,9 +124,6 @@ TARGET_LIBFILES += -lc -lgcc -lnosys -lm
 ################################################################################
 ### Specialized build targets
 
-.PHONY: FORCE
-FORCE:
-
 # Always re-build ieee-addr.o in case the command line passes a new NODEID
 $(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(OBJECTDIR)
 	$(TRACE_CC)


### PR DESCRIPTION
Put this definition in one place instead
of having a copy around in multiple targets.