### PR TITLE
Makefile.compile-test: add Clang warning check

### DIFF
--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -53,33 +53,26 @@ PRINT_LOGFILE ?= true
 PRINT_DIR ?= --no-print-directory
 MAKEOPTIONS += $(PRINT_DIR) $(SIZE_LOGFILE) WERROR=1
 
-# The stuff below is some GNU make magic to automatically make make
-# give each compile test a number, prefixed with a 0 if the number is
-# < 10, to match the way the simulation tests output works.
-nine := x x x x x x x x x
-max = $(subst xx,x,$(join ${1},${2}))
-gt = $(filter-out $(words ${1}),$(words $(call max,${1},${2})))
-addzero = $(if $(call gt,${nine},$(1)),$(words ${1}),0$(words ${1}))
-get_target = $(firstword $(subst :, ,$1))
-get_target_vars = $(wordlist 2,15,$(subst :, ,$1))
-
-define dooneexample
-@echo Building example $(3): $(1) $(4) for target $(2)
-@((cd $(EXAMPLESDIR)/$(1) && \
-   $(MAKE) $(4) TARGET=$(2) $(MAKEOPTIONS) clean && \
-   make -j$(CPUS) $(4) TARGET=$(2) $(MAKEOPTIONS)) || \
-  printf "%-75s %-40s %-20s TEST FAIL\n" "$(1)" "$(4)" "$(2)" >> summary)
-endef
-
-define doexample
-$(eval i+=x)
-$(call dooneexample,$(dir $(call get_target,${1})),$(notdir $(call get_target,${1})),$(call addzero,${i}),$(call get_target_vars,${1}))
-endef
-#end of GNU make magic
+# Rule for compiling examples.
+# EXAMPLES has the form directory/target:define1=value1:define2=value2:...
+# Mangle ":" to "_@_" and "=" to "@_@" to get a valid make rule name.
+DELIMIT1 := _@_
+DELIMIT2 := @_@
+EXAMPLES_TMP := $(subst =,$(DELIMIT2), $(subst :,$(DELIMIT1),$(EXAMPLES)))
+$(EXAMPLES_TMP):
+	$(eval _exlist := $(subst $(DELIMIT1), ,$(subst $(DELIMIT2),=,$@)))
+	$(eval _blob := $(firstword $(_exlist)))
+	$(eval _example := $(dir $(_blob)))
+	$(eval _target := $(notdir $(_blob)))
+	$(eval _defines := $(wordlist 2,15,$(_exlist)))
+	@echo Building: $(_example) $(_defines) for target $(_target)
+	@($(MAKE) -C $(EXAMPLESDIR)/$(_example) $(_defines) TARGET=$(_target) $(MAKEOPTIONS) clean && \
+          make -C $(EXAMPLESDIR)/$(_example) -j$(CPUS) $(_defines) TARGET=$(_target) $(MAKEOPTIONS)) || \
+         printf "%-75s %-40s %-20s TEST FAIL\n" "$(_example)" "$(_defines)" "$(_target)" >> summary
 
 examples: | $(EXAMPLESDIR)
 	@rm -f summary $(BINARY_SIZE_LOGFILE)
-	$(foreach ex, $(EXAMPLES), $(call doexample, ${ex}))
+	@$(MAKE) $(EXAMPLES_TMP)
 
 $(EXAMPLESDIR):
 	@echo "Could not find examples directory $(EXAMPLESDIR).\n"

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -51,7 +51,7 @@ ifdef BINARY_SIZE_LOGFILE
 endif
 PRINT_LOGFILE ?= true
 PRINT_DIR ?= --no-print-directory
-MAKEOPTIONS += $(PRINT_DIR) $(SIZE_LOGFILE) WERROR=1
+MAKEOPTIONS += $(PRINT_DIR) $(SIZE_LOGFILE) WERROR=1 $(MAKE_EXTRA_OPTIONS)
 
 # Rule for compiling examples.
 # EXAMPLES has the form directory/target:define1=value1:define2=value2:...
@@ -66,13 +66,16 @@ $(EXAMPLES_TMP):
 	$(eval _target := $(notdir $(_blob)))
 	$(eval _defines := $(wordlist 2,15,$(_exlist)))
 	@echo Building: $(_example) $(_defines) for target $(_target)
-	@($(MAKE) -C $(EXAMPLESDIR)/$(_example) $(_defines) TARGET=$(_target) $(MAKEOPTIONS) clean && \
+	$(Q)($(MAKE) -C $(EXAMPLESDIR)/$(_example) $(_defines) TARGET=$(_target) $(MAKEOPTIONS) clean && \
           make -C $(EXAMPLESDIR)/$(_example) -j$(CPUS) $(_defines) TARGET=$(_target) $(MAKEOPTIONS)) || \
          printf "%-75s %-40s %-20s TEST FAIL\n" "$(_example)" "$(_defines)" "$(_target)" >> summary
 
 examples: | $(EXAMPLESDIR)
 	@rm -f summary $(BINARY_SIZE_LOGFILE)
 	@$(MAKE) $(EXAMPLES_TMP)
+ifeq ($(CLANG_WARNINGS),1)
+	@$(MAKE) MAKE_EXTRA_OPTIONS=CLANG=1 $(EXAMPLES_TMP)
+endif
 
 $(EXAMPLESDIR):
 	@echo "Could not find examples directory $(EXAMPLESDIR).\n"


### PR DESCRIPTION
Add a second round of (optional) tests using
Clang. This will allow the CI to ensure that
code builds without warnings with Clang.

This PR is just the test infrastructure
support, there are still quite a few PRs with
warning fixes to be merged before the check
can be enabled in the CI.

This commit also makes it possible to run
the tests with:

make Q=''

and see the compiler invocations the same way
that one would when building an example.

This PR also removes the "make magic", which
makes the test framework ready for running
tests in parallel; the limitation now resides in the main
build system (https://github.com/contiki-ng/contiki-ng/pull/2473).
