### PR TITLE
Dockerfile: support uid/gid != 1000

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,6 @@ jobs:
         git clone --depth 1 https://github.com/contiki-ng/out-of-tree-tests $OUT_OF_TREE_TEST_PATH
         # Check out desired hash
         (cd $OUT_OF_TREE_TEST_PATH && git checkout $OUT_OF_TREE_TEST_VER)
-        # Set permissions for Docker mount
-        sudo chown -R 1000:1000 $OUT_OF_TREE_TEST_PATH
         # Set up docker mount
         echo DOCKER_ARGS=-v `pwd`/$OUT_OF_TREE_TEST_PATH:/home/user/out-of-tree-tests >> $GITHUB_ENV
 
@@ -144,8 +142,6 @@ jobs:
     # Fire up the container and run corresponding tests
     - name: Execute tests
       run: |
-        # Set permissions for Docker mount
-        sudo chown -R 1000:1000 .
         # Cache restores write-time timestamps, update timestamps to be more
         # recent than the files that were just checked out. Ensure the command
         # is successful with empty cache.
@@ -153,8 +149,6 @@ jobs:
         # Run test
         # FIXME: (2023) Remove "ccache -c", workaround for cache growing
         #        too large from ccache CI/ccache configuration mismatch.
-        docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -e GRADLE_USER_HOME=/home/user/contiki-ng/tools/cooja/.gradle_home $DOCKER_ARGS -v `pwd`:/home/user/contiki-ng -v $GITHUB_WORKSPACE/.ccache:/home/user/.ccache $DOCKER_IMG bash --login -c "source ../.bash_aliases && ccache --set-config=max_size='140M' && cimake -C tests/??-${{ matrix.test }}; ccache -c"
-        # Restore permissions for gradle_home so the cache action can work.
-        [ -d tools/cooja/.gradle_home ] && sudo chown -R 1001:1001 tools/cooja/.gradle_home || true
+        docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -e GRADLE_USER_HOME=/home/user/contiki-ng/tools/cooja/.gradle_home -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) $DOCKER_ARGS -v `pwd`:/home/user/contiki-ng -v $GITHUB_WORKSPACE/.ccache:/home/user/.ccache $DOCKER_IMG bash --login -c "source ../.bash_aliases && ccache --set-config=max_size='140M' && cimake -C tests/??-${{ matrix.test }}; ccache -c"
         # Check outcome of the test
         ./tests/check-test.sh `pwd`/tests/??-${{ matrix.test }}

--- a/doc/getting-started/Docker.md
+++ b/doc/getting-started/Docker.md
@@ -38,7 +38,7 @@ Then, it is a good idea to create an alias that will help start docker with all 
 On Linux, you can add the following to `~/.profile` or similar, for instance, to `~/.bashrc`:
 ```bash
 export CNG_PATH=<absolute-path-to-your-contiki-ng>
-alias contiker="docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 --mount type=bind,source=$CNG_PATH,destination=/home/user/contiki-ng -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/bus/usb:/dev/bus/usb -ti contiker/contiki-ng"
+alias contiker="docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 --mount type=bind,source=$CNG_PATH,destination=/home/user/contiki-ng -e DISPLAY=$DISPLAY -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/bus/usb:/dev/bus/usb -ti contiker/contiki-ng"
 ```
 
 ## Launching and Exiting

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -10,6 +10,7 @@ USER root
 # gdb: development tools.
 # git: development tools.
 # git-lfs: development tools (used by Gecko SDK).
+# gosu: used for UID-remapping.
 # iputils-ping: used by regression tests.
 # less: convenience tool.
 # lib32z1: 32-bit libz, probably used by some old 32-bit binary.
@@ -35,6 +36,7 @@ RUN apt-get -qq update && \
     gdb \
     git \
     git-lfs \
+    gosu \
     iputils-ping \
     less \
     lib32z1 \
@@ -147,6 +149,8 @@ WORKDIR                 ${HOME}
 COPY --chown=user:user files/cooja ${HOME}/.local/bin/cooja
 # Add aliases for CI. Use a file to avoid quoting issues.
 COPY --chown=user:user files/bash_aliases ${HOME}/.bash_aliases
+# Add login-script for UID/GID-remapping.
+COPY --chown=root:root files/remap-user.sh /usr/local/bin/remap-user.sh
 
 # Doxygen 1.8.17 in Ubuntu 20.04 gives (false) warnings on mqtt.h.
 # Use a binary from the Doxygen homepage, static linking started with 1.9.3.
@@ -172,4 +176,6 @@ RUN wget -nv https://sourceforge.net/projects/doxygen/files/rel-1.9.4/doxygen-1.
 WORKDIR ${CONTIKI_NG}
 
 # Start a bash
+USER root
+ENTRYPOINT ["/usr/local/bin/remap-user.sh"]
 CMD bash --login

--- a/tools/docker/files/remap-user.sh
+++ b/tools/docker/files/remap-user.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# Script that gives the container user uid $LOCAL_UID and gid $LOCAL_GID.
+# If $LOCAL_UID or $LOCAL_GID are not set, they default to 1000 (default
+# for the first user created in Ubuntu).
+
+USER_ID=${LOCAL_UID:-1000}
+GROUP_ID=${LOCAL_GID:-1000}
+
+[[ "$USER_ID" == "1000" ]] || usermod -u $USER_ID -o -m -d /home/user user
+[[ "$GROUP_ID" == "1000" ]] || groupmod -g $GROUP_ID user
+exec /usr/sbin/gosu user "$@"


### PR DESCRIPTION
Give the docker user the same uid/gid as
the host user. This removes the recursive
chown calls in the Github CI.