### PR TITLE
nrf5340: preprocess linker script

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf5340_application
+++ b/arch/cpu/nrf/Makefile.nrf5340_application
@@ -1,6 +1,6 @@
 include $(CONTIKI_CPU)/Makefile.libs  
 
-LDSCRIPT ?= $(NRFX_ROOT)/mdk/nrf5340_xxaa_application.ld
+SOURCE_LDSCRIPT ?= $(NRFX_ROOT)/mdk/nrf5340_xxaa_application.ld
 CFLAGS += -DNRF5340_XXAA_APPLICATION
 
 NRFX_ASM_SRCS += $(NRFX_ROOT)/mdk/gcc_startup_nrf5340_application.s
@@ -24,6 +24,9 @@ ifeq ($(CLANG),1)
 endif
 LDFLAGS += -mfloat-abi=hard 
 LDFLAGS += -mfpu=fpv5-sp-d16
+
+LDGENFLAGS += $(CFLAGS)
+LDGENFLAGS += -x c -P -E
 
 include $(CONTIKI)/$(CONTIKI_NG_CM33_DIR)/Makefile.cm33
 


### PR DESCRIPTION
This runs the linker script through the preprocessor. There are only constants in the linker script right now so the only thing that changes is the location of the linker script when invoking the final link.

This is preparation for adding TrustZone support
where the secure and non-secure areas must be
at separate addresses.