### PR TITLE
Makefile: add link-time-optimization option

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -139,6 +139,17 @@ endif
 
 CP ?= cp
 
+# Configure link-time-optimization (LTO).
+FLAGS_LTO ?= -flto
+
+ifdef LTO
+  CFLAGS += $(FLAGS_LTO)
+  LDFLAGS += $(FLAGS_LTO)
+  ifdef NO_LTO_TARGET
+    PLATFORM_ACTION = skip
+  endif
+endif
+
 # Decide whether to build or to skip this target for this platform
 ifneq ("", "$(PLATFORMS_ONLY)")
   ifeq ("","$(filter $(TARGET), $(PLATFORMS_ONLY))")

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -44,6 +44,9 @@ CONTIKI_SOURCEFILES        += $(CONTIKI_TARGET_SOURCEFILES)
 
 ### Compiler definitions
 
+# LTO is available in GCC 4.7.2, but crashes for MSP430.
+NO_LTO_TARGET = 1
+
 ifeq ($(WERROR),1)
 CFLAGSWERROR= -Wall -Werror
 endif

--- a/doc/project/Release-Notes-next.md
+++ b/doc/project/Release-Notes-next.md
@@ -1,0 +1,38 @@
+# Press release
+
+We are releasing version XXX of Contiki-NG. This release adds XXX, and support
+for link-time-optimization that can reduce the binary size up to 50% on some
+examples.
+
+## Find out more at:
+
+* GitHub repository: https://github.com/contiki-ng/contiki-ng
+* Documentation: https://contiki-ng.readthedocs.io/en/release-v4.9
+* Web site: http://contiki-ng.org
+* Nightly testbed runs: https://contiki-ng.github.io/testbed
+
+## Engage with the community:
+
+* Contiki-NG tag on Stack Overflow: https://stackoverflow.com/questions/tagged/contiki-ng
+* Github Discussions: https://github.com/contiki-ng/contiki-ng/discussions
+* Gitter: https://gitter.im/contiki-ng
+* Twitter: https://twitter.com/contiki_ng
+
+The Contiki-NG team
+
+## API changes for ports outside the main tree
+
+
+## Changelog
+
+### Contiki-NG
+
+* Support for link-time-optimization in the build system ([#2077](https://github.com/contiki-ng/contiki-ng/pull/2077))
+
+All [commits](https://github.com/contiki-ng/contiki-ng/compare/release/v4.8...develop) since v4.8.
+
+### Cooja
+
+* XXX ([#XXX](https://github.com/contiki-ng/cooja/pull/XXX))
+
+All [commits](https://github.com/contiki-ng/cooja/compare/630e719d01d3...master) since v4.8.


### PR DESCRIPTION
Add a build system option "LTO" so examples
can be built with "make <options> LTO=1".
Targets that do not support the option can
define NO_LTO_TARGET to have the PLATFORM_ACTION
set to skip when LTO is enabled.

The only targets that do not support
LTO are the msp430-based ones, the toolchain
recognizes the switch but crashes on every
program in the regression tests.

The size for hello-world in the docker container
without LTO:

  text	   data	    bss	    dec	    hex	filename
 118948	   2952	1110912	1232812	 12cfac	hello-world.native

and with LTO:

  text	   data	    bss	    dec	    hex	filename
  48579	   1728	  56568	 106875	  1a17b	hello-world.native