### PR TITLE
Update to ccache v4.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,9 +115,9 @@ jobs:
     # Install in /usr/bin so the ccache action gets the expected environment.
     - name: install ccache
       run: |
-        wget -nv https://github.com/ccache/ccache/releases/download/v4.6.1/ccache-4.6.1-linux-x86_64.tar.xz
-        sudo tar xf ccache-4.6.1-linux-x86_64.tar.xz -C /usr/bin --strip-components=1 --no-same-owner ccache-4.6.1-linux-x86_64/ccache
-        rm -f ccache-4.6.1-linux-x86_64.tar.xz
+        wget -nv https://github.com/ccache/ccache/releases/download/v4.6.2/ccache-4.6.2-linux-x86_64.tar.xz
+        sudo tar xf ccache-4.6.2-linux-x86_64.tar.xz -C /usr/bin --strip-components=1 --no-same-owner ccache-4.6.2-linux-x86_64/ccache
+        rm -f ccache-*-linux-x86_64.tar.xz
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2.2

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -155,9 +155,9 @@ RUN wget -nv https://www.doxygen.nl/files/doxygen-1.9.4.linux.bin.tar.gz && \
     tar zxf doxygen-1.9.4.linux.bin.tar.gz -C ${HOME}/.local && \
     rm -rf ${HOME}/.local/doxygen-1.9.4/html ${HOME}/.local/doxygen-1.9.4/*.pdf doxygen-1.9.4.linux.bin.tar.gz && \
     (cd ${HOME}/.local/bin && ln -s ../doxygen-1.9.4/bin/doxygen .) && \
-    wget -nv https://github.com/ccache/ccache/releases/download/v4.6.1/ccache-4.6.1-linux-x86_64.tar.xz && \
-    tar xf ccache-4.6.1-linux-x86_64.tar.xz -C ${HOME}/.local/bin --strip-components=1 ccache-4.6.1-linux-x86_64/ccache && \
-    rm ccache-4.6.1-linux-x86_64.tar.xz
+    wget -nv https://github.com/ccache/ccache/releases/download/v4.6.2/ccache-4.6.2-linux-x86_64.tar.xz && \
+    tar xf ccache-4.6.2-linux-x86_64.tar.xz -C ${HOME}/.local/bin --strip-components=1 ccache-4.6.2-linux-x86_64/ccache && \
+    rm ccache-*-linux-x86_64.tar.xz
 
 # By default, we use a Docker bind mount to share the repo with the host,
 # with Docker run option:


### PR DESCRIPTION
Nothing apparent that affects Contiki-NG in the issues fixed, but looks like a nice improvement over v4.6.1.