### PR TITLE
tsch: fix GCC 12/13 warning

### DIFF
--- a/arch/platform/zoul/contiki-conf.h
+++ b/arch/platform/zoul/contiki-conf.h
@@ -72,6 +72,7 @@ uint16_t *radio_tsch_timeslot_timing(void);
 #define RADIO_DELAY_BEFORE_RX     radio_delay_before_rx()
 #define RADIO_DELAY_BEFORE_DETECT radio_delay_before_detect()
 
+#define TSCH_CONF_DYNAMIC_TIMESLOT_TEMPLATE 1
 #define TSCH_CONF_DEFAULT_TIMESLOT_TIMING   radio_tsch_timeslot_timing()
 
 /*---------------------------------------------------------------------------*/

--- a/os/net/mac/tsch/tsch-conf.h
+++ b/os/net/mac/tsch/tsch-conf.h
@@ -450,6 +450,13 @@ by default, useful in case of duplicate seqno */
 #define TSCH_DEFAULT_TIMESLOT_TIMING tsch_timeslot_timing_us_10000
 #endif
 
+/* Is the timing template dynamic. */
+#ifdef TSCH_CONF_DYNAMIC_TIMESLOT_TEMPLATE
+#define TSCH_DYNAMIC_TIMESLOT_TEMPLATE TSCH_CONF_DYNAMIC_TIMESLOT_TEMPLATE
+#else
+#define TSCH_DYNAMIC_TIMESLOT_TEMPLATE 0
+#endif
+
 /* Configurable Rx guard time is micro-seconds */
 #ifndef TSCH_CONF_RX_WAIT
 #define TSCH_CONF_RX_WAIT 2200

--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -1000,11 +1000,13 @@ tsch_init(void)
 
   rtimer_clock_t t;
 
+#if TSCH_DYNAMIC_TIMESLOT_TEMPLATE
   /* Check that the platform provides a TSCH timeslot timing template */
   if(TSCH_DEFAULT_TIMESLOT_TIMING == NULL) {
     LOG_ERR("! platform does not provide a timeslot timing template.\n");
     return;
   }
+#endif
 
   /* Check that the radio can correctly report its max supported payload */
   if(NETSTACK_RADIO.get_value(RADIO_CONST_MAX_PAYLOAD_LEN, &radio_max_payload_len) != RADIO_RESULT_OK) {


### PR DESCRIPTION
GCC 12/13 will warn on most platforms
since this check is always false. Zoul
does however have a dynamic size, so
put the check under ifdef ZOUL.