### PR TITLE
Dockerfile: replace traceroute6 with mtr

### DIFF
--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -30,12 +30,12 @@ MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME
 
-# Do ping
-echo "Running Traceroute"
-traceroute6 $IPADDR -m 5 | tee $BASENAME.scriptlog
-# Fetch traceroute6 status code (not $? because this is piped)
+echo "Running mtr (traceroute)"
+# IPv6, 5 hops max, no DNS lookups, 3 pings each, output with report mode.
+mtr -6 -m 5 -n -c 3 -r $IPADDR | tee $BASENAME.scriptlog
+# Fetch mtr status code (not $? because this is piped)
 STATUS=${PIPESTATUS[0]}
-HOPS=`grep -v traceroute $BASENAME.scriptlog | wc -l`
+HOPS=`grep -e "^ " $BASENAME.scriptlog | wc -l`
 
 echo "Closing simulation and tunslip6"
 sleep 1

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     gdb \
     git \
     gtk-sharp2 \
-    iputils-tracepath \
     iputils-ping \
     less \
     lib32z1 \
@@ -36,6 +35,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     mono-complete \
     mosquitto \
     mosquitto-clients \
+    mtr-tiny \
     net-tools \
     openjdk-11-jdk \
     python3-dev \


### PR DESCRIPTION
More recent versions of iptuils-tracepath
do not contain traceroute6. The traceroute
package is the obvious replacement, but
that gives "* * *" as one or several results
in 17-tun-rpl-br.
    
The traceroute6 in traceroute most likely
uses a different way of probing hosts and
that doesn't work with Cooja and/or some
component in the regression tests.

Rather than diagnosing the exact issue,
install mtr-tiny and use that since it
works out of the box for the regression
tests.
