### PR TITLE
mqtt-client: fix printf format specifier

### DIFF
--- a/examples/mqtt-client/mqtt-client.c
+++ b/examples/mqtt-client/mqtt-client.c
@@ -844,7 +844,8 @@ state_machine(void)
       interval = connect_attempt < 3 ? RECONNECT_INTERVAL << connect_attempt :
         RECONNECT_INTERVAL << 3;
 
-      LOG_DBG("Disconnected. Attempt %u in %lu ticks\n", connect_attempt, interval);
+      LOG_DBG("Disconnected. Attempt %u in %lu ticks\n", connect_attempt,
+              (unsigned long)interval);
 
       etimer_set(&publish_periodic_timer, interval);
 


### PR DESCRIPTION
Cast the clock_time_t to an unsigned
long, so architectures with a small
clock_time_t builds without warnings.