### PR TITLE
Revert "vagrant: use nearby mirrors"

### DIFF
--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Use nearby mirrors.
-sudo sed -i -e 's#http://archive.ubuntu.com/ubuntu#mirror://mirrors.ubuntu.com/mirrors.txt#' /etc/apt/sources.list
-
 # Install i386 binary support on x64 system and required tools
 sudo dpkg --add-architecture i386
 sudo add-apt-repository --yes ppa:mosquitto-dev/mosquitto-ppa


### PR DESCRIPTION
The nearby mirrors work great in Sweden,
but there were intermittent CI failures
for the docker image.

This reverts commit 2f8dd337ed3f000c210fe44903ddc5a7ecfa69e4.