### PR TITLE
arm: remove false dependencies

### DIFF
--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -93,8 +93,6 @@ $(OUT_LST): $(OUT_ELF)
 	$(TRACE_OBJDUMP)
 	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > $@
 
-### We don't really need the .hex and .bin for the .$(TARGET) but let's make
-### sure they get built
-$(BUILD_DIR_BOARD)/%.$(TARGET): $(OUT_ELF) $(OUT_HEX) $(OUT_BIN)
+$(BUILD_DIR_BOARD)/%.$(TARGET): $(OUT_ELF)
 	$(TRACE_CP)
 	$(Q)cp $< $@


### PR DESCRIPTION
The hex and bin files are not required
for the target according to the comment,
so stop building them.

This is preparation to remove the customrules
for Cortex-M, but it also saves IO load
on the IO-limited CI machines.