### PR TITLE
native: remove WIN32 ifdefs

### DIFF
--- a/arch/cpu/native/rtimer-arch.c
+++ b/arch/cpu/native/rtimer-arch.c
@@ -38,9 +38,7 @@
  */
 
 #include <signal.h>
-#ifndef _WIN32
 #include <sys/time.h>
-#endif /* !_WIN32 */
 #include <stddef.h>
 
 #include "sys/rtimer.h"
@@ -65,15 +63,12 @@ interrupt(int sig)
 void
 rtimer_arch_init(void)
 {
-#ifndef _WIN32
   signal(SIGALRM, interrupt);
-#endif /* !_WIN32 */
 }
 /*---------------------------------------------------------------------------*/
 void
 rtimer_arch_schedule(rtimer_clock_t t)
 {
-#ifndef _WIN32
   struct itimerval val;
   rtimer_clock_t c;
 
@@ -87,6 +82,5 @@ rtimer_arch_schedule(rtimer_clock_t t)
 
   val.it_interval.tv_sec = val.it_interval.tv_usec = 0;
   setitimer(ITIMER_REAL, &val, NULL);
-#endif /* !_WIN32 */
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/platform/native/contiki-conf.h
+++ b/arch/platform/native/contiki-conf.h
@@ -41,9 +41,7 @@
 #include "native-def.h"
 /*---------------------------------------------------------------------------*/
 #include <inttypes.h>
-#ifndef WIN32_LEAN_AND_MEAN
 #include <sys/select.h>
-#endif
 
 struct select_callback {
   int  (* set_fd)(fd_set *fdr, fd_set *fdw);


### PR DESCRIPTION
There is no WIN32 support, so remove
the ifdefs.