### PR TITLE
tests: fix validation for new traceroute6

### DIFF
--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -35,7 +35,7 @@ echo "Running Traceroute"
 traceroute6 $IPADDR -m 5 | tee $BASENAME.scriptlog
 # Fetch traceroute6 status code (not $? because this is piped)
 STATUS=${PIPESTATUS[0]}
-HOPS=`wc $BASENAME.scriptlog -l | cut -f 1 -d ' '`
+HOPS=`grep -v traceroute $BASENAME.scriptlog | wc -l`
 
 echo "Closing simulation and tunslip6"
 sleep 1


### PR DESCRIPTION
The "traceroute6" line goes into the log
for some versions of traceroute6. Filter
that line out when counting the number
of hops.