### PR TITLE
cooja: fix printf for floats

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -31,9 +31,7 @@ ifneq ($(MAKECMDGOALS),clean)
   endif
 endif
 
-# Use dbg-io for IO functions like printf()
-MODULES += os/lib/dbg-io
-WRAPPED_FUNS = printf putchar puts snprintf sprintf vsnprintf
+WRAPPED_FUNS = printf putchar puts
 
 CC = gcc
 
@@ -46,7 +44,7 @@ else
   LDFLAGS += -shared -Wl,-zdefs
   LDFLAGS += -Wl,--warn-common
   LDFLAGS += -Wl,-T$(CONTIKI_NG_RELOC_PLATFORM_DIR)/cooja/cooja.ld
-  # Use the printf-family replacement functions in dbg-io.
+  # Use the printf-family replacement functions in cooja-log.c.
   LDFLAGS += $(addprefix -Wl$(COMMA)--wrap$(COMMA), $(WRAPPED_FUNS))
 endif
 

--- a/arch/platform/cooja/dev/rs232.c
+++ b/arch/platform/cooja/dev/rs232.c
@@ -46,7 +46,7 @@ char simSerialReceivingFlag;
 
 static int (* input_handler)(unsigned char) = NULL;
 
-void simlog_char(char c);
+int simlog_char(char c);
 /*-----------------------------------------------------------------------------------*/
 void rs232_init(void) { }
 /*-----------------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/printf.c
+++ b/os/lib/dbg-io/printf.c
@@ -61,8 +61,4 @@ printf(const char *fmt, ...)
   va_end(ap);
   return res;
 }
-
-#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
-extern int __wrap_printf(const char *fmt, ...) __attribute__((nonnull, alias("printf")));
-#endif
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/putchar.c
+++ b/os/lib/dbg-io/putchar.c
@@ -40,8 +40,4 @@ putchar(int c)
 {
   return dbg_putchar(c);
 }
-
-#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
-extern int __wrap_putchar(int c) __attribute__((alias("putchar")));
-#endif
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/puts.c
+++ b/os/lib/dbg-io/puts.c
@@ -41,8 +41,4 @@ puts(const char *str)
   dbg_send_bytes((unsigned char *)str, strlen(str));
   return dbg_putchar('\n');
 }
-
-#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
-extern int __wrap_puts(const char *str) __attribute__((nonnull, alias("puts")));
-#endif
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/snprintf.c
+++ b/os/lib/dbg-io/snprintf.c
@@ -82,9 +82,4 @@ vsnprintf(char *str, size_t size, const char *format, va_list ap)
   *buffer.pos = '\0';
   return res;
 }
-
-#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
-extern int __wrap_snprintf(char *str, size_t size, const char *format, ...) __attribute__((nonnull, nothrow, alias("snprintf")));
-extern int __wrap_vsnprintf(char *str, size_t size, const char *format, va_list ap) __attribute__((nonnull, nothrow, alias("vsnprintf")));
-#endif
 /*---------------------------------------------------------------------------*/

--- a/os/lib/dbg-io/sprintf.c
+++ b/os/lib/dbg-io/sprintf.c
@@ -58,8 +58,4 @@ sprintf(char *str, const char *format, ...)
   va_end(ap);
   return res;
 }
-
-#if defined(CONTIKI_TARGET_COOJA) && !defined(__APPLE__)
-extern int __wrap_sprintf(char *str, const char *format, ...) __attribute__((nonnull, nothrow, alias("sprintf")));
-#endif
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
There is no support for printing floats
in dbg-io, so stop using that.

The issues that f45a8c5327 tried to
avoid are not present on my computer,
which could be explained by 64-bit support
in Cooja, FFI instead of JNI, or using
-Wl,--wrap for wrapping the printf-family
of functions.

Fixes #2566