### PR TITLE
cooja: simplify Cooja quickstart rule

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -68,14 +68,10 @@ JAVA_CFLAGS = -I"$(JAVA_INCDIR)/include" -I"$(JAVA_INCDIR)/include/$(JAVA_OS_NAM
 
 ### Assuming simulator quickstart if no JNI library name set from Cooja
 ifndef LIBNAME
-ifneq ($(MAKECMDGOALS),clean)
-
 CURDIR := $(shell pwd)
 
-.PHONY: $(MAKECMDGOALS)
-$(MAKECMDGOALS):
-	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_DIR) run --args="-quickstart=$(addprefix $(CURDIR)/,$(firstword $(MAKECMDGOALS))) -contiki=$(realpath $(CONTIKI)) -logdir=$(CURDIR)"
-endif
+%.csc %.csc.gz: FORCE
+	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_DIR) run --args="-quickstart=$(addprefix $(CURDIR)/,$@) -contiki=$(realpath $(CONTIKI)) -logdir=$(CURDIR)"
 endif ## QUICKSTART
 
 # No stack end symbol available, code does not work on 64-bit architectures.


### PR DESCRIPTION
Only run Cooja quickstart on Cooja simulation files. Also, avoid build warnings when, for example, running `make TARGET=cooja viewconf`.