### PR TITLE
tests: remove -I/usr/local/include

### DIFF
--- a/tests/06-script-base/code-test-lc/Makefile
+++ b/tests/06-script-base/code-test-lc/Makefile
@@ -1,7 +1,7 @@
 CONTIKI = ../../..
 
 CC = gcc
-CFLAGS += -Wall -g -I/user/local/include
+CFLAGS += -Wall -g
 CFLAGS += -I$(CONTIKI)/os
 
 all: test_lc_switch test_lc_addrlabels

--- a/tests/06-script-base/code-test-memb/Makefile
+++ b/tests/06-script-base/code-test-memb/Makefile
@@ -3,7 +3,6 @@ CONTIKI = ../../..
 CC = gcc
 CFLAGS += -Wall -g
 CFLAGS += -I.
-CFLAGS += -I/user/local/include
 CFLAGS += -I$(CONTIKI)/os
 
 MEMB_C = $(CONTIKI)/os/lib/memb.c


### PR DESCRIPTION
The tests should not pick up various things
installed on the build machine.