### PR TITLE
Makefile: do not add cfs-coffee in arch

### DIFF
--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -26,7 +26,7 @@ CONTIKI_CPU_SOURCEFILES += ecc-curve.c
 CONTIKI_CPU_SOURCEFILES += dbg.c ieee-addr.c
 CONTIKI_CPU_SOURCEFILES += slip-arch.c slip.c
 CONTIKI_CPU_SOURCEFILES += i2c.c cc2538-temp-sensor.c vdd3-sensor.c
-CONTIKI_CPU_SOURCEFILES += cfs-coffee.c cfs-coffee-arch.c pwm.c
+CONTIKI_CPU_SOURCEFILES += cfs-coffee-arch.c pwm.c
 CONTIKI_CPU_SOURCEFILES += startup-gcc.c
 
 USB_SOURCEFILES += usb-core.c cdc-acm.c usb-arch.c usb-serial.c cdc-acm-descriptors.c

--- a/arch/platform/sky/Makefile.common
+++ b/arch/platform/sky/Makefile.common
@@ -1,6 +1,4 @@
-# $Id: Makefile.common,v 1.3 2010/08/24 16:24:11 joxe Exp $
-
-ARCH=spi-legacy.c ds2411.c xmem.c i2c.c sensors.c cfs-coffee.c \
+ARCH=spi-legacy.c ds2411.c xmem.c i2c.c sensors.c \
      cc2420.c cc2420-arch.c cc2420-arch-sfd.c \
      sky-sensors.c uip-ipchksum.c \
      uart1.c slip_uart1.c uart1-putchar.c platform.c

--- a/arch/platform/z1/Makefile.common
+++ b/arch/platform/z1/Makefile.common
@@ -7,7 +7,7 @@ SMALL=0
 
 ARCH = leds.c xmem.c i2cmaster.c \
        spi-legacy.c cc2420.c cc2420-arch.c cc2420-arch-sfd.c\
-       node-id-z1.c sensors.c button-sensor.c cfs-coffee.c \
+       node-id-z1.c sensors.c button-sensor.c \
        uart0.c uart0-putchar.c uip-ipchksum.c \
        slip.c slip_uart0.c z1-sensors.c adxl345.c temperature-sensor.c \
        z1-phidgets.c light-sensor.c battery-sensor.c sky-sensors.c tmp102.c \


### PR DESCRIPTION
The file cfs-coffee.c comes from
os/storage/cfs, so stop adding that file to
the architecture specific build files.