### PR TITLE
tests: stop producing unused logs

### DIFF
--- a/tests/06-script-base/02-test-lc-addrlabels.sh
+++ b/tests/06-script-base/02-test-lc-addrlabels.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/bin/sh -e
 ./run-test-lc.sh ${TESTNAME} 02-test-lc-addrlabels

--- a/tests/06-script-base/03-test-memb.sh
+++ b/tests/06-script-base/03-test-memb.sh
@@ -1,18 +1,9 @@
-#!/bin/sh
+#!/bin/sh -e
 
 TESTNAME=03-test-memb
 TEST_CODE_DIR=code-test-memb
 TARGET=test-memb
 
 make -C ${TEST_CODE_DIR} clean
-make -C ${TEST_CODE_DIR} ${TARGET}
-${TEST_CODE_DIR}/${TARGET} > ${TESTNAME}.log
-
-if [ $? -eq 0 ]; then
-    echo "${TESTNAME} TEST OK" > ${TESTNAME}.testlog
-    make -C ${TEST_CODE_DIR} clean
-    exit 0
-else
-    echo "${TESTNAME} TEST FAIL" > ${TESTNAME}.testlog
-    exit 1
-fi
+make -j4 -C ${TEST_CODE_DIR} ${TARGET}
+${TEST_CODE_DIR}/${TARGET}

--- a/tests/06-script-base/04-test-result-visualization.sh
+++ b/tests/06-script-base/04-test-result-visualization.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 TESTNAME=04-test-result-visualization
 
@@ -7,9 +7,9 @@ CONTIKI=../..
 TEST_CODE_DIR=code-result-visualization
 
 make -C ${TEST_CODE_DIR} clean
-make -C ${TEST_CODE_DIR}
+make -j4 -C ${TEST_CODE_DIR}
 
-${CONTIKI}/examples/benchmarks/result-visualization/run-analysis.py ${TEST_CODE_DIR}/COOJA.testlog > analysis.log || exit 1
+${CONTIKI}/examples/benchmarks/result-visualization/run-analysis.py ${TEST_CODE_DIR}/COOJA.testlog > analysis.log
 
 # check that some packets were sent and all were received
 grep "PDR=100" analysis.log > /dev/null || exit 1
@@ -21,8 +21,3 @@ grep "PDR=100" analysis.log > /dev/null || exit 1
 [ -f plot_par.pdf ] || exit 1
 [ -f plot_pdr.pdf ] || exit 1
 [ -f plot_rpl_switches.pdf ] || exit 1
-
-echo "${TESTNAME} TEST OK" > ${TESTNAME}.testlog
-
-# success
-exit 0

--- a/tests/06-script-base/run-test-lc.sh
+++ b/tests/06-script-base/run-test-lc.sh
@@ -1,18 +1,9 @@
-#!/bin/sh
+#!/bin/sh -e
 
 TEST_CODE_DIR=code-test-lc
 TESTNAME=$1
 TARGET=`echo ${TESTNAME} | sed -e 's/[0-9]*-\(.*\)/\1/'`
 
 make -C ${TEST_CODE_DIR} clean
-make -C ${TEST_CODE_DIR} ${TARGET}
-${TEST_CODE_DIR}/${TARGET} > ${TESTNAME}.log
-
-if [ $? -eq 0 ]; then
-    echo "${TESTNAME} TEST OK" > ${TESTNAME}.testlog
-    make -C ${TEST_CODE_DIR} clean
-    exit 0
-else
-    echo "${TESTNAME} TEST FAIL" > ${TESTNAME}.testlog
-    exit 1
-fi
+make -j4 -C ${TEST_CODE_DIR} ${TARGET}
+${TEST_CODE_DIR}/${TARGET}

--- a/tests/08-native-runs/01-test-data-structures.sh
+++ b/tests/08-native-runs/01-test-data-structures.sh
@@ -10,31 +10,20 @@ CODE=test-data-structures
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-make -C $CODE_DIR TARGET=native > make.log 2> make.err
+make -j4 -C $CODE_DIR TARGET=native || exit 1
 $CODE_DIR/$CODE.native > $CODE.log 2> $CODE.err &
 CPID=$!
-sleep 2
 
 echo "Closing native node"
 sleep 2
 kill_bg $CPID
 
 if grep -q "=check-me= FAILED" $CODE.log ; then
-  echo "==== make.log ====" ; cat make.log;
-  echo "==== make.err ====" ; cat make.err;
   echo "==== $CODE.log ====" ; cat $CODE.log;
   echo "==== $CODE.err ====" ; cat $CODE.err;
