### PR TITLE
CI: use hashFiles for docker image name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     # Construct the correct docker container image tag corresponding to this build
     - name: Figure out correct docker image tag
       run:
-        echo DOCKER_IMG=$DOCKER_BASE_IMG:$(git log -1 --oneline -- tools/docker/ | cut -d" " -f1) >> $GITHUB_ENV
+        echo DOCKER_IMG=$DOCKER_BASE_IMG:${{ hashFiles('tools/docker/**') }} >> $GITHUB_ENV
 
     # Try to download the image from dockerhub. If it works, use it.
     #


### PR DESCRIPTION
Using the git commit hash on the Dockerfile
ignores the content of the files copied into
the docker image. Compute a hash of everything
and use that to identify the docker image
instead.