### PR TITLE
Correct const placement in remaining lists

### DIFF
--- a/os/lib/circular-list.c
+++ b/os/lib/circular-list.c
@@ -56,13 +56,13 @@ circular_list_init(circular_list_t cl)
 }
 /*---------------------------------------------------------------------------*/
 void *
-circular_list_head(const circular_list_t cl)
+circular_list_head(const_circular_list_t cl)
 {
   return *cl;
 }
 /*---------------------------------------------------------------------------*/
 void *
-circular_list_tail(const circular_list_t cl)
+circular_list_tail(const_circular_list_t cl)
 {
   struct cl *this;
 
@@ -132,7 +132,7 @@ circular_list_add(circular_list_t cl, void *element)
 }
 /*---------------------------------------------------------------------------*/
 unsigned long
-circular_list_length(const circular_list_t cl)
+circular_list_length(const_circular_list_t cl)
 {
   unsigned long len = 1;
   struct cl *this;
@@ -149,7 +149,7 @@ circular_list_length(const circular_list_t cl)
 }
 /*---------------------------------------------------------------------------*/
 bool
-circular_list_is_empty(const circular_list_t cl)
+circular_list_is_empty(const_circular_list_t cl)
 {
   return *cl == NULL ? true : false;
 }

--- a/os/lib/circular-list.h
+++ b/os/lib/circular-list.h
@@ -79,9 +79,15 @@
   static circular_list_t name = (circular_list_t)&name##_circular_list
 /*---------------------------------------------------------------------------*/
 /**
- * \brief The circular, singly-linked list datatype
+ * The circular, singly-linked list datatype.
  */
 typedef void **circular_list_t;
+
+/**
+ * The non-modifiable circular, singly-linked list datatype.
+ */
+typedef void *const *const_circular_list_t;
+
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Initialise a circular, singly-linked list.
@@ -94,14 +100,14 @@ void circular_list_init(circular_list_t cl);
  * \param cl The circular, singly-linked list.
  * \return A pointer to the list's head, or NULL if the list is empty
  */
-void *circular_list_head(const circular_list_t cl);
+void *circular_list_head(const_circular_list_t cl);
 
 /**
  * \brief Return the tail of a circular, singly-linked list.
  * \param cl The circular, singly-linked list.
  * \return A pointer to the list's tail, or NULL if the list is empty
  */
-void *circular_list_tail(const circular_list_t cl);
+void *circular_list_tail(const_circular_list_t cl);
 
 /**
  * \brief Add an element to a circular, singly-linked list.
@@ -139,7 +145,7 @@ void circular_list_remove(circular_list_t cl, const void *element);
  * \param cl The circular, singly-linked list.
  * \return The number of elements in the list
  */
-unsigned long circular_list_length(const circular_list_t cl);
+unsigned long circular_list_length(const_circular_list_t cl);
 
 /**
  * \brief Determine whether a circular, singly-linked list is empty.
@@ -147,7 +153,7 @@ unsigned long circular_list_length(const circular_list_t cl);
  * \retval true The list is empty
  * \retval false The list is not empty
  */
-bool circular_list_is_empty(const circular_list_t cl);
+bool circular_list_is_empty(const_circular_list_t cl);
 /*---------------------------------------------------------------------------*/
 #endif /* CIRCULAR_LIST_H_ */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbl-circ-list.c
+++ b/os/lib/dbl-circ-list.c
@@ -57,13 +57,13 @@ dbl_circ_list_init(dbl_circ_list_t dblcl)
 }
 /*---------------------------------------------------------------------------*/
 void *
-dbl_circ_list_head(const dbl_circ_list_t dblcl)
+dbl_circ_list_head(const_dbl_circ_list_t dblcl)
 {
   return *dblcl;
 }
 /*---------------------------------------------------------------------------*/
 void *
-dbl_circ_list_tail(const dbl_circ_list_t dblcl)
+dbl_circ_list_tail(const_dbl_circ_list_t dblcl)
 {
   struct dblcl *this;
 
@@ -202,7 +202,7 @@ dbl_circ_list_add_before(dbl_circ_list_t dblcl, void *existing, void *element)
 }
 /*---------------------------------------------------------------------------*/
 unsigned long
-dbl_circ_list_length(const dbl_circ_list_t dblcl)
+dbl_circ_list_length(const_dbl_circ_list_t dblcl)
 {
   unsigned long len = 1;
   struct dblcl *this;
@@ -219,7 +219,7 @@ dbl_circ_list_length(const dbl_circ_list_t dblcl)
 }
 /*---------------------------------------------------------------------------*/
 bool
-dbl_circ_list_is_empty(const dbl_circ_list_t dblcl)
+dbl_circ_list_is_empty(const_dbl_circ_list_t dblcl)
 {
   return *dblcl == NULL ? true : false;
 }

--- a/os/lib/dbl-circ-list.h
+++ b/os/lib/dbl-circ-list.h
@@ -81,9 +81,15 @@
   static dbl_list_t name = (dbl_circ_list_t)&name##_dbl_circ_list
 /*---------------------------------------------------------------------------*/
 /**
- * \brief The doubly-linked list datatype
+ * The doubly-linked circular list datatype
  */
 typedef void **dbl_circ_list_t;
