### PR TITLE
Fix include of random-lib in rpl-icmp6

### DIFF
--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -51,7 +51,7 @@
 #include "net/routing/rpl-classic/rpl-private.h"
 #include "net/packetbuf.h"
 #include "net/ipv6/multicast/uip-mcast6.h"
-#include "random.h"
+#include "lib/random.h"
 
 #include "sys/log.h"
 


### PR DESCRIPTION
As in title, gave me trouble when making binaries for the FIT IoT-lab.