### PR TITLE
Use TI_UART_CONF_* for both TI platforms

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-conf.h
+++ b/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-conf.h
@@ -150,17 +150,26 @@
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/
+
+/* Deprecation warning for UART config */
+#ifdef CC26XX_UART_CONF_ENABLE
+#error CC26XX_UART_CONF_ENABLE is deprecated. Use TI_UART_CONF_ENABLE.
+#endif
+#ifdef CC26XX_UART_CONF_BAUD_RATE
+#error CC26XX_UART_CONF_BAUD_RATE is deprecated. Use TI_UART_CONF_BAUD_RATE.
+#endif
+
 /**
  * \name Character I/O Configuration
  *
  * @{
  */
-#ifndef CC26XX_UART_CONF_ENABLE
-#define CC26XX_UART_CONF_ENABLE            1 /**< Enable/Disable UART I/O */
+#ifndef TI_UART_CONF_ENABLE
+#define TI_UART_CONF_ENABLE                1 /**< Enable/Disable UART I/O */
 #endif
 
-#ifndef CC26XX_UART_CONF_BAUD_RATE
-#define CC26XX_UART_CONF_BAUD_RATE    115200 /**< Default UART0 baud rate */
+#ifndef TI_UART_CONF_BAUD_RATE
+#define TI_UART_CONF_BAUD_RATE        115200 /**< Default UART0 baud rate */
 #endif
 
 /* Enable I/O over the Debugger Devpack - Only relevant for the SensorTag */

--- a/arch/cpu/cc26x0-cc13x0/dev/cc26xx-uart.c
+++ b/arch/cpu/cc26x0-cc13x0/dev/cc26xx-uart.c
@@ -65,7 +65,7 @@ static int (*input_handler)(unsigned char c);
 /*---------------------------------------------------------------------------*/
 static bool
 usable(uint32_t pin) {
-  if(CC26XX_UART_CONF_ENABLE == 0 || pin == IOID_UNUSED) {
+  if(TI_UART_CONF_ENABLE == 0 || pin == IOID_UNUSED) {
     return false;
   }
 
@@ -161,7 +161,7 @@ configure(void)
 
   /* Configure the UART for 115,200, 8-N-1 operation. */
   ti_lib_uart_config_set_exp_clk(UART0_BASE, ti_lib_sys_ctrl_clock_get(),
-                                 CC26XX_UART_CONF_BAUD_RATE,
+                                 TI_UART_CONF_BAUD_RATE,
                                  (UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE |
                                   UART_CONFIG_PAR_NONE));
 

--- a/arch/platform/cc26x0-cc13x0/platform.c
+++ b/arch/platform/cc26x0-cc13x0/platform.c
@@ -175,7 +175,7 @@ platform_init_stage_two()
   random_init(0x1234);
 
   /* Character I/O Initialisation */
-#if CC26XX_UART_CONF_ENABLE
+#if TI_UART_CONF_ENABLE
   cc26xx_uart_init();
 #endif
 

--- a/examples/sensniff/cc26x0-cc13x0/target-conf.h
+++ b/examples/sensniff/cc26x0-cc13x0/target-conf.h
@@ -32,7 +32,7 @@
 #ifndef TARGET_CONF_H_
 #define TARGET_CONF_H_
 /*---------------------------------------------------------------------------*/
-#define CC26XX_UART_CONF_BAUD_RATE     460800
+#define TI_UART_CONF_BAUD_RATE         460800
 #define RF_BLE_CONF_ENABLED                 0
 #define CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE 1
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Renames `CC26XX_UART_CONF_*` defines in cc26x0-cc13x0 to `TI_UART_CONF_*`, which is what the simplelink platform uses - thus easing portability between the two platforms. I am happy to discuss the deprecation strategy - if we want to be more lenient we could e.g. assign the old define to the new (and optionally issue a warning).