### PR TITLE
zoul: fix return type of grove_gyro_read_reg

### DIFF
--- a/arch/platform/zoul/dev/grove-gyro.c
+++ b/arch/platform/zoul/dev/grove-gyro.c
@@ -66,7 +66,7 @@ grove_gyro_values_t gyro_values;
 /*---------------------------------------------------------------------------*/
 void (*grove_gyro_int_callback)(uint8_t value);
 /*---------------------------------------------------------------------------*/
-static uint16_t
+static int
 grove_gyro_read_reg(uint8_t reg, uint8_t *buf, uint8_t num)
 {
   if((buf == NULL) || (num <= 0)) {


### PR DESCRIPTION
GROVE_GYRO_ERROR is defined as -1, so use a signed type that can represent the value.