### PR TITLE
nrf5340: import TrustZone target config

### DIFF
--- a/arch/cpu/nrf/nrf5340/partition/flash_layout.h
+++ b/arch/cpu/nrf/nrf5340/partition/flash_layout.h
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2018-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __FLASH_LAYOUT_H__
+#define __FLASH_LAYOUT_H__
+
+/* Flash layout on NRF5340 Application MCU with BL2:
+ *
+ * 0x0000_0000 BL2 - MCUBoot (64 KB)
+ * 0x0001_0000 Primary image area (448 KB):
+ *    0x0001_0000 Secure     image primary (256 KB)
+ *    0x0005_0000 Non-secure image primary (192 KB)
+ * 0x0008_0000 Secondary image area (448 KB):
+ *    0x0008_0000 Secure     image secondary (256 KB)
+ *    0x000c_0000 Non-secure image secondary (192 KB)
+ * 0x000f_0000 Protected Storage Area (16 KB)
+ * 0x000f_4000 Internal Trusted Storage Area (8 KB)
+ * 0x000f_6000 NV counters area (4 KB)
+ * 0x000f_7000 Unused
+ *
+ * Flash layout on NRF5340 Application MCU without BL2:
+ *
+ * 0x0000_0000 Primary image area (960 KB):
+ *    0x0000_0000 Secure     image primary (480 KB)
+ *    0x0007_8000 Non-secure image primary (480 KB)
+ * 0x000f_0000 Protected Storage Area (16 KB)
+ * 0x000f_4000 Internal Trusted Storage Area (8 KB)
+ * 0x000f_6000 NV counters area (4 KB)
+ * 0x000f_7000 Unused
+ */
+
+/* This header file is included from linker scatter file as well, where only a
+ * limited C constructs are allowed. Therefore it is not possible to include
+ * here the platform_base_address.h to access flash related defines. To resolve
+ * this some of the values are redefined here with different names, these are
+ * marked with comment.
+ */
+
+/* Size of a Secure and of a Non-secure image */
+#ifdef PSA_API_TEST_IPC
+/* Firmware Framework test suites */
+#define FLASH_S_PARTITION_SIZE                (0x48000)       /* S partition: 288 kB*/
+#define FLASH_NS_PARTITION_SIZE               (0x28000)       /* NS partition: 160 kB*/
+#else
+#define FLASH_S_PARTITION_SIZE                (0x40000)       /* S partition: 256 kB*/
+#define FLASH_NS_PARTITION_SIZE               (0x30000)       /* NS partition: 192 kB*/
+#endif
+
+#define FLASH_MAX_PARTITION_SIZE        ((FLASH_S_PARTITION_SIZE >   \
+                                          FLASH_NS_PARTITION_SIZE) ? \
+                                         FLASH_S_PARTITION_SIZE :    \
+                                         FLASH_NS_PARTITION_SIZE)
+
+/* Sector size of the embedded flash hardware (erase/program) */
+#define FLASH_AREA_IMAGE_SECTOR_SIZE        (0x1000)           /* 4 KB. Flash memory program/erase operations have a page granularity. */
+
+/* FLASH size */
+#define FLASH_TOTAL_SIZE                    (0x100000)    /* 1024 kB. */
+
+/* Flash layout info for BL2 bootloader */
+#define FLASH_BASE_ADDRESS                  (0x00000000)
+
+
+/* Offset and size definitions of the flash partitions that are handled by the
+ * bootloader. The image swapping is done between IMAGE_PRIMARY and
+ * IMAGE_SECONDARY, SCRATCH is used as a temporary storage during image
+ * swapping.
+ */
+#define FLASH_AREA_BL2_OFFSET      (0x0)
+#define FLASH_AREA_BL2_SIZE        (0x10000) /* 64 KB */
+
+#if !defined(MCUBOOT_IMAGE_NUMBER) || (MCUBOOT_IMAGE_NUMBER == 1)
+/* Secure + Non-secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (FLASH_AREA_BL2_OFFSET + FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
+/* Secure + Non-secure secondary slot */
+#define FLASH_AREA_2_ID            (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_2_OFFSET        (FLASH_AREA_0_OFFSET + FLASH_AREA_0_SIZE)
+#define FLASH_AREA_2_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
+/* Not used, only the Non-swapping firmware upgrade operation
+ * is supported on NRF5340 Application MCU.
+ */
+#define FLASH_AREA_SCRATCH_ID      (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET  (FLASH_AREA_2_OFFSET + FLASH_AREA_2_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE    (0)
+/* Maximum number of image sectors supported by the bootloader. */
+#define MCUBOOT_MAX_IMG_SECTORS    ((FLASH_S_PARTITION_SIZE + \
+                                     FLASH_NS_PARTITION_SIZE) / \
+                                    FLASH_AREA_IMAGE_SECTOR_SIZE)
+#elif (MCUBOOT_IMAGE_NUMBER == 2)
+/* Secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (FLASH_AREA_BL2_OFFSET + FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE)
+/* Non-secure image primary slot */
+#define FLASH_AREA_1_ID            (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_1_OFFSET        (FLASH_AREA_0_OFFSET + FLASH_AREA_0_SIZE)
+#define FLASH_AREA_1_SIZE          (FLASH_NS_PARTITION_SIZE)
+/* Secure image secondary slot */
+#define FLASH_AREA_2_ID            (FLASH_AREA_1_ID + 1)
+#define FLASH_AREA_2_OFFSET        (FLASH_AREA_1_OFFSET + FLASH_AREA_1_SIZE)
+#define FLASH_AREA_2_SIZE          (FLASH_S_PARTITION_SIZE)
+/* Non-secure image secondary slot */
+#define FLASH_AREA_3_ID            (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_3_OFFSET        (FLASH_AREA_2_OFFSET + FLASH_AREA_2_SIZE)
+#define FLASH_AREA_3_SIZE          (FLASH_NS_PARTITION_SIZE)
+/* Not used, only the Non-swapping firmware upgrade operation
+ * is supported on NRF5340 Application MCU.
+ */
+#define FLASH_AREA_SCRATCH_ID      (FLASH_AREA_3_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET  (FLASH_AREA_3_OFFSET + FLASH_AREA_3_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE    (0)
+/* Maximum number of image sectors supported by the bootloader. */
+#define MCUBOOT_MAX_IMG_SECTORS    (FLASH_MAX_PARTITION_SIZE / \
+                                    FLASH_AREA_IMAGE_SECTOR_SIZE)
+#else /* MCUBOOT_IMAGE_NUMBER > 2 */
+#error "Only MCUBOOT_IMAGE_NUMBER 1 and 2 are supported!"
+#endif /* MCUBOOT_IMAGE_NUMBER */
+
+/* Not used, only the Non-swapping firmware upgrade operation
+ * is supported on nRF5340. The maximum number of status entries
+ * supported by the bootloader.
+ */
+#define MCUBOOT_STATUS_MAX_ENTRIES      (0)
+
+
+#define FLASH_PS_AREA_OFFSET            (FLASH_AREA_SCRATCH_OFFSET + \
+                                         FLASH_AREA_SCRATCH_SIZE)
+#define FLASH_PS_AREA_SIZE              (0x4000)   /* 16 KB */
+
+/* Internal Trusted Storage (ITS) Service definitions */
+#define FLASH_ITS_AREA_OFFSET           (FLASH_PS_AREA_OFFSET + \
+                                         FLASH_PS_AREA_SIZE)
+#define FLASH_ITS_AREA_SIZE             (0x2000)   /* 8 KB */
+
+/* NV Counters definitions */
+#define FLASH_NV_COUNTERS_AREA_OFFSET   (FLASH_ITS_AREA_OFFSET + \
+                                         FLASH_ITS_AREA_SIZE)
+#define FLASH_NV_COUNTERS_AREA_SIZE     (FLASH_AREA_IMAGE_SECTOR_SIZE)
+
+/* PSA MMIO Area definitions */
+#define FLASH_MMIO_AREA_OFFSET          (FLASH_NV_COUNTERS_AREA_OFFSET + \
+                                         FLASH_NV_COUNTERS_AREA_SIZE)
+#define FLASH_MMIO_AREA_SIZE            (FLASH_AREA_IMAGE_SECTOR_SIZE)
+
+/* Offset and size definition in flash area used by assemble.py */
+#define SECURE_IMAGE_OFFSET             (0x0)
+#define SECURE_IMAGE_MAX_SIZE           FLASH_S_PARTITION_SIZE
+
+#define NON_SECURE_IMAGE_OFFSET         (SECURE_IMAGE_OFFSET + \
+                                         SECURE_IMAGE_MAX_SIZE)
+#define NON_SECURE_IMAGE_MAX_SIZE       FLASH_NS_PARTITION_SIZE
+
+/* Flash device name used by BL2
+ * Name is defined in flash driver file: Driver_Flash.c
+ */
+#define FLASH_DEV_NAME Driver_FLASH0
+#define TFM_HAL_FLASH_PROGRAM_UNIT       (0x4)
+
+/* Protected Storage (PS) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M PS Integration Guide.
+ */
+#define TFM_HAL_PS_FLASH_DRIVER Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+/* Base address of dedicated flash area for PS */
+#define TFM_HAL_PS_FLASH_AREA_ADDR    FLASH_PS_AREA_OFFSET
+/* Size of dedicated flash area for PS */
+#define TFM_HAL_PS_FLASH_AREA_SIZE    FLASH_PS_AREA_SIZE
+#define PS_RAM_FS_SIZE                TFM_HAL_PS_FLASH_AREA_SIZE
+/* Number of physical erase sectors per logical FS block */
+#define TFM_HAL_PS_SECTORS_PER_BLOCK  (1)
+/* Smallest flash programmable unit in bytes */
+#define TFM_HAL_PS_PROGRAM_UNIT       (0x4)
+
+/* Internal Trusted Storage (ITS) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M ITS Integration Guide. The ITS should be in the internal flash, but is
+ * allocated in the external flash just for development platforms that don't
+ * have internal flash available.
+ */
+#define TFM_HAL_ITS_FLASH_DRIVER Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+/* Base address of dedicated flash area for ITS */
+#define TFM_HAL_ITS_FLASH_AREA_ADDR    FLASH_ITS_AREA_OFFSET
+/* Size of dedicated flash area for ITS */
+#define TFM_HAL_ITS_FLASH_AREA_SIZE    FLASH_ITS_AREA_SIZE
+#define ITS_RAM_FS_SIZE                TFM_HAL_ITS_FLASH_AREA_SIZE
+/* Number of physical erase sectors per logical FS block */
+#define TFM_HAL_ITS_SECTORS_PER_BLOCK  (1)
+/* Smallest flash programmable unit in bytes */
+#define TFM_HAL_ITS_PROGRAM_UNIT       (0x4)
+
+/* NV Counters definitions */
+#define TFM_NV_COUNTERS_AREA_ADDR    FLASH_NV_COUNTERS_AREA_OFFSET
+#define TFM_NV_COUNTERS_AREA_SIZE    (0x18) /* 24 Bytes */
+#define TFM_NV_COUNTERS_SECTOR_ADDR  FLASH_NV_COUNTERS_AREA_OFFSET
+#define TFM_NV_COUNTERS_SECTOR_SIZE  FLASH_AREA_IMAGE_SECTOR_SIZE
+
+/* Use Flash memory to store Code data */
+#define FLASH_BASE_ADDRESS (0x00000000)
+#define S_ROM_ALIAS_BASE   FLASH_BASE_ADDRESS
+#define NS_ROM_ALIAS_BASE  FLASH_BASE_ADDRESS
+
+/* Use SRAM memory to store RW data */
+#define SRAM_BASE_ADDRESS (0x20000000)
+#define S_RAM_ALIAS_BASE  SRAM_BASE_ADDRESS
+#define NS_RAM_ALIAS_BASE SRAM_BASE_ADDRESS
+
+#define TOTAL_ROM_SIZE FLASH_TOTAL_SIZE
+#define TOTAL_RAM_SIZE (0x00080000)     /* 512 kB */
+
+#endif /* __FLASH_LAYOUT_H__ */

