### PR TITLE
cc26x0-cc13x0: use status code that exists

### DIFF
--- a/arch/cpu/cc26x0-cc13x0/rf-core/ble-hal/rf-ble-cmd.c
+++ b/arch/cpu/cc26x0-cc13x0/rf-core/ble-hal/rf-ble-cmd.c
@@ -521,8 +521,7 @@ rf_ble_cmd_add_data_queue_entry(dataQueue_t *q, uint8_t *e)
   cmd.pEntry = e;
 
   if(rf_core_send_cmd((uint32_t)&cmd, &cmdsta) != RF_CORE_CMD_OK) {
-    LOG_ERR("could not add entry to data queue. status: 0x%04X\n",
-            CMD_GET_STATUS(&cmd));
+    LOG_ERR("could not add entry to data queue. status: 0x%04" PRIX32 "\n", cmdsta);
     return RF_BLE_CMD_ERROR;
   }
   return RF_BLE_CMD_OK;


### PR DESCRIPTION
The struct does not have a status field,
so print the cmdsta value instead.