### PR TITLE
nrf: make linkaddr-arch.c build with TrustZone

### DIFF
--- a/arch/cpu/nrf/sys/linkaddr-arch.c
+++ b/arch/cpu/nrf/sys/linkaddr-arch.c
@@ -73,8 +73,16 @@ populate_link_address(void)
   device_address[0] = (NORDIC_SEMI_VENDOR_OUI) >> 16 & 0xFF;
   device_address[1] = (NORDIC_SEMI_VENDOR_OUI) >> 8 & 0xFF;
   device_address[2] = NORDIC_SEMI_VENDOR_OUI & 0xFF;
+#if defined(NRF_FICR)
   device_address[3] = nrf_ficr_deviceid_get(NRF_FICR, 1) & 0xFF;
   device_address_low = nrf_ficr_deviceid_get(NRF_FICR, 0);
+#elif defined(NRF_FICR_S)
+  /* Secure TrustZone builds are handled by the previous branch, this
+   * branch puts in a dummy value for the non-secure TrustZone builds
+   * since NRF_FICR is not available. */
+  device_address[3] = 0;
+  device_address_low = 0;
+#endif
 
   memcpy(&device_address[4], &device_address_low, sizeof(device_address_low));
 


### PR DESCRIPTION
NRF_FICR is not available in non-secure mode when
building with TrustZone, so use a dummy address
for the non-secure TrustZone build for now.

This restores the behavior for non-secure TrustZone builds to how it was before commit 7d62acf0ee287.