### PR TITLE
msp430: only pass -Wall once

### DIFF
--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -45,7 +45,7 @@ CONTIKI_SOURCEFILES        += $(CONTIKI_TARGET_SOURCEFILES)
 ### Compiler definitions
 
 ifeq ($(WERROR),1)
-CFLAGSWERROR= -Wall -Werror
+  CFLAGSWERROR = -Werror
 endif
 
 CC       = msp430-gcc


### PR DESCRIPTION
The flag is already added to CFLAGS
a few lines below this definition.