### PR TITLE
add PLATFORM_HAS_LEDS to coojamote header files

### DIFF
--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -147,9 +147,10 @@ typedef unsigned long clock_time_t;
 
 #define BUTTON_HAL_CONF_DEBOUNCE_DURATION 0
 
-/* Notify various examples that we have Buttons */
+/* Notify various examples that we have Buttons and LEDs */
 #define PLATFORM_HAS_BUTTON    1
 #define PLATFORM_SUPPORTS_BUTTON_HAL 1
+#define PLATFORM_HAS_LEDS    1
 /*---------------------------------------------------------------------------*/
 /* Virtual LED colors */
 #define LEDS_CONF_COUNT                  3


### PR DESCRIPTION
Cooja motes implement the LED HAL API (thanks to https://github.com/contiki-ng/contiki-ng/pull/1044), but do not have the right defines in place, so it end up being unused.