### PR TITLE
Makefile: stop putting target in .

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,33 +28,6 @@ tools/coffee-manager/build/
 tools/coffee-manager/coffee.jar
 COOJA.testlog
 
-# platform build artifacts
-*.cc2538dk
-*.cooja
-*.native
-*.nrf52840
-*.openmote
-*.simplelink
-*.sky
-*.firmware
-*.cc26x0-cc13x0
-*.z1
-*.zoul
-*.nrf
-*.gecko
-
-# do not ignore platform makefiles
-!Makefile.cc2538dk
-!Makefile.cooja
-!Makefile.native
-!Makefile.nrf52840
-!Makefile.openmote
-!Makefile.sky
-!Makefile.cc26x0-cc13x0
-!Makefile.zoul
-!Makefile.nrf
-!Makefile.gecko
-
 # do not ignore images in documentation
 !tools/readthedocs/**/*.png
 !doc/**/*.png

--- a/Makefile.include
+++ b/Makefile.include
@@ -492,12 +492,11 @@ PROJECT_OBJECTFILES += ${addprefix $(OBJECTDIR)/,${call oname, $(PROJECT_FILTERE
 .PHONY: all clean distclean usage help targets boards savetarget savedefines viewconf
 
 clean:
-	$(Q)rm -f *.d *.e *.o $(CLEAN) \
-		$(addsuffix .$(TARGET), $(CONTIKI_PROJECT))
+	$(Q)rm -f *.e $(CLEAN)
 	$(Q)rm -rf $(BUILD_DIR_TARGET)
 
 distclean:
-	$(Q)for TARG in `ls $(CONTIKI_NG_RELOC_PLATFORM_DIR) $(TARGETDIRS)`; do \
+	$(Q)[ $(TARGETDIRS) = "" ] || for TARG in `ls $(TARGETDIRS)`; do \
 		$(MAKE) TARGET=$$TARG clean; \
 	done
 	$(Q)rm -rf $(BUILD_DIR)
@@ -657,9 +656,9 @@ ifdef BINARY_SIZE_LOGFILE
 endif
 endif
 
+# Keep an empty command so this is a rule, not just a prerequisite.
 %.$(TARGET): $(BUILD_DIR_BOARD)/%.$(TARGET)
-	$(TRACE_CP)
-	$(Q)$(CP) $< $@
+	@
 
 %.ramprof: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	$(NM) -S -td --size-sort $< | grep -i " [abdrw] " | cut -d' ' -f2,4
@@ -744,6 +743,6 @@ else
 # Match-anything pattern rule to allow the project makefiles to
 # abstract from the actual binary name. It needs to contain some
 # command in order to be a rule, not just a prerequisite.
-%: %.$(TARGET)
+%: $(BUILD_DIR_BOARD)/%.$(TARGET)
 	@
 endif

--- a/doc/getting-started/The-Contiki-NG-build-system.md
+++ b/doc/getting-started/The-Contiki-NG-build-system.md
@@ -9,16 +9,16 @@ all: $(CONTIKI_PROJECT)
 CONTIKI = ../..
 include $(CONTIKI)/Makefile.include
 ```
-After defining the project name and Contiki-NG path, the common makefile is simply included. By running `make` from this directory, the `hello-world` system will be build for the default target: `native`. The `native` target is a special platform that builds Contiki-NG as a program able to run on the development system (e.g. Linux). Just run the file `hello-world.native` after compiling it.
+After defining the project name and Contiki-NG path, the common makefile is simply included. By running `make` from this directory, the `hello-world` system will be build for the default target: `native`. The `native` target is a special platform that builds Contiki-NG as a program able to run on the development system (e.g. Linux). Just run the file `build/native/hello-world.native` after compiling it.
 
 To compile the hello-world application for a different platform, use the flag `TARGET`, e.g. with `TARGET=zoul`. On some platforms, an additional `BOARD` is necessary to further specify the target.
 
 ## Build system output structure
 The build system will generate a number of files that will be placed in a number of locations. This guide uses the `hello-world` example as a use-case, but the output will be the same for all other examples.
 
-The build system will always put the final build output file (firmware) in the example's `.` directory. This is the firmware to use to programme your device (embedded targets) or to execute (native paltform). For the hello-world example, this will be called `hello-world.$(TARGET)` (e.g. `hello-world.native` or `hello-world.zoul`.
+The build system will always put the final build output file (firmware) in the example's `build/$(TARGET)/[ $(BOARD) ]` directory. This is the firmware to use to programme your device (embedded targets) or to execute (native paltform). For the hello-world example, this will be called `build/$(TARGET)[ /$(BOARD) ]/hello-world.$(TARGET)` (e.g. `build/native/hello-world.native` or `build/zoul/hello-world.zoul`.
 
-The build system will also generate a `build/` directory, and within it various sub-directories, where it will place intermediate files. The logic is as follows:
+The build system will create a `build/` directory, and within it various sub-directories, where it will place intermediate files as well as the final build output file (firmware). The logic is as follows:
 
 * A directory named `build/$(TARGET)` will always be created (e.g. `build/native` or `build/zoul`).
 * If the platform supports the `BOARD` make variable, then a board-specific sub-directory will also be created under `build/$(TARGET)`. For example `build/zoul/remote-reva` or `build/cc26x0-cc13x0/launchpad/cc2650`.
@@ -27,7 +27,7 @@ The build system will also generate a `build/` directory, and within it various 
 
 With the above sub-directory structure in mind, the build system will output files as follows:
 * All compilation output files (`.o`) and dependency files (`.d`) will be placed under the `obj/` dir.
-* All link and post-processing out files (e.g. `hello-world.elf`, `hello-world.hex`, `hello-world.bin`) will be placed in `build/$(TARGET)/[ $(BOARD) ]/[ $(BUILD_DIR_CONFIG) ]`. In the same directory, you will often also file a `.map` file. Lastly, this directory will also always host a copy of the `hello-world.$(TARGET)` file.
+* All link and post-processing out files (e.g. `hello-world.elf`, `hello-world.hex`, `hello-world.bin`) will be placed in `build/$(TARGET)/[ $(BOARD) ]/[ $(BUILD_DIR_CONFIG) ]`. In the same directory, you will often also file a `.map` file. Lastly, this directory also holds the `hello-world.$(TARGET)` file.
 
 ## Cleaning
 To clean built artifacts, use:

--- a/doc/tutorials/CoAP.md
+++ b/doc/tutorials/CoAP.md
@@ -10,7 +10,7 @@ For a native install, see [doc:install-linux] or [doc:install-osx].
 Let us use the example under `examples/coap/coap-examples-server`.
 We will try it on a native server here, but the same thing can be done on a device, as described in [tutorial:ping].
 ```bash
-$ make && sudo ./coap-example-server.native
+$ make && sudo build/native/coap-example-server.native
 ```
 
 You should get:

--- a/doc/tutorials/Hello,-World!.md
+++ b/doc/tutorials/Hello,-World!.md
@@ -12,7 +12,7 @@ To run `hello-world` in native mode, type:
 ```shell
 $ cd examples/hello-world
 $ make TARGET=native
-$ ./hello-world.native
+$ build/native/hello-world.native
 ```
 
 You first see the Contiki-NG boot messages and then a line with the string "Hello, world". This line will repeat periodically. Contiki-NG debugging messages will also be printed. Note that the warning regarding opening the tun device can be ignored, as this example does not depend on the networking functionality.

--- a/doc/tutorials/LWM2M-and-IPSO-Objects.md
+++ b/doc/tutorials/LWM2M-and-IPSO-Objects.md
@@ -15,7 +15,7 @@ In most cases you will not need to change this address (details later on in this
 You can now build this example for the native platform and run it:
 ```bash
 $ make TARGET=native
-$ sudo ./example-ipso-objects.native 
+$ sudo build/native/example-ipso-objects.native
 ```
 
 When this process starts, it will create a virtual tunnel interface `tun0`. It will then register with the default LWM2M server address: `fd00::1`, which is the address of the `tun0` interface.

--- a/doc/tutorials/MQTT.md
+++ b/doc/tutorials/MQTT.md
@@ -65,7 +65,7 @@ Open a new terminal window (or use the one where you earlier ran `mosquitto_pub`
 
 Run the example:
 ```
-$ sudo ./mqtt-client.native 
+$ sudo build/native/mqtt-client.native
 [INFO: Main      ] Starting Contiki-NG-develop/v4.1-87-g1ffcaa8
 [INFO: Main      ]  Net: tun6
 [INFO: Main      ]  MAC: nullmac

--- a/doc/tutorials/RPL-border-router.md
+++ b/doc/tutorials/RPL-border-router.md
@@ -92,7 +92,7 @@ To do this, follow these two steps:
 1. Program your node with `slip-radio` instead of `rpl-border-router`.
 1. On the host computer, go to `examples/rpl-border-router`
     * Build the example for the native platform `make TARGET=native`
-    * Run `sudo ./border-router.native fd00::1/64`. If the USB serial port is not found, specify it via option `-s`.
+    * Run `sudo build/native/border-router.native fd00::1/64`. If the USB serial port is not found, specify it via option `-s`.
 
 This approach has the advantage of running the BR on an unconstrained device.
 The main downside, however, is that it separates the low layers (radio and MAC) from the rest of the stack (NET and up).

--- a/doc/tutorials/Timers-and-events.md
+++ b/doc/tutorials/Timers-and-events.md
@@ -75,7 +75,7 @@ or desktop computer.
 ```bash
 $ cd examples/libs/timers
 $ make
-$ ./all-timers.native
+$ build/native/all-timers.native
 [INFO: Main      ] Starting Contiki-NG-4.0
 [INFO: Main      ]  Net: tun6
 [INFO: Main      ]  MAC: nullmac

--- a/examples/rpl-udp/rpl-udp.resc
+++ b/examples/rpl-udp/rpl-udp.resc
@@ -16,7 +16,7 @@ emulation CreateIEEE802_15_4Medium "wireless"
 wireless SetRangeWirelessFunction 11
 
 ######################### UDP SERVER - begin #########################
-$bin=@udp-server.cc2538dk
+$bin=@build/cc2538dk/udp-server.cc2538dk
 $name="server"
 i @scripts/single-node/cc2538.resc
 connector Connect radio wireless
@@ -25,7 +25,7 @@ mach clear
 ########################## UDP SERVER - end ##########################
 
 ######################### UDP CLIENT - begin #########################
-$bin=@udp-client.cc2538dk
+$bin=@build/cc2538dk/udp-client.cc2538dk
 $name="client-1"
 i @scripts/single-node/cc2538.resc
 connector Connect radio wireless

--- a/examples/rpl-udp/rpl-udp.robot
+++ b/examples/rpl-udp/rpl-udp.robot
@@ -41,17 +41,17 @@ Should Talk Over Wireless Network
     Execute Command             emulation CreateIEEE802_15_4Medium "wireless"
     Execute Command             wireless SetRangeWirelessFunction 11
 
-    Create Machine              @${CURDIR}/udp-server.cc2538dk       "server"      1
+    Create Machine              @${CURDIR}/build/cc2538dk/udp-server.cc2538dk       "server"      1
     Execute Command             wireless SetPosition radio 0 0 0
     ${server-tester}=           Create Terminal Tester      ${UART}     machine=server
     Execute Command             mach clear
 
-    Create Machine              @${CURDIR}/udp-client.cc2538dk       "client-1"    2
+    Create Machine              @${CURDIR}/build/cc2538dk/udp-client.cc2538dk       "client-1"    2
     Execute Command             wireless SetPosition radio 10 0 0
     ${client1-tester}=          Create Terminal Tester      ${UART}     machine=client-1
     Execute Command             mach clear
 
-    Create Machine              @${CURDIR}/udp-client.cc2538dk       "client-2"    3
+    Create Machine              @${CURDIR}/build/cc2538dk/udp-client.cc2538dk       "client-2"    3
     Execute Command             wireless SetPosition radio 0 10 0
     ${client2-tester}=          Create Terminal Tester      ${UART}     machine=client-2
     Execute Command             mach clear

--- a/os/services/rpl-border-router/native/Makefile.native
+++ b/os/services/rpl-border-router/native/Makefile.native
@@ -7,7 +7,7 @@ MAKE_NET = MAKE_NET_IPV6
 
 PREFIX ?= fd00::1/64
 connect-router:	border-router.native
-	sudo rlwrap ./border-router.native $(PREFIX)
+	sudo rlwrap build/native/border-router.native $(PREFIX)
 
 connect-router-cooja:	border-router.native
-	sudo rlwrap ./border-router.native -a localhost $(PREFIX)
+	sudo rlwrap build/native/border-router.native -a localhost $(PREFIX)

--- a/tests/07-simulation-base/01-hello-world-sky.csc
+++ b/tests/07-simulation-base/01-hello-world-sky.csc
@@ -20,7 +20,7 @@
       <source>[CONTIKI_DIR]/examples/hello-world/hello-world.c</source>
       <commands>$(MAKE) TARGET=sky clean
 $(MAKE) -j$(CPUS) hello-world.sky TARGET=sky</commands>
-      <firmware>[CONTIKI_DIR]/examples/hello-world/hello-world.sky</firmware>
+      <firmware>[CONTIKI_DIR]/examples/hello-world/build/sky/hello-world.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>

--- a/tests/07-simulation-base/07-hello-world-z1.csc
+++ b/tests/07-simulation-base/07-hello-world-z1.csc
@@ -20,7 +20,7 @@
       <source>[CONTIKI_DIR]/examples/hello-world/hello-world.c</source>
       <commands>$(MAKE) TARGET=z1 clean
 $(MAKE) -j$(CPUS) hello-world.z1 TARGET=z1</commands>
-      <firmware>[CONTIKI_DIR]/examples/hello-world/hello-world.z1</firmware>
+      <firmware>[CONTIKI_DIR]/examples/hello-world/build/z1/hello-world.z1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>

--- a/tests/07-simulation-base/22-stack-guard-sky.csc
+++ b/tests/07-simulation-base/22-stack-guard-sky.csc
@@ -20,7 +20,7 @@
       <source>[CONTIKI_DIR]/examples/libs/stack-check/example-stack-check.c</source>
       <commands>$(MAKE) TARGET=sky clean
 $(MAKE) -j$(CPUS) example-stack-check.sky TARGET=sky</commands>
-      <firmware>[CONTIKI_DIR]/examples/libs/stack-check/example-stack-check.sky</firmware>
+      <firmware>[CONTIKI_DIR]/examples/libs/stack-check/build/sky/example-stack-check.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>

--- a/tests/07-simulation-base/23-rpl-tsch-z1.csc
+++ b/tests/07-simulation-base/23-rpl-tsch-z1.csc
@@ -20,7 +20,7 @@
       <source>[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
       <commands>$(MAKE) TARGET=z1 clean
       $(MAKE) -j$(CPUS) node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0 MAKE_WITH_PERIODIC_ROUTES_PRINT=1</commands>
-      <firmware>[CONTIKI_DIR]/examples/6tisch/simple-node/node.z1</firmware>
+      <firmware>[CONTIKI_DIR]/examples/6tisch/simple-node/build/z1/node.z1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>

--- a/tests/07-simulation-base/26-tsch-drift-z1.csc
+++ b/tests/07-simulation-base/26-tsch-drift-z1.csc
@@ -20,7 +20,7 @@
       <source>[CONTIKI_DIR]/examples/6tisch/simple-node/node.c</source>
       <commands>$(MAKE) TARGET=z1 clean
       $(MAKE) -j$(CPUS) node.z1 TARGET=z1</commands>
-      <firmware>[CONTIKI_DIR]/examples/6tisch/simple-node/node.z1</firmware>
+      <firmware>[CONTIKI_DIR]/examples/6tisch/simple-node/build/z1/node.z1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>

--- a/tests/07-simulation-base/31-data-structures-sky.csc
+++ b/tests/07-simulation-base/31-data-structures-sky.csc
@@ -20,7 +20,7 @@
       <source>[CONFIG_DIR]/code-data-structures/test-data-structures.c</source>
       <commands>$(MAKE) clean TARGET=sky
 $(MAKE) -j$(CPUS) test-data-structures.sky TARGET=sky</commands>
-      <firmware>[CONFIG_DIR]/code-data-structures/test-data-structures.sky</firmware>
+      <firmware>[CONFIG_DIR]/code-data-structures/build/sky/test-data-structures.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>

--- a/tests/08-native-runs/08-native-ping.sh
+++ b/tests/08-native-runs/08-native-ping.sh
@@ -10,7 +10,7 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-sudo $CONTIKI/examples/hello-world/hello-world.native &
+sudo $CONTIKI/examples/hello-world/build/native/hello-world.native &
 CPID=$!
 sleep 2
 

--- a/tests/08-native-runs/09-native-coap.sh
+++ b/tests/08-native-runs/09-native-coap.sh
@@ -13,7 +13,7 @@ declare -i TESTCOUNT=0
 
 # Starting Contiki-NG native node
 echo "Starting native CoAP server"
-sudo $CONTIKI/examples/coap/coap-example-server/coap-example-server.native &
+sudo $CONTIKI/examples/coap/coap-example-server/build/native/coap-example-server.native &
 CPID=$!
 sleep 2
 

--- a/tests/08-native-runs/10-snmp-server.sh
+++ b/tests/08-native-runs/10-snmp-server.sh
@@ -9,7 +9,7 @@ BASENAME=$(basename $0 .sh)
 IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
-sudo $CONTIKI/examples/snmp-server/snmp-server.native &
+sudo $CONTIKI/examples/snmp-server/build/native/snmp-server.native &
 CPID=$!
 printf "\r\n"
 

--- a/tests/08-native-runs/mqtt-client.sh
+++ b/tests/08-native-runs/mqtt-client.sh
@@ -41,7 +41,7 @@ sleep 2
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-sudo $VALGRIND_CMD $CODE_DIR/$CODE.native > $CLIENT_LOG 2> $CLIENT_ERR &
+sudo $VALGRIND_CMD $CODE_DIR/build/native/$CODE.native > $CLIENT_LOG 2> $CLIENT_ERR &
 CPID=$!
 
 # The mqtt-client will publish every 30 secs. Wait for 45

--- a/tests/08-native-runs/run-one.sh
+++ b/tests/08-native-runs/run-one.sh
@@ -10,7 +10,7 @@ test_init
 
 echo "-- Starting test $1"
 
-for TEST in ./${BIN_PREFIX}*.native; do
+for TEST in ./build/native/${BIN_PREFIX}*.native; do
   RUNLOG=$(basename $TEST .native).run.log
   register_logfile $RUNLOG
 

--- a/tests/17-tun-rpl-br/03-border-router-sky.csc
+++ b/tests/17-tun-rpl-br/03-border-router-sky.csc
@@ -21,7 +21,7 @@
       <source>[CONTIKI_DIR]/examples/rpl-border-router/border-router.c</source>
       <commands>$(MAKE) clean TARGET=sky
 $(MAKE) -j$(CPUS) border-router.sky TARGET=sky</commands>
-      <firmware>[CONTIKI_DIR]/examples/rpl-border-router/border-router.sky</firmware>
+      <firmware>[CONTIKI_DIR]/examples/rpl-border-router/build/sky/border-router.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
@@ -54,7 +54,7 @@ $(MAKE) -j$(CPUS) border-router.sky TARGET=sky</commands>
       <source>[CONTIKI_DIR]/examples/hello-world/hello-world.c</source>
       <commands>$(MAKE) clean TARGET=sky
 $(MAKE) -j$(CPUS) hello-world.sky TARGET=sky</commands>
-      <firmware>[CONTIKI_DIR]/examples/hello-world/hello-world.sky</firmware>
+      <firmware>[CONTIKI_DIR]/examples/hello-world/build/sky/hello-world.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>

--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -10,7 +10,7 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node - lwm2m/ipso objects"
-sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native &
+sudo $CONTIKI/examples/lwm2m-ipso-objects/build/native/example-ipso-objects.native &
 CPID=$!
 
 echo "Downloading leshan"

--- a/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
+++ b/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
@@ -9,7 +9,7 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node - lwm2m/ipso objects with Q-Mode"
-sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native &
+sudo $CONTIKI/examples/lwm2m-ipso-objects/build/native/example-ipso-objects.native &
 CPID=$!
 
 echo "Downloading leshan with Q-Mode support"

--- a/tests/20-packet-parsing/packet-injector.sh
+++ b/tests/20-packet-parsing/packet-injector.sh
@@ -27,7 +27,7 @@ do
     test_files=("$i")
     echo Injecting file $i
   fi
-  timeout -k 1s 2s "$CODE_DIR/$CODE.native" "${test_files[@]}"
+  timeout -k 1s 2s "$CODE_DIR/build/native/$CODE.native" "${test_files[@]}"
   INJECTOR_EXIT_CODE=$?
   echo "exit code:" $INJECTOR_EXIT_CODE
 


### PR DESCRIPTION
This change simplifies the distclean rule, and
avoids overwriting the binary in . when
building the same firmware for two different boards.

Long term, this change will enable more
parallelism in the build system since
the same binary can be built for two different
boards at the same time.

This also improves build performance slightly
since it avoids one copy of the binary for
each target.

This commit requires removing old binaries
from the tree for tests to pass. A dry run
of git clean will show the files:

git clean -n tests examples