### PR TITLE
rpl-timers: fix printf format specifier

### DIFF
--- a/os/net/routing/rpl-classic/rpl-timers.c
+++ b/os/net/routing/rpl-classic/rpl-timers.c
@@ -146,7 +146,8 @@ new_dio_interval(rpl_instance_t *instance)
   instance->dio_counter = 0;
 
   /* Schedule the timer. */
-  LOG_INFO("Scheduling DIO timer %lu ticks in future (Interval)\n", ticks);
+  LOG_INFO("Scheduling DIO timer %lu ticks in future (Interval)\n",
+           (unsigned long)ticks);
   ctimer_set(&instance->dio_timer, ticks, &handle_dio_timer, instance);
 
 #ifdef RPL_CALLBACK_NEW_DIO_INTERVAL
@@ -183,7 +184,7 @@ handle_dio_timer(void *ptr)
     }
     instance->dio_send = 0;
     LOG_DBG("Scheduling DIO timer %lu ticks in future (sent)\n",
-            instance->dio_next_delay);
+            (unsigned long)instance->dio_next_delay);
     ctimer_set(&instance->dio_timer, instance->dio_next_delay,
                handle_dio_timer, instance);
   } else {


### PR DESCRIPTION
Cast the printed variable so platforms
with a small clock_time_t builds without
warnings.