### PR TITLE
nrf: remove naked in hardfault-handler.c

### DIFF
--- a/arch/cpu/nrf/arm/hardfault-handler.c
+++ b/arch/cpu/nrf/arm/hardfault-handler.c
@@ -215,7 +215,7 @@ HardFault_Handler(void)
  * @brief Hardfault handler
  * 
  */
-void HardFault_Handler(void) __attribute__((naked));
+void HardFault_Handler(void);
 /*---------------------------------------------------------------------------*/
 /**
  * @brief Hardfault handler


### PR DESCRIPTION
Naked functions are only supposed to contain
inline assembly, and this function contains
regular C statements. Remove the naked
attribute for the non-assembly version
of the function.