### PR TITLE
native: stop declaring libc functions

### DIFF
--- a/arch/platform/native/contiki-conf.h
+++ b/arch/platform/native/contiki-conf.h
@@ -103,10 +103,6 @@ typedef unsigned long clock_time_t;
 #define LOG_CONF_ENABLED 1
 
 #define PLATFORM_SUPPORTS_BUTTON_HAL 1
-
-/* Not part of C99 but actually present */
-int strcasecmp(const char*, const char*);
-
 #define PLATFORM_CONF_PROVIDES_MAIN_LOOP 1
 #define PLATFORM_CONF_MAIN_ACCEPTS_ARGS  1
 #define PLATFORM_CONF_SUPPORTS_STACK_CHECK 0


### PR DESCRIPTION
This function is already declared by
the libc header.