### PR TITLE
tsch-adaptive-timesync: invert condition

### DIFF
--- a/os/net/mac/tsch/tsch-adaptive-timesync.c
+++ b/os/net/mac/tsch/tsch-adaptive-timesync.c
@@ -156,15 +156,14 @@ compensate_internal(uint32_t time_delta_usec, int32_t drift_ppm, int32_t *remain
   amount_ticks = US_TO_RTIMERTICKS(amount);
   *tick_conversion_error = amount - RTIMERTICKS_TO_US(amount_ticks);
 
-  if(ABS(amount_ticks) > RTIMER_ARCH_SECOND / 128) {
-    TSCH_LOG_ADD(tsch_log_message,
-                 snprintf(log->message, sizeof(log->message),
-                          "!too big compensation %" PRId32 " delta %" PRId32,
-                          amount_ticks, time_delta_usec));
-    amount_ticks = (amount_ticks > 0 ? RTIMER_ARCH_SECOND : -RTIMER_ARCH_SECOND) / 128;
+  if(ABS(amount_ticks) <= RTIMER_ARCH_SECOND / 128) {
+    return amount_ticks;
   }
-
-  return amount_ticks;
+  TSCH_LOG_ADD(tsch_log_message,
+               snprintf(log->message, sizeof(log->message),
+                        "!too big compensation %" PRId32 " delta %" PRId32,
+                        amount_ticks, time_delta_usec));
+  return (amount_ticks > 0 ? RTIMER_ARCH_SECOND : -RTIMER_ARCH_SECOND) / 128;
 }
 /*---------------------------------------------------------------------------*/
 /* Do the compensation step before scheduling a new timeslot */


### PR DESCRIPTION
This saves 12 bytes of text on some
MSP430 tests.