### PR TITLE
cooja: remove spurious return

### DIFF
--- a/arch/platform/cooja/platform.c
+++ b/arch/platform/cooja/platform.c
@@ -123,7 +123,6 @@ platform_init_stage_one()
 {
   gpio_hal_init();
   leds_arch_init();
-  return;
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
There is no point with having a return
statement at the end of a void function,
so remove it.