### PR TITLE
Makefile: enable Cooja to change BUILD_DIR

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -69,7 +69,7 @@ COOJA_PATH ?= $(CONTIKI_NG_TOOLS_DIR)/cooja
 JAVA = java
 GRADLE = $(COOJA_PATH)/gradlew
 
-BUILD_DIR = build
+BUILD_DIR ?= build
 BUILD_DIR_TARGET = $(BUILD_DIR)/$(TARGET)
 BUILD_DIR_TARGET_BOARD = $(BUILD_DIR_TARGET)/$(BOARD)
 # If BOARD was empty, make sure we don't end up with a sequence of slashes


### PR DESCRIPTION
Allow Cooja to select a different BUILD_DIR
through environment variables.

This is a way to ensure that the CI tests
work without requiring "make clean" in every
csc file.