### PR TITLE
Makefile: remove .PRECIOUS

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -548,10 +548,6 @@ endif
 ### Include Makefile.gcc for GCC specific definitions and actions
 include $(CONTIKI)/Makefile.gcc
 
-# Don't treat $(BUILD_DIR_BOARD)/%.$(TARGET) and $(TARGET) as intermediate
-# files because for many platforms they are in fact the primary target.
-.PRECIOUS: $(BUILD_DIR_BOARD)/%.$(TARGET) %.$(TARGET)
-
 ifeq ($(PLATFORM_ACTION),skip)
 # Skip this target.
 $(CONTIKI_PROJECT):

--- a/Makefile.include
+++ b/Makefile.include
@@ -19,6 +19,10 @@ MAKEFLAGS += --no-builtin-rules
 Makefile: ;
 Makefile.%: ;
 
+# The target logic makes all build artifacts implicit, prevent make from
+# removing object files upon build completion.
+.SECONDARY:
+
 ### Include a helper Makefile that creates variables for all Contiki-NG path
 ### locations.
 include $(CONTIKI)/Makefile.dir-variables

--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -74,9 +74,6 @@ OUT_BIN = $(BUILD_DIR_BOARD)/%.bin
 OUT_LST = $(BUILD_DIR_BOARD)/%.lst
 OUT_ELF = $(BUILD_DIR_BOARD)/%.elf
 
-### Don't treat the following files as intermediate
-.PRECIOUS: $(OUT_ELF) $(OUT_HEX) $(OUT_BIN)
-
 $(OUT_I16HEX): $(OUT_ELF)
 	$(TRACE_OBJCOPY)
 	$(Q)$(OBJCOPY) -O ihex $< $@

--- a/arch/platform/jn516x/Makefile.jn516x
+++ b/arch/platform/jn516x/Makefile.jn516x
@@ -208,8 +208,6 @@ MAKEFILES_CUSTOMRULES += $(CONTIKI_NG_RELOC_PLATFORM_DIR)/jn516x/Makefile.custom
 
 .PHONY: all clean
 
-.PRECIOUS: %.elf
-
 %.d: clean
 
 %.nm: %.$(TARGET)


### PR DESCRIPTION
The .PRECIOUS directive is a sledgehammer that keeps faulty intermediate files around. Tell make to not remove intermediate results instead with the .SECONDARY directive.