### PR TITLE
cc.h: add constructor/destructor attributes

### DIFF
--- a/os/sys/cc-gcc.h
+++ b/os/sys/cc-gcc.h
@@ -28,20 +28,5 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*---------------------------------------------------------------------------*/
-#ifndef CC_GCC_H_
-#define CC_GCC_H_
-#ifdef __GNUC__
+/* Dummy header to keep lwm2m building. */
 
-#ifndef CC_CONF_INLINE
-/* use __inline__ in case "inline" is not available for any reason */
-#define CC_CONF_INLINE __inline__
-#endif
-
-#define CC_CONF_ALIGN(n) __attribute__((__aligned__(n)))
-
-#define CC_CONF_NORETURN __attribute__((__noreturn__))
-
-#define CC_CONF_DEPRECATED(msg) __attribute__((deprecated(msg)))
-
-#endif /* __GNUC__ */
-#endif /* CC_GCC_H_ */

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -56,6 +56,14 @@
 
 #define CC_CONF_ALIGN(n) __attribute__((__aligned__(n)))
 
+#ifndef CC_CONF_CONSTRUCTOR
+#define CC_CONF_CONSTRUCTOR(prio) __attribute__((constructor(prio)))
+#endif /* CC_CONF_CONSTRUCTOR */
+
+#ifndef CC_CONF_DESTRUCTOR
+#define CC_CONF_DESTRUCTOR(prio) __attribute__((destructor(prio)))
+#endif /* CC_CONF_DESTRUCTOR */
+
 #define CC_CONF_DEPRECATED(msg) __attribute__((deprecated(msg)))
 
 #define CC_CONF_NORETURN __attribute__((__noreturn__))
@@ -81,6 +89,30 @@
 #else
 #define CC_NORETURN
 #endif /* CC_CONF_NORETURN */
+
+/**
+ * Configure if the C compiler supports marking functions as constructors
+ * e.g. with __attribute__((constructor(prio))).
+ *
+ * Lower priority runs before higher priority. Priorities 0-100 are reserved.
+ */
+#ifdef CC_CONF_CONSTRUCTOR
+#define CC_CONSTRUCTOR(prio) CC_CONF_CONSTRUCTOR(prio)
+#else
+#define CC_CONSTRUCTOR(prio)
+#endif /* CC_CONF_CONSTRUCTOR */
+
+/**
+ * Configure if the C compiler supports marking functions as destructors
+ * e.g. with __attribute__((destructor(prio))).
+ *
+ * Lower priority runs before higher priority. Priorities 0-100 are reserved.
+ */
+#ifdef CC_CONF_DESTRUCTOR
+#define CC_DESTRUCTOR(prio) CC_CONF_DESTRUCTOR(prio)
+#else
+#define CC_DESTRUCTOR(prio)
+#endif /* CC_CONF_DESTRUCTOR */
 
 /**
  * Configure if the C compiler supports marking functions as deprecated

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -46,7 +46,21 @@
 #define CC_H_
 
 #include "contiki.h"
-#include "sys/cc-gcc.h"
+
+#ifdef __GNUC__
+
+#ifndef CC_CONF_INLINE
+/* use __inline__ in case "inline" is not available for any reason */
+#define CC_CONF_INLINE __inline__
+#endif
+
+#define CC_CONF_ALIGN(n) __attribute__((__aligned__(n)))
+
+#define CC_CONF_DEPRECATED(msg) __attribute__((deprecated(msg)))
+
+#define CC_CONF_NORETURN __attribute__((__noreturn__))
+
+#endif /* __GNUC__ */
 
 #ifdef CC_CONF_INLINE
 #define CC_INLINE CC_CONF_INLINE


### PR DESCRIPTION
Allow annotating functions that should run
before and after main.

This will turn out to be convenient for parsing
command line options in environments that can
support that.