### PR TITLE
tests: fix Cooja warning

### DIFF
--- a/tests/07-simulation-base/20-cooja-rpl-tsch-orchestra.csc
+++ b/tests/07-simulation-base/20-cooja-rpl-tsch-orchestra.csc
@@ -21,8 +21,6 @@
       <source EXPORT="discard">[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
       <commands EXPORT="discard">make TARGET=cooja clean
 make -j$(CPUS) node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0 MAKE_WITH_PERIODIC_ROUTES_PRINT=1</commands>
-      <firmware
-          EXPORT="copy">[CONTIKI_DIR]/examples/6tisch/simple-node/node.mtype1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/07-simulation-base/24-cooja-rpl-tsch-orchestra-storing.csc
+++ b/tests/07-simulation-base/24-cooja-rpl-tsch-orchestra-storing.csc
@@ -21,8 +21,6 @@
       <source EXPORT="discard">[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
       <commands EXPORT="discard">make TARGET=cooja clean
 make -j$(CPUS) node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0 MAKE_WITH_PERIODIC_ROUTES_PRINT=1 MAKE_WITH_STORING_ROUTING=1</commands>
-      <firmware
-          EXPORT="copy">[CONTIKI_DIR]/examples/6tisch/simple-node/node.mtype1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/07-simulation-base/25-cooja-rpl-tsch-orchestra-link-based.csc
+++ b/tests/07-simulation-base/25-cooja-rpl-tsch-orchestra-link-based.csc
@@ -21,8 +21,6 @@
       <source EXPORT="discard">[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
       <commands EXPORT="discard">make TARGET=cooja clean
 make -j$(CPUS) node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0 MAKE_WITH_PERIODIC_ROUTES_PRINT=1 MAKE_WITH_STORING_ROUTING=1 MAKE_WITH_LINK_BASED_ORCHESTRA=1</commands>
-      <firmware
-          EXPORT="copy">[CONTIKI_DIR]/examples/6tisch/simple-node/node.mtype1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>

--- a/tests/07-simulation-base/27-cooja-rpl-tsch-orchestra-root-rule.csc
+++ b/tests/07-simulation-base/27-cooja-rpl-tsch-orchestra-root-rule.csc
@@ -21,8 +21,6 @@
       <source EXPORT="discard">[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
       <commands EXPORT="discard">make TARGET=cooja clean
 make -j$(CPUS) node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0 MAKE_WITH_PERIODIC_ROUTES_PRINT=1 MAKE_WITH_STORING_ROUTING=1 MAKE_WITH_ORCHESTRA_ROOT_RULE=1</commands>
-      <firmware
-          EXPORT="copy">[CONTIKI_DIR]/examples/6tisch/simple-node/node.mtype1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
       <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>


### PR DESCRIPTION
ContikiMoteType emits a warning because
it does not parse the firmware tag. Remove
the tag from the simulation files.