### PR TITLE
doc: update Docker documentation

### DIFF
--- a/doc/getting-started/Docker.md
+++ b/doc/getting-started/Docker.md
@@ -8,35 +8,35 @@ As all Continuous Integration tests are run in a Docker container, it is easy to
 ## Setup
 
 To get started, install Docker. On Ubuntu for instance (you'll need set up the repository; see [install-docker-ce] for details):
-```bash
+```shell
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 
 Make sure your user is added to the unix group `docker`:
-```bash
+```shell
 sudo usermod -aG docker <your-user>
 ```
 
 Log out, and log in again.
 
 Download the Contiki-NG image:
-```bash
-$ docker pull contiker/contiki-ng
+```shell
+docker pull contiker/contiki-ng
 ```
 
 This will automatically download `contiker/contiki-ng:latest`, which is the image used in CI and which we recommend for development. If you wish to use a different image version please follow the guidelines in the start of the article.
 The image is meant for use with Contiki-NG as a bind mount, which means you make the Contiki-NG repository on the host accessible from inside the container.
 This way, you can work on the codebase using host tools / editors, and build/run commands on the same codebase from the container.
 If you do not have it already, you need to check out Contiki-NG:
-```bash
-$ git clone https://github.com/contiki-ng/contiki-ng.git
-$ cd contiki-ng
-$ git submodule update --init --recursive
+```shell
+git clone https://github.com/contiki-ng/contiki-ng.git
+cd contiki-ng
+git submodule update --init --recursive
 ```
 
 Then, it is a good idea to create an alias that will help start docker with all required options.
 On Linux, you can add the following to `~/.profile` or similar, for instance, to `~/.bashrc`:
-```bash
+```shell
 export CNG_PATH=<absolute-path-to-your-contiki-ng>
 alias contiker="docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 --mount type=bind,source=$CNG_PATH,destination=/home/user/contiki-ng -e DISPLAY=$DISPLAY -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/bus/usb:/dev/bus/usb -ti contiker/contiki-ng"
 ```
@@ -45,8 +45,8 @@ alias contiker="docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=
 
 ### Shell for new container
 To start a bash inside a new container, simply type:
-```bash
-$ contiker
+```shell
+contiker
 ```
 
 You will be under `/home/user/contiki-ng` in the container, which is mapped to your local copy of Contiki-NG.
@@ -54,13 +54,13 @@ You will be under `/home/user/contiki-ng` in the container, which is mapped to y
 ### Additional shell for existing container
 Typing `contiker` as above will launch a new container. Sometimes it is useful to have multiple terminal sessions within a single container, e.g., to run a tunslip6 on one terminal and other commands on another one. To achieve this, start by running:
 
-```bash
-$ docker ps
+```shell
+docker ps
 ```
 This will present you with a list of container IDs. Select the ID of the container you wish to open a terminal for and then
 
-```bash
-$ docker exec -it <the ID> /bin/bash
+```shell
+docker exec -it <the ID> /bin/bash
 ```
 
 ### Exit
@@ -70,36 +70,36 @@ To exit a container, use `exit`.
 
 From the container, you can directly go to an example project and build it (see [tutorial:hello-world]).
 It is also possible to run CI tests, e.g.:
-```bash
-$ cd tests/14-rpl-lite
-$ make 01-rpl-up-route.testlog
-Running test 01-rpl-up-route with random Seed 1.................... OK
+```shell
+cd tests/14-rpl-lite
+make 01-rpl-up-route.testlog
+# Running test 01-rpl-up-route with random Seed 1.................... OK
 ```
 
 You can even start Cooja from the container:
-```bash
-$ cd tools/cooja
-$ ./gradlew run
+```shell
+cd tools/cooja
+./gradlew run
 ```
 
 Or use the shortcut:
-```bash
-$ cooja
+```shell
+cooja
 ```
 
 Or directly from the host (outside the container)
-```bash
-$ contiker cooja
+```shell
+contiker cooja
 ```
 
 It is also possible to start a container to just run one command, e.g.:
-```bash
-$ contiker bash -c ls
+```shell
+contiker bash -c ls
 ```
 
 To run a CI test:
-```bash
-$ contiker bash -c "make -C tests/14-rpl-lite 01-rpl-up-route.testlog"
+```shell
+contiker bash -c "make -C tests/14-rpl-lite 01-rpl-up-route.testlog"
 ```
 The user has `sudo` rights with no password (obviously sandboxed in the container).
 
@@ -128,8 +128,8 @@ You can run a Docker container from a WSL environment as well:
 1. Prepare `/etc/wsl.conf` to make WSL mount drives directly under `/` instead of under `/mnt` (see this [doc][wsl.conf] for further information)
 1. Place `contiki-ng` local repository somewhere other than under `%LOCALAPPDATA%`, for instance, `/c/Users/foobar/contiki-ng`
 1. Run the following command in a WSL shell
-```
-$ docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 --mount type=bind,source=/c/Users/foobar/contiki-ng,destination=/home/user/contiki-ng -e DISPLAY=host.docker.internal:0.0 -ti contiker/contiki-ng
+```shell
+docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 --mount type=bind,source=/c/Users/foobar/contiki-ng,destination=/home/user/contiki-ng -e DISPLAY=host.docker.internal:0.0 -ti contiker/contiki-ng
 ```
 
 [install-windows-docker-ce]:https://docs.docker.com/docker-for-windows/install/
@@ -154,7 +154,7 @@ If you don't need to run `cooja` with its GUI, the setup procedure becomes simpl
 `contiker` alias you need is slightly different depending on your Docker solution. Note you need `CNG_PATH` definition as mentioned above.
 
 #### for "Docker for Mac"
-```bash
+```shell
 export CNG_PATH=<absolute-path-to-your-contiki-ng>
 alias contiker="docker run                                                           \
                --privileged                                                          \
@@ -164,7 +164,7 @@ alias contiker="docker run                                                      
 ```
 
 #### for "Docker Toolbox on macOS"
-```bash
+```shell
 export CNG_PATH=<absolute-path-to-your-contiki-ng>
 alias contiker="docker run                                                           \
                --privileged                                                          \
@@ -186,15 +186,15 @@ Note that your host-based firewall may block connections on TCP Port 6000.
 1. prepare `contiker` alias
 1. open XQuartz: `$ open -a XQuartz`
 1. map TCP Port 6000 of 127.0.0.1 to the Unix-domain socket for XQuartz:
-    ```bash
-    $ socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"
+    ```shell
+    socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"
     ```
 1. run contiker: `$ contiker bash`
 
 Put the following lines into `~/.profile` or similar below the `CNG_PATH` definition.
 
 #### for "Docker for Mac"
-```bash
+```shell
 export CNG_PATH=<absolute-path-to-your-contiki-ng>
 alias contiker="docker run --privileged \
   --mount type=bind,source=$CNG_PATH,destination=/home/user/contiki-ng \
@@ -204,7 +204,7 @@ alias contiker="docker run --privileged \
 ```
 
 #### for "Docker Toolbox on macOS"
-```bash
+```shell
 export CNG_PATH=<absolute-path-to-your-contiki-ng>
 alias contiker="docker run --privileged \
   --mount type=bind,source=$CNG_PATH,destination=/home/user/contiki-ng \
@@ -229,12 +229,12 @@ As of release v4.5 (#1108), we host multiple docker container images on DockerHu
 
 Images tagged with a hash allow users who wish to use a specific Contiki-NG git version (after #1108) to download the corresponding container image. Let's assume you wish to use git version NNNNNN. To determine the hash and pull the corresponding container image, you can do something like this:
 
-```
-$ git checkout NNNNNN
-[...]
-$ tools/docker/print-dockerhash.sh
-<hash>
-$ docker pull contiker/contiki-ng:<hash>
+```shell
+git checkout NNNNNN
+# [...]
+tools/docker/print-dockerhash.sh
+# <hash>
+docker pull contiker/contiki-ng:<hash>
 ```
 
 ## Running out-of-tree-tests

--- a/doc/getting-started/Docker.md
+++ b/doc/getting-started/Docker.md
@@ -9,7 +9,7 @@ As all Continuous Integration tests are run in a Docker container, it is easy to
 
 To get started, install Docker. On Ubuntu for instance (you'll need set up the repository; see [install-docker-ce] for details):
 ```bash
-$ sudo apt-get install docker-ce
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```
 
 Make sure your user is added to the unix group `docker`:


### PR DESCRIPTION
Use the package names from docker.com, and make it possible to just cut and paste the code blocks into the shell for running commands.