--- a/arch/cpu/nrf/nrf5340/partition/region_defs.h
+++ b/arch/cpu/nrf/nrf5340/partition/region_defs.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2017-2020 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __REGION_DEFS_H__
+#define __REGION_DEFS_H__
+
+#include "flash_layout.h"
+
+#define BL2_HEAP_SIZE           (0x00001000)
+#define BL2_MSP_STACK_SIZE      (0x00001800)
+
+#define S_HEAP_SIZE             (0x00001000)
+#define S_MSP_STACK_SIZE_INIT   (0x00000400)
+#define S_MSP_STACK_SIZE        (0x00000800)
+#define S_PSP_STACK_SIZE        (0x00000800)
+
+#define NS_HEAP_SIZE            (0x00001000)
+#define NS_MSP_STACK_SIZE       (0x000000A0)
+#define NS_PSP_STACK_SIZE       (0x00000140)
+
+#define NS_ROM_LIMIT_ADDR 	 (0x7ffff)
+/* Size of nRF SPU (Nordic IDAU) regions */
+#define SPU_FLASH_REGION_SIZE   (0x00004000)
+#define SPU_SRAM_REGION_SIZE    (0x00002000)
+
+/* This size of buffer is big enough to store an attestation
+ * token produced by initial attestation service
+ */
+#define PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE   (0x250)
+
+/*
+ * SPU flash region granularity is 16 KB on nRF5340. Alignment
+ * of partitions is defined in accordance with this constraint.
+ */
+#ifdef BL2
+#ifndef LINK_TO_SECONDARY_PARTITION
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_0_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_2_OFFSET)
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_2_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_0_OFFSET)
+#endif /* !LINK_TO_SECONDARY_PARTITION */
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET (0x0)
+#endif /* BL2 */
+
+#ifndef LINK_TO_SECONDARY_PARTITION
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_0_OFFSET \
+                                           + FLASH_S_PARTITION_SIZE)
+#else
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_2_OFFSET \
+                                           + FLASH_S_PARTITION_SIZE)
+#endif /* !LINK_TO_SECONDARY_PARTITION */
+
+/* Boot partition structure if MCUBoot is used:
+ * 0x0_0000 Bootloader header
+ * 0x0_0400 Image area
+ * 0x0_FC00 Trailer
+ */
+/* IMAGE_CODE_SIZE is the space available for the software binary image.
+ * It is less than the FLASH_S_PARTITION_SIZE + FLASH_NS_PARTITION_SIZE
+ * because we reserve space for the image header and trailer introduced
+ * by the bootloader.
+ */
+#ifdef BL2
+#define BL2_HEADER_SIZE      (0x400)       /* 1 KB */
+#define BL2_TRAILER_SIZE     (0x400)       /* 1 KB */
+#else
+#define BL2_HEADER_SIZE      (0x0)
+#define BL2_TRAILER_SIZE     (0x0)
+#endif /* BL2 */
+
+#define IMAGE_S_CODE_SIZE \
+            (FLASH_S_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+#define IMAGE_NS_CODE_SIZE \
+            (FLASH_NS_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+
+/* Alias definitions for secure and non-secure areas*/
+#define S_ROM_ALIAS(x)  (S_ROM_ALIAS_BASE + (x))
+#define NS_ROM_ALIAS(x) (NS_ROM_ALIAS_BASE + (x))
+
+#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + (x))
+#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + (x))
+
+/* Secure regions */
+#define S_IMAGE_PRIMARY_AREA_OFFSET \
+                        (S_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
+#define S_CODE_START    (S_ROM_ALIAS(S_IMAGE_PRIMARY_AREA_OFFSET))
+#define S_CODE_SIZE     (IMAGE_S_CODE_SIZE)
+#define S_CODE_LIMIT    (S_CODE_START + S_CODE_SIZE - 1)
+
+#define S_DATA_START    (S_RAM_ALIAS(0x0))
+#define S_DATA_SIZE     (TOTAL_RAM_SIZE / 2)
+#define S_DATA_LIMIT    (S_DATA_START + S_DATA_SIZE - 1)
+
+/* The CMSE veneers shall be placed in an NSC region
+ * which will be placed in a secure SPU region with the given alignment.
+ */
+#define CMSE_VENEER_REGION_SIZE     (0x400)
+/* The Nordic IDAU has different alignment requirements than the ARM SAU, so
+ * these override the default start and end alignments. */
+#define CMSE_VENEER_REGION_START_ALIGN \
+            (ALIGN(SPU_FLASH_REGION_SIZE) - CMSE_VENEER_REGION_SIZE + \
+                (. > (ALIGN(SPU_FLASH_REGION_SIZE) - CMSE_VENEER_REGION_SIZE) \
+                    ? SPU_FLASH_REGION_SIZE : 0))
+#define CMSE_VENEER_REGION_END_ALIGN (ALIGN(SPU_FLASH_REGION_SIZE))
+/* We want the veneers placed in the secure code so it isn't placed at the very
+ * end. When placed in code, we don't need an absolute start address. */
+#define CMSE_VENEER_REGION_IN_CODE
+
+/* Non-secure regions */
+#define NS_IMAGE_PRIMARY_AREA_OFFSET \
+                        (NS_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
+#define NS_CODE_START   (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_AREA_OFFSET))
+#define NS_CODE_SIZE    (IMAGE_NS_CODE_SIZE)
+#define NS_CODE_LIMIT   (NS_CODE_START + NS_CODE_SIZE - 1)
+
+#define NS_DATA_START   (NS_RAM_ALIAS(S_DATA_SIZE))
+#ifdef PSA_API_TEST_IPC
+/* Last SRAM region must be kept secure for PSA FF tests */
+#define NS_DATA_SIZE    (TOTAL_RAM_SIZE - S_DATA_SIZE - SPU_SRAM_REGION_SIZE)
+#else
+#define NS_DATA_SIZE    (TOTAL_RAM_SIZE - S_DATA_SIZE)
+#endif
+#define NS_DATA_LIMIT   (NS_DATA_START + NS_DATA_SIZE - 1)
+
+/* NS partition information is used for SPU configuration */
+#define NS_PARTITION_START \
+            (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_PARTITION_OFFSET))
+#define NS_PARTITION_SIZE (FLASH_NS_PARTITION_SIZE)
+
+/* Secondary partition for new images in case of firmware upgrade */
+#define SECONDARY_PARTITION_START \
+            (NS_ROM_ALIAS(S_IMAGE_SECONDARY_PARTITION_OFFSET))
+#define SECONDARY_PARTITION_SIZE (FLASH_S_PARTITION_SIZE + \
+                                  FLASH_NS_PARTITION_SIZE)
+
+#ifdef BL2
+/* Bootloader regions */
+#define BL2_CODE_START    (S_ROM_ALIAS(FLASH_AREA_BL2_OFFSET))
+#define BL2_CODE_SIZE     (FLASH_AREA_BL2_SIZE)
+#define BL2_CODE_LIMIT    (BL2_CODE_START + BL2_CODE_SIZE - 1)
+
+#define BL2_DATA_START    (S_RAM_ALIAS(0x0))
+#define BL2_DATA_SIZE     (TOTAL_RAM_SIZE)
+#define BL2_DATA_LIMIT    (BL2_DATA_START + BL2_DATA_SIZE - 1)
+#endif /* BL2 */
+
+/* Shared data area between bootloader and runtime firmware.
+ * Shared data area is allocated at the beginning of the RAM, it is overlapping
+ * with TF-M Secure code's MSP stack
+ */
+#define BOOT_TFM_SHARED_DATA_BASE S_RAM_ALIAS_BASE
+#define BOOT_TFM_SHARED_DATA_SIZE (0x400)
+#define BOOT_TFM_SHARED_DATA_LIMIT (BOOT_TFM_SHARED_DATA_BASE + \
+                                    BOOT_TFM_SHARED_DATA_SIZE - 1)
+
+/* Regions used by psa-arch-tests to keep state */
+#define PSA_TEST_SCRATCH_AREA_SIZE (0x400)
+
+#ifdef PSA_API_TEST_IPC
+/* Firmware Framework test suites */
+#define FF_TEST_PARTITION_SIZE 0x100
+#define PSA_TEST_SCRATCH_AREA_BASE (NS_DATA_LIMIT + 1 - \
+                                    PSA_TEST_SCRATCH_AREA_SIZE - \
+                                    FF_TEST_PARTITION_SIZE)
+
+/* The psa-arch-tests implementation requires that the test partitions are
+ * placed in this specific order:
+ * TEST_NSPE_MMIO < TEST_SERVER < TEST_DRIVER
+ *
+ * TEST_NSPE_MMIO region must be in the NSPE, while TEST_SERVER and TEST_DRIVER
+ * must be in SPE.
+ *
+ * The TEST_NSPE_MMIO region is defined in the psa-arch-tests implementation,
+ * and it should be placed at the end of the NSPE area, after
+ * PSA_TEST_SCRATCH_AREA.
+ */
+#define FF_TEST_SERVER_PARTITION_MMIO_START  (NS_DATA_LIMIT + 1)
+#define FF_TEST_SERVER_PARTITION_MMIO_END    (FF_TEST_SERVER_PARTITION_MMIO_START + \
+                                              FF_TEST_PARTITION_SIZE - 1)
+#define FF_TEST_DRIVER_PARTITION_MMIO_START  (FF_TEST_SERVER_PARTITION_MMIO_END + 1)
+#define FF_TEST_DRIVER_PARTITION_MMIO_END    (FF_TEST_DRIVER_PARTITION_MMIO_START + \
+                                              FF_TEST_PARTITION_SIZE - 1)
+#else
+/* Development APIs test suites */
+#define PSA_TEST_SCRATCH_AREA_BASE (NS_DATA_LIMIT + 1 - \
+                                    PSA_TEST_SCRATCH_AREA_SIZE)
+#endif /* PSA_API_TEST_IPC */
+
+#endif /* __REGION_DEFS_H__ */

