### PR TITLE
print-dockerhash.sh: add set -o pipefail

### DIFF
--- a/tools/docker/print-dockerhash.sh
+++ b/tools/docker/print-dockerhash.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -o pipefail
+
 # Only hash the directory the script resides in.
 DOCKERDIR=$(dirname "$(readlink -f "$0")")
 


### PR DESCRIPTION
Ensure the script fails if things cannot
run.