### PR TITLE
mac-sequence: Fix vulnerability

### DIFF
--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -41,6 +41,7 @@
 
 #include "net/mac/csma/csma.h"
 #include "net/mac/csma/csma-security.h"
+#include "net/mac/mac-sequence.h"
 #include "net/packetbuf.h"
 #include "net/queuebuf.h"
 #include "dev/watchdog.h"
@@ -442,22 +443,9 @@ csma_output_packet(mac_callback_t sent, void *ptr)
 {
   struct packet_queue *q;
   struct neighbor_queue *n;
-  static uint8_t initialized = 0;
-  static uint8_t seqno;
   const linkaddr_t *addr = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
 
-  if(!initialized) {
-    initialized = 1;
-    /* Initialize the sequence number to a random value as per 802.15.4. */
-    seqno = random_rand();
-  }
-
-  if(seqno == 0) {
-    /* PACKETBUF_ATTR_MAC_SEQNO cannot be zero, due to a pecuilarity
-       in framer-802154.c. */
-    seqno++;
-  }
-  packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, seqno++);
+  mac_sequence_set_dsn();
   packetbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_DATAFRAME);
 
   /* Look for the neighbor entry */

--- a/os/net/mac/csma/csma.c
+++ b/os/net/mac/csma/csma.c
@@ -158,6 +158,7 @@ init(void)
   }
 #endif
 
+  mac_sequence_init();
 
 #if LLSEC802154_USES_AUX_HEADER
 #ifdef CSMA_LLSEC_DEFAULT_KEY0

--- a/os/net/mac/csma/csma.c
+++ b/os/net/mac/csma/csma.c
@@ -99,8 +99,6 @@ input_packet(void)
       LOG_WARN("drop duplicate link layer packet from ");
       LOG_WARN_LLADDR(packetbuf_addr(PACKETBUF_ADDR_SENDER));
       LOG_WARN_(", seqno %u\n", packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO));
-    } else {
-      mac_sequence_register_seqno();
     }
 
 #if CSMA_SEND_SOFT_ACK

--- a/os/net/mac/framer/framer-802154.c
+++ b/os/net/mac/framer/framer-802154.c
@@ -47,14 +47,6 @@
 #define LOG_MODULE "Frame 15.4"
 #define LOG_LEVEL LOG_LEVEL_FRAMER
 
-/**  \brief The sequence number (0x00 - 0xff) added to the transmitted
- *   data or MAC command frame. The default is a random value within
- *   the range.
- */
-static uint8_t mac_dsn;
-
-static uint8_t initialized = 0;
-
 /*---------------------------------------------------------------------------*/
 static int
 create_frame(int do_create)
@@ -68,26 +60,6 @@ create_frame(int do_create)
 
   /* init to zeros */
   memset(&params, 0, sizeof(params));
-
-  if(!initialized) {
-    initialized = 1;
-    mac_dsn = random_rand() & 0xff;
-  }
-
-  /*
-   * Before setting up "params", make sure we won't use 0 as the sequence number
-   * of a newly created frame.
-   *
-   * The case when do_create is 0 is ignored since it's for only length
-   * calculation. No sequence number is needed and should not be consumed.
-   */
-  if(do_create != 0 && packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO) == 0) {
-    if(mac_dsn == 0) {
-      mac_dsn++;
-    }
-    packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, mac_dsn);
-    mac_dsn++;
-  }
 
   framer_802154_setup_params(packetbuf_attr, packetbuf_holds_broadcast(),
                              &params);

--- a/os/net/mac/mac-sequence.c
+++ b/os/net/mac/mac-sequence.c
@@ -45,6 +45,7 @@
 #include <string.h>
 
 #include "contiki-net.h"
+#include "lib/random.h"
 #include "net/mac/mac-sequence.h"
 #include "net/packetbuf.h"
 
@@ -67,6 +68,20 @@ struct seqno {
 #endif /* NETSTACK_CONF_MAC_SEQNO_HISTORY */
 static struct seqno received_seqnos[MAX_SEQNOS];
 
+static uint8_t mac_dsn;
+
+/*---------------------------------------------------------------------------*/
+void
+mac_sequence_init(void)
+{
+  mac_dsn = random_rand();
+}
+/*---------------------------------------------------------------------------*/
+void
+mac_sequence_set_dsn(void)
+{
+  packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, mac_dsn++);
+}
 /*---------------------------------------------------------------------------*/
 int
 mac_sequence_is_duplicate(void)

