### PR TITLE
Send PROCESS_EVENT_EXITED only to running processes

### DIFF
--- a/os/sys/process.c
+++ b/os/sys/process.c
@@ -145,7 +145,11 @@ exit_process(struct process *p, const struct process *fromprocess)
      * deallocate state associated with this process.
      */
     for(q = process_list; q != NULL; q = q->next) {
-      if(p != q) {
+      /*
+       * since p is set to PROCESS_STATE_NONE above, it will
+       * automatically be excluded from this call list
+       */
+      if(q->state == PROCESS_STATE_RUNNING) {
         call_process(q, PROCESS_EVENT_EXITED, (process_data_t)p);
       }
     }


### PR DESCRIPTION
I was cleaning up my github account a bit, and was reminded of [this old PR I made for contiki](https://github.com/contiki-os/contiki/pull/2308).  I see its compatible with this project, so I thought I'd see if it's wanted here.

----

I use process events quite heavily for inter-process communication.  Because of this, I wanted to raise an alarm if `call_process` is called targeting a process which is not in a state to receive the call.

What I found, was that this happens frequently, but only with `PROCESS_EVENT_EXITED`.  The reason being: `exit_process` goes through all processes, regardless of their state, and notifies them.  Although there is no adverse effect of doing this, it is somewhat wasteful since it is not necessary to attempt to notify non-running processes that another process has exited. 

So I made this little patch to send `PROCESS_EVENT_EXITED` only to processes with the state `PROCESS_STATE_RUNNING`