### PR TITLE
CI: increase the workflow timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,9 @@ jobs:
   Contiki-NG:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    # Longest test in July 2022 takes 15 minutes.
-    timeout-minutes: 35
+    # Longest test in July 2022 takes 15 minutes. Building the docker image
+    # takes 10 minutes.
+    timeout-minutes: 45
     # Common environment variables
     env:
         OUT_OF_TREE_TEST_PATH: out-of-tree-tests


### PR DESCRIPTION
An unusually long docker image build will
make the tests timeout, so increase the timeout
slightly.