### PR TITLE
Improved USB build on nrf port and added documentation

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -19,7 +19,6 @@ CONTIKI_CPU_SOURCEFILES += temp-arch.c
 CONTIKI_CPU_SOURCEFILES += linkaddr-arch.c
 CONTIKI_CPU_SOURCEFILES += reset-arch.c
 CONTIKI_CPU_SOURCEFILES += slip-arch.c
-CONTIKI_CPU_SOURCEFILES += usb-arch.c
 
 # Overrides
 CONTIKI_CPU_SOURCEFILES += random.c
@@ -80,7 +79,7 @@ NRFX_INC_PATHS += hal
 EXTERNALDIRS += $(addprefix $(NRFX_ROOT)/, $(NRFX_INC_PATHS))
 
 ## Tinyusb
-ifdef TINYUSB
+ifeq ($(NRF_NATIVE_USB),1)
   CFLAGS += -DCFG_TUSB_MCU=OPT_MCU_NRF5X
   #nrf specific
   TINYUSB_C_SRCS += $(TINYUSB_ROOT)/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -112,6 +111,11 @@ ifdef TINYUSB
 
   CONTIKI_CPU_SOURCEFILES += usb.c
   CONTIKI_CPU_SOURCEFILES += usb_descriptors.c
+  CONTIKI_CPU_SOURCEFILES += usb-arch.c
+
+  CFLAGS += -DPLATFORM_DBG_CONF_USB=1
+  CFLAGS += -DPLAFTORM_SLIP_ARCH_CONF_USB=1
+  CFLAGS += -DNRF_NATIVE_USB=1
 endif
 
 CONTIKI_CPU_DIRS += usb/

--- a/arch/cpu/nrf/Makefile.nrf52840
+++ b/arch/cpu/nrf/Makefile.nrf52840
@@ -18,9 +18,6 @@ EXTERNALDIRS += $(NRFX_ROOT)/mdk/
 CFLAGS += -DCPU_CONF_PATH=\"nrf52840-conf.h\"
 CFLAGS += -DCPU_DEF_PATH=\"nrf52840-def.h\"
 
-## Tinyusb
-TINYUSB = 1
-
 CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 LDFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16

--- a/arch/cpu/nrf/Makefile.nrf5340_application
+++ b/arch/cpu/nrf/Makefile.nrf5340_application
@@ -15,9 +15,6 @@ CFLAGS += -DCPU_CONF_PATH=\"nrf5340-application-conf.h\"
 CFLAGS += -DCPU_DEF_PATH=\"nrf5340-application-def.h\"
 CFLAGS += -DNRFX_USBREG_ENABLED
 
-## Tinyusb
-TINYUSB = 1
-
 CFLAGS += -mfloat-abi=hard 
 CFLAGS += -mfpu=fpv5-sp-d16
 

--- a/arch/cpu/nrf/Makefile.nrf5340_network
+++ b/arch/cpu/nrf/Makefile.nrf5340_network
@@ -16,6 +16,10 @@ CFLAGS += -DCPU_DEF_PATH=\"nrf5340-network-def.h\"
 
 TARGET_LIBFILES += -lm
 
+ifeq ($(NRF_NATIVE_USB),1)
+$(error The nrf5340 network core does not support USB)
+endif
+
 include $(CONTIKI)/$(CONTIKI_NG_CM33_DIR)/Makefile.cm33+nodsp
 
 include $(CONTIKI_CPU)/Makefile.nrf

--- a/arch/platform/nrf/nrf52840/dongle/Makefile.dongle
+++ b/arch/platform/nrf/nrf52840/dongle/Makefile.dongle
@@ -5,6 +5,9 @@ BOARD_SOURCEFILES += board-sensors.c
 CFLAGS += -DBOARD_CONF_PATH=\"nrf52840-dongle-conf.h\"
 CFLAGS += -DBOARD_DEF_PATH=\"nrf52840-dongle-def.h\"
 
+# Dongle only has USB and not UART
+NRF_NATIVE_USB=1
+
 ### Include the common nrf52840 makefile
 include $(PLATFORM_ROOT_DIR)/nrf52840/Makefile.nrf52840
 

--- a/arch/platform/nrf/nrf52840/dongle/nrf52840-dongle-conf.h
+++ b/arch/platform/nrf/nrf52840/dongle/nrf52840-dongle-conf.h
@@ -45,11 +45,11 @@
 #define NRF52840_DK_CONF_H
 /*---------------------------------------------------------------------------*/
 #ifndef PLAFTORM_SLIP_ARCH_CONF_USB
-#define PLAFTORM_SLIP_ARCH_CONF_USB 1
+#define PLAFTORM_SLIP_ARCH_CONF_USB 0
 #endif
 /*---------------------------------------------------------------------------*/
 #ifndef PLATFORM_DBG_CONF_USB
-#define PLATFORM_DBG_CONF_USB   1
+#define PLATFORM_DBG_CONF_USB   0
 #endif
 /*---------------------------------------------------------------------------*/
 #endif /* NRF52840_DK_CONF_H */

--- a/arch/platform/nrf/platform.c
+++ b/arch/platform/nrf/platform.c
@@ -80,9 +80,9 @@ platform_init_stage_two(void)
   uarte_init();
 #endif /* NRF_HAS_UARTE */
 
-#if NRF_HAS_USB
+#if NRF_HAS_USB && defined(NRF_NATIVE_USB) && NRF_NATIVE_USB == 1
   usb_init();
-#endif /* NRF_HAS_USB */
+#endif /* NRF_HAS_USB && defined(NRF_NATIVE_USB) && NRF_NATIVE_USB == 1 */
 
   serial_line_init();
 

--- a/doc/platforms/nrf.md
+++ b/doc/platforms/nrf.md
@@ -92,6 +92,10 @@ set on the compilation command line:
   The default board is `nrf5340/dk/application`
   Dongle images are built with a bootloader-specific linker file and should be flashed using the `.dfu-upload` target.
 
+* `NRF_NATIVE_USB=<0,1>`  
+  Enables or disables the native USB support on boards that have USB support. 
+  This will automatically change the debug and the slip from UART to USB.
+ 
 ## Compilation Targets
 
 Invoking make solely with the `TARGET` variable set will build all

--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -48,6 +48,9 @@ hello-world/nrf:BOARD=nrf52840/dk \
 hello-world/nrf:BOARD=nrf52840/dongle \
 hello-world/nrf:BOARD=nrf5340/dk/application \
 hello-world/nrf:BOARD=nrf5340/dk/network \
+hello-world/nrf:BOARD=nrf52840/dk:NRF_NATIVE_USB=1 \
+hello-world/nrf:BOARD=nrf52840/dongle:NRF_NATIVE_USB=1 \
+hello-world/nrf:BOARD=nrf5340/dk/application:NRF_NATIVE_USB=1 \
 libs/data-structures/zoul \
 libs/deployment/openmote \
 libs/energest/zoul \


### PR DESCRIPTION
Default USB to 0 on nrf boards except dongle because it only supports USB
Added documentation to the new compilation option 