### PR TITLE
zoul: fix return type of ab08_read_reg

### DIFF
--- a/arch/platform/zoul/dev/rtcc.c
+++ b/arch/platform/zoul/dev/rtcc.c
@@ -120,7 +120,7 @@ check_leap_year(uint8_t val)
   return ((val % 4) && (val % 100)) || (val % 400);
 }
 /*---------------------------------------------------------------------------*/
-static uint16_t
+static int8_t
 ab08_read_reg(uint8_t reg, uint8_t *buf, uint8_t regnum)
 {
   i2c_master_enable();


### PR DESCRIPTION
AB08_ERROR is defined as -1, so use a signed
type that can represent the value.