### PR TITLE
Makefile: add --warn-common to LDFLAGS

### DIFF
--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -48,6 +48,7 @@ LDFLAGS += -mthumb -mabi=aapcs -mlittle-endian
 
 # Disallow undefined symbols in object files.
 LDFLAGS += -Wl,-zdefs
+LDFLAGS += -Wl,--warn-common
 
 OBJDUMP_FLAGS += --disassemble --source --disassembler-options=force-thumb
 

--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -55,6 +55,7 @@ endif
 # Disallow undefined symbols in object files.
 ifeq ($(HOST_OS),Linux)
 LDFLAGS += -Wl,-zdefs
+LDFLAGS += -Wl,--warn-common
 endif
 
 MAKE_MAC ?= MAKE_MAC_NULLMAC

--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -44,6 +44,7 @@ ifeq ($(HOST_OS),Darwin)
 else
   CFLAGS += -fPIC
   LDFLAGS += -shared -Wl,-zdefs
+  LDFLAGS += -Wl,--warn-common
   LDFLAGS += -Wl,-T$(CONTIKI_NG_RELOC_PLATFORM_DIR)/cooja/cooja.ld
   # Use the printf-family replacement functions in dbg-io.
   LDFLAGS += $(addprefix -Wl$(COMMA)--wrap$(COMMA), $(WRAPPED_FUNS))


### PR DESCRIPTION
This will make the linker warn if there are
multiple definitions of the same symbol that
end up in a common block.

This should not happen in practice since
GCC 10 enabled -fno-common by default, so
adding the warning is low risk.
