### PR TITLE
msp430: remove typedefs for u8_t & friends

### DIFF
--- a/arch/cpu/msp430/msp430-def.h
+++ b/arch/cpu/msp430/msp430-def.h
@@ -70,12 +70,6 @@
 
 #include <stdint.h>
 
-/* These names are deprecated, use C99 names. */
-typedef  uint8_t    u8_t;
-typedef uint16_t   u16_t;
-typedef uint32_t   u32_t;
-typedef  int32_t   s32_t;
-
 /* Types for clocks and uip_stats */
 typedef unsigned short uip_stats_t;
 typedef unsigned long clock_time_t;


### PR DESCRIPTION
These types are not used in the msp430
platforms, so remove them.