--- a/arch/cpu/nrf/nrf5340/target_cfg.c
+++ b/arch/cpu/nrf/nrf5340/target_cfg.c
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2018-2020 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include "target_cfg.h"
+#include "region_defs.h"
+
+#include <spu.h>
+#include <nrfx.h>
+#include <hal/nrf_gpio.h>
+
+#include "nrf5340_application_bitfields.h"
+
+#define PIN_XL1 0
+#define PIN_XL2 1
+
+/* To write into AIRCR register, 0x5FA value must be write to the VECTKEY field,
+ * otherwise the processor ignores the write.
+ */
+#define SCB_AIRCR_WRITE_MASK ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos))
+
+enum tfm_plat_err_t enable_fault_handlers(void)
+{
+    /* Explicitly set secure fault priority to the highest */
+    NVIC_SetPriority(SecureFault_IRQn, 0);
+
+    /* Enables BUS, MEM, USG and Secure faults */
+    SCB->SHCSR |= SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk | SCB_SHCSR_MEMFAULTENA_Msk | SCB_SHCSR_SECUREFAULTENA_Msk;
+    return TFM_PLAT_ERR_SUCCESS;
+}
+
+enum tfm_plat_err_t system_reset_cfg(void)
+{
+    uint32_t reg_value = SCB->AIRCR;
+
+    /* Clear SCB_AIRCR_VECTKEY value */
+    reg_value &= ~(uint32_t)(SCB_AIRCR_VECTKEY_Msk);
+
+    /* Enable system reset request only to the secure world */
+    reg_value |= (uint32_t)(SCB_AIRCR_WRITE_MASK | SCB_AIRCR_SYSRESETREQS_Msk);
+
+    SCB->AIRCR = reg_value;
+
+    return TFM_PLAT_ERR_SUCCESS;
+}
+
+
+/*----------------- NVIC interrupt target state to NS configuration ----------*/
+enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void)
+{
+    /* Target every interrupt to NS; unimplemented interrupts will be Write-Ignored */
+    for (uint8_t i = 0; i < sizeof(NVIC->ITNS) / sizeof(NVIC->ITNS[0]); i++) {
+        NVIC->ITNS[i] = /*0x50000*/ 0xFFFFFFFF;
+    }
+
+    /* Make sure that the SPU is targeted to S state */
+    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_SPU));
+
+#ifdef SECURE_UART1
+    /* UARTE1 is a secure peripheral, so its IRQ has to target S state */
+    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE1));
+#endif
+
+    return TFM_PLAT_ERR_SUCCESS;
+}
+
+/*----------------- NVIC interrupt enabling for S peripherals ----------------*/
+enum tfm_plat_err_t nvic_interrupt_enable(void)
+{
+    /* SPU interrupt enabling */
+    spu_enable_interrupts();
+
+    NVIC_ClearPendingIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPU));
+    NVIC_EnableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPU));
+
+    return TFM_PLAT_ERR_SUCCESS;
+}
+
+/*------------------- SAU/IDAU configuration functions -----------------------*/
+
+void sau_and_idau_cfg(void)
+{
+    /* IDAU (SPU) is always enabled. SAU is non-existent.
+     * Allow SPU to have precedence over (non-existing) ARMv8-M SAU.
+     */
+    TZ_SAU_Disable();
+    SAU->CTRL |= SAU_CTRL_ALLNS_Msk;
+}
+
+enum tfm_plat_err_t spu_periph_init_cfg(void)
+{
+    /* Peripheral configuration */
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_FPU));
+    spu_peripheral_config_non_secure((uint32_t)NRF_FPU, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_REGULATORS));
+    spu_peripheral_config_non_secure((uint32_t)NRF_REGULATORS, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_CLOCK));
+    spu_peripheral_config_non_secure((uint32_t)NRF_CLOCK, true); /*necesary*/
+    // NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPIM0));
+    // spu_peripheral_config_non_secure((uint32_t)NRF_SPIM0, false);
+#ifndef SECURE_UART1
+    /* UART1 is a secure peripheral, so we need to leave Serial-Box 1 as Secure */
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPIM1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM1, false);
+#endif
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPIM4));
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM4, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPIM2));
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM2, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPIM3));
+    spu_peripheral_config_non_secure((uint32_t)NRF_SPIM3, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SAADC));
+    spu_peripheral_config_non_secure((uint32_t)NRF_SAADC, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_TIMER0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER0, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_TIMER1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER1, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_TIMER2));
+    spu_peripheral_config_non_secure((uint32_t)NRF_TIMER2, false);
+    /*Before commeted*/
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_RTC0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_RTC0, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_RTC1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_RTC1, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_DPPIC));
+    spu_peripheral_config_non_secure((uint32_t)NRF_DPPIC, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_WDT0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_WDT0, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_WDT1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_WDT1, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_COMP));
+    spu_peripheral_config_non_secure((uint32_t)NRF_COMP, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_EGU0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU0, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_EGU1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU1, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_EGU2));
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU2, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_EGU3));
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU3, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_EGU4));
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU4, false);
+#ifndef PSA_API_TEST_IPC
+    /* EGU5 is used as a secure peripheral in PSA FF tests */
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_EGU5));
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU5, false);
+#endif
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_PWM0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM0, false); /*necesary*/
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_PWM1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM1, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_PWM2));
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM2, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_PWM3));
+    spu_peripheral_config_non_secure((uint32_t)NRF_PWM3, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_PDM0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_PDM0, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_I2S0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_I2S0, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_IPC));
+    spu_peripheral_config_non_secure((uint32_t)NRF_IPC, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_QSPI));
+    spu_peripheral_config_non_secure((uint32_t)NRF_QSPI, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_NFCT));
+    spu_peripheral_config_non_secure((uint32_t)NRF_NFCT, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_GPIOTE1_NS));
+    spu_peripheral_config_non_secure((uint32_t)NRF_GPIOTE1_NS, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_MUTEX));
+    spu_peripheral_config_non_secure((uint32_t)NRF_MUTEX, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_QDEC0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_QDEC0, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_QDEC1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_QDEC1, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_USBD));
+    spu_peripheral_config_non_secure((uint32_t)NRF_USBD, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_USBREGULATOR));
+    spu_peripheral_config_non_secure((uint32_t)NRF_USBREGULATOR, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_NVMC));
+    spu_peripheral_config_non_secure((uint32_t)NRF_NVMC, false);    /*necesary*/
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_P0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_P0, false);  /*necesary*/
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_P1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_P1, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_VMC));
+    spu_peripheral_config_non_secure((uint32_t)NRF_VMC, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_UARTE1));
+    spu_peripheral_config_non_secure((uint32_t)NRF_UARTE1, false);
+    /*This one is a skip as it is secure explicit*/
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_UARTE2));
+    spu_peripheral_config_non_secure((uint32_t)NRF_UARTE2, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_TWIM2));
+    spu_peripheral_config_non_secure((uint32_t)NRF_TWIM2, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_IPC_S));
+    spu_peripheral_config_non_secure((uint32_t)NRF_IPC_S, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_VMC_S));
+    spu_peripheral_config_non_secure((uint32_t)NRF_VMC_S, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_FPU_S));
+    spu_peripheral_config_non_secure((uint32_t)NRF_FPU_S, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_EGU1_S));
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU1_S, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_EGU2_S));
+    spu_peripheral_config_non_secure((uint32_t)NRF_EGU2_S, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_DPPIC_S));
+    spu_peripheral_config_non_secure((uint32_t)NRF_DPPIC_S, false);
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_REGULATORS_S));
+    spu_peripheral_config_non_secure((uint32_t)NRF_REGULATORS_S, false);
+
+    /* DPPI channel configuration */
+    spu_dppi_config_non_secure(false);
+
+    /* GPIO pin configuration (P0 and P1 ports) */
+    spu_gpio_config_non_secure(0, true); //P0.00 to P0.31
+    spu_gpio_config_non_secure(1, true); //P1.00 to P1.15
+
+    /* Configure properly the XL1 and XL2 pins so that the low-frequency crystal
+     * oscillator (LFXO) can be used.
+     * This configuration can be done only from secure code, as otherwise those
+     * register fields are not accessible.  That's why it is placed here.
+     */
+    nrf_gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
+    nrf_gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
+
+    /* Enable the instruction and data cache (this can be done only from secure
+     * code; that's why it is placed here).
+     */
+    NRF_CACHE->ENABLE = CACHE_ENABLE_ENABLE_Enabled;
+
+    return TFM_PLAT_ERR_SUCCESS;
+}
+
+void spu_periph_configure_to_secure(uint32_t periph_num)
+{
+    spu_peripheral_config_secure(periph_num, true);
+}
+
+void spu_periph_configure_to_non_secure(uint32_t periph_num)
+{
+    spu_peripheral_config_non_secure(periph_num, true);
+}
+
+
+void spu_periph_config_uarte(void)
+{
+    NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_UARTE0));
+    spu_peripheral_config_non_secure((uint32_t)NRF_UARTE0, false); 
+}
+
+void non_secure_configuration(void)
+{
+    spu_regions_reset_all_secure();
+    /*Hard coded linker script addresses*/
+    spu_regions_flash_config_non_secure((uint32_t)NS_CODE_START,(uint32_t)NS_ROM_LIMIT_ADDR);
+    spu_regions_sram_config_non_secure((uint32_t)NS_DATA_START,(uint32_t)NS_DATA_LIMIT);
+    spu_periph_init_cfg();
+}
+
+void configure_nonsecure_vtor_offset(uint32_t vtor_ns)
+{
+	SCB_NS->VTOR = vtor_ns;
+}
+
+void configure_nonsecure_msp(uint32_t msp_ns)
+{
+	__TZ_set_MSP_NS(msp_ns);
+}
+
+static void configure_nonsecure_psp(uint32_t psp_ns)
+{
+	__TZ_set_PSP_NS(psp_ns);
+}
+
+static void configure_nonsecure_control(uint32_t spsel_ns, uint32_t npriv_ns)
+{
+	uint32_t control_ns = __TZ_get_CONTROL_NS();
+
+	/* Only nPRIV and SPSEL bits are banked between security states. */
+	control_ns &= ~(CONTROL_SPSEL_Msk | CONTROL_nPRIV_Msk);
+
+	if (spsel_ns) {
+		control_ns |= CONTROL_SPSEL_Msk;
+	}
+	if (npriv_ns) {
+		control_ns |= CONTROL_nPRIV_Msk;
+	}
+
+	__TZ_set_CONTROL_NS(control_ns);
+}
+
+void tz_nonsecure_state_setup(const tz_nonsecure_setup_conf_t *p_ns_conf)
+{
+	configure_nonsecure_vtor_offset(p_ns_conf->vtor_ns);
+	configure_nonsecure_msp(p_ns_conf->msp_ns);
+	configure_nonsecure_psp(p_ns_conf->psp_ns);
+	/* Select which stack-pointer to use (MSP or PSP) and
+	 * the privilege level for thread mode.
+	 */
+	configure_nonsecure_control(p_ns_conf->control_ns.spsel,
+		p_ns_conf->control_ns.npriv);
+}