+
+/**
+ * The non-modifiable doubly-linked circular list type.
+ */
+typedef void *const *const_dbl_circ_list_t;
+
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Initialise a circular, doubly-linked list.
@@ -96,14 +102,14 @@ void dbl_circ_list_init(dbl_circ_list_t dblcl);
  * \param dblcl The circular, doubly-linked list.
  * \return A pointer to the list's head, or NULL if the list is empty
  */
-void *dbl_circ_list_head(const dbl_circ_list_t dblcl);
+void *dbl_circ_list_head(const_dbl_circ_list_t dblcl);
 
 /**
  * \brief Return the tail of a circular, doubly-linked list.
  * \param dblcl The circular, doubly-linked list.
  * \return A pointer to the list's tail, or NULL if the list is empty
  */
-void *dbl_circ_list_tail(const dbl_circ_list_t dblcl);
+void *dbl_circ_list_tail(const_dbl_circ_list_t dblcl);
 
 /**
  * \brief Add an element to the head of a circular, doubly-linked list.
@@ -177,7 +183,7 @@ void dbl_circ_list_remove(dbl_circ_list_t dblcl, const void *element);
  * \param dblcl The circular, doubly-linked list.
  * \return The number of elements in the list
  */
-unsigned long dbl_circ_list_length(const dbl_circ_list_t dblcl);
+unsigned long dbl_circ_list_length(const_dbl_circ_list_t dblcl);
 
 /**
  * \brief Determine whether a circular, doubly-linked list is empty.
@@ -185,7 +191,7 @@ unsigned long dbl_circ_list_length(const dbl_circ_list_t dblcl);
  * \retval true The list is empty
  * \retval false The list is not empty
  */
-bool dbl_circ_list_is_empty(const dbl_circ_list_t dblcl);
+bool dbl_circ_list_is_empty(const_dbl_circ_list_t dblcl);
 /*---------------------------------------------------------------------------*/
 #endif /* DBL_CIRC_LIST_H_ */
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbl-list.c
+++ b/os/lib/dbl-list.c
@@ -57,13 +57,13 @@ dbl_list_init(dbl_list_t dll)
 }
 /*---------------------------------------------------------------------------*/
 void *
-dbl_list_head(const dbl_list_t dll)
+dbl_list_head(const_dbl_list_t dll)
 {
   return *dll;
 }
 /*---------------------------------------------------------------------------*/
 void *
-dbl_list_tail(const dbl_list_t dll)
+dbl_list_tail(const_dbl_list_t dll)
 {
   struct dll *this;
 
@@ -201,7 +201,7 @@ dbl_list_add_before(dbl_list_t dll, void *existing, void *element)
 }
 /*---------------------------------------------------------------------------*/
 unsigned long
-dbl_list_length(const dbl_list_t dll)
+dbl_list_length(const_dbl_list_t dll)
 {
   unsigned long len = 0;
   struct dll *this;
@@ -218,7 +218,7 @@ dbl_list_length(const dbl_list_t dll)
 }
 /*---------------------------------------------------------------------------*/
 bool
-dbl_list_is_empty(const dbl_list_t dll)
+dbl_list_is_empty(const_dbl_list_t dll)
 {
   return *dll == NULL ? true : false;
 }

--- a/os/lib/dbl-list.h
+++ b/os/lib/dbl-list.h
@@ -81,9 +81,15 @@
   static dbl_list_t name = (dbl_list_t)&name##_dbl_list
 /*---------------------------------------------------------------------------*/
 /**
- * \brief The doubly-linked list datatype
+ * The doubly-linked list datatype.
  */
 typedef void **dbl_list_t;
+
+/**
+ * The non-modifiable doubly-linked list type.
+ */
+typedef void *const *const_dbl_list_t;
+
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Initialise a doubly-linked list.
@@ -96,14 +102,14 @@ void dbl_list_init(dbl_list_t dll);
  * \param dll The doubly-linked list.
  * \return A pointer to the list's head, or NULL if the list is empty
  */
-void *dbl_list_head(const dbl_list_t dll);
+void *dbl_list_head(const_dbl_list_t dll);
 
 /**
  * \brief Return the tail of a doubly-linked list.
  * \param dll The doubly-linked list.
  * \return A pointer to the list's tail, or NULL if the list is empty
  */
-void *dbl_list_tail(const dbl_list_t dll);
+void *dbl_list_tail(const_dbl_list_t dll);
 
 /**
  * \brief Add an element to the head of a doubly-linked list.
@@ -175,7 +181,7 @@ void dbl_list_remove(dbl_list_t dll, const void *element);
  * \param dll The doubly-linked list.
  * \return The number of elements in the list
  */
-unsigned long dbl_list_length(const dbl_list_t dll);
+unsigned long dbl_list_length(const_dbl_list_t dll);
 
 /**
  * \brief Determine whether a doubly-linked list is empty.
@@ -183,7 +189,7 @@ unsigned long dbl_list_length(const dbl_list_t dll);
  * \retval true The list is empty
  * \retval false The list is not empty
  */
-bool dbl_list_is_empty(const dbl_list_t dll);
+bool dbl_list_is_empty(const_dbl_list_t dll);
 /*---------------------------------------------------------------------------*/
 #endif /* DBL_LIST_H_ */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
In #2012, @pjonsson describes and fixes an issue with the `const` placement in the list library. This PR fixes the same issue for the remaining lists: circular-list, dbl-circ-list, and dbl-list.