### PR TITLE
cc2538-rf: Simplification

### DIFF
--- a/arch/cpu/cc2538/dev/cc2538-rf.c
+++ b/arch/cpu/cc2538/dev/cc2538-rf.c
@@ -1113,8 +1113,7 @@ PROCESS_THREAD(cc2538_rf_process, ev, data)
   PROCESS_BEGIN();
 
   while(1) {
-    /* Only if we are not in poll mode oder we are in poll mode and transceiver has to be reset */
-    PROCESS_YIELD_UNTIL((!poll_mode || (poll_mode && (rf_flags & RF_MUST_RESET))) && (ev == PROCESS_EVENT_POLL));
+    PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
 
     if(!poll_mode) {
       packetbuf_clear();


### PR DESCRIPTION
This PR removes redundant conditions from a `PROCESS_YIELD_UNTIL` in `cc2538-rf.c`.