--- a/arch/cpu/nrf/nrf5340/target_cfg.h
+++ b/arch/cpu/nrf/nrf5340/target_cfg.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2017-2019 Arm Limited
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __TARGET_CFG_H__
+#define __TARGET_CFG_H__
+
+/**
+ * \file target_cfg.h
+ * \brief nRF5340 target configuration header
+ *
+ * This file contains the platform specific functions to configure
+ * the Cortex-M33 core, memory permissions and security attribution
+ * on the nRF5340 platform.
+ *
+ * Memory permissions and security attribution are configured via
+ * the System Protection Unit (SPU) which is the nRF specific Implementation
+ * Defined Attribution Unit (IDAU).
+ */
+
+
+/**
+ * \brief TFM error codes.
+ */
+enum tfm_plat_err_t {
+    TFM_PLAT_ERR_SUCCESS = 0,
+    TFM_PLAT_ERR_SYSTEM_ERR = 0x3A5C,
+    TFM_PLAT_ERR_MAX_VALUE = 0x55A3,
+    TFM_PLAT_ERR_INVALID_INPUT = 0xA3C5,
+    TFM_PLAT_ERR_UNSUPPORTED = 0xC35A,
+    /* Following entry is only to ensure the error code of int size */
+    // TFM_PLAT_ERR_FORCE_INT_SIZE = INT_MAX
+};
+
+#define TFM_DRIVER_STDIO    Driver_USART1
+#define NS_DRIVER_STDIO     Driver_USART0
+
+/**  
+ * \brief A convenient struct to include all required Non-Secure state configuration.
+ */
+typedef struct tz_nonsecure_setup_conf {
+	uint32_t msp_ns;
+	uint32_t psp_ns;
+	uint32_t vtor_ns;
+	struct {
+		uint32_t npriv:1;
+		uint32_t spsel:1;
+		uint32_t reserved:30;
+	} control_ns;
+} tz_nonsecure_setup_conf_t;
+
+/**
+ * \brief Configure nonsecure vtor offset
+ */
+void configure_nonsecure_vtor_offset(uint32_t vtor_ns);
+
+
+/**
+ * \brief Store the addresses of memory regions
+ */
+struct memory_region_limits {
+    uint32_t non_secure_code_start;
+    uint32_t non_secure_partition_base;
+    uint32_t non_secure_partition_limit;
+    uint32_t veneer_base;
+    uint32_t veneer_limit;
+#ifdef BL2
+    uint32_t secondary_partition_base;
+    uint32_t secondary_partition_limit;
+#endif /* BL2 */
+};
+
+/**
+ * \brief Holds the data necessary to do isolation for a specific peripheral.
+ */
+struct platform_data_t
+{
+    uint32_t periph_start;
+    uint32_t periph_limit;
+};
+
+/**
+ * \brief Configures memory permissions via the System Protection Unit.
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t spu_init_cfg(void);
+
+/**
+ * \brief Configures peripheral permissions via the System Protection Unit.
+ *
+ * The function does the following:
+ * - grants Non-Secure access to nRF peripherals that are not Secure-only
+ * - grants Non-Secure access to DDPI channels
+ * - grants Non-Secure access to GPIO pins
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t spu_periph_init_cfg(void);
+
+/**
+ * \brief Setup nonsecure state
+ */
+void tz_nonsecure_state_setup(const tz_nonsecure_setup_conf_t *p_ns_conf);
+
+/**
+ * \brief Restrict access to peripheral to secure
+ */
+void spu_periph_configure_to_secure(uint32_t periph_num);
+
+/**
+ * \brief Allow non-secure access to peripheral
+ */
+void spu_periph_configure_to_non_secure(uint32_t periph_num);
+
+/**
+ * \brief Configures the NRF_UARTE0 non-secure
+ */
+void spu_periph_config_uarte(void);
+
+/**
+ * \brief Clears SPU interrupt.
+ */
+void spu_clear_irq(void);
+
+/**
+ * \brief Configures SAU and IDAU.
+ */
+void sau_and_idau_cfg(void);
+
+/**
+ * \brief Configure rom, ram and peripherials non-secure
+ */
+void non_secure_configuration(void);
+
+/**
+ * \brief Get non-secure vector table.
+ */
+uint32_t tfm_spm_hal_get_ns_VTOR(void);
+
+/**
+ * \brief Get non-secure MSP location. 
+ */
+uint32_t tfm_spm_hal_get_ns_MSP(void);
+
+/**
+ * \brief Get entry point location. 
+ */
+uint32_t tfm_spm_hal_get_ns_entry_point(void);
+
+/**
+ * \brief Enables the fault handlers and sets priorities.
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t enable_fault_handlers(void);
+
+/**
+ * \brief Configures the system reset request properties
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t system_reset_cfg(void);
+
+/**
+ * \brief Configures the system debug properties.
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t init_debug(void);
+
+/**
+ * \brief Configures all external interrupts to target the
+ *        NS state, apart for the ones associated to secure
+ *        peripherals (plus SPU)
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void);
+
+/**
+ * \brief This function enable the interrupts associated
+ *        to the secure peripherals (plus the isolation boundary violation
+ *        interrupts)
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t nvic_interrupt_enable(void);
+
+#endif /* __TARGET_CFG_H__ */


### PR DESCRIPTION
Import the TrustZone target config
from the trusted firmware project.
The source directory for these files
is:

root/platform/ext/target/nordic_nrf/common/nrf5340

These files are currently not connected
to the build system, they will be when
the TrustZone build support is added.