### PR TITLE
CI: rename cooja cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
           tools/cooja/build
           tools/cooja/.gradle
           tools/cooja/.gradle_home
-        key: ${{ runner.os }}-cooja-gradle-deps-${{ env.COOJA_COMMIT }}
+        key: cooja-${{ runner.os }}-gradle-deps-${{ env.COOJA_COMMIT }}
 
     # Fire up the container and run corresponding tests
     - name: Execute tests


### PR DESCRIPTION
This makes it possible to find the cache
by searching for cooja in the cache information
webinterface.