### PR TITLE
Update for Cooja long parameter names

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -452,7 +452,7 @@ $(GENDIR)/%: $(GENDIR)/%.diffupdate | $(GENDIR)
 
 # Start cooja through "make file.csc", where the real target is defined through the csc.
 %.csc %.csc.gz: FORCE
-	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_PATH) run --args="-quickstart=$(addprefix $(CURDIR)/,$@) -contiki=$(realpath $(CONTIKI)) -logdir=$(CURDIR)"
+	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_PATH) run --args="--contiki=$(realpath $(CONTIKI)) --logdir=$(CURDIR) $(addprefix $(CURDIR)/,$@)"
 
 ### Automatic dependency generation, see
 ### http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/#advanced

--- a/examples/benchmarks/result-visualization/run-cooja.py
+++ b/examples/benchmarks/result-visualization/run-cooja.py
@@ -51,7 +51,7 @@ def execute_test(cooja_file):
         return False
 
     filename = os.path.join(SELF_PATH, cooja_file)
-    args = " ".join([COOJA_PATH + "/gradlew --no-watch-fs --parallel --build-cache -p", COOJA_PATH, "run --args='-nogui=" + filename, "-contiki=" + CONTIKI_PATH, "-logdir=" + SELF_PATH + "'"])
+    args = " ".join([COOJA_PATH + "/gradlew --no-watch-fs --parallel --build-cache -p", COOJA_PATH, "run --args='--contiki=" + CONTIKI_PATH, "--no-gui", "--logdir=" + SELF_PATH, filename + "'"])
     sys.stdout.write("  Running Cooja, args={}\n".format(args))
 
     (retcode, output) = run_subprocess(args, '')

--- a/tests/Makefile.simulation-test
+++ b/tests/Makefile.simulation-test
@@ -63,7 +63,7 @@ endif
 # Successful simulations do nothing, failures appends test+seed to summary.
 tests: $(TESTS)
 	@for (( SEED=$(BASESEED); SEED < $$(( $(BASESEED) + $(RUNCOUNT) )); SEED++ )); do \
-          $(GRADLE) --no-watch-fs --parallel --build-cache -p $(CONTIKI)/tools/cooja run --args="$(addprefix -nogui=,$(realpath $^)) -contiki=$(realpath $(CONTIKI)) -logdir=$(dir $(realpath $<)) -random-seed=$$SEED" || \
+          $(GRADLE) --no-watch-fs --parallel --build-cache -p $(CONTIKI)/tools/cooja run --args="--no-gui --contiki=$(realpath $(CONTIKI)) --logdir=$(dir $(realpath $<)) --random-seed=$$SEED $(realpath $^)" || \
             echo "TEST FAIL: $^ seed $$SEED" >> summary; \
          done
 


### PR DESCRIPTION
Cooja uses the parameter --[no-]gui to decide
whether to use headless mode. This makes it possible to pass simulation files directly to Cooja without passing -nogui/-quickstart.

Parameter names also use double dashes.