### PR TITLE
rpl-border-router: remove unused define

### DIFF
--- a/os/services/rpl-border-router/native/module-macros.h
+++ b/os/services/rpl-border-router/native/module-macros.h
@@ -38,6 +38,3 @@
 #define SERIALIZE_ATTRIBUTES 1
 
 #define CMD_CONF_OUTPUT border_router_cmd_output
-
-/* used by wpcap (see /cpu/native/net/wpcap-drv.c) */
-#define SELECT_CALLBACK 1


### PR DESCRIPTION
This is the only place SELECT_CALLBACK
is mentioned in the Contiki-NG source
code.