### PR TITLE
Workaround for RPL forwarding inconsistency leading to dropped packet

### DIFF
--- a/os/net/routing/rpl-classic/rpl-ext-header.c
+++ b/os/net/routing/rpl-classic/rpl-ext-header.c
@@ -159,6 +159,10 @@ rpl_ext_header_hbh_update(uint8_t *ext_buf, int opt_offset)
       /* Packet must be dropped and dio trickle timer reset, see
          RFC6550 - 11.2.2.2 */
       rpl_reset_dio_timer(instance);
+      /* Don't drop packet if it was for us. Workaround for issue #2285 */
+      if(uip_ds6_is_my_addr(&UIP_IP_BUF->destipaddr)) {
+        return 1;
+      }
       return 0;
     }
 

--- a/tests/15-rpl-classic/js/12-rpl-rank-error.js
+++ b/tests/15-rpl-classic/js/12-rpl-rank-error.js
@@ -5,13 +5,11 @@ while(true) {
 
   if(msg.contains("RPL Option Error: Dropping Packet")) {
     log.log(time + " " + "node-" + id + " "+ msg + "\n");
-    // FIXME Logic inverted to showcase issue. Revert when implementing fix.
-    log.testOK();
+    log.testFailed();
   }
 
   if(msg.contains("Received all packets")) {
     log.log(time + " " + "node-" + id + " "+ msg + "\n");
-    // FIXME Logic inverted to showcase issue. Revert when implementing fix.
-    log.testFailed();
+    log.testOK();
   }
 }


### PR DESCRIPTION
This is a workaround for issue #2285, where received packets that are addressed to ourselves and are forwarded inconsistently (according to [RFC6550 Section 11.2.2.2](https://www.rfc-editor.org/rfc/rfc6550#section-11.2.2.2)), will be dropped. This happens as the packet goes through the RPL extension-header processing twice: In the first pass it will be marked with the Rank-Error bit, and in the second pass the bit is seen and the packet is dropped.

This PR
1. Adds a workaround to the issue, ensuring the packet is not dropped.
2. ~~Adds a simulation test-case that showcases the issue. The test fails without the workaround, and passes with it.~~. The test for the issue was added separately in #2548 . This PR simply reverts the logic in the test such that it passes only if the issue is resolved.

I am calling this a workaround because it only mitigates the dropping of the packet (the issue still causes reset of DIO timer and erroneous RPL statistics). I have taken this conservative low-risk approach because I am no RPL/uIP expert and I can't really judge what is the proper solution - e.g. if we should rather avoid the double processing of extension-headers in such cases (and if so how to safely implement). As such I will have no trouble if we don't merge this and rather leave it for others to work onward from.

For further details see test-description in #2548 and issue #2285.