### PR TITLE
Fix l2cap_channels OOB in get_channel_for_cid

### DIFF
--- a/os/net/mac/ble/ble-l2cap.c
+++ b/os/net/mac/ble/ble-l2cap.c
@@ -105,9 +105,9 @@ get_channel_for_addr(const linkaddr_t *peer_addr)
 static l2cap_channel_t *
 get_channel_for_cid(uint16_t own_cid)
 {
-  uint8_t i = own_cid - L2CAP_FLOW_CHANNEL;
+  int16_t i = own_cid - L2CAP_FLOW_CHANNEL;
   if(i >= 0 && i < l2cap_channel_count) {
-    return &l2cap_channels[own_cid - L2CAP_FLOW_CHANNEL];
+    return &l2cap_channels[i];
   } else {
     return NULL;
   }


### PR DESCRIPTION
While the bounds check is performed on `l2cap_channel_count`, only the lower byte is checked due to the uint8_t data type. Afterwards, the expression for `i` is re-calculated without the explicit data type, which means without truncation into 8 bits. Instead, the full 16-bit value is used as the channel index. This pointer will point out-of-bounds of the channel array.

This leads to a large 16 out-of-bounds channel id to be used as an index into the array for large CID inputs.

Sample value: 0xff41 -> 0xff41 - 0x41 = 0xff00 == 0x00 (as uint8_t)

This results in out-of-bounds memory to be interpreted as a channel object, and this memory to potentially be corrupted in the following call to `input_l2cap_frame_flow_channel`, which fills the out-of-bounds memory (the supposed channel object) with user-supplied data.

The fix here is to re-use the `i` variable as an index, which was used to perform the bounds check, and is truncated to 8 bits.

As a side note, due to the unsignedness of the data type `uint8_t i`, the check `i >= 0` is always true. Instead, a signed data type such as `int16_t` could be used to make the check take effect.