### PR TITLE
Common random-arch PRNG for simpelink and cc26xx-cc13xx

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/random.c
+++ b/arch/cpu/cc26x0-cc13x0/random.c
@@ -29,35 +29,39 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup cc26xx-trng
+ * \defgroup cc13x0-cc26x0-prng Pseudo Random Number Generator (PRNG) for CC13x0/CC26x0.
  * @{
  *
- * \file
+ * This file overrides os/lib/random.c. Note that the file name must
+ * match the original file for the override to work.
  *
- * This file overrides os/lib/random.c and calls SoC-specific RNG functions
+ * \file
+ *        Implementation of Pseudo Random Number Generator for CC13x0/CC26x0.
  */
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
-#include "dev/soc-trng.h"
+#include "lib/smallprng.h"
+/*---------------------------------------------------------------------------*/
+static smallprng_t smallprng;
 /*---------------------------------------------------------------------------*/
 /**
- * \brief      Generates a new random number using the hardware TRNG.
- * \return     The random number.
+ * \brief   Generates a new random number using smallprng.
+ * \return  The random number.
  */
 unsigned short
 random_rand(void)
 {
-  return (unsigned short)soc_trng_rand_synchronous() & 0xFFFF;
+  return (unsigned short)smallprng_rand(&smallprng);
 }
 /*---------------------------------------------------------------------------*/
 /**
- * \brief Function required by the API
- * \param seed Ignored.
+ * \brief       Initialize the PRNG.
+ * \param seed  Seed for the PRNG.
  */
 void
 random_init(unsigned short seed)
 {
-  soc_trng_init();
+  smallprng_init(&smallprng, seed);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/random.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/random.c
@@ -27,15 +27,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- /**
+/**
  * \addtogroup cc13xx-cc26xx-cpu
  * @{
  *
  * \defgroup cc13xx-cc26xx-prng Pseudo Random Number Generator (PRNG) for CC13xx/CC26xx.
  * @{
- *
- * Implementation based on Bob Jenkins' small noncryptographic PRNG.
- * - http://burtleburtle.net/bob/rand/smallprng.html
  *
  * This file overrides os/lib/random.c. Note that the file name must
  * match the original file for the override to work.
@@ -44,22 +41,13 @@
  *        Implementation of Pseudo Random Number Generator for CC13xx/CC26xx.
  * \author
  *        Edvard Pettersen <e.pettersen@ti.com>
+ *        Andreas Urke
  */
 /*---------------------------------------------------------------------------*/
-#include <contiki.h>
+#include "contiki.h"
+#include "lib/smallprng.h"
 /*---------------------------------------------------------------------------*/
-#include <stdint.h>
-/*---------------------------------------------------------------------------*/
-typedef struct {
-  uint32_t a;
-  uint32_t b;
-  uint32_t c;
-  uint32_t d;
-} ranctx_t;
-
-static ranctx_t ranctx;
-/*---------------------------------------------------------------------------*/
-#define rot32(x, k) (((x) << (k)) | ((x) >> (32 - (k))))
+static smallprng_t smallprng;
 /*---------------------------------------------------------------------------*/
 /**
  * \brief   Generates a new random number using the PRNG.
@@ -68,15 +56,7 @@ static ranctx_t ranctx;
 unsigned short
 random_rand(void)
 {
-  uint32_t e;
-
-  e        = ranctx.a - rot32(ranctx.b, 27);
-  ranctx.a = ranctx.b ^ rot32(ranctx.c, 17);
-  ranctx.b = ranctx.c + ranctx.d;
-  ranctx.c = ranctx.d + e;
-  ranctx.d = e        + ranctx.a;
-
-  return (unsigned short)ranctx.d;
+  return (unsigned short)smallprng_rand(&smallprng);
 }
 /*---------------------------------------------------------------------------*/
 /**
@@ -86,13 +66,7 @@ random_rand(void)
 void
 random_init(unsigned short seed)
 {
-  uint32_t i;
-
-  ranctx.a = 0xf1ea5eed;
-  ranctx.b = ranctx.c = ranctx.d = (uint32_t)seed;
-  for(i = 0; i < 20; ++i) {
-    (void)random_rand();
-  }
+  smallprng_init(&smallprng, seed);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/cc26x0-cc13x0/platform.c
+++ b/arch/platform/cc26x0-cc13x0/platform.c
@@ -57,6 +57,7 @@
 #include "dev/cc26xx-uart.h"
 #include "dev/soc-rtc.h"
 #include "dev/serial-line.h"
+#include "dev/soc-trng.h"
 #include "rf-core/rf-core.h"
 #include "sys_ctrl.h"
 #include "uart.h"
@@ -172,7 +173,10 @@ platform_init_stage_one()
 void
 platform_init_stage_two()
 {
-  random_init(0x1234);
+  soc_trng_init();
+
+  /* Use TRNG to seed random lib. */
+  random_init((uint16_t)soc_trng_rand_synchronous());
 
   /* Character I/O Initialisation */
 #if TI_UART_CONF_ENABLE

--- a/os/lib/smallprng.c
+++ b/os/lib/smallprng.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Andreas Urke
+ * Copyright (c) 2018, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/** \addtogroup smallprng
+ * @{
+ */
+
+/**
+ * \file
+ *        Implementation of small non-cryptographic random number generator
+ *        based on Edvard Pettersens random.c for simplelink platform,
+ *        which was based on Bob Jenkins' small non-cryptographic PRNG:
+ *        http://burtleburtle.net/bob/rand/smallprng.html
+ *
+ * \author
+ *        Andreas Urke
+ */
+
+#include "lib/smallprng.h"
+/*---------------------------------------------------------------------------*/
+#define rot32(x, k) (((x) << (k)) | ((x) >> (32 - (k))))
+/*---------------------------------------------------------------------------*/
+uint32_t
+smallprng_rand(smallprng_t *smallprng)
+{
+  uint32_t e = smallprng->a - rot32(smallprng->b, 27);
+  smallprng->a = smallprng->b ^ rot32(smallprng->c, 17);
+  smallprng->b = smallprng->c + smallprng->d;
+  smallprng->c = smallprng->d + e;
+  smallprng->d = e + smallprng->a;
+  return smallprng->d;
+}
+/*---------------------------------------------------------------------------*/
+void
+smallprng_init(smallprng_t *smallprng, uint32_t seed)
+{
+  smallprng->a = 0xf1ea5eed;
+  smallprng->b = smallprng->c = smallprng->d = seed;
+  for(uint8_t i = 0; i < 20; ++i) {
+    (void)smallprng_rand(smallprng);
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/os/lib/smallprng.h
+++ b/os/lib/smallprng.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, Andreas Urke
+ * Copyright (c) 2018, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/**
+ * \file
+ *          Small non-cryptographic pseudo-random number generator
+ * \author
+ *          Andreas Urke
+ */
+
+/** \addtogroup lib
+ * @{ */
+
+/**
+ * \defgroup smallprng Small PRNG library
+ *
+ * Implementation of a small PRNG based on Edvard Pettersens
+ * random.c for simplelink platform, which was based on Bob Jenkins'
+ * small non-cryptographic PRNG:
+ * http://burtleburtle.net/bob/rand/smallprng.html
+ *
+ * @{
+ */
+
+#ifndef SMALLPRNG_H_
+#define SMALLPRNG_H_
+
+#include <stdint.h>
+
+/**< Small-PRNG context, access only via smallprgn API */
+typedef struct {
+  uint32_t a;
+  uint32_t b;
+  uint32_t c;
+  uint32_t d;
+} smallprng_t;
+
+/*
+ * \brief Calculate a pseudo random number from the given small-PRGN
+ * \return A pseudo-random number
+ */
+uint32_t smallprng_rand(smallprng_t *smallprng);
+
+/*
+ * \brief Initialize the given small-PRGN
+ * \param smallprng - Context for the small-PRNG to initialize
+ * \param seed      - Seed for initialization
+ *
+ */
+void smallprng_init(smallprng_t *smallprng, uint32_t seed);
+
+#endif /* SMALLPRNG_H_ */
+
+/** @} */
+/** @} */

--- a/tests/08-native-runs/14-smallprng.sh
+++ b/tests/08-native-runs/14-smallprng.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+./run-one.sh 14-smallprng

--- a/tests/08-native-runs/14-smallprng/Makefile
+++ b/tests/08-native-runs/14-smallprng/Makefile
@@ -1,0 +1,8 @@
+CONTIKI_PROJECT = test-smallprng
+all: $(CONTIKI_PROJECT)
+
+TARGET = native
+
+MODULES += os/services/unit-test
+
+include ../../../Makefile.include

--- a/tests/08-native-runs/14-smallprng/test-smallprng.c
+++ b/tests/08-native-runs/14-smallprng/test-smallprng.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022, Andreas Urke
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Unit tests for the small PRNG library.
+ * \author
+ *         Andreas Urke
+ */
+
+#include "contiki.h"
+#include "lib/smallprng.h"
+
+#include "unit-test/unit-test.h"
+
+#include <stdio.h>
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+PROCESS(test_smallprng_process, "Test small-PRNG library");
+AUTOSTART_PROCESSES(&test_smallprng_process);
+/*---------------------------------------------------------------------------*/
+#define RAND_BUF_SIZE 128
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(output_sanity, "Basic sanity of the output");
+UNIT_TEST(output_sanity)
+{
+  UNIT_TEST_BEGIN();
+
+  smallprng_t smallprng1 = {0};
+  uint32_t seed = 1;
+
+  /* Test 1: Verify all output is not identical */
+  smallprng_init(&smallprng1, seed);
+  uint32_t rand_output1[RAND_BUF_SIZE] = {0};
+  for(int i = 0; i < RAND_BUF_SIZE; i++) {
+    rand_output1[i] = smallprng_rand(&smallprng1);
+  }
+
+  bool identical = true;
+  for(int i = 1; i < RAND_BUF_SIZE; i++) {
+    if(rand_output1[i-1] != rand_output1[i]) {
+      identical = false;
+      break;
+    }
+  }
+
+  UNIT_TEST_ASSERT(!identical);
+
+
+  /* Test 2: Verify output is identical for identical seed */
+  smallprng_t smallprng2 = {0};
+  smallprng_init(&smallprng2, seed);
+  uint32_t rand_output2[RAND_BUF_SIZE] = {0};
+  for(int i = 0; i < RAND_BUF_SIZE; i++) {
+    rand_output2[i] = smallprng_rand(&smallprng2);
+  }
+
+  UNIT_TEST_ASSERT(!memcmp(rand_output1, rand_output2, RAND_BUF_SIZE));
+
+
+  /* Test 3: Verify output is different for different seed */
+  seed = 2;
+  smallprng_init(&smallprng2, seed);
+  for(int i = 0; i < RAND_BUF_SIZE; i++) {
+    rand_output2[i] = smallprng_rand(&smallprng2);
+  }
+
+  UNIT_TEST_ASSERT(memcmp(rand_output1, rand_output2, RAND_BUF_SIZE));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(validate_output, "Validate output against python impl.");
+UNIT_TEST(validate_output)
+{
+  UNIT_TEST_BEGIN();
+
+  smallprng_t smallprng = {0};
+  uint32_t seed = 1;
+
+  smallprng_init(&smallprng, seed);
+
+  /*
+   * Verify output matches open-source Python implementation
+   * https://gist.github.com/tjoneslo/2c3b472f641bab4069b7
+   */
+  uint32_t rand_output = smallprng_rand(&smallprng);
+  UNIT_TEST_ASSERT(rand_output == 2723230452);
+
+  rand_output = smallprng_rand(&smallprng);
+  UNIT_TEST_ASSERT(rand_output == 519702369);
+
+  rand_output = smallprng_rand(&smallprng);
+  UNIT_TEST_ASSERT(rand_output == 858478259);
+
+  rand_output = smallprng_rand(&smallprng);
+  UNIT_TEST_ASSERT(rand_output == 3517897607);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(test_smallprng_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(output_sanity);
+  UNIT_TEST_RUN(validate_output);
+
+  if(!UNIT_TEST_PASSED(output_sanity) ||
+     !UNIT_TEST_PASSED(validate_output)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
+  printf("=check-me= DONE\n");
+  printf("---\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Currently the cc26xx-cc13xx platform uses the hardware True Random Number Generator (TRNG) in its random-arch implementation, while simplelink uses a pseudo-RNG (PRNG) with the TRNG only for the seed. The random.h API states `random_rand()` should return a pseudo-random number. Thus cc26xx-cc13xx is not giving the expected balance of entropy and resources spent (energy, time). This PR makes the two platforms consistent:
1. Takes the PRNG algorithm from simplelink and moves it into a new smallprng-library
2. Use the smallprng-library in random-arch for both simplelink and cc26xx-cc13xx
3. Seed random-arch in cc26xx-cc13xx using the TRNG

Tested using a launchpad/cc1310 for both platforms.