### PR TITLE
antelope,storage-cfs: Fix length of filename array

### DIFF
--- a/os/storage/antelope/storage-cfs.c
+++ b/os/storage/antelope/storage-cfs.c
@@ -333,7 +333,7 @@ error:
 db_result_t
 storage_get_index(index_t *index, relation_t *rel, attribute_t *attr)
 {
-  char filename[INDEX_NAME_LENGTH];
+  char filename[INDEX_NAME_LENGTH + 1];
   int fd;
   int r;
   struct index_record record;
@@ -369,7 +369,7 @@ storage_get_index(index_t *index, relation_t *rel, attribute_t *attr)
 db_result_t
 storage_put_index(index_t *index)
 {
-  char filename[INDEX_NAME_LENGTH];
+  char filename[INDEX_NAME_LENGTH + 1];
   int fd;
   int r;
   struct index_record record;


### PR DESCRIPTION
https://github.com/contiki-ng/contiki-ng/blob/406ae7da30fb5fadacf0d646a4dc4ac0513a2dec/os/storage/antelope/storage.h#L47-L49
The macro `INDEX_NAME_LENGTH` does not count the trailing null char.