### PR TITLE
cooja: use linker for section info

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -5,7 +5,7 @@
 ## The purpose of this file is to compile a shared library that
 ## can be loaded into the Java part of COOJA.
 
-EXPECTED_COOJA_VERSION = 2022052601
+EXPECTED_COOJA_VERSION = 2022071901
 
 ifndef CONTIKI
   $(error CONTIKI not defined!)
@@ -55,6 +55,7 @@ else
   CC = gcc
   CFLAGS += -fPIC -fcommon
   LDFLAGS += -shared -Wl,-zdefs -Wl,-Map=$(MAPFILE)
+  LDFLAGS += -Wl,-T$(CONTIKI_NG_RELOC_PLATFORM_DIR)/cooja/cooja.ld
 endif
 
 ifneq ($(HOST_OS),Darwin)

--- a/arch/platform/cooja/cooja.ld
+++ b/arch/platform/cooja/cooja.ld
@@ -1,0 +1,9 @@
+/* Define helper symbols to inform Cooja about start addresses and sizes
+   of segments. */
+SECTIONS{
+    cooja_bssSize = SIZEOF(.bss);
+    cooja_dataSize = SIZEOF(.data);
+    cooja_bssStart = ADDR(.bss);
+    cooja_dataStart = ADDR(.data);
+}
+INSERT BEFORE .lbss;


### PR DESCRIPTION
Define helper symbols to inform Cooja about
start addresses and sizes of segments.