### PR TITLE
msp430: do release builds by default

### DIFF
--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -4,7 +4,6 @@ ifdef nodeid
 CFLAGS += -DNODEID=$(nodeid)
 endif
 
-DEBUG = 1
 CFLAGS_DEBUG = -gstabs+
 
 ### Define the CPU directory


### PR DESCRIPTION
The debug info is not required for Cooja
to work in the regression tests, so build
a release build by default.

This is a sibling to commit 80b8223a22.