### PR TITLE
fixed size of strncopy to allow null termination

### DIFF
--- a/os/net/app-layer/http-socket/http-socket.c
+++ b/os/net/app-layer/http-socket/http-socket.c
@@ -634,7 +634,7 @@ http_socket_get(struct http_socket *s,
                 void *callbackptr)
 {
   initialize_socket(s);
-  strncpy(s->url, url, sizeof(s->url));
+  strncpy(s->url, url, sizeof(s->url) - 1);
   s->pos = pos;
   s->length = length;
   s->callback = callback;
@@ -657,7 +657,7 @@ http_socket_post(struct http_socket *s,
                  void *callbackptr)
 {
   initialize_socket(s);
-  strncpy(s->url, url, sizeof(s->url));
+  strncpy(s->url, url, sizeof(s->url) - 1);
   s->postdata = postdata;
   s->postdatalen = postdatalen;
   s->content_type = content_type;

--- a/os/net/app-layer/http-socket/websocket-http-client.c
+++ b/os/net/app-layer/http-socket/websocket-http-client.c
@@ -229,22 +229,22 @@ websocket_http_client_register(struct websocket_http_client_state *s,
   if(host == NULL) {
     return -1;
   }
-  strncpy(s->host, host, sizeof(s->host));
+  strncpy(s->host, host, sizeof(s->host) - 1);
 
   if(file == NULL) {
     return -1;
   }
-  strncpy(s->file, file, sizeof(s->file));
+  strncpy(s->file, file, sizeof(s->file) - 1);
 
   if(subprotocol == NULL) {
     return -1;
   }
-  strncpy(s->subprotocol, subprotocol, sizeof(s->subprotocol));
+  strncpy(s->subprotocol, subprotocol, sizeof(s->subprotocol) - 1);
 
   if(header == NULL) {
-    strncpy(s->header, "", sizeof(s->header));
+    strncpy(s->header, "", sizeof(s->header) - 1);
   } else {
-    strncpy(s->header, header, sizeof(s->header));
+    strncpy(s->header, header, sizeof(s->header) - 1);
   }
 
   if(port == 0) {


### PR DESCRIPTION
strncpy needs one more character at the end to ensure it copies the string into the buffer including null termination. This PR will reserve room for null-termination. 

