### PR TITLE
Makefile: avoid copy for diagnostic targets

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -482,10 +482,10 @@ endif
 	$(TRACE_CP)
 	$(Q)$(CP) $< $@
 
-%.ramprof: %.$(TARGET)
+%.ramprof: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	$(NM) -S -td --size-sort $< | grep -i " [abdrw] " | cut -d' ' -f2,4
 
-%.flashprof: %.$(TARGET)
+%.flashprof: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	$(NM) -S -td --size-sort $< | grep -i " [t] " | cut -d' ' -f2,4
 
 include $(CONTIKI)/Makefile.help

--- a/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -74,7 +74,7 @@ $(OBJECTDIR)/ccfg.o: ccfg.c FORCE | $(OBJECTDIR)
 RAM_SIZE = 0x00003E00
 FLASH_SIZE = 0x0001E000
 STACK_SIZE = 0
-%.size: %.$(TARGET)
+%.size: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	@$(SIZE) -A $< | egrep "data|bss" | awk '{s+=$$2} END {s=s+$(STACK_SIZE); f=$(RAM_SIZE)-s; printf "[RAM]   used %6d, free %6d\n",s,f;}'
 	@$(SIZE) -A $< | egrep "text|isr_vector" | awk '{s+=$$2} END {f=$(FLASH_SIZE)-s; printf "[Flash] used %6d, free %6d\n",s,f;}'
 

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -108,7 +108,7 @@ CLEAN += *.firmware *.ihex
 %.firmware:	%.${TARGET}
 	mv $< $@
 
-%.ihex: %.$(TARGET)
+%.ihex: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	$(OBJCOPY) $^ -O ihex $@
 
 $(COOJA_PATH)/build.xml:
@@ -124,8 +124,8 @@ $(COOJA_PATH)/mspsim/build.xml: $(COOJA_PATH)/build.xml
 $(COOJA_PATH)/mspsim/mspsim.jar: $(COOJA_PATH)/mspsim/build.xml
 	cd $(COOJA_PATH)/mspsim && ant jar
 
-%.mspsim:	%.${TARGET} ${COOJA_PATH}/mspsim/mspsim.jar
+%.mspsim: $(BUILD_DIR_BOARD)/%.${TARGET} ${COOJA_PATH}/mspsim/mspsim.jar
 	$(JAVA) -jar ${COOJA_PATH}/mspsim/mspsim.jar -platform=${TARGET} $<
 
-%.mspsim-maptable: %.$(TARGET)
+%.mspsim-maptable: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	$(JAVA) -classpath ${COOJA_PATH}/mspsim/mspsim.jar se.sics.mspsim.util.MapTable $(CONTIKI_NG_PROJECT_MAP)

--- a/arch/platform/jn516x/Makefile.jn516x
+++ b/arch/platform/jn516x/Makefile.jn516x
@@ -210,10 +210,10 @@ MAKEFILES_CUSTOMRULES += $(CONTIKI_NG_RELOC_PLATFORM_DIR)/jn516x/Makefile.custom
 
 %.d: clean
 
-%.nm: %.$(TARGET)
+%.nm: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	$(Q)$(NM) -nS $< > $@
 
-%.dmp: %.$(TARGET)
+%.dmp: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	$(Q)$(OBJDUMP) -d $< > $@
 
 $(BUILD_DIR_BOARD)/%.$(TARGET).bin: $(BUILD_DIR_BOARD)/%.$(TARGET)


### PR DESCRIPTION
Run the diagnostic tool on the built file
instead of copying the file and then running
the diagnostic tool on it.