### PR TITLE
Fix dependency generation for ieee-addr.c

### DIFF
--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -34,9 +34,7 @@ USB_SOURCEFILES += usb-core.c cdc-acm.c usb-arch.c usb-serial.c cdc-acm-descript
 CONTIKI_SOURCEFILES += $(CONTIKI_CPU_SOURCEFILES) $(USB_SOURCEFILES)
 
 ### Always re-build ieee-addr.o in case the command line passes a new NODEID
-$(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(DEPDIR)
-	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
+$(OBJECTDIR)/ieee-addr.o: FORCE
 
 ### This rule is used to generate the correct linker script
 LDGENFLAGS += $(CFLAGS)

--- a/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -58,9 +58,7 @@ endif
 BSL = $(CONTIKI_NG_TOOLS_DIR)/cc2538-bsl/cc2538-bsl.py
 
 ### Always re-build ieee-addr.o in case the command line passes a new NODEID
-$(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(DEPDIR)
-	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
+$(OBJECTDIR)/ieee-addr.o: FORCE
 
 $(OBJECTDIR)/ccfg.o: CFLAGS += -include "ccxxware-conf.h"
 

--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -128,9 +128,7 @@ LD_END_GROUP = -Wl,--end-group
 ### Specialized build targets
 
 # Always re-build ieee-addr.o in case the command line passes a new NODEID
-$(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(DEPDIR)
-	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
+$(OBJECTDIR)/ieee-addr.o: FORCE
 
 ################################################################################
 ### Sub-family Makefile


### PR DESCRIPTION
Use the rule in Makefile.include for building object files. This makes the dependency generation work, and that is a requirement for avoiding rebuilds in a future patch.