### PR TITLE
Stop rebuilding ccfg.o unless config has changed

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -62,11 +62,7 @@ $(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(OBJECTDIR)
 	$(TRACE_CC)
 	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
 
-### Always re-build ccfg.c so changes to ccfg-conf.h will apply without having
-### to make clean first
-$(OBJECTDIR)/ccfg.o: ccfg.c FORCE | $(OBJECTDIR)
-	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(CFLAGS) -include "ccxxware-conf.h" -c $< -o $@
+$(OBJECTDIR)/ccfg.o: CFLAGS += -include "ccxxware-conf.h"
 
 # a target that gives a user-friendly memory profile, taking into account the RAM
 # that is statically occupied by the stack as defined in the linker script

--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -132,12 +132,6 @@ $(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(OBJECTDIR)
 	$(TRACE_CC)
 	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
 
-# Always re-build ccfg-conf.c so any changes to CCFG configuration
-# always applies
-$(OBJECTDIR)/ccfg-conf.o: ccfg-conf.c FORCE | $(OBJECTDIR)
-	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
-
 ################################################################################
 ### Sub-family Makefile
 


### PR DESCRIPTION
The dependency generation in Makefile.include will ensure the object file is up to date with respect to its dependencies.