### PR TITLE
cooja: fail to build Cooja motes with a specified board

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -21,6 +21,10 @@ ifneq ($(MAKECMDGOALS),clean)
   ifneq ($(COOJA_VERSION),$(EXPECTED_COOJA_VERSION))
     $(error Got COOJA_VERSION $(COOJA_VERSION) but expected $(EXPECTED_COOJA_VERSION))
   endif
+
+  ifneq ($(BOARD),)
+    $(error Cooja motes do not support boards, please remove the configuration 'BOARD=$(BOARD)')
+  endif
 endif
 endif
 


### PR DESCRIPTION
Cooja can not find the output file if a Cooja mote is built with a board specified, as this will change where the output file is stored.