### PR TITLE
cooja: use gradlew to build

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -64,8 +64,9 @@ UPPERCASE_CMD = tr '[:lower:][\-/]' '[:upper:][__]'
 
 COMMA := ,
 
+COOJA_PATH ?= $(CONTIKI_NG_TOOLS_DIR)/cooja
 JAVA = java
-GRADLE = gradle
+GRADLE = $(COOJA_PATH)/gradlew
 
 BUILD_DIR = build
 BUILD_DIR_TARGET = $(BUILD_DIR)/$(TARGET)

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -1,5 +1,3 @@
-COOJA_PATH ?= $(CONTIKI_NG_TOOLS_DIR)/cooja
-
 ifdef nodeid
 CFLAGS += -DNODEID=$(nodeid)
 endif

--- a/examples/benchmarks/result-visualization/run-cooja.py
+++ b/examples/benchmarks/result-visualization/run-cooja.py
@@ -51,7 +51,7 @@ def execute_test(cooja_file):
         return False
 
     filename = os.path.join(SELF_PATH, cooja_file)
-    args = " ".join(["gradle --no-watch-fs --parallel --build-cache -p", COOJA_PATH, "run --args='-nogui=" + filename, "-contiki=" + CONTIKI_PATH, "-logdir=" + SELF_PATH + "'"])
+    args = " ".join([COOJA_PATH + "/gradlew --no-watch-fs --parallel --build-cache -p", COOJA_PATH, "run --args='-nogui=" + filename, "-contiki=" + CONTIKI_PATH, "-logdir=" + SELF_PATH + "'"])
     sys.stdout.write("  Running Cooja, args={}\n".format(args))
 
     (retcode, output) = run_subprocess(args, '')

--- a/tests/Makefile.simulation-test
+++ b/tests/Makefile.simulation-test
@@ -39,6 +39,8 @@ RUNCOUNT ?= 1
 
 CONTIKI ?= ../..
 
+GRADLE ?= $(CONTIKI)/tools/cooja/gradlew
+
 Q ?= @
 
 .PHONY: all clean tests
@@ -57,7 +59,7 @@ summary: clean
 # Successful simulations do nothing, failures appends test+seed to summary.
 %.testlog: %.csc
 	@for (( SEED=$(BASESEED); SEED < $$(( $(BASESEED) + $(RUNCOUNT) )); SEED++ )); do \
-          gradle --no-watch-fs --parallel --build-cache -p $(CONTIKI)/tools/cooja run --args="-nogui=$(realpath $<) -contiki=$(realpath $(CONTIKI)) -logdir=$(dir $(realpath $<)) -random-seed=$$SEED" || \
+          $(GRADLE) --no-watch-fs --parallel --build-cache -p $(CONTIKI)/tools/cooja run --args="-nogui=$(realpath $<) -contiki=$(realpath $(CONTIKI)) -logdir=$(dir $(realpath $<)) -random-seed=$$SEED" || \
             echo "TEST FAIL: $< seed $$SEED" >> summary; \
          done
 


### PR DESCRIPTION
This ensures the right version of gradle
is used for building.

Add a cooja submodule update in this PR to ensure that the gradle distribution is cached in the CI.