### PR TITLE
Dockerfile: add Java 17

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -76,6 +76,9 @@ RUN apt-get -qq update && \
     gradle \
     > /dev/null && \
   rm graalvm-ce-java11_amd64_22.2.0-0.deb && \
+  wget -nv https://github.com/dongjinleekr/graalvm-ce-deb/releases/download/22.2.0-0/graalvm-ce-java17_amd64_22.2.0-0.deb && \
+  dpkg -i graalvm-ce-java17_amd64_22.2.0-0.deb && \
+  rm graalvm-ce-java17_amd64_22.2.0-0.deb && \
   apt-get -qq clean
 
 # Install ARM toolchain


### PR DESCRIPTION
Add a separate non-default Java 17 to
the docker image. This simplifies the work
on making Cooja work with Java 17.