### PR TITLE
cooja: add dep generation for mtypeNNN.o

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -420,7 +420,8 @@ DEPFLAGS ?= -MT $@ -MMD -MP -MF $(DEPDIR)/$*.d
 # the second PROJECT_SOURCEFILES.
 # LDSCRIPT is generated with the preprocessor on some targets, so enable
 # those targets to avoid rebuilds as well.
-DEPFILES := $(addprefix $(DEPDIR)/, $(addsuffix .d, $(CONTIKI_PROJECT))) \
+DEPFILES := $(TARGET_DEPFILES) \
+            $(addprefix $(DEPDIR)/, $(addsuffix .d, $(CONTIKI_PROJECT))) \
             ${filter %.d, $(CONTIKI_SOURCEFILES:%.c=$(DEPDIR)/%.d) \
                           $(PROJECT_SOURCEFILES:%.c=$(DEPDIR)/%.d) \
                           $(PROJECT_SOURCEFILES:%.cpp=$(DEPDIR)/%.d)} \

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -125,9 +125,12 @@ $(BUILD_DIR_BOARD)/%.$(TARGET): MAPFILE = $(LIBNAME:.cooja=.map)
 # This is mtype<NNN>.o which is built from platform.c with
 # CLASSNAME passed from the environment by Cooja.
 MTYPE_OBJ = $(LIBNAME:.cooja=.o)
+MTYPE_DEP = $(DEPDIR)/$(notdir $(LIBNAME:.cooja=.d))
+
+TARGET_DEPFILES += $(MTYPE_DEP)
 
 PROJECT_OBJECTFILES += $(MTYPE_OBJ)
 
-$(MTYPE_OBJ): platform.c | $(DEPDIR)
+$(MTYPE_OBJ): platform.c $(MTYPE_DEP) | $(DEPDIR)
 	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
+	$(Q)$(CCACHE) $(CC) $(CFLAGS) -MT $@ -MMD -MP -MF $(MTYPE_DEP) -c $< -o $@


### PR DESCRIPTION
This is required to avoid renumbering
the motes needlessly.