### PR TITLE
CC2538: Eliminate magic number

### DIFF
--- a/arch/cpu/cc2538/cc2538-def.h
+++ b/arch/cpu/cc2538/cc2538-def.h
@@ -74,5 +74,15 @@
 #define GPIO_HAL_CONF_ARCH_SW_TOGGLE         1
 #define GPIO_HAL_CONF_PORT_PIN_NUMBERING     0
 /*---------------------------------------------------------------------------*/
+/**
+ * \name rtimer
+ *
+ * @{
+ */
+#ifndef RTIMER_CONF_GUARD_TIME
+#define RTIMER_CONF_GUARD_TIME (7)
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
 #endif /* CC2538_DEF_H_ */
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/cc2538/rtimer-arch.c
+++ b/arch/cpu/cc2538/rtimer-arch.c
@@ -77,8 +77,8 @@ rtimer_arch_schedule(rtimer_clock_t t)
    * New value must be 5 ticks in the future. The ST may tick once while we're
    * writing the registers. We play it safe here and we add a bit of leeway
    */
-  if((int32_t)(t - now) < 7) {
-    t = now + 7;
+  if(!RTIMER_CLOCK_LT(now, t - RTIMER_GUARD_TIME)) {
+    t = now + RTIMER_GUARD_TIME;
   }
 
   /* ST0 latches ST[1:3] and must be written last */


### PR DESCRIPTION
Currently, there is a magic number in the `rtimer_arch_schedule` implementation for CC2538 SoCs.