### PR TITLE
Simplify starting Cooja on a simulation file

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -449,6 +449,10 @@ distclean:
 $(GENDIR)/%: $(GENDIR)/%.diffupdate | $(GENDIR)
 	$(Q)diff $< $@ > /dev/null 2>&1 || mv $< $@
 
+# Start cooja through "make file.csc", where the real target is defined through the csc.
+%.csc %.csc.gz: FORCE
+	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_PATH) run --args="-quickstart=$(addprefix $(CURDIR)/,$@) -contiki=$(realpath $(CONTIKI)) -logdir=$(CURDIR)"
+
 ### Automatic dependency generation, see
 ### http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/#advanced
 

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -28,8 +28,6 @@ ifneq ($(MAKECMDGOALS),clean)
 endif
 endif
 
-COOJA_DIR = $(CONTIKI_NG_TOOLS_DIR)/cooja
-
 # Use dbg-io for IO functions like printf()
 MODULES += os/lib/dbg-io
 WRAPPED_FUNS = printf putchar puts snprintf sprintf vsnprintf
@@ -69,14 +67,6 @@ SIZE = size
 CP = true
 
 JAVA_CFLAGS = -I"$(JAVA_INCDIR)/include" -I"$(JAVA_INCDIR)/include/$(JAVA_OS_NAME)"
-
-### Assuming simulator quickstart if no JNI library name set from Cooja
-ifndef LIBNAME
-CURDIR := $(shell pwd)
-
-%.csc %.csc.gz: FORCE
-	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_DIR) run --args="-quickstart=$(addprefix $(CURDIR)/,$@) -contiki=$(realpath $(CONTIKI)) -logdir=$(CURDIR)"
-endif ## QUICKSTART
 
 # No stack end symbol available, code does not work on 64-bit architectures.
 MODULES_SOURCES_EXCLUDES += stack-check.c

--- a/tools/docker/files/bash_aliases
+++ b/tools/docker/files/bash_aliases
@@ -5,3 +5,7 @@
 cimake () {
   RELSTR=citest CFLAGS_DATE='-DDATE="\"05 29 07 22 14 24 07\""' make "$@"
 }
+
+# Enable "cscmake file.csc" anywhere in the tree. Use the native target
+# to silence warnings from the build system.
+alias cscmake='make -f $CONTIKI_NG/Makefile.include TARGET=native'


### PR DESCRIPTION
This is a makefile change and a new alias in the docker image so it's possible to type

cscmake sim.csc

from anywhere in the tree to quickstart Cooja with sim.csc.