### PR TITLE
Makefile: allow overriding Clang version

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -139,7 +139,9 @@ ifneq ($(MAKECMDGOALS),clean)
     ifndef SYSROOT
       SYSROOT := $(shell $(CC) $(CFLAGS) --print-sysroot)
     endif
-    CC := clang-14
+    # Default to the most recent Clang in Ubuntu.
+    CLANG_CC ?= clang-14
+    CC := $(CLANG_CC)
     AS := $(CC)
     LD := $(CC)
     CFLAGS += $(CFLAGS_CLANG)


### PR DESCRIPTION
Ubuntu ships clang-14, but OS X contains
clang-13. Add the possibility to override
the Clang version through $(CLANG_CC).