### PR TITLE
CI: lower the workflow timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
   Contiki-NG:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    # Longest test in July 2022 takes 15 minutes.
+    timeout-minutes: 35
     # Common environment variables
     env:
         OUT_OF_TREE_TEST_PATH: out-of-tree-tests


### PR DESCRIPTION
The tests take 15 minutes under normal
circumstances and the default github timeout
is 6 hours. Set a reasonable timeout so
a slow test will complete within the timeout,
but a myserious failure will be killed
before one has to leave the office.