### PR TITLE
tun-bridge.c: print error message

### DIFF
--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -210,7 +210,7 @@ tun_init()
   tunfd = tun_alloc(slip_config_tundev);
 
   if(tunfd == -1) {
-    err(1, "tun_init: open");
+    err(1, "tun_init: tun_alloc failed");
   }
 
   select_set_callback(tunfd, &tun_select_callback);


### PR DESCRIPTION
Put something about what failed as
the error message instead of just
"open".