### PR TITLE
Centralize clock_time_t definition

### DIFF
--- a/arch/cpu/arm/arm-def.h
+++ b/arch/cpu/arm/arm-def.h
@@ -48,13 +48,10 @@
  * Those values are not meant to be modified by the user
  * @{
  */
+#define CLOCK_CONF_SIZE 4
 #define CLOCK_CONF_SECOND 128
 
-/* Clock (time) comparison macro */
-#define CLOCK_LT(a, b)  ((signed long)((a) - (b)) < 0)
-
 /* Platform typedefs */
-typedef uint32_t clock_time_t;
 typedef uint32_t uip_stats_t;
 
 /** @} */

--- a/arch/cpu/msp430/f1xxx/clock.c
+++ b/arch/cpu/msp430/f1xxx/clock.c
@@ -41,7 +41,7 @@
 
 #define MAX_TICKS (~((clock_time_t)0) / 2)
 
-#define CLOCK_LT(a, b) ((int16_t)((a)-(b)) < 0)
+#define HW_CLOCK_LT(a, b) ((int16_t)((a)-(b)) < 0)
 
 static volatile unsigned long seconds;
 
@@ -73,7 +73,7 @@ ISR(TIMERA1, timera1)
 
     last_tar = read_tar();
     /* Make sure interrupt time is future */
-    while(!CLOCK_LT(last_tar, TACCR1)) {
+    while(!HW_CLOCK_LT(last_tar, TACCR1)) {
       TACCR1 += INTERVAL;
       ++count;
 

--- a/arch/cpu/msp430/f5xxx/clock.c
+++ b/arch/cpu/msp430/f5xxx/clock.c
@@ -41,7 +41,7 @@
 
 #define MAX_TICKS (~((clock_time_t)0) / 2)
 
-#define CLOCK_LT(a, b) ((int16_t)((a)-(b)) < 0)
+#define HW_CLOCK_LT(a, b) ((int16_t)((a)-(b)) < 0)
 
 static volatile unsigned long seconds;
 
@@ -73,7 +73,7 @@ ISR(TIMER1_A1, timera1)
 
     last_tar = read_tar();
     /* Make sure interrupt time is future */
-    while(!CLOCK_LT(last_tar, TA1CCR1)) {
+    while(!HW_CLOCK_LT(last_tar, TA1CCR1)) {
       TA1CCR1 += INTERVAL;
       ++count;
 

--- a/arch/cpu/msp430/msp430-def.h
+++ b/arch/cpu/msp430/msp430-def.h
@@ -70,11 +70,12 @@
 
 #include <stdint.h>
 
-/* Types for clocks and uip_stats */
+/* Platform typedefs. */
 typedef unsigned short uip_stats_t;
-typedef unsigned long clock_time_t;
 typedef long off_t;
 
+/* Make clock_time_t smaller than default for size reasons. */
+#define CLOCK_CONF_SIZE 4
 /* Our clock resolution, this is the same as Unix HZ. */
 #define CLOCK_CONF_SECOND 128UL
 

--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -104,7 +104,6 @@
 typedef unsigned short uip_stats_t;
 
 #define CLOCK_CONF_SECOND 1000L
-typedef uint64_t clock_time_t;
 
 /* Use 64-bit rtimer (default in Contiki-NG is 32) */
 #define RTIMER_CONF_CLOCK_SIZE 8

--- a/arch/platform/native/contiki-conf.h
+++ b/arch/platform/native/contiki-conf.h
@@ -94,8 +94,6 @@ typedef unsigned int uip_stats_t;
 
 #include <ctype.h>
 
-typedef unsigned long clock_time_t;
-
 #define CLOCK_CONF_SECOND 1000
 
 #define LOG_CONF_ENABLED 1

--- a/arch/platform/zoul/orion/enc28j60-arch-gpio.c
+++ b/arch/platform/zoul/orion/enc28j60-arch-gpio.c
@@ -42,7 +42,6 @@
  * eth-gw GPIO arch specifics
  */
 /*---------------------------------------------------------------------------*/
-#include "clock.h"
 #include "dev/gpio.h"
 /*---------------------------------------------------------------------------*/
 #define CLK_PORT    GPIO_PORT_TO_BASE(ETH_SPI_CLK_PORT)

--- a/doc/programming/Porting-Contiki-NG-to-new-platforms.md
+++ b/doc/programming/Porting-Contiki-NG-to-new-platforms.md
@@ -30,7 +30,7 @@ If not, let's assume that your MCU is called `my-new-mcu`.
 * Under `arch/cpu/my-new-mcu`, create the following files:
   * `Makefile.my-new-mcu`: This is where you will explain to the build system how to build firmware images suitable for your MCU.
   * `my-new-mcu-conf.h`: This is where you will put MCU-specific macros that users are expected to be able to modify (for example whether you want your internal watchdog timer to be enabled/disabled).
-  * `my-new-mcu-def.h`: This is where you will put MCU-specific macros that users should _not_ modify. One such example is the `typedef` for `clock_time_t` and the number of software clock ticks per second `CLOCK_CONF_SECOND`
+  * `my-new-mcu-def.h`: This is where you will put MCU-specific macros that users should _not_ modify. One such example is the `define` for `CLOCK_CONF_SIZE` and the number of software clock ticks per second `CLOCK_CONF_SECOND`
   * `doxygen-group.txt`: This is where you will define where your CPU code's documentation will be located in the API doc structure. See for example [`arch/cpu/cc2538/doxygen-group.txt`](https://github.com/contiki-ng/contiki-ng/tree/develop/arch/cpu/cc2538/doxygen-group.txt).
 
 #### Configure the build system

--- a/doc/project/Release-Notes-next.md
+++ b/doc/project/Release-Notes-next.md
@@ -20,6 +20,13 @@ The Contiki-NG team
 
 ## API changes for ports outside the main tree
 
+### Centralized clock_time_t definition
+
+Ports should now define `CLOCK_CONF_SIZE` instead of a typedef for `clock_time_t`
+([#2550](https://github.com/contiki-ng/contiki-ng/pull/2550)).
+
+This is similar to how `RTIMER_CONF_CLOCK_SIZE` is already handled.
+
 ## Cooja API changes for plugins outside the main tree
 
 ## Changelog

--- a/os/sys/clock.h
+++ b/os/sys/clock.h
@@ -69,6 +69,27 @@
 #ifndef CLOCK_H_
 #define CLOCK_H_
 
+#include <stdint.h>
+
+/** \brief The clock size (in bytes). */
+#ifdef CLOCK_CONF_SIZE
+#define CLOCK_SIZE CLOCK_CONF_SIZE
+#else /* CLOCK_CONF_SIZE */
+#define CLOCK_SIZE 8
+#endif /* CLOCK_CONF_SIZE */
+
+/* Define clock_time_t before including contiki.h, so etimer.h
+ * and other header files have clock_time_t defined. */
+#if CLOCK_SIZE == 4
+typedef uint32_t clock_time_t;
+#define CLOCK_LT(a, b)  ((int32_t)((a) - (b)) < 0)
+#elif CLOCK_SIZE == 8
+typedef uint64_t clock_time_t;
+#define CLOCK_LT(a, b)  ((int64_t)((a) - (b)) < 0)
+#else
+#error Unsupported clock_time_t size (check CLOCK_CONF_SIZE)
+#endif
+
 #include "contiki.h"
 
 /**


### PR DESCRIPTION
Use a similar construct as rtimer
for defining the size of clock_time_t.