### PR TITLE
Add missing renaming of TSCH schedule function per PR#2040

### DIFF
--- a/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-ns.c
+++ b/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-ns.c
@@ -91,7 +91,7 @@ remove_uc_link(const linkaddr_t *linkaddr)
 {
   if(linkaddr != NULL) {
     uint16_t timeslot = get_node_timeslot(linkaddr);
-    tsch_schedule_remove_link_by_timeslot(sf_unicast, timeslot, 0);
+    tsch_schedule_remove_link_by_offsets(sf_unicast, timeslot, 0);
     tsch_queue_free_packets_to(linkaddr);
   }
 }


### PR DESCRIPTION
Develop got broken after merging #2040 due to one call of the renamed TSCH schedule functions was missed. This PR fixes. ~Not sure why the test did not fail in #2040 but too late to investigate this now😴~ Test did not fail in #2040 because it was rebased the day before the offending changes was added in #1540 🤦‍♂️ Memo to self: Re-run CI (or rebase) PRs that have been stale for a while before merging.