### PR TITLE
Makefile: add ld script preprocessing rule

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -454,6 +454,10 @@ $(GENDIR)/%: $(GENDIR)/%.diffupdate | $(GENDIR)
 %.csc %.csc.gz: FORCE
 	$(Q)$(GRADLE) --no-watch-fs --parallel --build-cache -p $(COOJA_PATH) run --args="--contiki=$(realpath $(CONTIKI)) --logdir=$(CURDIR) $(addprefix $(CURDIR)/,$@)"
 
+ifdef SOURCE_LDSCRIPT
+LDSCRIPT = $(OBJECTDIR)/$(notdir $(SOURCE_LDSCRIPT:.lds=.ld))
+endif
+
 ### Automatic dependency generation, see
 ### http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/#advanced
 
@@ -490,6 +494,14 @@ QUOTE := '
 # expression for each LHS=RHS in $(REPLACEMENTS).
 $(GENDIR)/%: %.in | $(GENDIR)
 	$(Q)sed $(addprefix -e , $(addsuffix =g$(QUOTE), $(addprefix $(QUOTE)s=, $(REPLACEMENTS)))) $< > $@
+endif
+
+ifndef CUSTOM_RULE_LDS_TO_OBJECTDIR_LD
+ifdef SOURCE_LDSCRIPT
+$(LDSCRIPT): $(SOURCE_LDSCRIPT) $(DEPDIR)/$(notdir $(LDSCRIPT)).d | $(DEPDIR)
+	$(TRACE_CC)
+	$(Q)$(CCACHE) $(CC) $(LDGENFLAGS) -MT $@ -MMD -MP -MF $(DEPDIR)/$(@F).d $< | grep -v '^\s*#\s*pragma\>' > $@
+endif
 endif
 
 ifndef CUSTOM_RULE_C_TO_OBJECTDIR_O

--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -1,7 +1,6 @@
 ifndef SOURCE_LDSCRIPT
 SOURCE_LDSCRIPT = $(CONTIKI_CPU)/cc2538.lds
 endif
-LDSCRIPT = $(OBJECTDIR)/cc2538.ld
 
 CFLAGS += -DCMSIS_DEV_HDR=\"cc2538_cm3.h\"
 
@@ -50,10 +49,5 @@ LDGENFLAGS += $(CFLAGS)
 LDGENFLAGS += -imacros "contiki-conf.h" -imacros "dev/cc2538-dev.h"
 LDGENFLAGS += -imacros "dev/flash.h" -imacros "cfs-coffee-arch.h"
 LDGENFLAGS += -x c -P -E
-
-# NB: Assumes LDSCRIPT was not overridden and is in $(OBJECTDIR)
-$(LDSCRIPT): $(SOURCE_LDSCRIPT) $(DEPDIR)/$(notdir $(LDSCRIPT)).d | $(DEPDIR)
-	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(LDGENFLAGS) -MT $@ -MMD -MP -MF $(DEPDIR)/$(@F).d $< | grep -v '^\s*#\s*pragma\>' > $@
 
 include $(CONTIKI)/$(CONTIKI_NG_CM3_DIR)/Makefile.cm3


### PR DESCRIPTION
Move the cc2538 preprocessing rule so
all targets can use it. This is preparation
for adding TrustZone support.

The output of:

    cimake NUMCORES=1 Q=''

for 02-compile-arm-ports is identical
before/after this patch.