### PR TITLE
tests: make separate Renode category

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         # Always run all jobs in the matrix, even if one fails
         fail-fast: false
         matrix:
-            test: [ documentation, compile-base, compile-arm-ports, compile-tools, out-of-tree-build, rpl-lite, rpl-classic, simulation-base, ipv6, ieee802154, tun-rpl-br, script-base, native-runs, ipv6-nbr, coap-lwm2m, packet-parsing ]
+            test: [ documentation, compile-base, compile-arm-ports, compile-tools, out-of-tree-build, rpl-lite, rpl-classic, renode-simulation, simulation-base, ipv6, ieee802154, tun-rpl-br, script-base, native-runs, ipv6-nbr, coap-lwm2m, packet-parsing ]
 
     # Checks-out the contiki-ng $GITHUB_WORKSPACE, so your job can access it
     steps:

--- a/tests/04-renode-simulation/01-rpl-udp.sh
+++ b/tests/04-renode-simulation/01-rpl-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-TESTNAME=05-test-renode
+TESTNAME=01-rpl-udp
 TEST_CODE_DIR=../../examples/rpl-udp
 TARGET=cc2538dk
 

--- a/tests/04-renode-simulation/01-rpl-udp.sh
+++ b/tests/04-renode-simulation/01-rpl-udp.sh
@@ -7,7 +7,7 @@ TARGET=cc2538dk
 make -C ${TEST_CODE_DIR} clean TARGET=${TARGET}
 make -C ${TEST_CODE_DIR} TARGET=${TARGET}
 
-renode-test ${TEST_CODE_DIR}/rpl-udp.robot > ${TESTNAME}.log
+renode-test --show-log ${TEST_CODE_DIR}/rpl-udp.robot
 
 if [ $? -eq 0 ]; then
     echo "${TESTNAME} TEST OK" > ${TESTNAME}.testlog

--- a/tests/04-renode-simulation/01-rpl-udp.sh
+++ b/tests/04-renode-simulation/01-rpl-udp.sh
@@ -6,14 +6,4 @@ TARGET=cc2538dk
 
 make -C ${TEST_CODE_DIR} clean TARGET=${TARGET}
 make -C ${TEST_CODE_DIR} TARGET=${TARGET}
-
 renode-test --show-log ${TEST_CODE_DIR}/rpl-udp.robot
-
-if [ $? -eq 0 ]; then
-    echo "${TESTNAME} TEST OK" > ${TESTNAME}.testlog
-    make -C ${TEST_CODE_DIR} clean TARGET=${TARGET}
-    exit 0
-else
-    echo "${TESTNAME} TEST FAIL" > ${TESTNAME}.testlog
-    exit 1
-fi

--- a/tests/04-renode-simulation/Makefile
+++ b/tests/04-renode-simulation/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.script-test


### PR DESCRIPTION
PR https://github.com/contiki-ng/contiki-ng/pull/2535 adds a second set of test jobs for macOS.

There seems to be more Linux runners than macOS runners available, so split out the Renode
tests into a separate category, so the Renode tests can be limited to only run on Linux in the CI.

Also make some tweaks to the test itself, display logs on the console instead of a file, and stop
producing logs since the test framework no longer relies on those.

I get a lot of warnings that look like `[WARNING] server/sysbus: [cpu: 0x204DD4] (tag: 'ADC') ReadDoubleWord from non existing peripheral at 0x400D7018, returning 0x0.`, but those are not new.