### PR TITLE
snmp: remove double typedef

### DIFF
--- a/os/net/app-layer/snmp/snmp-api.h
+++ b/os/net/app-layer/snmp/snmp-api.h
@@ -56,11 +56,6 @@
  */
 
 /**
- * @brief The MIB Resource struct
- */
-typedef struct snmp_mib_resource_s snmp_mib_resource_t;
-
-/**
  * @brief Initializes statically an oid with the "null" terminator
  *
  * @remarks This should be used inside handlers when declaring an oid


### PR DESCRIPTION
This is already typedefed in snmp-mib.h.