### PR TITLE
Dockerfile: upgrade to Ubuntu 22.04 LTS

### DIFF
--- a/doc/project/Release-Notes-next.md
+++ b/doc/project/Release-Notes-next.md
@@ -4,6 +4,9 @@ We are releasing version XXX of Contiki-NG. This release adds XXX, and support
 for link-time-optimization that can reduce the binary size up to 50% on some
 examples.
 
+Various parts of the user experience for developers have been improved in this release:
+* Docker image updated to Ubuntu 22.04.
+
 ## Find out more at:
 
 * GitHub repository: https://github.com/contiki-ng/contiki-ng

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -8,13 +8,7 @@ USER root
 # Tools
 RUN apt-get -qq update && \
     apt-get -qq -y --no-install-recommends install \
-      ca-certificates \
-      gnupg \
-      software-properties-common > /dev/null && \
-    apt-get -qq clean
-
-RUN add-apt-repository ppa:mosquitto-dev/mosquitto-ppa && \
-  apt-get -qq update && \
+      ca-certificates > /dev/null && \
   apt-get -qq -y --no-install-recommends install \
     ant \
     build-essential \


### PR DESCRIPTION
There are no mosquitto packages on the PPA
for this version of Ubuntu so use the packages
in Ubuntu instead. These are version 2.0.11
instead of 2.0.14, but 08-native-runs still
passes with this version.