### PR TITLE
Only pass non-constant defines to objects that need them

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -342,10 +342,13 @@ RELSTR:=${shell git --git-dir ${CONTIKI}/.git --work-tree ${CONTIKI} describe \
 endif
 
 ifneq ($(RELSTR),)
-CFLAGS += -DCONTIKI_VERSION_STRING=\"Contiki-NG-$(RELSTR)\"
+CONTIKI_VERSION = -DCONTIKI_VERSION_STRING=\"Contiki-NG-$(RELSTR)\"
 else
-CFLAGS += -DCONTIKI_VERSION_STRING=\"Contiki-NG\"
+CONTIKI_VERSION = -DCONTIKI_VERSION_STRING=\"Contiki-NG\"
 endif
+
+# These files are compiled with -DCONTIKI_VERSION_STRING in CFLAGS.
+NEEDS_CONTIKI_VERSION_FILES += contiki-main.c lwm2m-device.c
 
 ### Harmonize filename of a .map file, if the platform's build system wants
 ### to create one
@@ -390,6 +393,10 @@ DEPFILES := ${filter %.d, $(CONTIKI_SOURCEFILES:%.c=$(DEPDIR)/%.d) \
                           $(PROJECT_SOURCEFILES:%.cpp=$(DEPDIR)/%.d)}
 $(DEPFILES):
 include $(wildcard $(DEPFILES))
+
+# Add CONTIKI_VERSION to CFLAGS for these files.
+NEEDS_VERSION_OBJFILES = $(NEEDS_CONTIKI_VERSION_FILES:%.c=$(OBJECTDIR)/%.o)
+$(NEEDS_VERSION_OBJFILES): CFLAGS += $(CONTIKI_VERSION)
 
 # Include custom build rule Makefiles specified by platforms/CPUs.
 include $(MAKEFILES_CUSTOMRULES)
@@ -516,7 +523,7 @@ ifdef MAKE_COAP_DTLS_KEYSTORE
 	@echo "##### \"MAKE_COAP_DTLS_KEYSTORE\": _______________ $(MAKE_COAP_DTLS_KEYSTORE)"
 endif
 	@echo "----------------- C variables: -----------------"
-	$(Q)$(CC) $(CFLAGS) -E $(VIEWCONF) | grep \#\#\#\#\#
+	$(Q)$(CC) $(CONTIKI_VERSION) $(CFLAGS) -E $(VIEWCONF) | grep \#\#\#\#\#
 	@echo "------------------------------------------------"
 	@echo "'==' Means the flag is set to a given a value"
 	@echo "'->' Means the flag is unset, but will default to a given value"

--- a/arch/platform/zoul/Makefile.zoul
+++ b/arch/platform/zoul/Makefile.zoul
@@ -20,7 +20,10 @@ BSL_SPEED ?= 460800
 
 # Works in Linux and probably on OSX too (RTCC example)
 COMPILE_DATE := $(shell date +"%02u %02d %02m %02y %02H %02M %02S")
-CFLAGS += -DDATE="\"$(COMPILE_DATE)\""
+CFLAGS_DATE ?= -DDATE="\"$(COMPILE_DATE)\""
+
+# Compile platform.o with -DDATE, other files without it.
+$(OBJECTDIR)/platform.o: CFLAGS += $(CFLAGS_DATE)
 
 ### Configure the build for the board and pull in board-specific sources
 CONTIKI_TARGET_DIRS += . dev

--- a/arch/platform/zoul/Makefile.zoul
+++ b/arch/platform/zoul/Makefile.zoul
@@ -19,7 +19,8 @@ BSL_FLAGS += -e -w -v
 BSL_SPEED ?= 460800
 
 # Works in Linux and probably on OSX too (RTCC example)
-CFLAGS += -DDATE="\"`date +"%02u %02d %02m %02y %02H %02M %02S"`\""
+COMPILE_DATE := $(shell date +"%02u %02d %02m %02y %02H %02M %02S")
+CFLAGS += -DDATE="\"$(COMPILE_DATE)\""
 
 ### Configure the build for the board and pull in board-specific sources
 CONTIKI_TARGET_DIRS += . dev

--- a/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/Makefile
+++ b/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/Makefile
@@ -5,6 +5,8 @@ PLATFORMS_ONLY = cc26x0-cc13x0
 
 MODULES_REL += ./resources
 
+NEEDS_CONTIKI_VERSION_FILES += res-device.c
+
 PROJECT_SOURCEFILES += coap-server.c net-uart.c mqtt-client.c
 PROJECT_SOURCEFILES += httpd-simple.c
 

--- a/examples/snmp-server/Makefile
+++ b/examples/snmp-server/Makefile
@@ -5,6 +5,8 @@ MODULES += os/net/app-layer/snmp
 
 MODULES_REL += ./resources
 
+NEEDS_CONTIKI_VERSION_FILES += snmp-SNMP-MIB-2-System.c
+
 CONTIKI = ../..
 
 include $(CONTIKI)/Makefile.include


### PR DESCRIPTION
Defines such as `CONTIKI_VERSION_STRING` and `DATE` are different on almost every make invocation. Only pass these defines to files that need them, so ccache can get a direct hit for the other files.