### PR TITLE
Add early command line parsing

### DIFF
--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -230,17 +230,6 @@ set_global_address(void)
 }
 #endif
 /*---------------------------------------------------------------------------*/
-int contiki_argc = 0;
-char **contiki_argv;
-/*---------------------------------------------------------------------------*/
-void
-platform_process_args(int argc, char **argv)
-{
-  /* crappy way of remembering and accessing argc/v */
-  contiki_argc = argc;
-  contiki_argv = argv;
-}
-/*---------------------------------------------------------------------------*/
 void
 platform_init_stage_one()
 {

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -66,6 +66,10 @@
 #define LOG_LEVEL LOG_LEVEL_MAIN
 
 #if PLATFORM_MAIN_ACCEPTS_ARGS
+/*---------------------------------------------------------------------------*/
+int contiki_argc;
+char **contiki_argv;
+/*---------------------------------------------------------------------------*/
 #include "lib/list.h"
 
 LIST(contiki_options);
@@ -134,7 +138,7 @@ help_callback(const char *optarg)
 CONTIKI_OPTION(CONTIKI_MAX_INIT_PRIO + 1, { "help", no_argument, NULL, 'h' },
                help_callback, "display this help and exit\n");
 /*---------------------------------------------------------------------------*/
-__attribute__((unused)) static int
+static int
 parse_argv(int *argc, char ***argv)
 {
   prog = *argv[0];
@@ -176,7 +180,13 @@ parse_argv(int *argc, char ***argv)
 int
 main(int argc, char **argv)
 {
-  platform_process_args(argc, argv);
+  int rv;
+  if((rv = parse_argv(&argc, &argv)) != 0) {
+    return rv;
+  }
+  /* Remember argc/argv after command line options. */
+  contiki_argc = argc;
+  contiki_argv = argv;
 #else
 int
 main(void)

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -64,16 +64,124 @@
 #include "sys/log.h"
 #define LOG_MODULE "Main"
 #define LOG_LEVEL LOG_LEVEL_MAIN
+
+#if PLATFORM_MAIN_ACCEPTS_ARGS
+#include "lib/list.h"
+
+LIST(contiki_options);
+static const char *prog;
+static const char *help_usage;
+static const char *help_suffix;
+/*---------------------------------------------------------------------------*/
+void
+contiki_set_usage(const char *msg)
+{
+  help_usage = msg;
+}
+/*---------------------------------------------------------------------------*/
+void
+contiki_set_extra_help(const char *msg)
+{
+  help_suffix = msg;
+}
+/*---------------------------------------------------------------------------*/
+void
+contiki_add_option(struct contiki_callback_option *option)
+{
+  static bool initialized = false;
+  if(!initialized) {
+    list_init(contiki_options);
+    initialized = true;
+  }
+  list_add(contiki_options, option);
+}
+/*---------------------------------------------------------------------------*/
+static void
+print_help(void)
+{
+  printf("usage: %s [options]%s", prog, help_usage ? help_usage : "\n");
+  printf("Options are:\n");
+  for(struct contiki_callback_option *r = list_head(contiki_options);
+      r != NULL; r = r->next) {
+    if(!r->help) {
+      continue;
+    }
+    int short_len = r->opt_struct.flag == NULL && r->opt_struct.val ? 6 : 0;
+    if(short_len) {
+      printf("  -%c, ", (char)r->opt_struct.val);
+    }
+    int has_arg = r->opt_struct.has_arg;
+    const char *arg_desc = has_arg == no_argument ? "" :
+      has_arg == optional_argument ? " [value]" : " value  ";
+    printf(" %c-%s%s%s\t%s", strlen(r->opt_struct.name) == 1 ? ' ' : '-',
+           r->opt_struct.name, arg_desc,
+           /* Insert extra tab for short option names. */
+           short_len + 3 + strlen(r->opt_struct.name) + strlen(arg_desc) < 8
+             ? "\t" : "",
+           r->help);
+  }
+  if(help_suffix) {
+    printf("%s", help_suffix);
+  }
+}
+/*---------------------------------------------------------------------------*/
+CC_NORETURN static int
+help_callback(const char *optarg)
+{
+  print_help();
+  exit(0);
+}
+CONTIKI_OPTION(CONTIKI_MAX_INIT_PRIO + 1, { "help", no_argument, NULL, 'h' },
+               help_callback, "display this help and exit\n");
+/*---------------------------------------------------------------------------*/
+__attribute__((unused)) static int
+parse_argv(int *argc, char ***argv)
+{
+  prog = *argv[0];
+  const int num_options = list_length(contiki_options);
+  struct contiki_callback_option options[num_options];
+  struct option long_options[num_options + 1];
+
+  int i = 0;
+  for(struct contiki_callback_option *r = list_head(contiki_options);
+      r != NULL; ++i, r = r->next) {
+    memcpy(&long_options[i], &r->opt_struct, sizeof(struct option));
+    memcpy(&options[i], r, sizeof(struct contiki_callback_option));
+  }
+  /* Null terminate options. */
+  memset(&long_options[i], 0, sizeof(struct option));
+
+  while(1) {
+    int ix = 0;
+    int c = getopt_long_only(*argc, *argv, "", long_options, &ix);
+    if(c == -1) { /* Processed all options. */
+      break;
+    }
+    if(c == '?') { /* Unknown option, print help and return error. */
+      print_help();
+      return 1;
+    }
+    if(options[ix].callback) { /* Option has a callback, call with optarg. */
+      int rv;
+      if((rv = options[ix].callback(optarg)) != 0) {
+        return rv;
+      }
+    }
+  }
+  *argc -= optind - 1;
+  *argv += optind - 1;
+  return 0;
+}
 /*---------------------------------------------------------------------------*/
 int
-#if PLATFORM_MAIN_ACCEPTS_ARGS
 main(int argc, char **argv)
 {
   platform_process_args(argc, argv);
 #else
+int
 main(void)
 {
-#endif
+#endif /* PLATFORM_MAIN_ACCEPTS_ARGS */
   platform_init_stage_one();
 
   clock_init();

--- a/os/services/rpl-border-router/native/slip-config.c
+++ b/os/services/rpl-border-router/native/slip-config.c
@@ -47,6 +47,7 @@
 #include <sys/ioctl.h>
 #include <err.h>
 #include "contiki.h"
+#include "sys/platform.h"
 
 int slip_config_verbose = 0;
 const char *slip_config_ipaddr;
@@ -63,116 +64,29 @@ uint16_t slip_config_basedelay = 0;
 #endif
 speed_t slip_config_b_rate = BAUDRATE;
 
+#define BAUDRATE_PRIO CONTIKI_VERBOSE_PRIO + 20
+
+CONTIKI_USAGE(300, " ipaddress\n"
+                   "example parameters: -L -v=2 -s ttyUSB1 fd00::1/64\n\n");
+CONTIKI_EXTRA_HELP(300,
+                   "\nVerbosity level:\n"
+                   "  0   No messages\n"
+                   "  1   Encapsulated SLIP debug messages (default)\n"
+                   "  2   Printable strings after they are received\n"
+                   "  3   Printable strings and SLIP packet notifications\n"
+                   "  4   All printable characters as they are received\n"
+                   "  5   All SLIP packets in hex\n");
 /*---------------------------------------------------------------------------*/
-int
-slip_config_handle_arguments(int argc, char **argv)
+CC_CONSTRUCTOR(CONTIKI_MIN_INIT_PRIO - 1) static void
+init_slip_config_data(void)
 {
-  const char *prog;
-  int c;
-  int baudrate = 115200;
-
-  slip_config_verbose = 0;
-
-  prog = argv[0];
-  while((c = getopt(argc, argv, "B:H:D:Lhs:t:v::d::a:p:T")) != -1) {
-    switch(c) {
-    case 'B':
-      baudrate = atoi(optarg);
-      break;
-
-    case 'H':
-      slip_config_flowcontrol = 1;
-      break;
-
-    case 'L':
-      slip_config_timestamp = 1;
-      break;
-
-    case 's':
-      if(strncmp("/dev/", optarg, 5) == 0) {
-        slip_config_siodev = optarg + 5;
-      } else {
-        slip_config_siodev = optarg;
-      }
-      break;
-
-    case 't':
-      if(strncmp("/dev/", optarg, 5) == 0) {
-        strncpy(slip_config_tundev, optarg + 5, sizeof(slip_config_tundev) - 1);
-      } else {
-        strncpy(slip_config_tundev, optarg, sizeof(slip_config_tundev) - 1);
-      }
-      slip_config_tundev[sizeof(slip_config_tundev) - 1] = '\0';
-      break;
-
-    case 'a':
-      slip_config_host = optarg;
-      break;
-
-    case 'p':
-      slip_config_port = optarg;
-      break;
-
-    case 'd':
-      slip_config_basedelay = 10;
-      if(optarg) {
-        slip_config_basedelay = atoi(optarg);
-      }
-      break;
-
-    case 'v':
-      slip_config_verbose = 2;
-      if(optarg) {
-        slip_config_verbose = atoi(optarg);
-      }
-      break;
-
-    case '?':
-    case 'h':
-    default:
-      fprintf(stderr, "usage:  %s [options] ipaddress\n", prog);
-      fprintf(stderr, "example: border-router.native -L -v2 -s ttyUSB1 fd00::1/64\n");
-      fprintf(stderr, "Options are:\n");
-#ifdef linux
-      fprintf(stderr, " -B baudrate    9600,19200,38400,57600,115200,921600 (default 115200)\n");
-#else
-      fprintf(stderr, " -B baudrate    9600,19200,38400,57600,115200 (default 115200)\n");
-#endif
-      fprintf(stderr, " -H             Hardware CTS/RTS flow control (default disabled)\n");
-      fprintf(stderr, " -L             Log output format (adds time stamps)\n");
-      fprintf(stderr, " -s siodev      Serial device (default /dev/ttyUSB0)\n");
-      fprintf(stderr, " -a host        Connect via TCP to server at <host>\n");
-      fprintf(stderr, " -p port        Connect via TCP to server at <host>:<port>\n");
-      fprintf(stderr, " -t tundev      Name of interface (default tun0)\n");
-#ifdef __APPLE__
-      fprintf(stderr, " -v level       Verbosity level\n");
-#else
-      fprintf(stderr, " -v[level]      Verbosity level\n");
-#endif
-      fprintf(stderr, "    -v0         No messages\n");
-      fprintf(stderr, "    -v1         Encapsulated SLIP debug messages (default)\n");
-      fprintf(stderr, "    -v2         Printable strings after they are received\n");
-      fprintf(stderr, "    -v3         Printable strings and SLIP packet notifications\n");
-      fprintf(stderr, "    -v4         All printable characters as they are received\n");
-      fprintf(stderr, "    -v5         All SLIP packets in hex\n");
-#ifndef __APPLE__
-      fprintf(stderr, "    -v          Equivalent to -v3\n");
-#endif
-      fprintf(stderr, " -d[basedelay]  Minimum delay between outgoing SLIP packets.\n");
-      fprintf(stderr, "                Actual delay is basedelay*(#6LowPAN fragments) milliseconds.\n");
-      fprintf(stderr, "                -d is equivalent to -d10.\n");
-      exit(1);
-      break;
-    }
-  }
-  argc -= optind - 1;
-  argv += optind - 1;
-
-  if(argc != 2 && argc != 3) {
-    err(1, "usage: %s [-B baudrate] [-H] [-L] [-s siodev] [-t tundev] [-T] [-v verbosity] [-d delay] [-a serveraddress] [-p serverport] ipaddress", prog);
-  }
-  slip_config_ipaddr = argv[1];
-
+  strcpy(slip_config_tundev, "tun0");
+}
+/*---------------------------------------------------------------------------*/
+static int
+baudrate_callback(const char *optarg)
+{
+  int baudrate = atoi(optarg);
   switch(baudrate) {
   case -2:
     break;			/* Use default. */
@@ -197,14 +111,112 @@ slip_config_handle_arguments(int argc, char **argv)
     break;
 #endif
   default:
-    err(1, "unknown baudrate %d", baudrate);
-    break;
+    fprintf(stderr, "unknown baudrate %s", optarg);
+    return 1;
+  }
+  return 0;
+}
+CONTIKI_OPTION(BAUDRATE_PRIO, { "B", required_argument, NULL, 0 },
+               baudrate_callback,
+#ifdef linux
+               "baudrate (9600,19200,38400,57600,115200,921600)"
+#else
+               "baudrate (9600,19200,38400,57600,115200)"
+#endif
+               " (default 115200)\n");
+CONTIKI_OPTION(BAUDRATE_PRIO + 1,
+               { "H", no_argument, &slip_config_flowcontrol, 1 }, NULL,
+               "hardware CTS/RTS flow control (default disabled)\n");
+CONTIKI_OPTION(BAUDRATE_PRIO + 2,
+               { "L", no_argument, &slip_config_timestamp, 1 }, NULL,
+               "log output format (adds time stamps)\n");
+static int
+device_callback(const char *optarg)
+{
+  slip_config_siodev = optarg + (strncmp("/dev/", optarg, 5) == 0 ? 5 : 0);
+  return 0;
+}
+CONTIKI_OPTION(BAUDRATE_PRIO + 3, { "s", required_argument, NULL, 0 },
+               device_callback, "serial device (default /dev/ttyUSB0)\n");
+static int
+host_callback(const char *optarg)
+{
+  slip_config_host = optarg;
+  return 0;
+}
+CONTIKI_OPTION(BAUDRATE_PRIO + 4, { "a", required_argument, NULL, 0 },
+               host_callback, "connect via TCP to server at <value>\n");
+static int
+port_callback(const char *optarg)
+{
+  slip_config_port = optarg;
+  return 0;
+}
+CONTIKI_OPTION(BAUDRATE_PRIO + 5, { "p", required_argument, NULL, 0 },
+               port_callback, "connect via TCP to server on port <value>\n");
+static int
+dev_callback(const char *optarg)
+{
+  strncpy(slip_config_tundev,
+          optarg + (strncmp("/dev/", optarg, 5) == 0 ? 5 : 0),
+          sizeof(slip_config_tundev) - 1);
+  slip_config_tundev[sizeof(slip_config_tundev) - 1] = '\0';
+  return 0;
+}
+CONTIKI_OPTION(BAUDRATE_PRIO + 6, { "t", required_argument, NULL, 0 },
+               dev_callback, "name of interface (default tun0)\n");
+static int
+delay_callback(const char *optarg)
+{
+  slip_config_basedelay = optarg ? atoi(optarg) : 10;
+  if(slip_config_basedelay < 0 ||
+     (slip_config_basedelay == 0 && optarg && optarg[0] != '0')) {
+    fprintf(stderr, "Delay '%s' could not be parsed as a number\n", optarg);
+    return 1;
   }
 
-  if(*slip_config_tundev == '\0') {
-    /* Use default. */
-    strcpy(slip_config_tundev, "tun0");
+  return 0;
+}
+CONTIKI_OPTION(BAUDRATE_PRIO + 7, { "d", optional_argument, NULL, 0 },
+               delay_callback,
+               "minimum delay between outgoing SLIP packets (default 10)\n"
+               "\t\tActual delay is basedelay * (#6LowPAN fragments)"
+               " milliseconds.\n");
+/*---------------------------------------------------------------------------*/
+int
+slip_config_handle_arguments(int argc, char **argv)
+{
+  if(argc != 2 && argc != 3) {
+    err(1, "usage: [-B baudrate] [-H] [-L] [-s siodev] [-t tundev] [-T] [-v verbosity] [-d delay] [-a serveraddress] [-p serverport] ipaddress");
   }
+  slip_config_ipaddr = argv[1];
   return 1;
 }
 /*---------------------------------------------------------------------------*/
+static int
+verbose_callback(const char *optarg)
+{
+  slip_config_verbose = optarg ? atoi(optarg) : 3;
+  if(slip_config_verbose < 0 || slip_config_verbose > 5 ||
+     (slip_config_verbose == 0 && optarg && optarg[0] != '0')) {
+    fprintf(stderr, "Verbose level '%s' not between 0 and 5\n", optarg);
+    return 1;
+  }
+  return 0;
+}
+CONTIKI_OPTION(CONTIKI_VERBOSE_PRIO, { "v", optional_argument, NULL, 0 },
+               verbose_callback, "verbosity level (0-5)\n");
+/*---------------------------------------------------------------------------*/
+/* Hidden compatibility options with legacy parameter names. */
+CONTIKI_OPTION(CONTIKI_VERBOSE_PRIO + 1,
+               { "v0", no_argument, &slip_config_verbose, 0 }, NULL, NULL);
+CONTIKI_OPTION(CONTIKI_VERBOSE_PRIO + 2,
+               { "v1", no_argument, &slip_config_verbose, 1 }, NULL, NULL);
+CONTIKI_OPTION(CONTIKI_VERBOSE_PRIO + 3,
+               { "v2", no_argument, &slip_config_verbose, 2 }, NULL, NULL);
+CONTIKI_OPTION(CONTIKI_VERBOSE_PRIO + 4,
+               { "v3", no_argument, &slip_config_verbose, 3 }, NULL, NULL);
+CONTIKI_OPTION(CONTIKI_VERBOSE_PRIO + 5,
+               { "v4", no_argument, &slip_config_verbose, 4 }, NULL, NULL);
+CONTIKI_OPTION(CONTIKI_VERBOSE_PRIO + 6,
+               { "v5", no_argument, &slip_config_verbose, 5 }, NULL, NULL);

--- a/os/sys/platform.h
+++ b/os/sys/platform.h
@@ -109,6 +109,11 @@ struct contiki_callback_option {
   int (*callback)(const char *);
   const char *help;
 };
+
+/** A global argc, after parsing command line options. */
+extern int contiki_argc;
+/** A global argv, after parsing command line options. */
+extern char **contiki_argv;
 #endif /* PLATFORM_MAIN_ACCEPTS_ARGS */
 
 /**
@@ -278,20 +283,6 @@ void platform_idle(void);
  * It is the port developer's responsibility to implement this function.
  */
 void platform_main_loop(void);
-/*---------------------------------------------------------------------------*/
-/**
- * \brief Allow the platform to process main's command line arguments
- *
- * If the platform wishes main() to accept arguments, then the \os main will
- * call this function here so that the platform can process/store those
- * arguments.
- *
- * This function will only get called if PLATFORM_MAIN_ACCEPTS_ARGS
- * is non-zero.
- *
- * It is the port developer's responsibility to implement this function.
- */
-void platform_process_args(int argc, char**argv);
 /*---------------------------------------------------------------------------*/
 #endif /* PLATFORM_H_ */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This is a different approach for the infrastructure parts of https://github.com/contiki-ng/contiki-ng/pull/755.

This pull request allows each compilation unit to specify their own command line options, and switches the border-router to use the new API.

The compilation units add their options before `main` is run, and parsing command line options is the first thing that happen inside `main`, so command line options can be used to configure things before processes are started.

The code uses `getopt_long_only` so legacy parameters (`-v0`..`-v5`) still work. The `getopt_long_only` function is widely available, but if the SDK for some platform does not provide that function, users can put in the code from newlib/picolibc or one of the BSDs and things should work.

This PR is already quite a few lines so there is no conflict detection, I'm sure calling `getopt_long` with two options that have the same name will give "interesting" results.
