### PR TITLE
cooja: exclude slip-arch.c with NULLNET

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -229,6 +229,7 @@ ifeq ($(MAKE_NET),MAKE_NET_NULLNET)
   MODULES += $(CONTIKI_NG_NET_DIR)/nullnet
   # SLIP uses the rxbuf defined in uIP.
   MODULES_SOURCES_EXCLUDES += slip.c
+  CONTIKI_SOURCES_EXCLUDES_COOJA += slip-arch.c
   CONTIKI_SOURCES_EXCLUDES_NATIVE += tun6-net.c
 endif
 

--- a/arch/platform/cooja/slip-arch.c
+++ b/arch/platform/cooja/slip-arch.c
@@ -28,8 +28,6 @@
  *
  */
 
-#if !defined(NETSTACK_CONF_WITH_NULLNET) || !NETSTACK_CONF_WITH_NULLNET
-
 #include "dev/slip.h"
 #include "dev/rs232.h"
 
@@ -39,4 +37,3 @@ slip_arch_init()
   rs232_set_input(slip_input_byte);
 }
 
-#endif


### PR DESCRIPTION
Use the new build system support to exclude
the file instead.