### PR TITLE
border-router.c: fix copyright year

### DIFF
--- a/examples/rpl-border-router/border-router.c
+++ b/examples/rpl-border-router/border-router.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 201, RISE SICS
+ * Copyright (c) 2017, RISE SICS
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This file was created in 2017, fix the copyright
year to that instead of "201".