### PR TITLE
Dockerfile: forward arguments to Cooja

### DIFF
--- a/tools/docker/files/cooja
+++ b/tools/docker/files/cooja
@@ -11,6 +11,6 @@ function exit_cleanup() {
   kill $PID
 }
 
-ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $HOME/contiki-ng/tools/cooja/build.xml run_bigmem
+ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $HOME/contiki-ng/tools/cooja/build.xml run_bigmem "$@"
 
 exit_cleanup


### PR DESCRIPTION
Make the Cooja script forward its arguments
to ant. This makes it possible to quickstart
simulations through the cooja script.