### PR TITLE
nrf: use TARGET_LIBFILES for libraries

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -41,12 +41,13 @@ CFLAGS += -DNRFX_UARTE_ENABLED
 CFLAGS += -DNRFX_UARTE0_ENABLED
 
 LDFLAGS += --specs=nano.specs
-LDFLAGS += -lgcc -lc -lnosys
 LDFLAGS += -L $(NRFX_ROOT)/mdk
 LDFLAGS += -Wl,--defsym=_stack=end
 LDFLAGS += -Wl,--defsym=_stack_origin=__stack
 LDFLAGS += -Wl,--defsym=_heap=end
 LDFLAGS += -Wl,--defsym=_eheap=__stack
+
+TARGET_LIBFILES += -lgcc -lc -lnosys
 
 #source common to all targets
 NRFX_C_SRCS += $(NRFX_ROOT)/drivers/src/nrfx_wdt.c

--- a/arch/cpu/nrf52832/Makefile.nrf52832
+++ b/arch/cpu/nrf52832/Makefile.nrf52832
@@ -144,7 +144,8 @@ LDFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 # let linker to dump unused sections
 LDFLAGS += -Wl,--gc-sections
 # use newlib in nano version
-LDFLAGS += --specs=nano.specs -lc -lnosys
+LDFLAGS += --specs=nano.specs
+TARGET_LIBFILES += -lc -lnosys
 
 # Assembler flags
 ifneq ($(NRF52_WITHOUT_SOFTDEVICE),1)

--- a/arch/cpu/nrf52840/Makefile.nrf52840
+++ b/arch/cpu/nrf52840/Makefile.nrf52840
@@ -55,8 +55,9 @@ CFLAGS += -ggdb
 CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 LDFLAGS += -mabi=aapcs -mfloat-abi=hard -mfpu=fpv4-sp-d16
-LDFLAGS += --specs=nano.specs -lc -lnosys
+LDFLAGS += --specs=nano.specs
 LDFLAGS += -L $(NRF5_SDK_ROOT)/modules/nrfx/mdk
+TARGET_LIBFILES += -lc -lnosys
 
 # nRF52 SDK sources
 NRF52_SDK_C_SRCS += components/boards/boards.c \


### PR DESCRIPTION
Libraries should be linked through
TARGET_LIBFILES, not LDFLAGS.