### PR TITLE
Fix stack address escape

### DIFF
--- a/arch/cpu/cc2538/dev/aes.c
+++ b/arch/cpu/cc2538/dev/aes.c
@@ -123,6 +123,9 @@ aes_load_keys(const void *keys, uint8_t key_size, uint8_t count,
   /* Wait for operation to complete */
   while(!(REG(AES_CTRL_INT_STAT) & AES_CTRL_INT_STAT_RESULT_AV));
 
+  /* Clean up the keys */
+  REG(AES_DMAC_CH0_EXTADDR) = 0x00000000;
+
   /* Check for absence of errors in DMA and key store */
   if(REG(AES_CTRL_INT_STAT) & AES_CTRL_INT_STAT_DMA_BUS_ERR) {
     REG(AES_CTRL_INT_CLR) = AES_CTRL_INT_CLR_DMA_BUS_ERR;


### PR DESCRIPTION
Fix storing the address of a local variable in non-local memory:
https://github.com/contiki-ng/contiki-ng/blob/8518cbaff6a717d02444b686a75cdb240648fbf4/arch/cpu/cc2538/dev/aes.c#L116