### PR TITLE
Fix typo in Cooja led configuration

### DIFF
--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -154,7 +154,7 @@ typedef unsigned long clock_time_t;
 /*---------------------------------------------------------------------------*/
 /* Virtual LED colors */
 #define LEDS_CONF_COUNT                  3
-#define LEDS_CONF_GREEEN                 1
+#define LEDS_CONF_GREEN                  1
 #define LEDS_CONF_RED                    2
 #define LEDS_CONF_YELLOW                 4
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This replacement for #2432 only fixes the typo in the green led configuration. The author has not responded for some time, and https://github.com/contiki-ng/cooja/pull/1298 fixed the led colors in Cooja, making the other changes in #2432 unnecessary.

Thanks to asereq for finding the issues and suggesting a solution.