### PR TITLE
memb: Confine return type of memb_numfree

### DIFF
--- a/os/lib/memb.c
+++ b/os/lib/memb.c
@@ -104,11 +104,11 @@ memb_inmemb(struct memb *m, void *ptr)
     (char *)ptr < (char *)m->mem + (m->num * m->size);
 }
 /*---------------------------------------------------------------------------*/
-int
+size_t
 memb_numfree(struct memb *m)
 {
   int i;
-  int num_free = 0;
+  size_t num_free = 0;
 
   for(i = 0; i < m->num; ++i) {
     if(m->used[i] == false) {

--- a/os/lib/memb.h
+++ b/os/lib/memb.h
@@ -64,6 +64,7 @@
 #define MEMB_H_
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include "sys/cc.h"
 
 /**
@@ -147,7 +148,7 @@ int memb_inmemb(struct memb *m, void *ptr);
  *
  * \return the number of free (available) memory blocks
  */
-int  memb_numfree(struct memb *m);
+size_t memb_numfree(struct memb *m);
 
 /** @} */
 /** @} */

--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -302,7 +302,7 @@ free_packet(struct neighbor_queue *n, struct packet_queue *p, int status)
     queuebuf_free(p->buf);
     memb_free(&metadata_memb, p->ptr);
     memb_free(&packet_memb, p);
-    LOG_DBG("free_queued_packet, queue length %d, free packets %d\n",
+    LOG_DBG("free_queued_packet, queue length %d, free packets %zu\n",
            list_length(n->packet_queue), memb_numfree(&packet_memb));
     if(list_head(n->packet_queue) != NULL) {
       /* There is a next packet. We reset current tx information */
@@ -499,7 +499,7 @@ csma_output_packet(mac_callback_t sent, void *ptr)
 
             LOG_INFO("sending to ");
             LOG_INFO_LLADDR(addr);
-            LOG_INFO_(", len %u, seqno %u, queue length %d, free packets %d\n",
+            LOG_INFO_(", len %u, seqno %u, queue length %d, free packets %zu\n",
                     packetbuf_datalen(),
                     packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO),
                     list_length(n->packet_queue), memb_numfree(&packet_memb));

--- a/os/net/queuebuf.c
+++ b/os/net/queuebuf.c
@@ -294,7 +294,7 @@ queuebuf_init(void)
 #endif /* QUEUEBUF_STATS */
 }
 /*---------------------------------------------------------------------------*/
-int
+size_t
 queuebuf_numfree(void)
 {
   return memb_numfree(&bufmem);

--- a/os/net/queuebuf.h
+++ b/os/net/queuebuf.h
@@ -54,6 +54,7 @@
 #define QUEUEBUF_H_
 
 #include "net/packetbuf.h"
+#include <stdlib.h>
 
 #ifdef QUEUEBUF_CONF_ENABLED
 #define QUEUEBUF_ENABLED QUEUEBUF_CONF_ENABLED
@@ -115,7 +116,7 @@ packetbuf_attr_t queuebuf_attr(struct queuebuf *b, uint8_t type);
 
 void queuebuf_debug_print(void);
 
-int queuebuf_numfree(void);
+size_t queuebuf_numfree(void);
 
 #endif /* __QUEUEBUF_H__ */
 


### PR DESCRIPTION
Presently, the function `memb_numfree` returns `int`, suggesting that an error might occur. However, this function cannot fail and, in the code base, nobody is checking for errors anyway. Therefore, this PR changes the return type to `size_t`.