### PR TITLE
Update tools/cooja submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,15 +125,16 @@ jobs:
         key: compilation-${{ matrix.test }}
         max-size: 250M
 
-    # Keep a cache of the Cooja build/dist files. Keyed on Cooja repo
-    # commit to ensure clean rebuild when updating Cooja submodule.
+    # Keep a cache of the Cooja build files and gradle files. Keyed on Cooja
+    # repo commit to ensure clean rebuild when updating Cooja submodule.
     - name: Cache Cooja Artifacts
       uses: actions/cache@v3
       with:
         path: |
           tools/cooja/build
           tools/cooja/.gradle
-        key: ${{ runner.os }}-cooja-${{ env.COOJA_COMMIT }}
+          tools/cooja/.gradle_home
+        key: ${{ runner.os }}-cooja-gradle-deps-${{ env.COOJA_COMMIT }}
 
     # Fire up the container and run corresponding tests
     - name: Execute tests
@@ -142,11 +143,13 @@ jobs:
         sudo chown -R 1000:1000 .
         # Cache restores write-time timestamps, update timestamps to be more
         # recent than the files that were just checked out. Ensure the command
-        # is successful when build/dist are not found in cache.
+        # is successful with empty cache.
         find tools/cooja/build tools/cooja/.gradle -exec touch {} \; 2>/dev/null || true
         # Run test
         # FIXME: (2023) Remove "ccache -c", workaround for cache growing
         #        too large from ccache CI/ccache configuration mismatch.
-        docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true $DOCKER_ARGS -v `pwd`:/home/user/contiki-ng -v $GITHUB_WORKSPACE/.ccache:/home/user/.ccache $DOCKER_IMG bash --login -c "source ../.bash_aliases && ccache --set-config=max_size='250M' && cimake -C tests/??-${{ matrix.test }}; ccache -c"
+        docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -e GRADLE_USER_HOME=/home/user/contiki-ng/tools/cooja/.gradle_home $DOCKER_ARGS -v `pwd`:/home/user/contiki-ng -v $GITHUB_WORKSPACE/.ccache:/home/user/.ccache $DOCKER_IMG bash --login -c "source ../.bash_aliases && ccache --set-config=max_size='250M' && cimake -C tests/??-${{ matrix.test }}; ccache -c"
+        # Restore permissions for gradle_home so the cache action can work.
+        [ -d tools/cooja/.gradle_home ] && sudo chown -R 1001:1001 tools/cooja/.gradle_home || true
         # Check outcome of the test
         ./tests/check-test.sh `pwd`/tests/??-${{ matrix.test }}


### PR DESCRIPTION
Set GRADLE_USER_HOME for the CI and update the cache.

Commits:
72ef2fde Always register default mote interfaces
ad4efb9d AbstractApplicationMote: remove unused object
ba1ae0cc Memory: update long size for 64-bit arch
2edc7e01 Always register default skins
175b8f46 CoreComm: compile as java 11
17722f8e Stop synchronizing on non-final fields
8d0201cc Remove always-true parameter
1d41fc9c Use un-deprecated newInstance()
fb3673f5 Use try-with-resources
950e4e5e Stop concatenating args to StringBuffer.append()
ba504bbd Use zero-length array in toArray()
cd898e0d Un-javadoc the license of files
795cc4a3 gradle: remove unnecessary semicolon
556363de Use external nashorn engine
ef890eb5 CDF_Normal: fix javadoc warnings
890c31ee Cooja: use first <simulation> in config
8b2a7fee Simulation: change setConfigXML signature
5f2c8825 Cooja: cleanup verifyProjects
9a809a8e Cooja: hoist error check
4117f99c CoreComm: ensure new names are used
41371226 CoreComm: fix wording in javadoc
8835676b CoreComm: shorten class creation
57d63072 CoreComm: remove unused container
b77de263 Visualizer: remove unused movedMotes
05e998ae ScriptRunner: initialize SyntaxKit in constructor
bf819bba ContikiMoteType: remove one pass over mapfile
6937a3d2 ContikiMoteType: simplify from assumptions
9537f556 ContikiMoteType: do not parse common on Linux
908325a3 ContikiMoteType: inline method