### PR TITLE
Prefer OS random_rand() over rand()

### DIFF
--- a/os/net/app-layer/coap/coap-transactions.c
+++ b/os/net/app-layer/coap/coap-transactions.c
@@ -46,6 +46,7 @@
 #include "coap-timer.h"
 #include "lib/memb.h"
 #include "lib/list.h"
+#include "lib/random.h"
 #include <stdlib.h>
 
 /* Log configuration */
@@ -109,7 +110,7 @@ coap_send_transaction(coap_transaction_t *t)
         coap_timer_set_callback(&t->retrans_timer, coap_retransmit_transaction);
         coap_timer_set_user_data(&t->retrans_timer, t);
         t->retrans_interval =
-          COAP_RESPONSE_TIMEOUT_TICKS + (rand() %
+          COAP_RESPONSE_TIMEOUT_TICKS + (random_rand() %
                                          COAP_RESPONSE_TIMEOUT_BACKOFF_MASK);
         LOG_DBG("Initial interval %lu msec\n",
                 (unsigned long)t->retrans_interval);


### PR DESCRIPTION
As in title, I only found one such occurrence.

H/T https://www.thingsquare.com/blog/articles/rand-may-call-malloc/ by @adamdunkels. 
Note I was unable to reproduce the described issue with cc13x0-cc26x0 and the coap-examples.

