### PR TITLE
Fix the lifetime value of the default prefix information option in rpl-classic

### DIFF
--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -533,6 +533,7 @@ rpl_set_prefix(rpl_dag_t *dag, uip_ipaddr_t *prefix, unsigned len)
   memcpy(&dag->prefix_info.prefix, prefix, (len + 7) / 8);
   dag->prefix_info.length = len;
   dag->prefix_info.flags = UIP_ND6_RA_FLAG_AUTONOMOUS;
+  dag->prefix_info.lifetime = RPL_ROUTE_INFINITE_LIFETIME;
   LOG_INFO("Prefix set - will announce this in DIOs\n");
   if(dag->rank != ROOT_RANK(dag->instance)) {
     /* Autoconfigure an address if this node does not already have an address


### PR DESCRIPTION
In rpl-lite, the default value for the prefix information lifetime is set to infinity. Previously, in rpl-classic, this value was not set at all and thus was 0. A value of 0 does not make sense, since the lifetime of the prefix then would be 0 seconds. We now do the same thing as rpl-lite.