-
   printf "%-32s TEST FAIL\n" "$CODE" | tee $CODE.testlog;
-  rm -f make.log make.err $CODE.log $CODE.err
+  rm -f $CODE.log $CODE.err
   exit 1
-else
-  cp $CODE.log $CODE.testlog
-  printf "%-32s TEST OK\n" "$CODE" | tee $CODE.testlog;
 fi
 
-rm -f make.log make.err $CODE.log $CODE.err
-
-# We do not want Make to stop -> Return 0
-# The Makefile will check if a log contains FAIL at the end
-exit 0
+rm -f $CODE.log $CODE.err

--- a/tests/08-native-runs/02-mqtt-client-31.sh
+++ b/tests/08-native-runs/02-mqtt-client-31.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 MQTT_VERSION="3_1" ./mqtt-client.sh "$@"

--- a/tests/08-native-runs/03-mqtt-client-31-valgrind.sh
+++ b/tests/08-native-runs/03-mqtt-client-31-valgrind.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 MQTT_VERSION="3_1" VALGRIND_CMD="valgrind" ./mqtt-client.sh "$@"

--- a/tests/08-native-runs/04-mqtt-client-311.sh
+++ b/tests/08-native-runs/04-mqtt-client-311.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 MQTT_VERSION="3_1_1" ./mqtt-client.sh "$@"

--- a/tests/08-native-runs/05-mqtt-client-311-valgrind.sh
+++ b/tests/08-native-runs/05-mqtt-client-311-valgrind.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 VALGRIND_CMD="valgrind" MQTT_VERSION="3_1_1" ./mqtt-client.sh "$@"

--- a/tests/08-native-runs/06-mqtt-client-5.sh
+++ b/tests/08-native-runs/06-mqtt-client-5.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 MQTT_VERSION="5" ./mqtt-client.sh "$@"

--- a/tests/08-native-runs/07-mqtt-client-5-valgrind.sh
+++ b/tests/08-native-runs/07-mqtt-client-5-valgrind.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 VALGRIND_CMD="valgrind" MQTT_VERSION="5" ./mqtt-client.sh "$@"

--- a/tests/08-native-runs/08-native-ping.sh
+++ b/tests/08-native-runs/08-native-ping.sh
@@ -10,8 +10,8 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-make -C $CONTIKI/examples/hello-world > make.log 2> make.err
-sudo $CONTIKI/examples/hello-world/hello-world.native > node.log 2> node.err &
+make -j4 -C $CONTIKI/examples/hello-world || exit 1
+sudo $CONTIKI/examples/hello-world/hello-world.native &
 CPID=$!
 sleep 2
 
@@ -29,19 +29,8 @@ if [ $STATUS -eq 0 ] ; then
   cp $BASENAME.log $BASENAME.testlog
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
 else
-  echo "==== make.log ====" ; cat make.log;
-  echo "==== make.err ====" ; cat make.err;
-  echo "==== node.log ====" ; cat node.log;
-  echo "==== node.err ====" ; cat node.err;
   echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
 
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
-  rm -f make.log make.err node.log node.err
   exit 1
 fi
-
-rm -f make.log make.err node.log node.err
-
-# We do not want Make to stop -> Return 0
-# The Makefile will check if a log contains FAIL at the end
-exit 0

--- a/tests/08-native-runs/09-native-coap.sh
+++ b/tests/08-native-runs/09-native-coap.sh
@@ -13,8 +13,8 @@ declare -i TESTCOUNT=0
 
 # Starting Contiki-NG native node
 echo "Starting native CoAP server"
-make -C $CONTIKI/examples/coap/coap-example-server > make.log 2> make.err
-sudo $CONTIKI/examples/coap/coap-example-server/coap-example-server.native > node.log 2> node.err &
+make -j4 -C $CONTIKI/examples/coap/coap-example-server || exit 1
+sudo $CONTIKI/examples/coap/coap-example-server/coap-example-server.native &
 CPID=$!
 sleep 2
 
@@ -44,20 +44,11 @@ kill_bg $CPID
 if [ $TESTCOUNT -eq $OKCOUNT ] ; then
   printf "%-32s TEST OK    %3d/%d\n" "$BASENAME" "$OKCOUNT" "$TESTCOUNT" | tee $BASENAME.testlog;
 else
