### PR TITLE
heapmem: include the code only if the arena size is configured

### DIFF
--- a/os/lib/heapmem.c
+++ b/os/lib/heapmem.c
@@ -36,28 +36,24 @@
  * 	Nicolas Tsiftes <nvt@acm.org>
  */
 
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "contiki.h"
+#include "lib/heapmem.h"
+#include "sys/cc.h"
+
+#ifdef HEAPMEM_CONF_ARENA_SIZE
+
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "HeapMem"
 #define LOG_LEVEL LOG_LEVEL_WARN
 
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
-
-#include "lib/heapmem.h"
-#include "sys/cc.h"
-
 /* The HEAPMEM_CONF_ARENA_SIZE parameter determines the size of the
    space that will be statically allocated in this module. */
-#ifdef HEAPMEM_CONF_ARENA_SIZE
 #define HEAPMEM_ARENA_SIZE HEAPMEM_CONF_ARENA_SIZE
-#else
-/* If the heap size is not set, we use a minimal size that will ensure
-   that all allocation attempts fail. */
-#define HEAPMEM_ARENA_SIZE 1
-#endif
-/* HEAPMEM_CONF_ARENA_SIZE */
 
 /*
  * The HEAPMEM_CONF_SEARCH_MAX parameter limits the time spent on
@@ -613,3 +609,5 @@ heapmem_alignment(void)
 {
   return HEAPMEM_ALIGNMENT;
 }
+
+#endif /* HEAPMEM_CONF_ARENA_SIZE */

--- a/os/lib/heapmem.h
+++ b/os/lib/heapmem.h
@@ -52,6 +52,10 @@
  * heapmem_realloc(), because the chunk structure immediately precedes
  * the memory of the chunk.
  *
+ * \note If the HEAPMEM_CONF_ARENA_SIZE parameter is not set, the
+ * heapmem implementation will not be compiled, which could lead to a
+ * linking error if other modules call heapmem functions.
+ *
  * \note This module does not contain a corresponding function to the
  *       standard C function calloc().
  *


### PR DESCRIPTION
This PR removes a GCC 12 compiler warning, which is a false positive.