### PR TITLE
Ip64 bounds checks

### DIFF
--- a/os/services/ip64/ip64-dns64.c
+++ b/os/services/ip64/ip64-dns64.c
@@ -195,6 +195,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       LOG_WARN("ip64_dns64_6to4: packet ended while parsing\n");
       return ipv6datalen;
     }
+    /* TODO (functionality): Should replace q[DNS_QUESTION_TYPE1] == DNS_TYPE_A ? */
     if(q[DNS_QUESTION_CLASS0] == 0 && q[DNS_QUESTION_CLASS1] == DNS_CLASS_IN &&
        q[DNS_QUESTION_TYPE0] == 0 && q[DNS_QUESTION_TYPE1] == DNS_TYPE_AAAA) {
       q[DNS_QUESTION_TYPE1] = DNS_TYPE_AAAA;
@@ -236,6 +237,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
           return ipv6datalen;
         }
         n = *adata;
+        /* TODO (functionality): should copy length field n to acopy? */
         adata++;
         acopy++;
 

--- a/os/services/ip64/ip64-dns64.c
+++ b/os/services/ip64/ip64-dns64.c
@@ -155,6 +155,11 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
   uint8_t *q;
   struct dns_hdr *hdr;
 
+  if(ipv4datalen < sizeof(struct dns_hdr)) {
+    LOG_WARN("ip64_dns64_4to6: packet ended while parsing header (in)\n");
+    return ipv6datalen;
+  }
+
   hdr = (struct dns_hdr *)ipv4data;
   LOG_DBG("dns64_4to6 id: %02x%02x\n", hdr->id[0], hdr->id[1]);
   LOG_DBG("dns64_4to6 flags1: 0x%02x\n", hdr->flags1);
@@ -174,19 +179,22 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
   qcopy = ipv6data + sizeof(struct dns_hdr);
   for(i = 0; i < ((hdr->numquestions[0] << 8) + hdr->numquestions[1]); i++) {
     do {
+      if(qdata >= ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
       qlen = *qdata;
       qdata++;
       qcopy++;
-      for(j = 0; j < qlen; j++) {
-        qdata++;
-        qcopy++;
-        if(qdata > ipv4data + ipv4datalen) {
-          LOG_WARN("dns64_4to6: packet ended while parsing\n");
-          return ipv6datalen;
-        }
-      }
+      qdata += qlen;
+      qcopy += qlen;
     } while(qlen != 0);
+
     q = qcopy;
+    if(q + DNS_QUESTION_SIZE > ipv6data + ipv6datalen) {
+      LOG_WARN("ip64_dns64_6to4: packet ended while parsing\n");
+      return ipv6datalen;
+    }
     if(q[DNS_QUESTION_CLASS0] == 0 && q[DNS_QUESTION_CLASS1] == DNS_CLASS_IN &&
        q[DNS_QUESTION_TYPE0] == 0 && q[DNS_QUESTION_TYPE1] == DNS_TYPE_AAAA) {
       q[DNS_QUESTION_TYPE1] = DNS_TYPE_AAAA;
@@ -201,25 +209,60 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
   /* Go through the answers section and update the answers. */
   for(i = 0; i < ((hdr->numanswers[0] << 8) + hdr->numanswers[1]); i++) {
+    if(adata >= ipv4data + ipv4datalen) {
+      LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+      return ipv6datalen;
+    }
 
     n = *adata;
     if(n & 0xc0) {
       /* Short-hand name format: 2 bytes */
+      if(adata + 2 > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+      if(acopy + 2 > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
+
       *acopy++ = *adata++;
       *acopy++ = *adata++;
     } else {
       /* Name spelled out */
       do {
+        if(adata >= ipv4data + ipv4datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+          return ipv6datalen;
+        }
         n = *adata;
         adata++;
         acopy++;
+
+        if(adata + n > ipv4data + ipv4datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+          return ipv6datalen;
+        }
+        if(acopy + n > ipv6data + ipv6datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+          return ipv6datalen;
+        }
+
         for(j = 0; j < n; j++) {
           *acopy++ = *adata++;
         }
       } while(n != 0);
     }
 
+    if(adata + 2 > ipv4data + ipv4datalen) {
+      LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+      return ipv6datalen;
+    }
     if(adata[0] == 0 && adata[1] == DNS_TYPE_A) {
+      if(acopy + 2 > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
       /* Update the type field from A to AAAA */
       *acopy = *adata;
       acopy++;
@@ -230,6 +273,16 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
       /* Get the length of the address record. Should be 4. */
       lenptr = &acopy[6];
+
+      if(adata + 2 + 4 + 2 > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+      if(acopy + 2 + 4 + 2 > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
+
       len = (adata[6] << 8) + adata[7];
 
       /* Copy the class, the TTL, and the data length */
@@ -237,8 +290,18 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       acopy += 8;
       adata += 8;
 
+      if(adata + len > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+
       if(len == 4) {
         uip_ip4addr_t addr;
+
+        if(acopy + sizeof(uip_ip6addr_t) > ipv6data + ipv6datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+          return ipv6datalen;
+        }
         uip_ipaddr(&addr, adata[0], adata[1], adata[2], adata[3]);
         ip64_addr_4to6(&addr, (uip_ip6addr_t *)acopy);
 
@@ -249,11 +312,24 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
         ipv6datalen += 12;
 
       } else {
+        if(acopy + len > ipv6data + ipv6datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+          return ipv6datalen;
+        }
         memcpy(acopy, adata, len);
         acopy += len;
         adata += len;
       }
     } else {
+      if(adata + 2 + 2 + 4 + 2 > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+      if(acopy + 2 + 2 + 4 + 2 > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
+
       len = (adata[8] << 8) + adata[9];
 
       /* Copy the type, class, the TTL, and the data length */
@@ -261,6 +337,14 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       acopy += 10;
       adata += 10;
 
+      if(adata + len > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+      if(acopy + len > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
       /* Copy the data */
       memcpy(acopy, adata, len);
       acopy += len;


### PR DESCRIPTION
I added bounds checks to the DNS parsing of ip64.

I opted for leaving the current logic as it is and for inserting checks which are easy to understand and verify manually.

For two potential functional issues I added comments in a separate commit (marked with `TODO (functionality)`):
1. One update of the DNS type between `DNS_TYPE_AAAA` <-> `DNS_TYPE_A` seems to be a NO-OP right now. This may have originally been a copy-paste issue.
2. A missing copy of the size field of DNS names

I did not apply the functional changes as I do not know whether anyone relied on the respective behavior.