### PR TITLE
Makefile: add dep generation for $(LDSCRIPT)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -395,10 +395,14 @@ DEPFLAGS ?= -MT $@ -MMD -MP -MF $(DEPDIR)/$*.d
 # file type and filter out the results we want. Without the filter, DEPFILES
 # will contain cpp files from the first PROJECT_SOURCEFILES and c files from
 # the second PROJECT_SOURCEFILES.
+# LDSCRIPT is generated with the preprocessor on some targets, so enable
+# those targets to avoid rebuilds as well.
 DEPFILES := $(addprefix $(DEPDIR)/, $(addsuffix .d, $(CONTIKI_PROJECT))) \
             ${filter %.d, $(CONTIKI_SOURCEFILES:%.c=$(DEPDIR)/%.d) \
                           $(PROJECT_SOURCEFILES:%.c=$(DEPDIR)/%.d) \
-                          $(PROJECT_SOURCEFILES:%.cpp=$(DEPDIR)/%.d)}
+                          $(PROJECT_SOURCEFILES:%.cpp=$(DEPDIR)/%.d)} \
+            $(addprefix $(DEPDIR)/, $(addsuffix .d, $(notdir $(LDSCRIPT))))
+
 $(DEPFILES):
 include $(wildcard $(DEPFILES))
 

--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -45,8 +45,8 @@ LDGENFLAGS += -imacros "dev/flash.h" -imacros "cfs-coffee-arch.h"
 LDGENFLAGS += -x c -P -E
 
 # NB: Assumes LDSCRIPT was not overridden and is in $(OBJECTDIR)
-$(LDSCRIPT): $(SOURCE_LDSCRIPT) FORCE | $(DEPDIR)
+$(LDSCRIPT): $(SOURCE_LDSCRIPT) $(DEPDIR)/$(notdir $(LDSCRIPT)).d | $(DEPDIR)
 	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(LDGENFLAGS) $< | grep -v '^\s*#\s*pragma\>' > $@
+	$(Q)$(CCACHE) $(CC) $(LDGENFLAGS) -MT $@ -MMD -MP -MF $(DEPDIR)/$(@F).d $< | grep -v '^\s*#\s*pragma\>' > $@
 
 include $(CONTIKI)/$(CONTIKI_NG_CM3_DIR)/Makefile.cm3


### PR DESCRIPTION
This avoids rebuilding the linker script
unless dependencies have changed.