-  echo "==== make.log ====" ; cat make.log;
-  echo "==== make.err ====" ; cat make.err;
-  echo "==== node.log ====" ; cat node.log;
-  echo "==== node.err ====" ; cat node.err;
   echo "==== coap.log ====" ; cat coap.log;
   echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
-
   printf "%-32s TEST FAIL  %3d/%d\n" "$BASENAME" "$OKCOUNT" "$TESTCOUNT" | tee $BASENAME.testlog;
-  rm -f make.log make.err node.log node.err coap.log
+  rm -f coap.log
   exit 1
 fi
 
-rm -f  make.log make.err node.log node.err coap.log
-
-# We do not want Make to stop -> Return 0
-# The Makefile will check if a log contains FAIL at the end
-exit 0
+rm -f coap.log

--- a/tests/08-native-runs/11-aes-ccm.sh
+++ b/tests/08-native-runs/11-aes-ccm.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 ./run-one.sh 11-aes-ccm

--- a/tests/08-native-runs/12-heapmem.sh
+++ b/tests/08-native-runs/12-heapmem.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 ./run-one.sh 12-heapmem

--- a/tests/08-native-runs/13-coffee.sh
+++ b/tests/08-native-runs/13-coffee.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 ./run-one.sh 13-coffee

--- a/tests/10-ipv6-nbr/01-test-nbr-multi-addrs.sh
+++ b/tests/10-ipv6-nbr/01-test-nbr-multi-addrs.sh
@@ -12,10 +12,5 @@ SRC_DIR=${TEST_DIR}/nbr-multi-addrs
 EXEC_FILE_NAME=test.native
 
 make -C ${SRC_DIR} clean
-
-echo "build the test program..."
-make -C ${SRC_DIR} > ${TEST_NAME}.log
-
-echo "run the test..."
-${SRC_DIR}/${EXEC_FILE_NAME} | tee ${TEST_NAME}.log | \
-    grep -vE '^\[' >> ${TEST_NAME}.testlog
+make -j4 -C ${SRC_DIR}
+${SRC_DIR}/${EXEC_FILE_NAME}

--- a/tests/17-tun-rpl-br/test-border-router.sh
+++ b/tests/17-tun-rpl-br/test-border-router.sh
@@ -36,9 +36,7 @@ echo "Closing tunslip6"
 kill $MPID
 
 if [ $STATUS -eq 0 ]; then
-  printf "%-32s TEST OK\n" "$BASENAME" > $BASENAME.testlog
   exit 0
 else
-  printf "%-32s TEST FAIL\n" "$BASENAME" > $BASENAME.testlog
   exit 1
 fi

--- a/tests/17-tun-rpl-br/test-native-border-router.sh
+++ b/tests/17-tun-rpl-br/test-native-border-router.sh
@@ -36,9 +36,7 @@ echo "Closing nbr"
 kill $MPID
 
 if [ $STATUS -eq 0 ]; then
-  printf "%-32s TEST OK\n" "$BASENAME" > $BASENAME.testlog
   exit 0
 else
-  printf "%-32s TEST FAIL\n" "$BASENAME" > $BASENAME.testlog
   exit 1
 fi

--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -10,9 +10,9 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node - lwm2m/ipso objects"
-make -C $CONTIKI/examples/lwm2m-ipso-objects clean >/dev/null
-make -C $CONTIKI/examples/lwm2m-ipso-objects > make.log 2> make.err
-sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native > node.log 2> node.err &
+make -C $CONTIKI/examples/lwm2m-ipso-objects clean || exit 1
+make -j4 -C $CONTIKI/examples/lwm2m-ipso-objects || exit 1
+sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native &
 CPID=$!
 
 echo "Downloading leshan"
@@ -40,25 +40,14 @@ echo "Closing leshan"
 kill_bg $LESHID
 
 
-if grep -q 'OK' leshan.err ; then
-  cp leshan.err $BASENAME.testlog;
-  printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
-else
-  echo "==== make.log ====" ; cat make.log;
-  echo "==== make.err ====" ; cat make.err;
-  echo "==== node.log ====" ; cat node.log;
-  echo "==== node.err ====" ; cat node.err;
+if ! grep -q 'OK' leshan.err ; then
   echo "==== leshan.log ====" ; cat leshan.log;
   echo "==== leshan.err ====" ; cat leshan.err;
   echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
 
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
-  rm -f make.log make.err node.log node.err leshan.log leshan.err
+  rm -f leshan.log leshan.err
   exit 1
 fi
 
