### PR TITLE
Replace int with bool in comparisons of link layer addresses

### DIFF
--- a/os/net/linkaddr.c
+++ b/os/net/linkaddr.c
@@ -65,7 +65,7 @@ linkaddr_copy(linkaddr_t *dest, const linkaddr_t *src)
 	memcpy(dest, src, LINKADDR_SIZE);
 }
 /*---------------------------------------------------------------------------*/
-int
+bool
 linkaddr_cmp(const linkaddr_t *addr1, const linkaddr_t *addr2)
 {
 	return (memcmp(addr1, addr2, LINKADDR_SIZE) == 0);

--- a/os/net/linkaddr.h
+++ b/os/net/linkaddr.h
@@ -85,15 +85,9 @@ void linkaddr_copy(linkaddr_t *dest, const linkaddr_t *from);
  * \brief      Compare two link-layer addresses
  * \param addr1 The first address
  * \param addr2 The second address
- * \return     Non-zero if the addresses are the same, zero if they are different
- *
- *             This function compares two link-layer addresses and returns
- *             the result of the comparison. The function acts like
- *             the '==' operator and returns non-zero if the addresses
- *             are the same, and zero if the addresses are different.
- *
+ * \return     True if the addresses are the same, false if they are different
  */
-int linkaddr_cmp(const linkaddr_t *addr1, const linkaddr_t *addr2);
+bool linkaddr_cmp(const linkaddr_t *addr1, const linkaddr_t *addr2);
 
 
 /**

--- a/os/net/mac/framer/frame802154.c
+++ b/os/net/mac/framer/frame802154.c
@@ -221,16 +221,16 @@ frame802154_check_dest_panid(frame802154_t *frame)
 }
 /*---------------------------------------------------------------------------*/
 /* Check is the address is a broadcast address, whatever its size */
-int
+bool
 frame802154_is_broadcast_addr(uint8_t mode, const uint8_t *addr)
 {
   int i = mode == FRAME802154_SHORTADDRMODE ? 2 : 8;
   while(i-- > 0) {
     if(addr[i] != 0xff) {
-      return 0;
+      return false;
     }
   }
-  return 1;
+  return true;
 }
 /*---------------------------------------------------------------------------*/
 /* Check and extract source and destination linkaddr from frame */

--- a/os/net/mac/framer/frame802154.h
+++ b/os/net/mac/framer/frame802154.h
@@ -67,6 +67,7 @@
 
 #include "contiki.h"
 #include "net/linkaddr.h"
+#include <stdbool.h>
 
 #ifdef IEEE802154_CONF_PANID
 #define IEEE802154_PANID           IEEE802154_CONF_PANID
@@ -228,7 +229,7 @@ void frame802154_has_panid(frame802154_fcf_t *fcf, int *has_src_pan_id, int *has
 /* Check if the destination PAN ID, if any, matches ours */
 int frame802154_check_dest_panid(frame802154_t *frame);
 /* Check is the address is a broadcast address, whatever its size */
-int frame802154_is_broadcast_addr(uint8_t mode, const uint8_t *addr);
+bool frame802154_is_broadcast_addr(uint8_t mode, const uint8_t *addr);
 /* Check and extract source and destination linkaddr from frame */
 int frame802154_extract_linkaddr(frame802154_t *frame, linkaddr_t *source_address, linkaddr_t *dest_address);
 

--- a/os/net/packetbuf.c
+++ b/os/net/packetbuf.c
@@ -227,7 +227,7 @@ packetbuf_addr(uint8_t type)
   return &packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr;
 }
 /*---------------------------------------------------------------------------*/
-int
+bool
 packetbuf_holds_broadcast(void)
 {
   return linkaddr_cmp(&packetbuf_addrs[PACKETBUF_ADDR_RECEIVER - PACKETBUF_ADDR_FIRST].addr, &linkaddr_null);

--- a/os/net/packetbuf.h
+++ b/os/net/packetbuf.h
@@ -265,10 +265,10 @@ int               packetbuf_set_addr(uint8_t type, const linkaddr_t *addr);
 const linkaddr_t *packetbuf_addr(uint8_t type);
 
 /**
- * \brief      Checks whether the current packet is a broadcast.
- * \retval 0   iff current packet is not a broadcast
+ * \brief       Checks whether the current packet is a broadcast.
+ * \retval true iff the current packet is a broadcast
  */
-int               packetbuf_holds_broadcast(void);
+bool              packetbuf_holds_broadcast(void);
 
 void              packetbuf_attr_clear(void);
 


### PR DESCRIPTION
Small improvement to use the bool datatype in comparisons of link layer addresses.