### PR TITLE
antelope: fix compiler warning

### DIFF
--- a/os/storage/antelope/storage-cfs.c
+++ b/os/storage/antelope/storage-cfs.c
@@ -177,6 +177,7 @@ storage_get_relation(relation_t *rel, char *name)
     }
   }
 
+  (void)i;
   PRINTF("DB: Read %d attributes\n", i);
 
   cfs_close(fd);


### PR DESCRIPTION
The i variable is only used in debug
mode, so add a read to silence a compiler
warning.