### PR TITLE
Allow overriding NETSTACK_CONF_RADIO for simplelink platforms

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-conf.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-conf.h
@@ -187,7 +187,9 @@
 #if (RF_MODE == RF_MODE_SUB_1_GHZ) && (SUPPORTS_PROP_MODE)
 
 /* Netstack configuration. */
+#ifndef NETSTACK_CONF_RADIO
 #define NETSTACK_CONF_RADIO         prop_mode_driver
+#endif
 
 /* CSMA configuration. */
 #define CSMA_CONF_ACK_WAIT_TIME                (RTIMER_SECOND / 300)
@@ -198,7 +200,9 @@
 #elif (RF_MODE == RF_MODE_2_4_GHZ) && (SUPPORTS_IEEE_MODE)
 
 /* Netstack configuration. */
+#ifndef NETSTACK_CONF_RADIO
 #define NETSTACK_CONF_RADIO         ieee_mode_driver
+#endif
 
 /* CSMA configuration. */
 #define CSMA_CONF_SEND_SOFT_ACK     0
@@ -221,7 +225,9 @@
 #if (RF_MODE == RF_MODE_2_4_GHZ) && (SUPPORTS_IEEE_MODE)
 
 /* Netstack configuration */
+#ifndef NETSTACK_CONF_RADIO
 #define NETSTACK_CONF_RADIO         ieee_mode_driver
+#endif
 
 /* CSMA configuration */
 #define CSMA_CONF_SEND_SOFT_ACK     0


### PR DESCRIPTION
As in title. Mimics cc26x0-cc13x0.