### PR TITLE
Makefile: use sort to remove duplicates

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -111,8 +111,6 @@ $(1) \
 }}}}
 endef
 
-uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
-
 # Rule to force rebuilds.
 .PHONY: FORCE
 FORCE:
@@ -281,7 +279,8 @@ else ifeq ($(MAKE_ROUTING),MAKE_ROUTING_NULLROUTING)
 endif
 
 MODULEDIRS = $(MODULES_REL) ${addprefix $(CONTIKI)/, $(MODULES)}
-UNIQUEMODULES = $(call uniq,$(MODULEDIRS))
+# Sort removes duplicates.
+UNIQUEMODULES = $(sort $(MODULEDIRS))
 MODULES_SOURCES = ${foreach d, $(UNIQUEMODULES), ${subst ${d}/,,${wildcard $(d)/*.c}}}
 
 # Include module-specific makefiles

--- a/arch/cpu/nrf52832/Makefile.nrf52832
+++ b/arch/cpu/nrf52832/Makefile.nrf52832
@@ -47,9 +47,6 @@ ifneq ($(NRF52_JLINK_SN),)
 JLINK_OPTS += -SelectEmuBySN $(NRF52_JLINK_SN)
 endif
 
-#function for removing duplicates in a list
-remduplicates = $(strip $(if $1,$(firstword $1) $(call remduplicates,$(filter-out $(firstword $1),$1))))
-
 ### CPU-dependent directories
 CONTIKI_CPU_DIRS += . dev ble #compat
 
@@ -160,10 +157,11 @@ ASMFLAGS += -DBLE_STACK_SUPPORT_REQD
 
 C_SOURCE_FILE_NAMES = $(notdir $(C_SOURCE_FILES))
 CONTIKI_SOURCEFILES += $(C_SOURCE_FILE_NAMES)
-C_PATHS = $(call remduplicates, $(dir $(C_SOURCE_FILES) ) )
+# Sort removes duplicates.
+C_PATHS = $(sort $(dir $(C_SOURCE_FILES)))
 
 ASM_SOURCE_FILE_NAMES = $(notdir $(ASM_SOURCE_FILES))
-ASM_PATHS = $(call remduplicates, $(dir $(ASM_SOURCE_FILES) ))
+ASM_PATHS = $(sort $(dir $(ASM_SOURCE_FILES)))
 ASM_OBJECTS = $(addprefix $(OBJECT_DIRECTORY)/, $(ASM_SOURCE_FILE_NAMES:.s=.o) )
 
 vpath %.c $(C_PATHS)


### PR DESCRIPTION
Sort in GNU Make is documented to remove
duplicates so use that instead of defining
a recursive function.