### PR TITLE
tests: internalize out-of-tree test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
     timeout-minutes: 45
     # Common environment variables
     env:
-        OUT_OF_TREE_TEST_PATH: out-of-tree-tests
-        OUT_OF_TREE_TEST_VER: 2869ae7
         DOCKER_BASE_IMG: contiker/contiki-ng
 
     strategy:
@@ -97,17 +95,6 @@ jobs:
           docker tag $DOCKER_IMG $DOCKER_BASE_IMG:latest
           docker push $DOCKER_BASE_IMG:latest
         fi
-
-    # Clone the repo used for out-of-tree builds if required
-    - name: Clone the repo used for out-of-tree builds if required
-      if: matrix.test == 'out-of-tree-build'
-      run: |
-        mkdir -p $OUT_OF_TREE_TEST_PATH
-        git clone --depth 1 https://github.com/contiki-ng/out-of-tree-tests $OUT_OF_TREE_TEST_PATH
-        # Check out desired hash
-        (cd $OUT_OF_TREE_TEST_PATH && git checkout $OUT_OF_TREE_TEST_VER)
-        # Set up docker mount
-        echo DOCKER_ARGS=-v `pwd`/$OUT_OF_TREE_TEST_PATH:/home/user/out-of-tree-tests >> $GITHUB_ENV
 
     # The docker image contains ccache, but the ccache action uses the ccache
     # outside docker for statistics, so install the same ccache version.

--- a/tests/19-out-of-tree-build/Makefile
+++ b/tests/19-out-of-tree-build/Makefile
@@ -1,3 +1,5 @@
+CONTIKI_DIR := $(abspath $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))/../..)
+
 EXAMPLESDIR=$(HOME)/out-of-tree-tests
 
 EXAMPLES = \
@@ -7,5 +9,24 @@ hello-world/openmote \
 hello-world/cc26x0-cc13x0 \
 hello-world/simplelink:BOARD=launchpad/cc26x2r1 \
 hello-world/simplelink:BOARD=sensortag/cc2650 \
+
+# Construct DIR_TARGET based on whether EXAMPLESDIR exists.
+# Put a common dummy string first since targets cannot start with "-".
+DIR_TARGET = examplesdir-$(wildcard $(EXAMPLESDIR))
+DIR_PRESENT = examplesdir-$(EXAMPLESDIR)
+DIR_ABSENT = examplesdir-
+
+# Copy examples/hello-world to $(EXAMPLESDIR), and adjust Makefile.
+preparation: | $(DIR_TARGET)
+	@cp -a $(CONTIKI_DIR)/examples/hello-world $(EXAMPLESDIR)
+	@perl -pi -e "s|^CONTIKI =.*$$|CONTIKI = $(CONTIKI_DIR)|g" $(EXAMPLESDIR)/hello-world/Makefile
+	$(MAKE) all
+
+$(DIR_ABSENT):
+	@mkdir -p $(EXAMPLESDIR)
+
+$(DIR_PRESENT):
+	@echo "Remove $(EXAMPLESDIR) before running this test.\n"
+	@false
 
 include ../Makefile.compile-test

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -77,23 +77,16 @@ $(call dooneexample,$(dir $(call get_target,${1})),$(notdir $(call get_target,${
 endef
 #end of GNU make magic
 
-examples: | $(EXAMPLESDIR)
+examples:
 	@rm -f summary $(BINARY_SIZE_LOGFILE)
 	$(foreach ex, $(EXAMPLES), $(call doexample, ${ex}))
-
-$(EXAMPLESDIR):
-	@echo "Could not find examples directory $(EXAMPLESDIR).\n"
-	@echo "If this failure is when running 19-out-of-tree-builds, clone"
-	@echo "https://github.com/contiki-ng/out-of-tree-tests into"
-	@echo "$(EXAMPLESDIR) and run the test again.\n"
-	@false
 
 summary: examples
 	@echo "========== Summary =========="
 	@([ ! -f summary ] && $(PRINT_LOGFILE) && echo "All tests OK" && touch summary) || \
           (echo "Failures:" && cat summary && false)
 
-clean: | $(EXAMPLESDIR)
+clean:
 	@rm -f summary $(BINARY_SIZE_LOGFILE)
 	@$(foreach example, $(EXAMPLES), \
            $(foreach target, $(EXAMPLESTARGETS), \


### PR DESCRIPTION
The out-of-tree-test is a copy of
examples/hello-world with a special
definition of CONTIKI.

Make the copy dynamically in the test
instead, so the test can be run without
cloning a separate repository.

This removes the need for the CI to
clone a separate repository, to pass
special arguments to Docker to mount
the repository in the right place,
and ensures the hello-world code has been
updated with any API changes in Contiki-NG.