### PR TITLE
cooja: build mtype.c as regular file

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -74,7 +74,7 @@ COOJA_INTFS	= beep.c ip.c leds-arch.c moteid.c \
 		    clock.c cooja-log.c cfs-cooja.c cooja-radio.c \
 			eeprom.c slip-arch.c
 
-COOJA_CORE = platform.c random.c sensors.c leds.c gpio-hal-arch.c buttons.c
+COOJA_CORE = platform.c mtype.c random.c sensors.c leds.c gpio-hal-arch.c buttons.c
 
 # (COOJA_SOURCEFILES contains additional sources set from simulator)
 CONTIKI_TARGET_SOURCEFILES = \
@@ -88,18 +88,3 @@ ifeq ($(WERROR),1)
 CFLAGSNO += -Werror
 endif
 CFLAGS   += $(CFLAGSNO)
-
-# This is mtype<NNN>.o which is built from mtype.c.
-MTYPE_OBJ = $(LIBNAME:.cooja=.o)
-MTYPE_DEP = $(DEPDIR)/$(notdir $(LIBNAME:.cooja=.d))
-
-# LIBNAME is not set for example in QUICKSTART or for clean
-ifdef LIBNAME
-TARGET_DEPFILES += $(MTYPE_DEP)
-endif # LIBNAME
-
-PROJECT_OBJECTFILES += $(MTYPE_OBJ)
-
-$(MTYPE_OBJ): mtype.c $(MTYPE_DEP) | $(DEPDIR)
-	$(TRACE_CC)
-	$(Q)$(CCACHE) $(CC) $(CFLAGS) -MT $@ -MMD -MP -MF $(MTYPE_DEP) -c $< -o $@


### PR DESCRIPTION
After removing JNI, mtype.c can be built the same
way as the other files in the platform.