### PR TITLE
msp430: sort sections by alignment

### DIFF
--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -77,6 +77,7 @@ CFLAGSNO = -Wall -mmcu=$(MCU) $(CFLAGSWERROR)
 endif
 CFLAGS  += -Os -fno-strict-aliasing -std=gnu99
 LDFLAGS += -mmcu=$(MCU) -Wl,-Map=$(CONTIKI_NG_PROJECT_MAP)
+LDFLAGS += -Wl,--sort-section=alignment
 
 ### These flags can reduce the code size and RAM usage with up to 10%
 SMALL ?= 1


### PR DESCRIPTION
This saves 2-8 bytes of text and a few bytes
of bss for the tests in 01-compile-base.

Before:

  47905	    880	   6758	  55543	   d8f7	build/sky/snmp-server.sky
  46545	    908	   5734	  53187	   cfc3	build/z1/snmp-server.z1
  41803	    326	   5742	  47871	   baff	build/z1/hello-world.z1
  42995	    314	   6766	  50075	   c39b	build/sky/example-stack-check.sky
  44663	    334	   6094	  51091	   c793	build/sky/border-router.sky
  29413	    300	   4504	  34217	   85a9	build/sky/slip-radio.sky
  32037	    268	   5660	  37965	   944d	build/sky/nullnet-broadcast.sky
  32037	    276	   5660	  37973	   9455	build/sky/nullnet-unicast.sky

After:

  47903	    880	   6756	  55539	   d8f3	build/sky/snmp-server.sky
  46540	    906	   5720	  53166	   cfae	build/z1/snmp-server.z1
  41795	    324	   5728	  47847	   bae7	build/z1/hello-world.z1
  42992	    314	   6764	  50070	   c396	build/sky/example-stack-check.sky
  44659	    334	   6090	  51083	   c78b	build/sky/border-router.sky
  29410	    300	   4502	  34212	   85a4	build/sky/slip-radio.sky
  32035	    268	   5658	  37961	   9449	build/sky/nullnet-broadcast.sky
  32033	    276	   5658	  37967	   944f	build/sky/nullnet-unicast.sky