### PR TITLE
Enable excluding specific source files from a MODULE

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -328,7 +328,11 @@ endif
 MODULEDIRS = $(MODULES_REL) ${addprefix $(CONTIKI)/, $(MODULES)}
 # Sort removes duplicates.
 UNIQUEMODULES = $(sort $(MODULEDIRS))
-MODULES_SOURCES = ${foreach d, $(UNIQUEMODULES), ${subst ${d}/,,${wildcard $(d)/*.c}}}
+MODULES_SOURCES = ${foreach d, $(UNIQUEMODULES), \
+	${subst ${d}/, \
+		, \
+		${filter-out ${addprefix $(CONTIKI)/, $(MODULES_EXCLUSIONS)}, \
+				${wildcard $(d)/*.c}}}}
 
 # Include module-specific makefiles
 MODULES_INCLUDES = ${wildcard ${foreach d, $(UNIQUEMODULES), $(d)/Makefile.${notdir $(d)}}}


### PR DESCRIPTION
This PR enables excluding specific source files from a MODULE through `MODULES_EXCLUSIONS += <path>/source.c`. Unlike `MODULES_SOURCES_EXCLUDES`, the full path is used to resolve situations where a C file with the same name appears both in the module and Contiki-NG.