### PR TITLE
Stop defining reserved identifiers

### DIFF
--- a/os/lib/ringbufindex.h
+++ b/os/lib/ringbufindex.h
@@ -37,8 +37,8 @@
  *         Simon Duquennoy <simonduq@sics.se>
  */
 
-#ifndef __RINGBUFINDEX_H__
-#define __RINGBUFINDEX_H__
+#ifndef RINGBUFINDEX_H_
+#define RINGBUFINDEX_H_
 
 #include "contiki.h"
 
@@ -116,4 +116,4 @@ int ringbufindex_full(const struct ringbufindex *r);
  */
 int ringbufindex_empty(const struct ringbufindex *r);
 
-#endif /* __RINGBUFINDEX_H__ */
+#endif /* RINGBUFINDEX_H_ */

--- a/os/net/mac/tsch/sixtop/sixtop-conf.h
+++ b/os/net/mac/tsch/sixtop/sixtop-conf.h
@@ -39,8 +39,8 @@
  *         Yasuyuki Tanaka <yasuyuki.tanaka@inf.ethz.ch>
  */
 
-#ifndef __SIXTOP_CONF_H__
-#define __SIXTOP_CONF_H__
+#ifndef SIXTOP_CONF_H_
+#define SIXTOP_CONF_H_
 
 /**
  * \brief The maximum number of Scheduling Functions in the system.
@@ -61,5 +61,5 @@
 #define SIXTOP_MAX_TRANSACTIONS 1
 #endif
 
-#endif /* !__SIXTOP_CONF_H__ */
+#endif /* !SIXTOP_CONF_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-adaptive-timesync.h
+++ b/os/net/mac/tsch/tsch-adaptive-timesync.h
@@ -37,8 +37,8 @@
  *	TSCH adaptive time synchronization
 */
 
-#ifndef __TSCH_ADAPTIVE_TIMESYNC_H__
-#define __TSCH_ADAPTIVE_TIMESYNC_H__
+#ifndef TSCH_ADAPTIVE_TIMESYNC_H_
+#define TSCH_ADAPTIVE_TIMESYNC_H_
 
 /********** Includes **********/
 
@@ -73,5 +73,5 @@ long int tsch_adaptive_timesync_get_drift_ppm(void);
 void tsch_adaptive_timesync_reset(void);
 
 
-#endif /* __TSCH_ADAPTIVE_TIMESYNC_H__ */
+#endif /* TSCH_ADAPTIVE_TIMESYNC_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-asn.h
+++ b/os/net/mac/tsch/tsch-asn.h
@@ -39,8 +39,8 @@
  *         Simon Duquennoy <simonduq@sics.se>
 */
 
-#ifndef __TSCH_ASN_H__
-#define __TSCH_ASN_H__
+#ifndef TSCH_ASN_H_
+#define TSCH_ASN_H_
 
 /************ Types ***********/
 
@@ -95,5 +95,5 @@ struct tsch_asn_divisor_t {
    + (uint16_t)((asn).ms1b * (div).asn_ms1b_remainder % (div).val)) \
   % (div).val
 
-#endif /* __TSCH_ASN_H__ */
+#endif /* TSCH_ASN_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-conf.h
+++ b/os/net/mac/tsch/tsch-conf.h
@@ -39,8 +39,8 @@
  *         Simon Duquennoy <simonduq@sics.se>
  */
 
-#ifndef __TSCH_CONF_H__
-#define __TSCH_CONF_H__
+#ifndef TSCH_CONF_H_
+#define TSCH_CONF_H_
 
 /********** Includes **********/
 
@@ -450,5 +450,5 @@ by default, useful in case of duplicate seqno */
 #define TSCH_CONF_RX_WAIT 2200
 #endif /* TSCH_CONF_RX_WAIT */
 
-#endif /* __TSCH_CONF_H__ */
+#endif /* TSCH_CONF_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-const.h
+++ b/os/net/mac/tsch/tsch-const.h
@@ -39,8 +39,8 @@
  *         Simon Duquennoy <simonduq@sics.se>
  */
 
-#ifndef __TSCH_CONST_H__
-#define __TSCH_CONST_H__
+#ifndef TSCH_CONST_H_
+#define TSCH_CONST_H_
 
 /********** Includes **********/
 #include "net/packetbuf.h"
