### PR TITLE
Make stack check boundary volatile to prevent optimization

### DIFF
--- a/os/sys/stack-check.c
+++ b/os/sys/stack-check.c
@@ -73,7 +73,8 @@ extern int _stack_origin;
 void
 stack_check_init(void)
 {
-  uint8_t *p;
+  /* Make this volatile to prevent the compiler from optimising the while loop */
+  volatile uint8_t *p;
 
   /* Make this static to avoid destroying it in the while loop */
   static void *stack_top;


### PR DESCRIPTION
The stack check init makes an assumption about the stack boundary by using the address of the local variable as a boundary. This assumption holds as long as no other local variable or function is executed within this function.

```c
void
stack_check_init(void)
{
  uint8_t *p;

  /* Make this static to avoid destroying it in the while loop */
  static void *stack_top;
  /* Use address of this local variable as a boundary */
  stack_top = &p;

  /* Note: this is expected to be called before the WDT is started! */
  p = &_stack;
  while(p < (uint8_t *)stack_top) {
    *p++ = STACK_FILL;
  }

#if STACK_CHECK_PERIODIC_CHECKS
  /* Start the periodic checker process */
  process_start(&stack_check_process, NULL);
#endif
}
```

That is not guaranteed, the compiler can replace the while loop with a messet and break the assumption.

```assembly
0000a428 <stack_check_init>:
    a428:	b500      	push	{lr}
    a42a:	4808      	ldr	r0, [pc, #32]	; (a44c <stack_check_init+0x24>)
    a42c:	b083      	sub	sp, #12
    a42e:	aa01      	add	r2, sp, #4
    a430:	4282      	cmp	r2, r0
    a432:	9001      	str	r0, [sp, #4]
    a434:	d903      	bls.n	a43e <stack_check_init+0x16>
    a436:	1a12      	subs	r2, r2, r0
    a438:	21cd      	movs	r1, #205	; 0xcd
    a43a:	f009 fe6d 	bl	14118 <memset>
    a43e:	4804      	ldr	r0, [pc, #16]	; (a450 <stack_check_init+0x28>)
    a440:	2100      	movs	r1, #0
    a442:	b003      	add	sp, #12
    a444:	f85d eb04 	ldr.w	lr, [sp], #4
    a448:	f7fa bf80 	b.w	534c <process_start>
    a44c:	20000000 	andcs	r0, r0, r0
    a450:	20001774 	andcs	r1, r0, r4, ror r7
```

This can be fixed by setting the local variable as volatile to prevent the compiler from optimising it.

```assembly
0000a428 <stack_check_init>:
    a428:	4b07      	ldr	r3, [pc, #28]	; (a448 <stack_check_init+0x20>)
    a42a:	b082      	sub	sp, #8
    a42c:	aa01      	add	r2, sp, #4
    a42e:	429a      	cmp	r2, r3
    a430:	9301      	str	r3, [sp, #4]
    a432:	d904      	bls.n	a43e <stack_check_init+0x16>
    a434:	21cd      	movs	r1, #205	; 0xcd
    a436:	f803 1b01 	strb.w	r1, [r3], #1
    a43a:	4293      	cmp	r3, r2
    a43c:	d1fb      	bne.n	a436 <stack_check_init+0xe>
    a43e:	4803      	ldr	r0, [pc, #12]	; (a44c <stack_check_init+0x24>)
    a440:	2100      	movs	r1, #0
    a442:	b002      	add	sp, #8
    a444:	f7fa bf82 	b.w	534c <process_start>
    a448:	20000000 	andcs	r0, r0, r0
    a44c:	20001774 	andcs	r1, r0, r4, ror r7
```

