### PR TITLE
msp430: use dbg-io

### DIFF
--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -4,6 +4,9 @@ endif
 
 CFLAGS_DEBUG = -gstabs+
 
+# Use dbg-io for IO functions like printf()
+MODULES += os/lib/dbg-io
+
 ### Define the CPU directory
 CONTIKI_CPU = $(CONTIKI_NG_RELOC_CPU_DIR)/msp430
 

--- a/arch/cpu/msp430/dev/uart0-putchar.c
+++ b/arch/cpu/msp430/dev/uart0-putchar.c
@@ -5,10 +5,9 @@
 #include <string.h>
 /*---------------------------------------------------------------------------*/
 #define SLIP_END     0300
-#undef putchar
 /*---------------------------------------------------------------------------*/
 int
-putchar(int c)
+dbg_putchar(int c)
 {
 #if SLIP_ARCH_CONF_ENABLED
   static char debug_frame = 0;
@@ -37,6 +36,20 @@ putchar(int c)
   return c;
 }
 
+unsigned int
+dbg_send_bytes(const unsigned char *s, unsigned int len)
+{
+  unsigned int i = 0;
+  while(s && *s != 0) {
+    if(i >= len) {
+      break;
+    }
+    dbg_putchar(*s++);
+    i++;
+  }
+  return i;
+}
+
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 /* The printf() in newlib in GCC 9 from Texas Instruments uses the
  * "TI C I/O" protocol which is not implemented in GDB. The user manual
@@ -46,7 +59,7 @@ write(int fd, const char *buf, int len)
 {
   int i = 0;
   for(; i < len && buf[i]; i++) {
-    putchar(buf[i]);
+    dbg_putchar(buf[i]);
   }
   return i;
 }

--- a/arch/cpu/msp430/dev/uart1-putchar.c
+++ b/arch/cpu/msp430/dev/uart1-putchar.c
@@ -5,10 +5,9 @@
 #include <string.h>
 /*---------------------------------------------------------------------------*/
 #define SLIP_END     0300
-#undef putchar
 /*---------------------------------------------------------------------------*/
 int
-putchar(int c)
+dbg_putchar(int c)
 {
 #if SLIP_ARCH_CONF_ENABLED
   static char debug_frame = 0;
@@ -35,5 +34,19 @@ putchar(int c)
   }
 #endif /* SLIP_ARCH_CONF_ENABLED */
   return c;
+}
+
+unsigned int
+dbg_send_bytes(const unsigned char *s, unsigned int len)
+{
+  unsigned int i = 0;
+  while(s && *s != 0) {
+    if(i >= len) {
+      break;
+    }
+    dbg_putchar(*s++);
+    i++;
+  }
+  return i;
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This adds support for using %zu in printf
on MSP430.