### PR TITLE
mac-sequence: Set destination sequence number (DSN) in mac-sequence.c

### DIFF
--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -41,6 +41,7 @@
 
 #include "net/mac/csma/csma.h"
 #include "net/mac/csma/csma-security.h"
+#include "net/mac/mac-sequence.h"
 #include "net/packetbuf.h"
 #include "net/queuebuf.h"
 #include "dev/watchdog.h"
@@ -442,22 +443,9 @@ csma_output_packet(mac_callback_t sent, void *ptr)
 {
   struct packet_queue *q;
   struct neighbor_queue *n;
-  static uint8_t initialized = 0;
-  static uint8_t seqno;
   const linkaddr_t *addr = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
 
-  if(!initialized) {
-    initialized = 1;
-    /* Initialize the sequence number to a random value as per 802.15.4. */
-    seqno = random_rand();
-  }
-
-  if(seqno == 0) {
-    /* PACKETBUF_ATTR_MAC_SEQNO cannot be zero, due to a pecuilarity
-       in framer-802154.c. */
-    seqno++;
-  }
-  packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, seqno++);
+  mac_sequence_set_dsn();
   packetbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_DATAFRAME);
 
   /* Look for the neighbor entry */

--- a/os/net/mac/csma/csma.c
+++ b/os/net/mac/csma/csma.c
@@ -158,6 +158,7 @@ init(void)
   }
 #endif
 
+  mac_sequence_init();
 
 #if LLSEC802154_USES_AUX_HEADER
 #ifdef CSMA_LLSEC_DEFAULT_KEY0

--- a/os/net/mac/framer/framer-802154.c
+++ b/os/net/mac/framer/framer-802154.c
@@ -47,14 +47,6 @@
 #define LOG_MODULE "Frame 15.4"
 #define LOG_LEVEL LOG_LEVEL_FRAMER
 
-/**  \brief The sequence number (0x00 - 0xff) added to the transmitted
- *   data or MAC command frame. The default is a random value within
- *   the range.
- */
-static uint8_t mac_dsn;
-
-static uint8_t initialized = 0;
-
 /*---------------------------------------------------------------------------*/
 static int
 create_frame(int do_create)
@@ -68,26 +60,6 @@ create_frame(int do_create)
 
   /* init to zeros */
   memset(&params, 0, sizeof(params));
-
-  if(!initialized) {
-    initialized = 1;
-    mac_dsn = random_rand() & 0xff;
-  }
-
-  /*
-   * Before setting up "params", make sure we won't use 0 as the sequence number
-   * of a newly created frame.
-   *
-   * The case when do_create is 0 is ignored since it's for only length
-   * calculation. No sequence number is needed and should not be consumed.
-   */
-  if(do_create != 0 && packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO) == 0) {
-    if(mac_dsn == 0) {
-      mac_dsn++;
-    }
-    packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, mac_dsn);
-    mac_dsn++;
-  }
 
   framer_802154_setup_params(packetbuf_attr, packetbuf_holds_broadcast(),
                              &params);

--- a/os/net/mac/mac-sequence.c
+++ b/os/net/mac/mac-sequence.c
@@ -45,6 +45,7 @@
 #include <string.h>
 
 #include "contiki-net.h"
+#include "lib/random.h"
 #include "net/mac/mac-sequence.h"
 #include "net/packetbuf.h"
 
@@ -67,6 +68,20 @@ struct seqno {
 #endif /* NETSTACK_CONF_MAC_SEQNO_HISTORY */
 static struct seqno received_seqnos[MAX_SEQNOS];
 
+static uint8_t mac_dsn;
+
+/*---------------------------------------------------------------------------*/
+void
+mac_sequence_init(void)
+{
+  mac_dsn = random_rand();
+}
+/*---------------------------------------------------------------------------*/
+void
+mac_sequence_set_dsn(void)
+{
+  packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, mac_dsn++);
+}
 /*---------------------------------------------------------------------------*/
 int
 mac_sequence_is_duplicate(void)

--- a/os/net/mac/mac-sequence.h
+++ b/os/net/mac/mac-sequence.h
@@ -46,6 +46,16 @@
 #define MAC_SEQUENCE_H
 
 /**
+ * brief       Initializes the destination sequence number to a random value.
+ */
+void mac_sequence_init(void);
+
+/**
+ * \brief      Sets and increments the destination sequence number.
+ */
+void mac_sequence_set_dsn(void);
+
+/**
  * \brief      Tell whether the packetbuf is a duplicate packet
  * \return     Non-zero if the packetbuf is a duplicate packet, zero otherwise
  *

--- a/os/services/rpl-border-router/native/border-router-mac.c
+++ b/os/services/rpl-border-router/native/border-router-mac.c
@@ -40,6 +40,7 @@
 #include "net/packetbuf.h"
 #include "net/queuebuf.h"
 #include "net/netstack.h"
+#include "net/mac/mac-sequence.h"
 #include "packetutils.h"
 #include "border-router.h"
 #include <string.h>
@@ -126,6 +127,9 @@ send_packet(mac_callback_t sent, void *ptr)
   /* Will make it send only DATA packets... for now */
   packetbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_DATAFRAME);
 
+  /* set destination sequence number */
+  mac_sequence_set_dsn();
+
   LOG_INFO("sending packet (%u bytes)\n", packetbuf_datalen());
 
   if(NETSTACK_FRAMER.create() < 0) {
@@ -189,6 +193,7 @@ static void
 init(void)
 {
   callback_pos = 0;
+  mac_sequence_init();
 }
 /*---------------------------------------------------------------------------*/
 const struct mac_driver border_router_mac_driver = {


### PR DESCRIPTION
The motivation behind this PR is to eliminate duplicate code and to avoid special handling for DSN=0.