### PR TITLE
arm: enable building secure code

### DIFF
--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -23,6 +23,9 @@ CFLAGS += -Wall
 CFLAGS += -std=c99
 CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
 CFLAGS += -fshort-enums -fomit-frame-pointer
+ifeq ($(TRUSTZONE_SECURE_BUILD),1)
+  CFLAGS += -mcmse
+endif
 ifeq ($(WERROR),1)
   CFLAGS += -Werror
 endif


### PR DESCRIPTION
Add an option TRUSTZONE_SECURE_BUILD that controls whether -mcmse should be passed to the compiler.

This is a build-internal option to prepare for
making it possible to build Contiki-NG with TrustZone.