### PR TITLE
sixtop: align return type with decl

### DIFF
--- a/os/net/mac/tsch/sixtop/sixp-nbr.c
+++ b/os/net/mac/tsch/sixtop/sixp-nbr.c
@@ -117,7 +117,7 @@ sixp_nbr_free(sixp_nbr_t *nbr)
   }
 }
 /*---------------------------------------------------------------------------*/
-int
+int16_t
 sixp_nbr_get_next_seqno(sixp_nbr_t *nbr)
 {
   assert(nbr != NULL);


### PR DESCRIPTION
Use the same return type for the funtion
and the declaration.