### PR TITLE
cc2538.lds: fix spacing

### DIFF
--- a/arch/cpu/cc2538/cc2538.lds
+++ b/arch/cpu/cc2538/cc2538.lds
@@ -68,7 +68,7 @@ SECTIONS
         *(.text*)
         *(.rodata*)
         _etext = .;
-    } > FLASH_FW= 0
+    } > FLASH_FW = 0
 
     .socdata (NOLOAD) :
     {


### PR DESCRIPTION
ARM GCC 12 gives a warning that disappears
when adding a space between the variable name
and the equals sign.