### PR TITLE
nrf52840: align uart0_init with prototype

### DIFF
--- a/arch/cpu/nrf52840/dev/uart0.c
+++ b/arch/cpu/nrf52840/dev/uart0.c
@@ -82,7 +82,7 @@ uart0_writeb(unsigned char c)
 }
 /*---------------------------------------------------------------------------*/
 void
-uart0_init(unsigned long ubr)
+uart0_init(void)
 {
   nrf_uart_disable(UART_INSTANCE);
   nrf_gpio_cfg_output(TX_PIN);

--- a/arch/cpu/nrf52840/dev/uart0.h
+++ b/arch/cpu/nrf52840/dev/uart0.h
@@ -45,7 +45,7 @@
 #include <stdint.h>
 #include "contiki.h"
 
-void uart0_init();
+void uart0_init(void);
 void uart0_writeb(uint8_t byte);
 
 void uart0_set_input(int (*input)(unsigned char c));


### PR DESCRIPTION
This is the function called from platform.c.