--- a/os/net/mac/mac-sequence.c
+++ b/os/net/mac/mac-sequence.c
@@ -55,6 +55,8 @@ struct seqno {
   uint8_t seqno;
 };
 
+static void mac_sequence_register_seqno(void);
+
 #ifdef NETSTACK_CONF_MAC_SEQNO_MAX_AGE
 #define SEQNO_MAX_AGE NETSTACK_CONF_MAC_SEQNO_MAX_AGE
 #else /* NETSTACK_CONF_MAC_SEQNO_MAX_AGE */
@@ -109,10 +111,11 @@ mac_sequence_is_duplicate(void)
       break;
     }
   }
+  mac_sequence_register_seqno();
   return 0;
 }
 /*---------------------------------------------------------------------------*/
-void
+static void
 mac_sequence_register_seqno(void)
 {
   int i, j;

--- a/os/net/mac/mac-sequence.h
+++ b/os/net/mac/mac-sequence.h
@@ -65,12 +65,4 @@ void mac_sequence_set_dsn(void);
  */
 int mac_sequence_is_duplicate(void);
 
-/**
- * \brief      Register the sequence number of the packetbuf
- *
- *             This function is used to add the sequence number of the incoming
- *             packet to the history.
- */
-void mac_sequence_register_seqno(void);
-
 #endif /* MAC_SEQUENCE_H */

--- a/os/net/mac/mac-sequence.h
+++ b/os/net/mac/mac-sequence.h
@@ -45,6 +45,12 @@
 #ifndef MAC_SEQUENCE_H
 #define MAC_SEQUENCE_H
 
+enum mac_sequence_result {
+  MAC_SEQUENCE_NO_DUPLICATE = 0,
+  MAC_SEQUENCE_DUPLICATE,
+  MAC_SEQUENCE_ERROR,
+};
+
 /**
  * brief       Initializes.
  */
@@ -56,13 +62,14 @@ void mac_sequence_init(void);
 void mac_sequence_set_dsn(void);
 
 /**
- * \brief      Tell whether the packetbuf is a duplicate packet
- * \return     Non-zero if the packetbuf is a duplicate packet, zero otherwise
+ * \brief      Detects duplicates and updates deduplication data in one go.
  *
- *             This function is used to check for duplicate packet by comparing
- *             the sequence number of the incoming packet with the last few ones
- *             we saw, filtering with the link-layer address.
+ *             This function detects duplicate frames by comparing the
+ *             sequence number of the incoming unicast or broadcast frame
+ *             with that of the last unicast or broadcast frame from the
+ *             sender, respectively. The internal deduplication data is
+ *             updated when the incoming frame turns out to be no duplicate.
  */
-int mac_sequence_is_duplicate(void);
+enum mac_sequence_result mac_sequence_is_duplicate(void);
 
 #endif /* MAC_SEQUENCE_H */

--- a/os/net/mac/mac-sequence.h
+++ b/os/net/mac/mac-sequence.h
@@ -46,6 +46,16 @@
 #define MAC_SEQUENCE_H
 
 /**
+ * brief       Initializes.
+ */
+void mac_sequence_init(void);
+
+/**
+ * \brief      Sets and increments the destination sequence number.
+ */
+void mac_sequence_set_dsn(void);
+
+/**
  * \brief      Tell whether the packetbuf is a duplicate packet
  * \return     Non-zero if the packetbuf is a duplicate packet, zero otherwise
  *

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -1185,8 +1185,6 @@ packet_input(void)
         LOG_WARN("! drop dup ll from ");
         LOG_WARN_LLADDR(packetbuf_addr(PACKETBUF_ADDR_SENDER));
         LOG_WARN_(" seqno %u\n", packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO));
-      } else {
-        mac_sequence_register_seqno();
       }
     }
 

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -127,8 +127,6 @@ struct tsch_asn_t tsch_current_asn;
 /* Device rank or join priority:
  * For PAN coordinator: 0 -- lower is better */
 uint8_t tsch_join_priority;
-/* The current TSCH sequence number, used for unicast data frames only */
-static uint8_t tsch_packet_seqno;
 /* Current period for EB output */
 static clock_time_t tsch_current_eb_period;
 /* Current period for keepalive output */
@@ -1063,7 +1061,7 @@ tsch_init(void)
   ringbufindex_init(&input_ringbuf, TSCH_MAX_INCOMING_PACKETS);
   ringbufindex_init(&dequeued_ringbuf, TSCH_DEQUEUED_ARRAY_SIZE);
 
-  tsch_packet_seqno = random_rand();
+  mac_sequence_init();
   tsch_is_initialized = 1;
 
 #if TSCH_AUTOSTART
@@ -1102,12 +1100,7 @@ send_packet(mac_callback_t sent, void *ptr)
 
   /* Ask for ACK if we are sending anything other than broadcast */
   if(!linkaddr_cmp(addr, &linkaddr_null)) {
-    /* PACKETBUF_ATTR_MAC_SEQNO cannot be zero, due to a pecuilarity
-           in framer-802154.c. */
-    if(++tsch_packet_seqno == 0) {
-      tsch_packet_seqno++;
-    }
-    packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, tsch_packet_seqno);
+    mac_sequence_set_dsn();
     packetbuf_set_attr(PACKETBUF_ATTR_MAC_ACK, 1);
   } else {
     /* Broadcast packets shall be added to broadcast queue
@@ -1150,7 +1143,8 @@ send_packet(mac_callback_t sent, void *ptr)
       LOG_ERR("! can't send packet to ");
       LOG_ERR_LLADDR(addr);
       LOG_ERR_(" with seqno %u, queue %u/%u %u/%u\n",
-          tsch_packet_seqno, tsch_queue_nbr_packet_count(n),
+          packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO),
+          tsch_queue_nbr_packet_count(n),
           TSCH_QUEUE_NUM_PER_NEIGHBOR, tsch_queue_global_packet_count(),
           QUEUEBUF_NUM);
       ret = MAC_TX_QUEUE_FULL;
@@ -1159,7 +1153,8 @@ send_packet(mac_callback_t sent, void *ptr)
       LOG_INFO("send packet to ");
       LOG_INFO_LLADDR(addr);
       LOG_INFO_(" with seqno %u, queue %u/%u %u/%u, len %u %u\n",
-             tsch_packet_seqno, tsch_queue_nbr_packet_count(n),
+             packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO),
+             tsch_queue_nbr_packet_count(n),
              TSCH_QUEUE_NUM_PER_NEIGHBOR, tsch_queue_global_packet_count(),
              QUEUEBUF_NUM, p->header_len, queuebuf_datalen(p->qb));
     }

--- a/os/services/rpl-border-router/native/border-router-mac.c
+++ b/os/services/rpl-border-router/native/border-router-mac.c
@@ -40,6 +40,7 @@
 #include "net/packetbuf.h"
 #include "net/queuebuf.h"
 #include "net/netstack.h"
+#include "net/mac/mac-sequence.h"
 #include "packetutils.h"
 #include "border-router.h"
 #include <string.h>
@@ -126,6 +127,9 @@ send_packet(mac_callback_t sent, void *ptr)
   /* Will make it send only DATA packets... for now */
   packetbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_DATAFRAME);
 
+  /* set destination sequence number */
+  mac_sequence_set_dsn();
+
   LOG_INFO("sending packet (%u bytes)\n", packetbuf_datalen());
 
   if(NETSTACK_FRAMER.create() < 0) {
@@ -189,6 +193,7 @@ static void
 init(void)
 {
   callback_pos = 0;
+  mac_sequence_init();
 }
 /*---------------------------------------------------------------------------*/
 const struct mac_driver border_router_mac_driver = {


### PR DESCRIPTION
Currently, the `mac-sequence` module does not ensure to keep the most recent destination sequence number received from a neighbor. Instead, it has a sort of ring buffer, which basically overwrites the oldest destination sequence number. This is problematic for TSCH's replay protection. Assume an acknowledgment frame from a node A to node B is missed and A receives a lot of frames from other neighbors than B. Then, A's ring buffer gets filled with other sequence numbers and by the time B retransmits, B's sequence number may no longer reside in A's ring buffer. This PR fixes this issue by keeping track of the last destination sequence number per neighbor.