-rm -f make.log make.err node.log node.err leshan.log leshan.err
-
-# We do not want Make to stop -> Return 0
-# The Makefile will check if a log contains FAIL at the end
-exit 0
+rm -f leshan.log leshan.err

--- a/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
+++ b/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
@@ -9,9 +9,9 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node - lwm2m/ipso objects with Q-Mode"
-make -C $CONTIKI/examples/lwm2m-ipso-objects clean >/dev/null
-make -C $CONTIKI/examples/lwm2m-ipso-objects DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 > make.log 2> make.err
-sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native > node.log 2> node.err &
+make -C $CONTIKI/examples/lwm2m-ipso-objects clean || exit 1
+make -j4 -C $CONTIKI/examples/lwm2m-ipso-objects DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 || exit 1
+sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native &
 CPID=$!
 
 echo "Downloading leshan with Q-Mode support"
@@ -46,21 +46,14 @@ then
   cp leshan.err $BASENAME.testlog;
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
 else
-  echo "==== make.log ====" ; cat make.log;
-  echo "==== make.err ====" ; cat make.err;
-  echo "==== node.log ====" ; cat node.log;
-  echo "==== node.err ====" ; cat node.err;
   echo "==== leshan.log ====" ; cat leshan.log;
   echo "==== leshan.err ====" ; cat leshan.err;
   echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
 
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
-  rm -f make.log make.err node.log node.err leshan.log leshan.err
+  rm -f leshan.log leshan.err
   exit 1
 fi
 
-rm -f make.log make.err node.log node.err leshan.log leshan.err
+rm -f leshan.log leshan.err
 
-# We do not want Make to stop -> Return 0
-# The Makefile will check if a log contains FAIL at the end
-exit 0

--- a/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
+++ b/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
@@ -7,8 +7,8 @@ BASENAME=09-lwm2m-qmode-standalone-test
 
 # Building standalone posix example
 echo "Compiling standalone posix example"
-make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m clean >/dev/null
-make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 >make.log 2>make.err
+make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m clean || exit 1
+make -j4 CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 || exit 1
 
 echo "Downloading leshan with Q-Mode support"
 LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
@@ -18,7 +18,7 @@ java --add-opens java.base/java.util=ALL-UNNAMED -jar $LESHAN_JAR -lp 5686 -slp 
 LESHID=$!
 
 echo "Starting lwm2m standalone example"
-example-lwm2m-standalone/lwm2m/lwm2m-example coap://127.0.0.1:5686 > node.log 2> node.err &
+example-lwm2m-standalone/lwm2m/lwm2m-example coap://127.0.0.1:5686 &
 
 CPID=$!
 
@@ -45,21 +45,13 @@ then
   cp leshan.err $BASENAME.testlog;
   printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
 else
-  echo "==== make.log ====" ; cat make.log;
-  echo "==== make.err ====" ; cat make.err;
-  echo "==== node.log ====" ; cat node.log;
-  echo "==== node.err ====" ; cat node.err;
   echo "==== leshan.log ====" ; cat leshan.log;
   echo "==== leshan.err ====" ; cat leshan.err;
   echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
 
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
-  rm -f make.log make.err node.log node.err leshan.log leshan.err
+  rm -f leshan.log leshan.err
   exit 1
 fi
 
-rm -f make.log make.err node.log node.err leshan.log leshan.err
-
-# We do not want Make to stop -> Return 0
-# The Makefile will check if a log contains FAIL at the end
-exit 0
+rm -f leshan.log leshan.err

--- a/tests/20-packet-parsing/packet-injector.sh
+++ b/tests/20-packet-parsing/packet-injector.sh
@@ -17,7 +17,7 @@ echo packet dir = $PACKET_DIR
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-make -C $CODE_DIR TARGET=native
+make -j4 -C $CODE_DIR TARGET=native || exit 1
 
 for i in $PACKET_DIR/*
 do
@@ -60,12 +60,6 @@ if [ $((TIMEDOUT + FAILED)) -gt 0 ]; then
 
   sleep 3
   exit 1
-else
-  printf "%-32s TEST OK\n" "$CODE-$TEST_PROTOCOL"
 fi
 
 sleep 3
-
-# We do not want Make to stop -> Return 0
-# The Makefile will check if a log contains FAIL at the end
-exit 0


### PR DESCRIPTION
The build system regulates how much information
that is printed when compiling, so stop piping
output to files when possible. This provides
timestamps in the CI logs.

Also add -j4 on calls to make to get some
parallelism, and stop tests early
with either executing the shell with -e
or adding "|| exit 1" to the make commands.