### PR TITLE
Workaround for DAO having garbled content after RPL forwarding error

### DIFF
--- a/os/net/routing/rpl-classic/rpl-ext-header.c
+++ b/os/net/routing/rpl-classic/rpl-ext-header.c
@@ -486,8 +486,9 @@ update_hbh_header(void)
           LOG_WARN("RPL generate No-Path DAO\n");
           parent = rpl_get_parent((uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
           if(parent != NULL) {
-            dao_output_target(parent, &UIP_IP_BUF->destipaddr,
-                              RPL_ZERO_LIFETIME);
+            rpl_schedule_unicast_dao_immediately(instance, parent,
+                                                 &UIP_IP_BUF->destipaddr,
+                                                 RPL_ZERO_LIFETIME);
           }
           /* Drop packet. */
           return 0;

--- a/os/net/routing/rpl-classic/rpl-private.h
+++ b/os/net/routing/rpl-classic/rpl-private.h
@@ -343,6 +343,9 @@ rpl_of_t *rpl_find_of(rpl_ocp_t);
 void rpl_schedule_dao(rpl_instance_t *);
 void rpl_schedule_dao_immediately(rpl_instance_t *);
 void rpl_schedule_unicast_dio_immediately(rpl_instance_t *instance);
+void rpl_schedule_unicast_dao_immediately(
+    rpl_instance_t *instance, rpl_parent_t *parent,
+    uip_ipaddr_t *prefix, uint8_t lifetime);
 void rpl_cancel_dao(rpl_instance_t *instance);
 void rpl_schedule_probing(rpl_instance_t *instance);
 void rpl_schedule_probing_now(rpl_instance_t *instance);

--- a/os/net/routing/rpl-classic/rpl-timers.c
+++ b/os/net/routing/rpl-classic/rpl-timers.c
@@ -361,6 +361,30 @@ rpl_schedule_dao_immediately(rpl_instance_t *instance)
   schedule_dao(instance, 0);
 }
 /*---------------------------------------------------------------------------*/
+static void
+handle_unicast_dao_timer(void *ptr_instance)
+{
+  rpl_instance_t *instance = (rpl_instance_t *)ptr_instance;
+  if(instance->unicast_dao_prefix != NULL && instance->unicast_dao_target) {
+    dao_output_target(instance->unicast_dao_target,
+                      instance->unicast_dao_prefix,
+                      instance->unicast_dao_lifetime);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_schedule_unicast_dao_immediately(rpl_instance_t *instance,
+                                     rpl_parent_t *parent,
+                                     uip_ipaddr_t *prefix,
+                                     uint8_t lifetime)
+{
+  instance->unicast_dao_target = parent;
+  instance->unicast_dao_prefix = prefix;
+  instance->unicast_dao_lifetime = lifetime;
+  ctimer_set(&instance->unicast_dao_timer, 0,
+             handle_unicast_dao_timer, instance);
+}
+/*---------------------------------------------------------------------------*/
 void
 rpl_cancel_dao(rpl_instance_t *instance)
 {

--- a/os/net/routing/rpl-classic/rpl.h
+++ b/os/net/routing/rpl-classic/rpl.h
@@ -265,6 +265,10 @@ struct rpl_instance {
 #if RPL_WITH_DAO_ACK
   struct ctimer dao_retransmit_timer;
 #endif /* RPL_WITH_DAO_ACK */
+  struct ctimer unicast_dao_timer;
+  rpl_parent_t *unicast_dao_target;
+  uip_ipaddr_t *unicast_dao_prefix;
+  uint8_t unicast_dao_lifetime;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/tests/15-rpl-classic/js/13-rpl-dao-garbled.js
+++ b/tests/15-rpl-classic/js/13-rpl-dao-garbled.js
@@ -16,8 +16,6 @@ while(true) {
   else if(id == 1) {
     // Fail if garbled DAO is received
     if(msg.contains("icmpv6 bad checksum")) {
-      // FIXME Logic inverted to showcase issue. Revert when implementing fix.
-      log.testOK();
       log.testFailed();
     }
 
@@ -31,14 +29,12 @@ while(true) {
     else if(msg.contains("No more routes to fd00::203:3:3:3")) {
       // Route has been removed, verify it was preceded as expected
       if(forwarding_error_occurred && no_path_dao_received) {
-        // FIXME Logic inverted to showcase issue. Revert when implementing fix.
-        log.testFailed();
+        log.testOK();
       }
 
       log.log("Forwarding error occurred: " + forwarding_error_occurred + "\n")
       log.log("No-path DAO received: " + no_path_dao_received + "\n")
-      // FIXME Logic inverted to showcase issue. Revert when implementing fix.
-      log.testOK();
+      log.testFailed();
     }
   }
 }


### PR DESCRIPTION
This PR
1. Proposes a workaround to RPL issue #2377 
2. ~~Adds a test that showcases #2377~~ The test for the issue was added separately in #2548. This PR simply reverts the logic in the test such that it passes only if the issue is resolved.

In short, #2377 describes how No-Path DAOs that are sent when detecting RPL forwarding error will have garbled content and the receiver will discard it with error-log: `icmpv6 bad checksum`. The workaround adds a small delay (next tick) to the generation of the DAO, and this resolves the issue. I am no uIP/RPL expert and I have not identified the root cause as to why the content is garbled (see some ideas in #2377). As such, I will have no trouble if we don't merge this and rather leave it for others to work onward from.

For further details see test-description in #2548 and issue #2377.