### PR TITLE
cooja: wrap dbg-io funs and call them

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -63,6 +63,8 @@ endif
 # Command converting lowercase to uppercase, and "-" and "/" to "_".
 UPPERCASE_CMD = tr '[:lower:][\-/]' '[:upper:][__]'
 
+COMMA := ,
+
 JAVA = java
 
 BUILD_DIR = build
@@ -314,7 +316,6 @@ endif
 
 ### Forward comma-separated list of arbitrary defines to the compiler
 
-COMMA := ,
 CFLAGS += ${addprefix -D,${subst $(COMMA), ,$(DEFINES)}}
 
 ### Setup directory search path for source and header files
@@ -460,10 +461,6 @@ TARGET_LIBEXTRAS = $(LD_START_GROUP) $(TARGET_LIBFILES) $(LD_END_GROUP)
 # outputs to LIBNAME on all platforms.
 $(BUILD_DIR_BOARD)/%.$(TARGET): LIBNAME ?= $@
 $(BUILD_DIR_BOARD)/%.$(TARGET): $(OBJECTDIR)/%.o $(LDSCRIPT) $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(CONTIKI_OBJECTFILES)
-ifdef REDEFINE_PRINTF
-	@echo Redefining printf,sprintf,vsnprintf,etc.
-	$(Q)$(foreach OBJ,$^, $(OBJCOPY) --redefine-syms $(CONTIKI)/arch/platform/$(TARGET)/redefine.syms $(OBJ); )
-endif
 	$(TRACE_LD)
 	$(Q)$(LD) $(LDFLAGS) $(TARGET_STARTFILES) ${filter-out $(LDSCRIPT) %.a,$^} \
 	    ${filter %.a,$^} $(TARGET_LIBEXTRAS) -o $(LIBNAME)

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -28,6 +28,7 @@ COOJA_DIR = $(CONTIKI_NG_TOOLS_DIR)/cooja
 
 # Use dbg-io for IO functions like printf()
 MODULES += os/lib/dbg-io
+WRAPPED_FUNS = printf putchar puts snprintf sprintf vsnprintf
 
 JAVA_INCDIR := $(shell $(JAVA) -XshowSettings:properties -version 2>&1 | grep java.home | awk -F"= " '{print $$2}')
 ifneq ($(MAKECMDGOALS),clean)
@@ -49,13 +50,16 @@ else ifeq ($(HOST_OS),Darwin)
   CFLAGS += -fno-common -DHAVE_SNPRINTF
   LDFLAGS_WERROR = -Wl,-fatal_warnings
   LDFLAGS += -dynamiclib -fno-common -framework $(JAVA_FRAMEWORK)
-  # No objcopy in OS X, disable.
-  OBJCOPY = true
 else
   JAVA_OS_NAME = linux
   CC = gcc
   CFLAGS += -fPIC -fcommon
   LDFLAGS += -shared -Wl,-zdefs -Wl,-Map=$(MAPFILE)
+endif
+
+ifneq ($(HOST_OS),Darwin)
+  # Use the printf-family replacement functions in dbg-io.
+  LDFLAGS += $(addprefix -Wl$(COMMA)--wrap$(COMMA), $(WRAPPED_FUNS))
 endif
 
 LD = $(CC)
@@ -64,11 +68,8 @@ SIZE = size
 # Cooja need. Just disable the final copy so Cooja can share the build
 # system with the rest of Contiki-NG.
 CP = true
-OBJCOPY ?= objcopy
 
 JAVA_CFLAGS = -I"$(JAVA_INCDIR)/include" -I"$(JAVA_INCDIR)/include/$(JAVA_OS_NAME)"
-
-REDEFINE_PRINTF = 1
 
 ### Assuming simulator quickstart if no JNI library name set from Cooja
 ifndef LIBNAME

--- a/arch/platform/cooja/redefine.syms
+++ b/arch/platform/cooja/redefine.syms
@@ -1,7 +1,0 @@
-# Symbols to redefine to ensure use of Contiki-NG implementations
-printf    log_printf
-sprintf   log_sprintf
-snprintf  log_snprintf
-vsnprintf log_vsnprintf
-puts      log_puts
-putchar   log_putchar

--- a/os/lib/dbg-io/printf.c
+++ b/os/lib/dbg-io/printf.c
@@ -61,4 +61,8 @@ printf(const char *fmt, ...)
   va_end(ap);
   return res;
 }
+
+#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
+extern int __wrap_printf(const char *fmt, ...) __attribute__((nonnull, alias("printf")));
+#endif
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/putchar.c
+++ b/os/lib/dbg-io/putchar.c
@@ -41,4 +41,8 @@ putchar(int c)
   dbg_putchar(c);
   return c;
 }
+
+#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
+extern int __wrap_putchar(int c) __attribute__((alias("putchar")));
+#endif
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/puts.c
+++ b/os/lib/dbg-io/puts.c
@@ -42,4 +42,8 @@ puts(const char *str)
   dbg_putchar('\n');
   return 0;
 }
+
+#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
+extern int __wrap_puts(const char *str) __attribute__((nonnull, alias("puts")));
+#endif
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/snprintf.c
+++ b/os/lib/dbg-io/snprintf.c
@@ -82,4 +82,9 @@ vsnprintf(char *str, size_t size, const char *format, va_list ap)
   *buffer.pos = '\0';
   return res;
 }
+
+#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
+extern int __wrap_snprintf(char *str, size_t size, const char *format, ...) __attribute__((nonnull, nothrow, alias("snprintf")));
+extern int __wrap_vsnprintf(char *str, size_t size, const char *format, va_list ap) __attribute__((nonnull, nothrow, alias("vsnprintf")));
+#endif
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/sprintf.c
+++ b/os/lib/dbg-io/sprintf.c
@@ -58,4 +58,8 @@ sprintf(char *str, const char *format, ...)
   va_end(ap);
   return res;
 }
+
+#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
+extern int __wrap_sprintf(char *str, const char *format, ...) __attribute__((nonnull, nothrow, alias("sprintf")));
+#endif
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This removes the non-errorchecked symbol
renaming done through objcopy and uses
the --wrap parameter to ld instead.

MacOS X does not come with objcopy so
the symbol renaming has never been
active on that platform.