### PR TITLE
Use CCFG_CONF_* for both TI platforms

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -69,7 +69,7 @@ $(GENDIR)/ieee-addr-id.h.diffupdate: FORCE
 $(OBJECTDIR)/ieee-addr.o: CFLAGS += -I$(GENDIR)
 $(OBJECTDIR)/ieee-addr.o: $(GENDIR)/ieee-addr-id.h
 
-$(OBJECTDIR)/ccfg.o: CFLAGS += -include "ccxxware-conf.h"
+$(OBJECTDIR)/ccfg.o: CFLAGS += -include "ccfg-conf.h"
 
 # a target that gives a user-friendly memory profile, taking into account the RAM
 # that is statically occupied by the stack as defined in the linker script

--- a/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-conf.h
+++ b/arch/cpu/cc26x0-cc13x0/cc13xx-cc26xx-conf.h
@@ -193,12 +193,12 @@
  * \name JTAG interface configuration
  *
  * Enable/Disable the JTAG DAP and TAP interfaces on the chip.
- * Setting this to 0 will disable access to the debug interface
+ * Setting this to 1 will disable access to the debug interface
  * to secure deployed images.
  * @{
  */
-#ifndef CCXXWARE_CONF_JTAG_INTERFACE_ENABLE
-#define CCXXWARE_CONF_JTAG_INTERFACE_ENABLE              1
+#ifndef CCFG_CONF_JTAG_INTERFACE_DISABLE
+#define CCFG_CONF_JTAG_INTERFACE_DISABLE             0
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/
@@ -213,11 +213,11 @@
 
 /* Backward compatibility */
 #ifdef ROM_BOOTLOADER_ENABLE
-#define CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE ROM_BOOTLOADER_ENABLE
+#define CCFG_CONF_ROM_BOOTLOADER_ENABLE ROM_BOOTLOADER_ENABLE
 #endif
 
-#ifndef CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE
-#define CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE              1
+#ifndef CCFG_CONF_ROM_BOOTLOADER_ENABLE
+#define CCFG_CONF_ROM_BOOTLOADER_ENABLE              1
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/cc26x0-cc13x0/ccfg-conf.h
+++ b/arch/cpu/cc26x0-cc13x0/ccfg-conf.h
@@ -31,18 +31,33 @@
  * \addtogroup cc26xx
  * @{
  *
- * \defgroup cc26xx-ccxxware-conf CCxxware-specific configuration
+ * \defgroup cc13xx-cc26xx-ccfg Customer Configuration (CCFG)
  *
  * @{
  *
  * \file
- *  CCxxware-specific configuration for the cc26x0-cc13x0 CPU family
+ *  CCFG configuration for the cc26x0-cc13x0 CPU family
  */
-#ifndef CCXXWARE_CONF_H_
-#define CCXXWARE_CONF_H_
+#ifndef CCFG_CONF_H_
+#define CCFG_CONF_H_
 
 #include "contiki-conf.h"
 
+/*---------------------------------------------------------------------------*/
+#ifdef CCXXWARE_CONF_JTAG_INTERFACE_ENABLE
+#error CCXXWARE_CONF_JTAG_INTERFACE_ENABLE is deprecated. Use \
+  CCFG_CONF_JTAG_INTERFACE_DISABLE.
+#endif
+#ifdef CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE
+#error CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE is deprecated. Use \
+  CCFG_CONF_ROM_BOOTLOADER_ENABLE.
+#endif
+#ifdef CCXXWARE_CONF_BL_PIN_NUMBER
+#error CCXXWARE_CONF_BL_PIN_NUMBER is deprecated. Use CCFG_CONF_BL_PIN_NUMBER.
+#endif
+#ifdef CCXXWARE_CONF_BL_LEVEL
+#error CCXXWARE_CONF_BL_LEVEL is deprecated. Use CCFG_CONF_BL_LEVEL.
+#endif
 /*---------------------------------------------------------------------------*/
 /**
  * \brief JTAG interface configuration
@@ -50,15 +65,7 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-#if CCXXWARE_CONF_JTAG_INTERFACE_ENABLE
-#define SET_CCFG_CCFG_TI_OPTIONS_TI_FA_ENABLE           0xC5
-#define SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE          0xC5
-#define SET_CCFG_CCFG_TAP_DAP_0_PRCM_TAP_ENABLE         0xC5
-#define SET_CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE         0xC5
-#define SET_CCFG_CCFG_TAP_DAP_1_PBIST2_TAP_ENABLE       0xC5
-#define SET_CCFG_CCFG_TAP_DAP_1_PBIST1_TAP_ENABLE       0xC5
-#define SET_CCFG_CCFG_TAP_DAP_1_WUC_TAP_ENABLE          0xC5
-#else
+#if CCFG_CONF_JTAG_INTERFACE_DISABLE
 #define SET_CCFG_CCFG_TI_OPTIONS_TI_FA_ENABLE           0x00
 #define SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE          0x00
 #define SET_CCFG_CCFG_TAP_DAP_0_PRCM_TAP_ENABLE         0x00
@@ -66,6 +73,14 @@
 #define SET_CCFG_CCFG_TAP_DAP_1_PBIST2_TAP_ENABLE       0x00
 #define SET_CCFG_CCFG_TAP_DAP_1_PBIST1_TAP_ENABLE       0x00
 #define SET_CCFG_CCFG_TAP_DAP_1_WUC_TAP_ENABLE          0x00
+#else
+#define SET_CCFG_CCFG_TI_OPTIONS_TI_FA_ENABLE           0xC5
+#define SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE          0xC5
+#define SET_CCFG_CCFG_TAP_DAP_0_PRCM_TAP_ENABLE         0xC5
+#define SET_CCFG_CCFG_TAP_DAP_0_TEST_TAP_ENABLE         0xC5
+#define SET_CCFG_CCFG_TAP_DAP_1_PBIST2_TAP_ENABLE       0xC5
+#define SET_CCFG_CCFG_TAP_DAP_1_PBIST1_TAP_ENABLE       0xC5
+#define SET_CCFG_CCFG_TAP_DAP_1_WUC_TAP_ENABLE          0xC5
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/
@@ -75,10 +90,10 @@
  * Those values are not meant to be modified by the user
  * @{
  */
-#if CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE
+#if CCFG_CONF_ROM_BOOTLOADER_ENABLE
 #define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE      0xC5
-#define SET_CCFG_BL_CONFIG_BL_LEVEL               CCXXWARE_CONF_BL_LEVEL
-#define SET_CCFG_BL_CONFIG_BL_PIN_NUMBER          CCXXWARE_CONF_BL_PIN_NUMBER
+#define SET_CCFG_BL_CONFIG_BL_LEVEL               CCFG_CONF_BL_LEVEL
+#define SET_CCFG_BL_CONFIG_BL_PIN_NUMBER          CCFG_CONF_BL_PIN_NUMBER
 #define SET_CCFG_BL_CONFIG_BL_ENABLE              0xC5
 #else
 #define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE      0x00
@@ -88,7 +103,7 @@
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/
-#endif /* CCXXWARE_CONF_H_ */
+#endif /* CCFG_CONF_H_ */
 /*---------------------------------------------------------------------------*/
 /**
  * @}

--- a/arch/platform/cc26x0-cc13x0/launchpad/cc1310/board.h
+++ b/arch/platform/cc26x0-cc13x0/launchpad/cc1310/board.h
@@ -136,14 +136,14 @@
 /**
  * \brief ROM bootloader configuration
  *
- * Change CCXXWARE_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
- * button triggers the bootloader on reset. Use CCXXWARE_CONF_BL_LEVEL to
+ * Change CCFG_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
+ * button triggers the bootloader on reset. Use CCFG_CONF_BL_LEVEL to
  * control the pin level that enables the bootloader (0: low, 1: high). It is
  * also possible to use any other externally-controlled DIO.
  * @{
  */
-#define CCXXWARE_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_LEFT
-#define CCXXWARE_CONF_BL_LEVEL        0
+#define CCFG_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_LEFT
+#define CCFG_CONF_BL_LEVEL        0
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/cc26x0-cc13x0/launchpad/cc1350/board.h
+++ b/arch/platform/cc26x0-cc13x0/launchpad/cc1350/board.h
@@ -154,14 +154,14 @@
 /**
  * \brief ROM bootloader configuration
  *
- * Change CCXXWARE_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
- * button triggers the bootloader on reset. Use CCXXWARE_CONF_BL_LEVEL to
+ * Change CCFG_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
+ * button triggers the bootloader on reset. Use CCFG_CONF_BL_LEVEL to
  * control the pin level that enables the bootloader (0: low, 1: high). It is
  * also possible to use any other externally-controlled DIO.
  * @{
  */
-#define CCXXWARE_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_LEFT
-#define CCXXWARE_CONF_BL_LEVEL        0
+#define CCFG_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_LEFT
+#define CCFG_CONF_BL_LEVEL        0
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/cc26x0-cc13x0/launchpad/cc2640r2/board.h
+++ b/arch/platform/cc26x0-cc13x0/launchpad/cc2640r2/board.h
@@ -136,14 +136,14 @@
 /**
  * \brief ROM bootloader configuration
  *
- * Change CCXXWARE_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
- * button triggers the bootloader on reset. Use CCXXWARE_CONF_BL_LEVEL to
+ * Change CCFG_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
+ * button triggers the bootloader on reset. Use CCFG_CONF_BL_LEVEL to
  * control the pin level that enables the bootloader (0: low, 1: high). It is
  * also possible to use any other externally-controlled DIO.
  * @{
  */
-#define CCXXWARE_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_LEFT
-#define CCXXWARE_CONF_BL_LEVEL        0
+#define CCFG_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_LEFT
+#define CCFG_CONF_BL_LEVEL        0
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/cc26x0-cc13x0/launchpad/cc2650/board.h
+++ b/arch/platform/cc26x0-cc13x0/launchpad/cc2650/board.h
@@ -136,14 +136,14 @@
 /**
  * \brief ROM bootloader configuration
  *
- * Change CCXXWARE_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
- * button triggers the bootloader on reset. Use CCXXWARE_CONF_BL_LEVEL to
+ * Change CCFG_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
+ * button triggers the bootloader on reset. Use CCFG_CONF_BL_LEVEL to
  * control the pin level that enables the bootloader (0: low, 1: high). It is
  * also possible to use any other externally-controlled DIO.
  * @{
  */
-#define CCXXWARE_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_LEFT
-#define CCXXWARE_CONF_BL_LEVEL        0
+#define CCFG_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_LEFT
+#define CCFG_CONF_BL_LEVEL        0
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/cc26x0-cc13x0/sensortag/cc1350/board.h
+++ b/arch/platform/cc26x0-cc13x0/sensortag/cc1350/board.h
@@ -254,8 +254,8 @@
  * Sensortags do not support the bootloader
  * @{
  */
-#define CCXXWARE_CONF_BL_PIN_NUMBER   IOID_UNUSED
-#define CCXXWARE_CONF_BL_LEVEL        0
+#define CCFG_CONF_BL_PIN_NUMBER   IOID_UNUSED
+#define CCFG_CONF_BL_LEVEL        0
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/cc26x0-cc13x0/sensortag/cc2650/board.h
+++ b/arch/platform/cc26x0-cc13x0/sensortag/cc2650/board.h
@@ -235,8 +235,8 @@
  * Sensortags do not support the bootloader
  * @{
  */
-#define CCXXWARE_CONF_BL_PIN_NUMBER   IOID_UNUSED
-#define CCXXWARE_CONF_BL_LEVEL        0
+#define CCFG_CONF_BL_PIN_NUMBER   IOID_UNUSED
+#define CCFG_CONF_BL_LEVEL        0
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/cc26x0-cc13x0/srf06/cc13x0/board.h
+++ b/arch/platform/cc26x0-cc13x0/srf06/cc13x0/board.h
@@ -213,14 +213,14 @@
 /**
  * \brief ROM bootloader configuration
  *
- * Change CCXXWARE_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
- * button triggers the bootloader on reset. Use CCXXWARE_CONF_BL_LEVEL to
+ * Change CCFG_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
+ * button triggers the bootloader on reset. Use CCFG_CONF_BL_LEVEL to
  * control the pin level that enables the bootloader (0: low, 1: high). It is
  * also possible to use any other externally-controlled DIO.
  * @{
  */
-#define CCXXWARE_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_SELECT
-#define CCXXWARE_CONF_BL_LEVEL        0
+#define CCFG_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_SELECT
+#define CCFG_CONF_BL_LEVEL        0
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/arch/platform/cc26x0-cc13x0/srf06/cc26x0/board.h
+++ b/arch/platform/cc26x0-cc13x0/srf06/cc26x0/board.h
@@ -213,14 +213,14 @@
 /**
  * \brief ROM bootloader configuration
  *
- * Change CCXXWARE_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
- * button triggers the bootloader on reset. Use CCXXWARE_CONF_BL_LEVEL to
+ * Change CCFG_CONF_BL_PIN_NUMBER to BOARD_IOID_KEY_xyz to select which
+ * button triggers the bootloader on reset. Use CCFG_CONF_BL_LEVEL to
  * control the pin level that enables the bootloader (0: low, 1: high). It is
  * also possible to use any other externally-controlled DIO.
  * @{
  */
-#define CCXXWARE_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_SELECT
-#define CCXXWARE_CONF_BL_LEVEL        0
+#define CCFG_CONF_BL_PIN_NUMBER   BOARD_IOID_KEY_SELECT
+#define CCFG_CONF_BL_LEVEL        0
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/doc/platforms/srf06-cc26xx.md
+++ b/doc/platforms/srf06-cc26xx.md
@@ -219,7 +219,7 @@ For more information on the serial bootloader, see its README under the `tools/c
 For deployment/production images, it is _strongly_ recommended to:
 
 * Disable the ROM bootloader by defining `ROM_BOOTLOADER_ENABLE` as 0. In doing so, it is impossible to enter bootloader mode unless one first erases the device's flash.
-* Disable the JTAG interface, by defining `CCXXWARE_CONF_JTAG_INTERFACE_ENABLE` as 0. In doing so, the only JTAG operation available will be a device forced mass erase (using SmartRF Flash Programmer or UniFlash).
+* Disable the JTAG interface, by defining `CCFG_CONF_JTAG_INTERFACE_DISABLE` as 1. In doing so, the only JTAG operation available will be a device forced mass erase (using SmartRF Flash Programmer or UniFlash).
 
 Both macros have default values set in `arch/cpu/cc26xx-cc13xx/cc13xx-cc26xx-conf.h`. You can change this file, or you can override the defaults in `contiki-conf.h` or `project-conf.h`.
 

--- a/doc/project/Release-Notes-next.md
+++ b/doc/project/Release-Notes-next.md
@@ -50,6 +50,7 @@ Examples for PowerTracker and other plugins can be found in the PR
 ### Contiki-NG
 
 * Support for link-time-optimization in the build system ([#2077](https://github.com/contiki-ng/contiki-ng/pull/2077))
+* Consolidate configuration defines of TI platforms. Prefixes `CCXXWARE_CONF` and `CC26XX_UART_CONF` are deprecated in favor of `CCFG_CONF` and `TI_UART_CONF`. ([#2311](https://github.com/contiki-ng/contiki-ng/pull/2311), [#2387](https://github.com/contiki-ng/contiki-ng/pull/2387))
 
 All [commits](https://github.com/contiki-ng/contiki-ng/compare/release/v4.8...develop) since v4.8.
 

--- a/examples/platform-specific/cc26x0-cc13x0/base-demo/project-conf.h
+++ b/examples/platform-specific/cc26x0-cc13x0/base-demo/project-conf.h
@@ -32,7 +32,7 @@
 #define PROJECT_CONF_H_
 /*---------------------------------------------------------------------------*/
 /* Enable the ROM bootloader */
-#define CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE   1
+#define CCFG_CONF_ROM_BOOTLOADER_ENABLE       1
 /*---------------------------------------------------------------------------*/
 /* Change to match your configuration */
 #define IEEE802154_CONF_PANID            0xABCD

--- a/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/project-conf.h
+++ b/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/project-conf.h
@@ -64,7 +64,7 @@
 #define SENSORTAG_CC2650_REV_1_2_0            0
 /*---------------------------------------------------------------------------*/
 /* Enable the ROM bootloader */
-#define CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE   1
+#define CCFG_CONF_ROM_BOOTLOADER_ENABLE       1
 /*---------------------------------------------------------------------------*/
 /*
  * Shrink the size of the uIP buffer, routing table and ND cache.

--- a/examples/sensniff/cc26x0-cc13x0/target-conf.h
+++ b/examples/sensniff/cc26x0-cc13x0/target-conf.h
@@ -34,7 +34,7 @@
 /*---------------------------------------------------------------------------*/
 #define TI_UART_CONF_BAUD_RATE         460800
 #define RF_BLE_CONF_ENABLED                 0
-#define CCXXWARE_CONF_ROM_BOOTLOADER_ENABLE 1
+#define CCFG_CONF_ROM_BOOTLOADER_ENABLE     1
 /*---------------------------------------------------------------------------*/
 #define SENSNIFF_IO_DRIVER_H "pool/cc13xx-cc26xx-io.h"
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The two TI platforms are not aligned when it comes to configuring the CCFG: cc26x0-cc13x0 platform uses `CCXXWARE_CONF` prefix, while simplelink platform uses `CCFG_CONF` prefix. This PR refactors such that they both use `CCFG_CONF`, making it easier to move an application between the two platforms.

Using same deprecation-strategy as in #2311 
