### PR TITLE
Update tools/cooja submodule

### DIFF
--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -20,7 +20,7 @@ LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
 wget -nv -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
 sleep 10
 echo "Starting leshan server"
-java -jar $LESHAN_JAR >leshan.log 2>leshan.err &
+java --add-opens java.base/java.util=ALL-UNNAMED -jar $LESHAN_JAR >leshan.log 2>leshan.err &
 LESHID=$!
 
 COUNTER=10

--- a/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
+++ b/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
@@ -15,7 +15,7 @@ echo "Downloading leshan"
 LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
 wget -nv -nc https://joakimeriksson.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server"
-java -jar $LESHAN_JAR -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
+java --add-opens java.base/java.util=ALL-UNNAMED -jar $LESHAN_JAR -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
 LESHID=$!
 
 echo "Starting lwm2m standalone example"

--- a/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
+++ b/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
@@ -14,7 +14,7 @@ echo "Downloading leshan with Q-Mode support"
 LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
 wget -nv -nc https://carlosgp143.github.io/resources/$LESHAN_JAR
 echo "Starting leshan server with Q-Mode enabled"
-java -jar $LESHAN_JAR -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
+java --add-opens java.base/java.util=ALL-UNNAMED -jar $LESHAN_JAR -lp 5686 -slp 5687 >leshan.log 2>leshan.err &
 LESHID=$!
 
 echo "Starting lwm2m standalone example"

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -14,7 +14,7 @@ USER root
 # lib32z1: 32-bit libz, probably used by some old 32-bit binary.
 # libcanberra-gtk-module: remove warning message from renode.
 # libcoap2-bin: used by regression tests.
-# libxtst6: required for GraalVM/Java11 to run Cooja in GUI mode.
+# libxtst6: required for GraalVM/Java17 to run Cooja in GUI mode.
 # mosquitto: used by the regression tests.
 # mtr-tiny: used by the regression tests.
 # net-tools: used by the regression tests.
@@ -58,8 +58,8 @@ RUN apt-get -qq update && \
     snmp \
     snmp-mibs-downloader \
     > /dev/null && \
-  wget -nv https://github.com/dongjinleekr/graalvm-ce-deb/releases/download/22.2.0-0/graalvm-ce-java11_amd64_22.2.0-0.deb && \
-  dpkg --unpack graalvm-ce-java11_amd64_22.2.0-0.deb && \
+  wget -nv https://github.com/dongjinleekr/graalvm-ce-deb/releases/download/22.2.0-0/graalvm-ce-java17_amd64_22.2.0-0.deb && \
+  dpkg --unpack graalvm-ce-java17_amd64_22.2.0-0.deb && \
   apt-get -qq -y --no-install-recommends install \
     ca-certificates-java \
     java-common \
@@ -70,9 +70,6 @@ RUN apt-get -qq update && \
   apt-get -qq -y --no-install-recommends install \
     ant \
     > /dev/null && \
-  rm graalvm-ce-java11_amd64_22.2.0-0.deb && \
-  wget -nv https://github.com/dongjinleekr/graalvm-ce-deb/releases/download/22.2.0-0/graalvm-ce-java17_amd64_22.2.0-0.deb && \
-  dpkg -i graalvm-ce-java17_amd64_22.2.0-0.deb && \
   rm graalvm-ce-java17_amd64_22.2.0-0.deb && \
   apt-get -qq clean
 


### PR DESCRIPTION
Update Dockerfile to only include GraalVM/Java17.

Commits:
e507ea37 Build Cooja as Java 17