### PR TITLE
border-router-cmds: use regular return value

### DIFF
--- a/os/services/rpl-border-router/native/border-router-cmds.c
+++ b/os/services/rpl-border-router/native/border-router-cmds.c
@@ -78,36 +78,31 @@ hextoi(const uint8_t *buf, int len)
   return v;
 }
 /*---------------------------------------------------------------------------*/
-static const uint8_t *
-dectoi(const uint8_t *buf, int len, int *v)
+static int
+dectoi(const uint8_t *buf, int len)
 {
   int negative = 0;
-  *v = 0;
   if(len <= 0) {
-    return buf;
+    return 0;
   }
   if(*buf == '$') {
-    *v = hextoi(buf + 1, len - 1);
-    return buf;
+    return hextoi(buf + 1, len - 1);
   }
   if(*buf == '0' && *(buf + 1) == 'x' && len > 2) {
-    *v = hextoi(buf + 2, len - 2);
-    return buf;
+    return hextoi(buf + 2, len - 2);
   }
   if(*buf == '-') {
     negative = 1;
     buf++;
   }
+  int v = 0;
   for(; len > 0; len--, buf++) {
     if(*buf < '0' || *buf > '9') {
       break;
     }
-    *v = (*v * 10) + ((*buf - '0') & 0xf);
+    v = (v * 10) + ((*buf - '0') & 0xf);
   }
-  if(negative) {
-    *v = - *v;
-  }
-  return buf;
+  return negative ? -v : v;
 }
 /*---------------------------------------------------------------------------*/
 
@@ -131,8 +126,7 @@ border_router_cmd_handler(const uint8_t *data, int len)
       case 'C': {
         /* send on a set-param thing! */
         uint8_t set_param[] = {'!', 'V', 0, RADIO_PARAM_CHANNEL, 0, 0 };
-        int channel;
-        dectoi(&data[2], len - 2, &channel);
+        int channel = dectoi(&data[2], len - 2);
         set_param[5] = channel & 0xff;
         write_to_slip(set_param, sizeof(set_param));
         return 1;
@@ -140,8 +134,7 @@ border_router_cmd_handler(const uint8_t *data, int len)
       case 'P': {
         /* send on a set-param thing! */
         uint8_t set_param[] = {'!', 'V', 0, RADIO_PARAM_PAN_ID, 0, 0 };
-        int pan_id;
-        dectoi(&data[2], len - 2, &pan_id);
+        int pan_id = dectoi(&data[2], len - 2);
         set_param[4] = (pan_id >> 8) & 0xff;
         set_param[5] = pan_id & 0xff;
         write_to_slip(set_param, sizeof(set_param));

--- a/os/services/rpl-border-router/native/border-router-cmds.c
+++ b/os/services/rpl-border-router/native/border-router-cmds.c
@@ -129,12 +129,10 @@ border_router_cmd_handler(const uint8_t *data, int len)
       case 'C': {
         /* send on a set-param thing! */
         uint8_t set_param[] = {'!', 'V', 0, RADIO_PARAM_CHANNEL, 0, 0 };
-        int channel = -1;
+        int channel;
         dectoi(&data[2], len - 2, &channel);
-        if(channel >= 0) {
-          set_param[5] = channel & 0xff;
-          write_to_slip(set_param, sizeof(set_param));
-        }
+        set_param[5] = channel & 0xff;
+        write_to_slip(set_param, sizeof(set_param));
         return 1;
       }
       case 'P': {

--- a/os/services/rpl-border-router/native/border-router-cmds.c
+++ b/os/services/rpl-border-router/native/border-router-cmds.c
@@ -231,11 +231,11 @@ PROCESS_THREAD(border_router_cmd_process, ev, data)
       LOG_DBG("Got serial data!!! %s of len: %zd\n",
               (char *)data, strlen((char *)data));
       command_context = CMD_CONTEXT_STDIO;
-      if(cmd_input(data, strlen((char *)data))) {
-        /* Commnand executed - all is fine */
-      } else {
+      if(!cmd_input(data, strlen((char *)data))) {
         /* did not find command - run shell and see if ... */
-        PROCESS_PT_SPAWN(&shell_input_pt, shell_input(&shell_input_pt, serial_shell_output, data));
+        PROCESS_PT_SPAWN(&shell_input_pt,
+                         shell_input(&shell_input_pt, serial_shell_output,
+                                     data));
       }
     }
   }

--- a/os/services/rpl-border-router/native/border-router-cmds.c
+++ b/os/services/rpl-border-router/native/border-router-cmds.c
@@ -228,8 +228,8 @@ PROCESS_THREAD(border_router_cmd_process, ev, data)
   while(1) {
     PROCESS_YIELD();
     if(ev == serial_line_event_message && data != NULL) {
-      LOG_DBG("Got serial data!!! %s of len: %u\n",
-             (char *)data, (unsigned)strlen((char *)data));
+      LOG_DBG("Got serial data!!! %s of len: %zd\n",
+              (char *)data, strlen((char *)data));
       command_context = CMD_CONTEXT_STDIO;
       if(cmd_input(data, strlen((char *)data))) {
         /* Commnand executed - all is fine */

--- a/os/services/rpl-border-router/native/border-router-cmds.c
+++ b/os/services/rpl-border-router/native/border-router-cmds.c
@@ -60,22 +60,22 @@ void nbr_print_stat(void);
 /*---------------------------------------------------------------------------*/
 PROCESS(border_router_cmd_process, "Border router cmd process");
 /*---------------------------------------------------------------------------*/
-static const uint8_t *
-hextoi(const uint8_t *buf, int len, int *v)
+static int
+hextoi(const uint8_t *buf, int len)
 {
-  *v = 0;
+  int v = 0;
   for(; len > 0; len--, buf++) {
     if(*buf >= '0' && *buf <= '9') {
-      *v = (*v << 4) + ((*buf - '0') & 0xf);
+      v = (v << 4) + ((*buf - '0') & 0xf);
     } else if(*buf >= 'a' && *buf <= 'f') {
-      *v = (*v << 4) + ((*buf - 'a' + 10) & 0xf);
+      v = (v << 4) + ((*buf - 'a' + 10) & 0xf);
     } else if(*buf >= 'A' && *buf <= 'F') {
-      *v = (*v << 4) + ((*buf - 'A' + 10) & 0xf);
+      v = (v << 4) + ((*buf - 'A' + 10) & 0xf);
     } else {
       break;
     }
   }
-  return buf;
+  return v;
 }
 /*---------------------------------------------------------------------------*/
 static const uint8_t *
@@ -87,10 +87,12 @@ dectoi(const uint8_t *buf, int len, int *v)
     return buf;
   }
   if(*buf == '$') {
-    return hextoi(buf + 1, len - 1, v);
+    *v = hextoi(buf + 1, len - 1);
+    return buf;
   }
   if(*buf == '0' && *(buf + 1) == 'x' && len > 2) {
-    return hextoi(buf + 2, len - 2, v);
+    *v = hextoi(buf + 2, len - 2);
+    return buf;
   }
   if(*buf == '-') {
     negative = 1;


### PR DESCRIPTION
Remove an always-true if, convert the helper functions to use a regular return value, and invert the if-statement to remove an empty body.