### PR TITLE
tests: make non-termination explicit

### DIFF
--- a/tests/17-tun-rpl-br/01-border-router-cooja.csc
+++ b/tests/17-tun-rpl-br/01-border-router-cooja.csc
@@ -202,7 +202,8 @@ make -j$(CPUS) hello-world.cooja TARGET=cooja</commands>
     <plugin_config>
       <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
 /* Set simulaion speed to real time */
-sim.setSpeedLimit(1.0);</script>
+sim.setSpeedLimit(1.0);
+while (true) { YIELD(); }</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/02-border-router-cooja-tsch.csc
+++ b/tests/17-tun-rpl-br/02-border-router-cooja-tsch.csc
@@ -203,7 +203,8 @@ make -j$(CPUS) hello-world.cooja TARGET=cooja MAKE_MAC=MAKE_MAC_TSCH DEFINES=TSC
     <plugin_config>
       <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
 /* Set simulaion speed to real time */
-sim.setSpeedLimit(1.0);</script>
+sim.setSpeedLimit(1.0);
+while (true) { YIELD(); }</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/03-border-router-sky.csc
+++ b/tests/17-tun-rpl-br/03-border-router-sky.csc
@@ -200,7 +200,8 @@ make -j$(CPUS) hello-world.sky TARGET=sky</commands>
     <plugin_config>
       <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
 /* Set simulaion speed to real time */
-sim.setSpeedLimit(1.0);</script>
+sim.setSpeedLimit(1.0);
+while (true) { YIELD(); }</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/04-border-router-traceroute.csc
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.csc
@@ -202,7 +202,8 @@ make -j$(CPUS) hello-world.cooja TARGET=cooja</commands>
     <plugin_config>
       <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
 /* Set simulaion speed to real time */
-sim.setSpeedLimit(1.0);</script>
+sim.setSpeedLimit(1.0);
+while (true) { YIELD(); }</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/07-native-border-router-cooja.csc
+++ b/tests/17-tun-rpl-br/07-native-border-router-cooja.csc
@@ -204,7 +204,8 @@ make -j$(CPUS) hello-world.cooja TARGET=cooja</commands>
 /* Set simulaion speed to real time. Required for
  * Native BR test, as the Native BR will run as a
  * unix process, at real time. */
-sim.setSpeedLimit(1.0);</script>
+sim.setSpeedLimit(1.0);
+while (true) { YIELD(); }</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/08-border-router-cooja-frag.csc
+++ b/tests/17-tun-rpl-br/08-border-router-cooja-frag.csc
@@ -202,7 +202,8 @@ make -j$(CPUS) hello-world.cooja TARGET=cooja</commands>
     <plugin_config>
       <script>TIMEOUT(10000000000); /* milliseconds. no action at timeout */
 /* Set simulaion speed to real time */
-sim.setSpeedLimit(1.0);</script>
+sim.setSpeedLimit(1.0);
+while (true) { YIELD(); }</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>

--- a/tests/17-tun-rpl-br/09-native-border-router-cooja-frag.csc
+++ b/tests/17-tun-rpl-br/09-native-border-router-cooja-frag.csc
@@ -204,7 +204,8 @@ make -j$(CPUS) hello-world.cooja TARGET=cooja</commands>
 /* Set simulaion speed to real time. Required for
  * Native BR test, as the Native BR will run as a
  * unix process, at real time. */
-sim.setSpeedLimit(1.0);</script>
+sim.setSpeedLimit(1.0);
+while (true) { YIELD(); }</script>
       <active>true</active>
     </plugin_config>
     <width>600</width>


### PR DESCRIPTION
Cooja currently adds this loop implicitly
at the end of all user scripts, and that
prevents a nice shutdown of Cooja.

Add the infinite loop to the tests that
requires it, to make way for changing
Cooja to shutdown nicely.