### PR TITLE
Fix incorrect comparisons

### DIFF
--- a/arch/platform/zoul/dev/grove-gyro.c
+++ b/arch/platform/zoul/dev/grove-gyro.c
@@ -623,7 +623,7 @@ configure(int type, int value)
     return grove_gyro_dlpf(value);
 
   case GROVE_GYRO_SAMPLE_RATE_DIVIDER:
-    if((value < 0) && (value > 0xFF)) {
+    if((value < 0) || (value > 0xFF)) {
       PRINTF("Gyro: invalid sampling rate div, it must be an 8-bit value\n");
       return GROVE_GYRO_ERROR;
     }

--- a/arch/platform/zoul/dev/rtcc.c
+++ b/arch/platform/zoul/dev/rtcc.c
@@ -421,7 +421,7 @@ rtcc_set_alarm_time_date(simple_td_map *data, uint8_t state, uint8_t repeat,
     return AB08_ERROR;
   }
 
-  if((state >= RTCC_ALARM_MAX) || (repeat >= RTCC_REPEAT_100THS)) {
+  if((state >= RTCC_ALARM_MAX) || (repeat > RTCC_REPEAT_100THS)) {
     PRINTF("RTC: invalid alarm config type or state\n");
     return AB08_ERROR;
   }

--- a/arch/platform/zoul/dev/servo.c
+++ b/arch/platform/zoul/dev/servo.c
@@ -58,7 +58,7 @@ servo_position(uint16_t gptab, uint8_t port, uint8_t pin, uint16_t pos)
   uint8_t gpt_ab;
   uint32_t count = 0;
 
-  if((gptab < SERVO_CHANNEL_1) && (gptab > SERVO_CHANNEL_7)) {
+  if((gptab < SERVO_CHANNEL_1) || (gptab > SERVO_CHANNEL_7)) {
     PRINTF("Servo: invalid servo channel\n");
     return SERVO_ERROR;
   }
@@ -107,7 +107,7 @@ servo_stop(uint16_t gptab, uint8_t port, uint8_t pin)
   uint8_t gpt_num;
   uint8_t gpt_ab;
 
-  if((gptab < SERVO_CHANNEL_1) && (gptab > SERVO_CHANNEL_7)) {
+  if((gptab < SERVO_CHANNEL_1) || (gptab > SERVO_CHANNEL_7)) {
     PRINTF("Servo: invalid servo channel\n");
     return SERVO_ERROR;
   }

--- a/examples/platform-specific/zoul/test-bmp085-bmp180.c
+++ b/examples/platform-specific/zoul/test-bmp085-bmp180.c
@@ -60,7 +60,7 @@ static struct etimer et;
 PROCESS_THREAD(remote_bmpx8x_process, ev, data)
 {
   PROCESS_BEGIN();
-  static uint16_t pressure;
+  static int pressure;
   static int16_t temperature;
 
   /* Use Contiki's sensor macro to enable the sensor */

--- a/examples/platform-specific/zoul/test-grove-light-sensor.c
+++ b/examples/platform-specific/zoul/test-grove-light-sensor.c
@@ -61,7 +61,7 @@ PROCESS_THREAD(remote_grove_light_process, ev, data)
 {
   PROCESS_BEGIN();
 
-  uint16_t ldr;
+  int ldr;
 
   /* Use pin number not mask, for example if using the PA5 pin then use 5 */
   adc_sensors.configure(ANALOG_GROVE_LIGHT, 5);

--- a/examples/platform-specific/zoul/test-grove-loudness-sensor.c
+++ b/examples/platform-specific/zoul/test-grove-loudness-sensor.c
@@ -61,7 +61,7 @@ PROCESS_THREAD(remote_grove_loudness_process, ev, data)
 {
   PROCESS_BEGIN();
 
-  uint16_t loudness;
+  int loudness;
 
   /* Use pin number not mask, for example if using the PA5 pin then use 5 */
   adc_sensors.configure(ANALOG_GROVE_LOUDNESS, ADC_PIN);

--- a/examples/platform-specific/zoul/test-pm10-sensor.c
+++ b/examples/platform-specific/zoul/test-pm10-sensor.c
@@ -66,7 +66,7 @@ PROCESS_THREAD(test_pm10_sensor_process, ev, data)
 {
   PROCESS_BEGIN();
 
-  static uint16_t pm10_value;
+  static int pm10_value;
 
   /* Use pin number not mask, for example if using the PA5 pin then use 2 */
   pm10.configure(SENSORS_ACTIVE, ADC_PIN);

--- a/examples/platform-specific/zoul/test-rotation-sensor.c
+++ b/examples/platform-specific/zoul/test-rotation-sensor.c
@@ -61,7 +61,7 @@ PROCESS_THREAD(remote_rotation_process, ev, data)
 {
   PROCESS_BEGIN();
 
-  uint16_t rotation;
+  int rotation;
 
   /* Use pin number not mask, for example if using the PA5 pin then use 5 */
   adc_sensors.configure(ANALOG_PHIDGET_ROTATION_1109, 5);


### PR DESCRIPTION
1. Fix some logical operators
2. The comparison uint16_t != -1 is always true. Should use an int to save the return value of a function that returns an int.