### PR TITLE
stack-check: 64-bit fixes

### DIFF
--- a/examples/libs/stack-check/example-stack-check.c
+++ b/examples/libs/stack-check/example-stack-check.c
@@ -50,8 +50,9 @@ AUTOSTART_PROCESSES(&example_process);
 static void
 nested_function(void)
 {
-  printf("stack usage: %" PRId32 " permitted: %" PRId32 "\n",
-         stack_check_get_usage(), stack_check_get_reserved_size());
+  printf("stack usage: %u permitted: %u\n",
+         (unsigned)stack_check_get_usage(),
+         (unsigned)stack_check_get_reserved_size());
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/sys/stack-check.h
+++ b/os/sys/stack-check.h
@@ -54,6 +54,8 @@
 
 #include "contiki-conf.h"
 
+#include <stddef.h>
+
 /* Determine whether stack checking is supported depending on the plaform. */
 #ifdef PLATFORM_CONF_SUPPORTS_STACK_CHECK
 #if !PLATFORM_CONF_SUPPORTS_STACK_CHECK
@@ -104,8 +106,9 @@ void stack_check_init(void);
  *             In addition, this function can warn if the stack memory range
  *             has been completely used, but it cannot detect
  *             and warn if stack overflow has already taken place.
+ *             Returns SIZE_MAX when an error occurs.
  */
-int32_t stack_check_get_usage(void);
+size_t stack_check_get_usage(void);
 
 /**
  * \brief      Calculate the maximal permitted stack usage.
@@ -113,7 +116,7 @@ int32_t stack_check_get_usage(void);
  *             This function returns the number of bytes between the origin
  *             of the stack and the end of heap.
  */
-int32_t stack_check_get_reserved_size(void);
+size_t stack_check_get_reserved_size(void);
 
 /**
  * \brief      The origin point from which the stack grows (an optional #define)


### PR DESCRIPTION
Use the C99 type size_t to represent
pointer differences.

This reduces the size of the text segment
on MSP430 by 100+ bytes.