### PR TITLE
cooja: use gradle instead of ant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
       with:
         path: |
           tools/cooja/build
-          tools/cooja/dist
+          tools/cooja/.gradle
         key: ${{ runner.os }}-cooja-${{ env.COOJA_COMMIT }}
 
     # Fire up the container and run corresponding tests
@@ -143,7 +143,7 @@ jobs:
         # Cache restores write-time timestamps, update timestamps to be more
         # recent than the files that were just checked out. Ensure the command
         # is successful when build/dist are not found in cache.
-        find tools/cooja/build tools/cooja/dist -exec touch {} \; 2>/dev/null || true
+        find tools/cooja/build tools/cooja/.gradle -exec touch {} \; 2>/dev/null || true
         # Run test
         # FIXME: (2023) Remove "ccache -c", workaround for cache growing
         #        too large from ccache CI/ccache configuration mismatch.

--- a/Makefile.include
+++ b/Makefile.include
@@ -65,6 +65,7 @@ UPPERCASE_CMD = tr '[:lower:][\-/]' '[:upper:][__]'
 COMMA := ,
 
 JAVA = java
+GRADLE = gradle
 
 BUILD_DIR = build
 BUILD_DIR_TARGET = $(BUILD_DIR)/$(TARGET)

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -121,11 +121,11 @@ $(COOJA_PATH)/java:
 	@echo '----------------'
 	@false
 
-$(COOJA_PATH)/dist/cooja.jar: | $(COOJA_PATH)/java
-	ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $(COOJA_PATH)/build.xml jar
+$(COOJA_PATH)/build/libs/cooja-full.jar: | $(COOJA_PATH)/java
+	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_PATH) fulljar
 
-%.mspsim: $(BUILD_DIR_BOARD)/%.${TARGET} | $(COOJA_PATH)/java
-	$(Q)ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $(COOJA_PATH)/build.xml run-mspsim -Dargs="-platform=${TARGET}" -DFIRMWAREFILE=$(realpath $<)
+%.mspsim: $(BUILD_DIR_BOARD)/%.${TARGET} ${COOJA_PATH}/build/libs/cooja-full.jar
+	  $(Q)$(JAVA) -classpath ${COOJA_PATH}/build/libs/cooja-full.jar se.sics.mspsim.Main -platform=${TARGET} $(realpath $<)
 
-%.mspsim-maptable: $(BUILD_DIR_BOARD)/%.$(TARGET) ${COOJA_PATH}/dist/cooja.jar
-	$(Q)$(JAVA) -classpath ${COOJA_PATH}/dist/cooja.jar se.sics.mspsim.util.MapTable $(CONTIKI_NG_PROJECT_MAP)
+%.mspsim-maptable: $(BUILD_DIR_BOARD)/%.$(TARGET) ${COOJA_PATH}/build/libs/cooja-full.jar
+	$(Q)$(JAVA) -classpath ${COOJA_PATH}/build/libs/cooja-full.jar se.sics.mspsim.util.MapTable $(CONTIKI_NG_PROJECT_MAP)

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -74,7 +74,7 @@ CURDIR := $(shell pwd)
 
 .PHONY: $(MAKECMDGOALS)
 $(MAKECMDGOALS):
-	$(Q)ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $(COOJA_DIR)/build.xml run_bigmem -Dargs="-quickstart=$(addprefix $(CURDIR)/,$(firstword $(MAKECMDGOALS))) -contiki=$(realpath $(CONTIKI)) -logdir=$(CURDIR)"
+	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_DIR) run --args="-quickstart=$(addprefix $(CURDIR)/,$(firstword $(MAKECMDGOALS))) -contiki=$(realpath $(CONTIKI)) -logdir=$(CURDIR)"
 endif
 endif ## QUICKSTART
 

--- a/examples/benchmarks/result-visualization/run-cooja.py
+++ b/examples/benchmarks/result-visualization/run-cooja.py
@@ -9,7 +9,7 @@ SELF_PATH = os.path.dirname(os.path.abspath(__file__))
 # move three levels up
 CONTIKI_PATH = os.path.dirname(os.path.dirname(os.path.dirname(SELF_PATH)))
 
-build_xml = os.path.normpath(os.path.join(CONTIKI_PATH, "tools", "cooja", "build.xml"))
+COOJA_PATH = os.path.normpath(os.path.join(CONTIKI_PATH, "tools", "cooja"))
 cooja_input = 'cooja.csc'
 cooja_output = 'COOJA.testlog'
 
@@ -51,7 +51,7 @@ def execute_test(cooja_file):
         return False
 
     filename = os.path.join(SELF_PATH, cooja_file)
-    args = " ".join(["ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f", build_xml, "run_bigmem -Dargs='-nogui=" + filename, "-contiki=" + CONTIKI_PATH, "-logdir=" + SELF_PATH + "'"])
+    args = " ".join(["gradle --no-watch-fs --parallel --build-cache -p", COOJA_PATH, "run --args='-nogui=" + filename, "-contiki=" + CONTIKI_PATH, "-logdir=" + SELF_PATH + "'"])
     sys.stdout.write("  Running Cooja, args={}\n".format(args))
 
     (retcode, output) = run_subprocess(args, '')

--- a/tests/Makefile.simulation-test
+++ b/tests/Makefile.simulation-test
@@ -57,7 +57,7 @@ summary: clean
 # Successful simulations do nothing, failures appends test+seed to summary.
 %.testlog: %.csc
 	@for (( SEED=$(BASESEED); SEED < $$(( $(BASESEED) + $(RUNCOUNT) )); SEED++ )); do \
-          ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $(CONTIKI)/tools/cooja/build.xml run_bigmem -Dargs="-nogui=$(realpath $<) -contiki=$(realpath $(CONTIKI)) -logdir=$(dir $(realpath $<)) -random-seed=$$SEED" || \
+          gradle --no-watch-fs --parallel --build-cache -p $(CONTIKI)/tools/cooja run --args="-nogui=$(realpath $<) -contiki=$(realpath $(CONTIKI)) -logdir=$(dir $(realpath $<)) -random-seed=$$SEED" || \
             echo "TEST FAIL: $< seed $$SEED" >> summary; \
          done
 

--- a/tools/docker/files/cooja
+++ b/tools/docker/files/cooja
@@ -11,6 +11,6 @@ function exit_cleanup() {
   kill $PID
 }
 
-ant -e -logger org.apache.tools.ant.listener.SimpleBigProjectLogger -f $HOME/contiki-ng/tools/cooja/build.xml run_bigmem "$@"
+gradle --no-watch-fs --parallel --build-cache -p $HOME/contiki-ng/tools/cooja run "$@"
 
 exit_cleanup


### PR DESCRIPTION
This switches to using the Gradle build system
for Cooja. This will make it easier to update
dependencies without having to store every JAR
in the repository.