@@ -85,5 +85,5 @@
 #define TSCH_CLOCK_TO_TICKS(c) (((c) * RTIMER_SECOND) / CLOCK_SECOND)
 #define TSCH_CLOCK_TO_SLOTS(c, timeslot_length) ((TSCH_CLOCK_TO_TICKS(c) + timeslot_length - 1) / timeslot_length)
 
-#endif /* __TSCH_CONST_H__ */
+#endif /* TSCH_CONST_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-log.h
+++ b/os/net/mac/tsch/tsch-log.h
@@ -37,8 +37,8 @@
  *	TSCH per-slot logging
 */
 
-#ifndef __TSCH_LOG_H__
-#define __TSCH_LOG_H__
+#ifndef TSCH_LOG_H_
+#define TSCH_LOG_H_
 
 /********** Includes **********/
 
@@ -149,5 +149,5 @@ void tsch_log_stop(void);
 
 #endif /* (TSCH_LOG_PER_SLOT == 0) */
 
-#endif /* __TSCH_LOG_H__ */
+#endif /* TSCH_LOG_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-packet.h
+++ b/os/net/mac/tsch/tsch-packet.h
@@ -37,8 +37,8 @@
  *	TSCH packet parsing and creation. EBs and EACKs.
 */
 
-#ifndef __TSCH_PACKET_H__
-#define __TSCH_PACKET_H__
+#ifndef TSCH_PACKET_H_
+#define TSCH_PACKET_H_
 
 /********** Includes **********/
 
@@ -128,5 +128,5 @@ void tsch_packet_eackbuf_set_attr(uint8_t type, const packetbuf_attr_t val);
  */
 packetbuf_attr_t tsch_packet_eackbuf_attr(uint8_t type);
 
-#endif /* __TSCH_PACKET_H__ */
+#endif /* TSCH_PACKET_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-queue.h
+++ b/os/net/mac/tsch/tsch-queue.h
@@ -37,8 +37,8 @@
  *	TSCH queues
 */
 
-#ifndef __TSCH_QUEUE_H__
-#define __TSCH_QUEUE_H__
+#ifndef TSCH_QUEUE_H_
+#define TSCH_QUEUE_H_
 
 /********** Includes **********/
 
@@ -189,5 +189,5 @@ void tsch_queue_update_all_backoff_windows(const linkaddr_t *dest_addr);
  */
 void tsch_queue_init(void);
 
-#endif /* __TSCH_QUEUE_H__ */
+#endif /* TSCH_QUEUE_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-roots.h
+++ b/os/net/mac/tsch/tsch-roots.h
@@ -30,8 +30,8 @@
  * \author Atis Elsts <atis.elsts@gmail.com>
  */
 
-#ifndef __TSCH_ROOTS_H__
-#define __TSCH_ROOTS_H__
+#ifndef TSCH_ROOTS_H_
+#define TSCH_ROOTS_H_
 
 /**
  * Add address as a potential RPL root that is a single-hop neighbor in the TSCH network.
@@ -64,4 +64,4 @@ int tsch_roots_is_root(const linkaddr_t *address);
  */
 void tsch_roots_init(void);
 
-#endif /* __TSCH_ROOTS_H__ */
+#endif /* TSCH_ROOTS_H_ */

--- a/os/net/mac/tsch/tsch-rpl.h
+++ b/os/net/mac/tsch/tsch-rpl.h
@@ -35,8 +35,8 @@
  *	TSCH-RPL interaction
 */
 
-#ifndef __TSCH_RPL_H__
-#define __TSCH_RPL_H__
+#ifndef TSCH_RPL_H_
+#define TSCH_RPL_H_
 
 /********** Includes **********/
 
@@ -86,5 +86,5 @@ void tsch_rpl_callback_parent_switch(rpl_parent_t *old, rpl_parent_t *new);
  */
 int tsch_rpl_check_dodag_joined(void);
 
-#endif /* __TSCH_RPL_H__ */
+#endif /* TSCH_RPL_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-schedule.h
+++ b/os/net/mac/tsch/tsch-schedule.h
@@ -37,8 +37,8 @@
  *	TSCH scheduling engine
 */
 
-#ifndef __TSCH_SCHEDULE_H__
-#define __TSCH_SCHEDULE_H__
+#ifndef TSCH_SCHEDULE_H_
+#define TSCH_SCHEDULE_H_
 
 /********** Includes **********/
 
@@ -162,5 +162,5 @@ struct tsch_slotframe *tsch_schedule_slotframe_head(void);
  */
 struct tsch_slotframe *tsch_schedule_slotframe_next(struct tsch_slotframe *sf);
 
