### PR TITLE
Fix broken maintainers link in doc.

### DIFF
--- a/doc/project/Organization.md
+++ b/doc/project/Organization.md
@@ -1,6 +1,6 @@
 # Organization
 
-Contiki-NG has a group of [maintainers], a subset of which constitutes the [board].
+Contiki-NG has a group of [maintainers], which also constitutes the board.
 The maintainers are in charge of commenting on issues, keeping documentation up-to-date, reviewing and merging pull requests as per the guidelines in [doc:contributing].
 The board, in addition, takes care of general management aspects such as organizational decisions, future directions, etc.
 
@@ -9,6 +9,5 @@ Active contributors who demonstrated high standards will be invited to join as m
 Conversely, maintainers who become inactive over many months will be considered for removal.
 The board can be dissolved whenever a majority of maintainers decide so -- they will then be responsible for selecting new board members.
 
-[board]: https://github.com/orgs/contiki-ng/teams/board/members
-[maintainers]: https://github.com/orgs/contiki-ng/teams/maintainers/members
+[maintainers]: https://github.com/orgs/contiki-ng/people
 [doc:contributing]: /doc/project/Contributing


### PR DESCRIPTION
Fixes #1771 . The current doc. points to the maintainers team which it seems [github does not intend to be public](https://docs.github.com/en/organizations/organizing-members-into-teams/changing-team-visibility): _"People who are not members of the organization cannot view any teams."_. This PR takes a simple approach and links to the organization members instead - which is correct as long as all members are maintainers, as today. Ping @joakimeriksson to make sure I remember the board-part correctly.