### PR TITLE
Remove __CYGWIN__ ifdefs

### DIFF
--- a/arch/cpu/native/net/tun6-net.c
+++ b/arch/cpu/native/net/tun6-net.c
@@ -70,7 +70,6 @@ static const char *config_ipaddr = "fd00::1/64";
 static char config_tundev[IFNAMSIZ + 1] = "tun0";
 
 
-#ifndef __CYGWIN__
 static int tunfd = -1;
 
 static int set_fd(fd_set *rset, fd_set *wset);
@@ -79,7 +78,6 @@ static const struct select_callback tun_select_callback = {
   set_fd,
   handle_fd
 };
-#endif /* __CYGWIN__ */
 
 static int ssystem(const char *fmt, ...)
      __attribute__((__format__ (__printf__, 1, 2)));
@@ -190,18 +188,6 @@ tun_alloc(char *dev, uint16_t devsize)
   return devopen(dev, O_RDWR);
 }
 #endif
-
-#ifdef __CYGWIN__
-/*wpcap process is used to connect to host interface */
-static void
-tun_init()
-{
-  setvbuf(stdout, NULL, _IOLBF, 0); /* Line buffered output. */
-}
-
-#else
-
-
 /*---------------------------------------------------------------------------*/
 static void
 tun_init()
@@ -304,7 +290,6 @@ handle_fd(fd_set *rset, fd_set *wset)
     tcpip_input();
   }
 }
-#endif /*  __CYGWIN_ */
 
 static void input(void)
 {

--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -48,10 +48,6 @@
 #include <sys/select.h>
 #include <errno.h>
 
-#ifdef __CYGWIN__
-#include "net/wpcap-drv.h"
-#endif /* __CYGWIN__ */
-
 #include "contiki.h"
 #include "net/netstack.h"
 
@@ -234,18 +230,6 @@ platform_process_args(int argc, char **argv)
   /* crappy way of remembering and accessing argc/v */
   contiki_argc = argc;
   contiki_argv = argv;
-
-  /* native under windows is hardcoded to use the first one or two args */
-  /* for wpcap configuration so this needs to be "removed" from         */
-  /* contiki_args (used by the native-border-router) */
-#ifdef __CYGWIN__
-  contiki_argc--;
-  contiki_argv++;
-#ifdef UIP_FALLBACK_INTERFACE
-  contiki_argc--;
-  contiki_argv++;
-#endif
-#endif
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -274,12 +258,7 @@ void
 platform_init_stage_three()
 {
 #if NETSTACK_CONF_WITH_IPV6
-#ifdef __CYGWIN__
-  process_start(&wpcap_process, NULL);
-#endif
-
   set_global_address();
-
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
   /* Make standard output unbuffered. */

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -365,11 +365,7 @@ write_to_serial(int outfd, const uint8_t *inbuf, int len)
   int i;
 
   if(slip_config_verbose > 2) {
-#ifdef __CYGWIN__
-    printf("Packet from WPCAP of length %d - write SLIP\n", len);
-#else
     printf("Packet from TUN of length %d - write SLIP\n", len);
-#endif
     if(slip_config_verbose > 4) {
 #if WIRESHARK_IMPORT_FORMAT
       printf("0000");

--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -71,7 +71,6 @@ extern const char *slip_config_ipaddr;
 extern char slip_config_tundev[32];
 extern uint16_t slip_config_basedelay;
 
-#ifndef __CYGWIN__
 static int tunfd;
 
 static int set_fd(fd_set *rset, fd_set *wset);
@@ -80,7 +79,6 @@ static const struct select_callback tun_select_callback = {
   set_fd,
   handle_fd
 };
-#endif /* __CYGWIN__ */
 
 int ssystem(const char *fmt, ...)
      __attribute__((__format__ (__printf__, 1, 2)));
@@ -182,17 +180,6 @@ tun_alloc(char *dev)
   return devopen(dev, O_RDWR);
 }
 #endif
-
-#ifdef __CYGWIN__
-/*wpcap process is used to connect to host interface */
-void
-tun_init()
-{
-  setvbuf(stdout, NULL, _IOLBF, 0); /* Line buffered output. */
-
-  slip_init();
-}
-#else
 
 static uint16_t delaymsec = 0;
 static uint32_t delaystartsec, delaystartmsec;
@@ -313,6 +300,4 @@ handle_fd(fd_set *rset, fd_set *wset)
     }
   }
 }
-#endif /*  __CYGWIN_ */
-
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The build support for Cygwin was removed
after 4.8, so remove the ifdefs in the code
too.