### PR TITLE
CI: reduce fetch-depth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout github repo (+ download lfs dependencies)
       uses: actions/checkout@v3
       with:
-          fetch-depth: '0'
+          fetch-depth: 2
           submodules: 'recursive'
           persist-credentials: false
           lfs: true


### PR DESCRIPTION
Reduce the fetch-depth from the entire
history down to 2 now that the Docker
image hash is computed based on file
content rather than the git hash.

A fetch-depth of 2 should be enough to
detect which files that were changed
in a PR, for example for running additional
checks such as code-formatting or similar
on them.