### PR TITLE
Makefile: remove unused $(AROPTS)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -457,10 +457,6 @@ $(OBJECTDIR)/%.e: %.cpp | $(OBJECTDIR)
 	$(Q)$(CCACHE) $(CXX) $(CXXFLAGS) -E $< -o $@
 endif
 
-ifndef AROPTS
-  AROPTS = rc
-endif
-
 ifndef LD
   LD = $(CC)
 endif

--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -47,7 +47,6 @@ ifeq ($(NATIVE_CAN_OPTIIMIZE),1)
 endif
 
 ifeq ($(HOST_OS),Darwin)
-AROPTS = -rc
 LDFLAGS_WERROR := -Wl,-fatal_warnings
 LDFLAGS += -Wl,-flat_namespace
 CFLAGS += -DHAVE_SNPRINTF=1 -U__ASSERT_USE_STDERR


### PR DESCRIPTION
The intermediate archives are no longer
built so remove the now unused AROPTS.