### PR TITLE
cooja: allow building outside Cooja

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -556,6 +556,12 @@ ifndef LD
   LD = $(CC)
 endif
 
+# Force re-linking when LIBNAME is set. This ensures Cooja will always
+# get a fresh binary, even when user has run make manually in their shell.
+ifdef LIBNAME
+  INTERNAL_DEPS += FORCE
+endif
+
 ifndef CUSTOM_RULE_LINK
 # Targets can define LD_START_GROUP and LD_END_GROUP to resolve circular
 # dependencies between linked libraries, see:
@@ -571,9 +577,9 @@ TARGET_LIBEXTRAS = $(LD_START_GROUP) $(TARGET_LIBFILES) $(LD_END_GROUP)
 # a compatibility line for link rule so we can have a single rule that
 # outputs to LIBNAME on all platforms.
 $(BUILD_DIR_BOARD)/%.$(TARGET): LIBNAME ?= $@
-$(BUILD_DIR_BOARD)/%.$(TARGET): $(OBJECTDIR)/%.o $(LDSCRIPT) $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(CONTIKI_OBJECTFILES)
+$(BUILD_DIR_BOARD)/%.$(TARGET): $(OBJECTDIR)/%.o $(LDSCRIPT) $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) $(CONTIKI_OBJECTFILES) $(INTERNAL_DEPS)
 	$(TRACE_LD)
-	$(Q)$(LD) $(LDFLAGS) $(TARGET_STARTFILES) $(sort ${filter-out $(LDSCRIPT) %.a,$^}) ${filter %.a,$^} $(TARGET_LIBEXTRAS) -o $(LIBNAME)
+	$(Q)$(LD) $(LDFLAGS) $(TARGET_STARTFILES) $(sort ${filter-out FORCE $(LDSCRIPT) %.a,$^}) ${filter %.a,$^} $(TARGET_LIBEXTRAS) -o $(LIBNAME)
 ifdef BINARY_SIZE_LOGFILE
 	$(Q)$(SIZE) $(LIBNAME) | grep $(BUILD_DIR_BOARD) >> $(BINARY_SIZE_LOGFILE)
 endif

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -1,10 +1,3 @@
-## The COOJA Simulator Contiki platform Makefile
-##
-## This makefile should normally never be called directly, but
-## rather from inside the COOJA simulator.
-## The purpose of this file is to compile a shared library that
-## can be loaded into the Java part of COOJA.
-
 EXPECTED_COOJA_VERSION = 2022071901
 
 ifndef CONTIKI
@@ -13,17 +6,11 @@ endif
 
 # Detect incompatible Cooja versions when not performing "make clean".
 ifneq ($(MAKECMDGOALS),clean)
-  ifndef LIBNAME
-    $(warning Cooja target should be built by Cooja)
-    $(error Use TARGET=native for quickstarting a .csc simulation file)
-  endif
-
-  ifndef COOJA_VERSION
-    $(error COOJA_VERSION not defined, please upgrade Cooja)
-  endif
-
-  ifneq ($(COOJA_VERSION),$(EXPECTED_COOJA_VERSION))
-    $(error Got COOJA_VERSION $(COOJA_VERSION) but expected $(EXPECTED_COOJA_VERSION))
+  # If LIBNAME is set, build is done under Cooja.
+  ifdef LIBNAME
+    ifneq ($(COOJA_VERSION),$(EXPECTED_COOJA_VERSION))
+      $(error Got COOJA_VERSION $(COOJA_VERSION) but expected $(EXPECTED_COOJA_VERSION))
+    endif
   endif
 
   ifneq ($(BOARD),)


### PR DESCRIPTION
Removing JNI removed many failure cases from
the build system, so it is now safe to build
binaries targeting Cooja from the shell.
The binaries built from the shell are named
in the same way that they are for other targets.
Cooja will not use these libraries though,
and instead generate a random name that has
not previously been used.