### PR TITLE
Makefile.gecko: fix build for Clang

### DIFF
--- a/arch/cpu/gecko/Makefile.gecko
+++ b/arch/cpu/gecko/Makefile.gecko
@@ -197,7 +197,9 @@ CONTIKI_CPU_SOURCEFILES += cfs-coffee-arch.c
 ### common
 CONTIKI_CPU_SOURCEFILES += sl_uartdrv_init.c
 
-LDFLAGS += --specs=nosys.specs
+ifeq ($(CLANG),0)
+  LDFLAGS += --specs=nosys.specs
+endif
 LDFLAGS += -Wl,--defsym=_stack=__StackLimit
 LDFLAGS += -Wl,--defsym=_stack_origin=__StackTop
 LDFLAGS += -Wl,--defsym=_heap=__HeapBase


### PR DESCRIPTION
Add the same exception as the other
cpu Makefiles contain for Clang.