### PR TITLE
cooja: add gcc 10 support on Linux

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -54,7 +54,7 @@ else ifeq ($(HOST_OS),Darwin)
 else
   JAVA_OS_NAME = linux
   CC = gcc
-  CFLAGS += -fPIC
+  CFLAGS += -fPIC -fcommon
   LDFLAGS += -shared -Wl,-zdefs -Wl,-Map=$(MAPFILE)
 endif
 


### PR DESCRIPTION
Cooja cannot find the information required
in the map file when objects are compiled
with -fno-common. This is the default
with GCC 10/Clang 11 and later, so add
the -fcommon to our build for now.