-#endif /* __TSCH_SCHEDULE_H__ */
+#endif /* TSCH_SCHEDULE_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-security.h
+++ b/os/net/mac/tsch/tsch-security.h
@@ -37,8 +37,8 @@
  *	TSCH security
 */
 
-#ifndef __TSCH_SECURITY_H__
-#define __TSCH_SECURITY_H__
+#ifndef TSCH_SECURITY_H_
+#define TSCH_SECURITY_H_
 
 /********** Includes **********/
 
@@ -146,5 +146,5 @@ unsigned int tsch_security_parse_frame(const uint8_t *hdr, int hdrlen,
  */
 void tsch_security_set_packetbuf_attr(uint8_t frame_type);
 
-#endif /* __TSCH_SECURITY_H__ */
+#endif /* TSCH_SECURITY_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-slot-operation.h
+++ b/os/net/mac/tsch/tsch-slot-operation.h
@@ -37,8 +37,8 @@
  *	TSCH runtime operation within timeslots
 */
 
-#ifndef __TSCH_SLOT_OPERATION_H__
-#define __TSCH_SLOT_OPERATION_H__
+#ifndef TSCH_SLOT_OPERATION_H_
+#define TSCH_SLOT_OPERATION_H_
 
 /********** Includes **********/
 
@@ -94,5 +94,5 @@ void tsch_slot_operation_sync(rtimer_clock_t next_slot_start,
  */
 void tsch_slot_operation_start(void);
 
-#endif /* __TSCH_SLOT_OPERATION_H__ */
+#endif /* TSCH_SLOT_OPERATION_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-stats.h
+++ b/os/net/mac/tsch/tsch-stats.h
@@ -39,8 +39,8 @@
  * @{
 */
 
-#ifndef __TSCH_STATS_H__
-#define __TSCH_STATS_H__
+#ifndef TSCH_STATS_H_
+#define TSCH_STATS_H_
 
 /********** Includes **********/
 
@@ -219,5 +219,5 @@ tsch_stats_index_to_channel(uint8_t channel_index)
 }
 
 
-#endif /* __TSCH_STATS_H__ */
+#endif /* TSCH_STATS_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch-types.h
+++ b/os/net/mac/tsch/tsch-types.h
@@ -39,8 +39,8 @@
  *         Simon Duquennoy <simonduq@sics.se>
  */
 
-#ifndef __TSCH_TYPES_H__
-#define __TSCH_TYPES_H__
+#ifndef TSCH_TYPES_H_
+#define TSCH_TYPES_H_
 
 /********** Includes **********/
 
@@ -154,5 +154,5 @@ struct input_packet {
   uint8_t channel; /* Channel we received the packet on */
 };
 
-#endif /* __TSCH_CONF_H__ */
+#endif /* TSCH_CONF_H_ */
 /** @} */

--- a/os/net/mac/tsch/tsch.h
+++ b/os/net/mac/tsch/tsch.h
@@ -41,8 +41,8 @@ frequency hopping for enhanced reliability.
 *	Main API declarations for TSCH.
 */
 
-#ifndef __TSCH_H__
-#define __TSCH_H__
+#ifndef TSCH_H_
+#define TSCH_H_
 
 /********** Includes **********/
 
@@ -262,5 +262,5 @@ uint64_t tsch_get_network_uptime_ticks(void);
   */
 void tsch_disassociate(void);
 
-#endif /* __TSCH_H__ */
+#endif /* TSCH_H_ */
 /** @} */

--- a/os/services/ip64/ip64-dhcpc.h
+++ b/os/services/ip64/ip64-dhcpc.h
@@ -29,8 +29,8 @@
  * This file is part of the Contiki operating system.
  *
  */
-#ifndef __IP64_DHCPC_H__
-#define __IP64_DHCPC_H__
+#ifndef IP64_DHCPC_H_
+#define IP64_DHCPC_H_
 
 struct ip64_dhcpc_state {
   struct pt pt;
@@ -59,4 +59,4 @@ void ip64_dhcpc_appcall(process_event_t ev, void *data);
 void ip64_dhcpc_configured(const struct ip64_dhcpc_state *s);
 void ip64_dhcpc_unconfigured(const struct ip64_dhcpc_state *s);
 
-#endif /* __IP64_DHCPC_H__ */
+#endif /* IP64_DHCPC_H_ */

--- a/os/services/orchestra/orchestra-conf.h
+++ b/os/services/orchestra/orchestra-conf.h
@@ -35,8 +35,8 @@
  * \author Simon Duquennoy <simonduq@sics.se>
  */
 
-#ifndef __ORCHESTRA_CONF_H__
-#define __ORCHESTRA_CONF_H__
+#ifndef ORCHESTRA_CONF_H_
+#define ORCHESTRA_CONF_H_
 
 #ifdef ORCHESTRA_CONF_RULES
 #define ORCHESTRA_RULES ORCHESTRA_CONF_RULES
@@ -163,4 +163,4 @@
 #define ORCHESTRA_EB_MAX_CHANNEL_OFFSET 1
 #endif
 
-#endif /* __ORCHESTRA_CONF_H__ */
+#endif /* ORCHESTRA_CONF_H_ */

--- a/os/services/orchestra/orchestra.h
+++ b/os/services/orchestra/orchestra.h
@@ -35,8 +35,8 @@
  * \author Simon Duquennoy <simonduq@sics.se>
  */
 
-#ifndef __ORCHESTRA_H__
-#define __ORCHESTRA_H__
+#ifndef ORCHESTRA_H_
+#define ORCHESTRA_H_
 
 #include "net/mac/tsch/tsch.h"
 #include "orchestra-conf.h"
@@ -80,4 +80,4 @@ void orchestra_callback_root_node_updated(const linkaddr_t *root, uint8_t is_add
 /* Returns nonzero if the root slotframe should be used to transmit to the specific address */
 uint8_t orchestra_is_root_schedule_active(const linkaddr_t *addr);
 
-#endif /* __ORCHESTRA_H__ */
+#endif /* ORCHESTRA_H_ */

--- a/os/services/tsch-cs/tsch-cs.h
+++ b/os/services/tsch-cs/tsch-cs.h
@@ -34,8 +34,8 @@
  *         Atis Elsts <atis.elsts@bristol.ac.uk>
  */
 
-#ifndef __TSCH_CS_H__
-#define __TSCH_CS_H__
+#ifndef TSCH_CS_H_
+#define TSCH_CS_H_
 
 #include "contiki.h"
 #include <stdbool.h>
@@ -73,4 +73,4 @@ bool tsch_cs_process(void);
 typedef uint16_t tsch_cs_bitmap_t;
 
 
-#endif /* __TSCH_CS_H__ */
+#endif /* TSCH_CS_H_ */

--- a/os/sys/cc-gcc.h
+++ b/os/sys/cc-gcc.h
@@ -28,8 +28,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-#ifndef _CC_GCC_H_
-#define _CC_GCC_H_
+#ifndef CC_GCC_H_
+#define CC_GCC_H_
 #ifdef __GNUC__
 
 #ifndef CC_CONF_INLINE
@@ -44,4 +44,4 @@
 #define CC_CONF_DEPRECATED(msg) __attribute__((deprecated(msg)))
 
 #endif /* __GNUC__ */
-#endif /* _CC_GCC_H_ */
+#endif /* CC_GCC_H_ */

--- a/os/sys/log-conf.h
+++ b/os/sys/log-conf.h
@@ -43,8 +43,8 @@
 /** \addtogroup log
 * @{ */
 
-#ifndef __LOG_CONF_H__
-#define __LOG_CONF_H__
+#ifndef LOG_CONF_H_
+#define LOG_CONF_H_
 
 /* Log only the last 16 bytes of link-layer and IPv6 addresses (or, if)
  * the deployment module is enabled, the node IDs */
@@ -157,7 +157,7 @@
 #define LOG_CONF_LEVEL_MAIN                        LOG_LEVEL_INFO
 #endif /* LOG_CONF_LEVEL_MAIN */
 
-#endif /* __LOG_CONF_H__ */
+#endif /* LOG_CONF_H_ */
 
 /** @} */
 /** @} */

--- a/os/sys/log.h
+++ b/os/sys/log.h
@@ -48,8 +48,8 @@
  *
  */
 
-#ifndef __LOG_H__
-#define __LOG_H__
+#ifndef LOG_H_
+#define LOG_H_
 
 #include <stdio.h>
 #include "net/linkaddr.h"
@@ -302,7 +302,7 @@ int log_get_level(const char *module);
 */
 const char *log_level_to_str(int level);
 
-#endif /* __LOG_H__ */
+#endif /* LOG_H_ */
 
 /** @} */
 /** @} */


### PR DESCRIPTION
All identifiers that begin with an underscore
followed by a capital letter or by another
underscore are reserved in C. Use other names
for headerguards.