### PR TITLE
os/net: fix null pointer dereference

### DIFF
--- a/os/net/app-layer/coap/coap-uip.c
+++ b/os/net/app-layer/coap/coap-uip.c
@@ -414,6 +414,11 @@ PROCESS_THREAD(coap_engine, ev, data)
 
   /* new connection with remote host */
   udp_conn = udp_new(NULL, 0, NULL);
+  if(udp_conn == NULL) {
+    LOG_ERR("No UDP connection available, exiting the process!\n");
+    PROCESS_EXIT();
+  }
+
   udp_bind(udp_conn, SERVER_LISTEN_PORT);
   LOG_INFO("Listening on port %u\n", uip_ntohs(udp_conn->lport));
 

--- a/os/net/ipv6/multicast/esmrf.c
+++ b/os/net/ipv6/multicast/esmrf.c
@@ -151,6 +151,11 @@ icmp_output()
   payload_len = UIP_ICMP_MOB + uip_slen;
 
   dag_t = rpl_get_any_dag();
+  if(!dag_t) {
+    PRINTF("ESMRF: No DODAG\n");
+    return;
+  }
+
   uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &dag_t->dag_id);
   uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
 

--- a/os/net/routing/rpl-classic/rpl-dag-root.c
+++ b/os/net/routing/rpl-classic/rpl-dag-root.c
@@ -125,6 +125,10 @@ rpl_dag_root_start(void)
 
   rpl_set_root(RPL_DEFAULT_INSTANCE, ipaddr);
   rpl_dag_t *dag = rpl_get_any_dag();
+  if(dag == NULL) {
+    LOG_ERR("failed to create a DAG: cannot get any DAG\n");
+    return -3;
+  }
 
   /* If there are routes in this DAG, we remove them all as we are
      from now on the new dag root and the old routes are wrong. */

--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -684,6 +684,11 @@ dao_input_storing(void)
   pos = 0;
   instance_id = buffer[pos++];
   instance = rpl_get_instance(instance_id);
+  if(instance == NULL) {
+    LOG_ERR("Cannot get RPL instance\n");
+    return;
+  }
+
   lifetime = instance->default_lifetime;
 
   flags = buffer[pos++];


### PR DESCRIPTION
Check return values of following functions for null:
   - udp_new
   - rpl_get_any_dag
   - rpl_get_instance

This closes #2421.