### PR TITLE
TSCH: Missing #include in tsch-packet.c

### DIFF
--- a/os/net/mac/tsch/tsch-packet.c
+++ b/os/net/mac/tsch/tsch-packet.c
@@ -51,6 +51,7 @@
 #include "net/netstack.h"
 #include "lib/ccm-star.h"
 #include "lib/aes-128.h"
+#include <string.h>
 
 /* Log configuration */
 #include "sys/log.h"


### PR DESCRIPTION
This PR inserts a missing `#include` into `tsch-packet.c` so as to fix compilation errors.