### PR TITLE
Makefile: add support for clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,44 @@
+# FIXME: disabled checks that should be re-enabled:
+#  * readability-identifier-naming
+#  * misc-redundant-expression
+#  * llvm-include-order
+#  * llvm-else-after-return
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming,-llvm-header-guard,-readability-identifier-naming,-misc-redundant-expression,-llvm-include-order,-llvm-else-after-return'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
+# Configure naming to lower_case, but allow UPPER_CASE for certain places.
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ConstantCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ConstantIgnoredRegexp
+    value:           "^[A-Z0-9_]*$"
+  - key:             readability-identifier-naming.EnumCase
+    value:           lower_case
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           lower_case
+  - key:             readability-identifier-naming.EnumConstantIgnoredRegexp
+    value:           "^[A-Z0-9_]*$"
+  - key:             readability-identifier-naming.FunctionCase
+    value:           lower_case
+  - key:             readability-identifier-naming.FunctionIgnoredRegexp
+    value:           "^_.*$"
+  - key:             readability-identifier-naming.MemberCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ParameterCase
+    value:           lower_case
+  - key:             readability-identifier-naming.UnionCase
+    value:           lower_case
+  - key:             readability-identifier-naming.VariableCase
+    value:           lower_case
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           lower_case
+  - key:             readability-identifier-naming.StaticConstantIgnoredRegexp
+    value:           "^[A-Z0-9_]*$"
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           lower_case
+  - key:             readability-identifier-naming.StaticVariableIgnoredRegexp
+    value:           "^[A-Z0-9_]*$"
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           1

--- a/Makefile.include
+++ b/Makefile.include
@@ -27,6 +27,7 @@ WERROR ?= 1
 
 # Disable Clang by default.
 CLANG ?= 0
+TIDY ?= 0
 
 include $(CONTIKI)/Makefile.identify-target
 
@@ -133,6 +134,7 @@ ifneq ($(MAKECMDGOALS),clean)
     endif
     # Default to the most recent Clang in Ubuntu.
     CLANG_CC ?= clang-15
+    CLANG_TIDY ?= clang-tidy-15
     CC := $(CLANG_CC)
     AS := $(CC)
     LD := $(CC)
@@ -430,15 +432,24 @@ CONTIKI_CPU_DIRS_CONCAT    = ${addprefix $(CONTIKI_CPU)/, \
                                $(CONTIKI_CPU_DIRS)}
 
 SOURCEDIRS += . $(PROJECTDIRS) $(CONTIKI_TARGET_DIRS_CONCAT) \
-              $(CONTIKI_CPU_DIRS_CONCAT) $(MODULEDIRS) $(EXTERNALDIRS)
+              $(CONTIKI_CPU_DIRS_CONCAT) $(MODULEDIRS)
 
-vpath %.c $(SOURCEDIRS)
-vpath %.cpp $(SOURCEDIRS)
-vpath %.in $(SOURCEDIRS)
-vpath %.S $(SOURCEDIRS)
-vpath %.s $(SOURCEDIRS)
+vpath %.c $(SOURCEDIRS) $(EXTERNALDIRS)
+vpath %.cpp $(SOURCEDIRS) $(EXTERNALDIRS)
+vpath %.in $(SOURCEDIRS) $(EXTERNALDIRS)
+vpath %.S $(SOURCEDIRS) $(EXTERNALDIRS)
+vpath %.s $(SOURCEDIRS) $(EXTERNALDIRS)
 
-CFLAGS += ${addprefix -I,$(SOURCEDIRS) $(CONTIKI)}
+CFLAGS += $(addprefix -I,$(SOURCEDIRS))
+# EXTERNALDIRS are used for third-party code, consider them system
+# includes with Clang so clang-tidy does not try to enforce the Contiki-NG
+# style on them.
+ifeq ($(CLANG),1)
+CFLAGS += $(addprefix -isystem,$(EXTERNALDIRS))
+else
+CFLAGS += $(addprefix -I,$(EXTERNALDIRS))
+endif
+CFLAGS += $(addprefix -I,$(CONTIKI))
 
 ### Check for a git repo and pass version if found
 ifndef RELSTR
@@ -544,6 +555,13 @@ endif
 
 ifndef CUSTOM_RULE_C_TO_OBJECTDIR_O
 $(OBJECTDIR)/%.o: %.c | $(DEPDIR)
+ifeq ($(CLANG),1)
+ifeq ($(TIDY),1)
+	$(Q)if git ls-files --error-unmatch $< >/dev/null 2>&1; then \
+          $(CLANG_TIDY) $< -- $(CFLAGS); \
+        fi
+endif
+endif
 	$(TRACE_CC)
 	$(Q)$(CCACHE) $(CC) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 ifeq ($(CHECK_STRUCTS),1)
@@ -553,6 +571,13 @@ endif
 
 ifndef CUSTOM_RULE_CPP_TO_OBJECTDIR_O
 $(OBJECTDIR)/%.o: %.cpp | $(DEPDIR)
+ifeq ($(CLANG),1)
+ifeq ($(TIDY),1)
+	$(Q)if git ls-files --error-unmatch $< >/dev/null 2>&1; then \
+          $(CLANG_TIDY) $< -- $(CXXFLAGS); \
+        fi
+endif
+endif
 	$(TRACE_CXX)
 	$(Q)$(CCACHE) $(CXX) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 ifeq ($(CHECK_STRUCTS),1)

--- a/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
+++ b/arch/cpu/cc26x0-cc13x0/Makefile.cc26x0-cc13x0
@@ -20,8 +20,8 @@ TI_XXWARE_STARTUP_SRCS = ccfg.c startup_gcc.c
 
 ### MODULES will add some of these to the include path, but we need to add
 ### them earlier to prevent filename clashes with Contiki core files
-CFLAGS += -I$(TI_XXWARE) -I$(CONTIKI)/$(TI_XXWARE_SRC)
-CFLAGS += -I$(TI_XXWARE)/inc
+CFLAGS += -isystem$(TI_XXWARE) -isystem$(CONTIKI)/$(TI_XXWARE_SRC)
+CFLAGS += -isystem$(TI_XXWARE)/inc
 MODULES += $(TI_XXWARE_SRC)
 
 LDSCRIPT ?= $(CONTIKI_CPU)/cc26xx.ld


### PR DESCRIPTION
Add clang-tidy to the rules for compiling
C/C++ files, and a minimal clang-tidy
configuration where almost everything
is disabled by default.

The functionality can be tested with:

make TIDY=1