### PR TITLE
tsch: fix printf format specifiers

### DIFF
--- a/os/net/mac/tsch/tsch-adaptive-timesync.c
+++ b/os/net/mac/tsch/tsch-adaptive-timesync.c
@@ -158,8 +158,9 @@ compensate_internal(uint32_t time_delta_usec, int32_t drift_ppm, int32_t *remain
 
   if(ABS(amount_ticks) > RTIMER_ARCH_SECOND / 128) {
     TSCH_LOG_ADD(tsch_log_message,
-        snprintf(log->message, sizeof(log->message),
-            "!too big compensation %ld delta %ld", (long int)amount_ticks, (long int)time_delta_usec));
+                 snprintf(log->message, sizeof(log->message),
+                          "!too big compensation %" PRId32 " delta %" PRId32,
+                          amount_ticks, time_delta_usec));
     amount_ticks = (amount_ticks > 0 ? RTIMER_ARCH_SECOND : -RTIMER_ARCH_SECOND) / 128;
   }
 


### PR DESCRIPTION
This avoids a warning with GCC 13.