### PR TITLE
tests: compile test simple-node on z1

### DIFF
--- a/tests/01-compile-base/Makefile
+++ b/tests/01-compile-base/Makefile
@@ -5,6 +5,7 @@ EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
 EXAMPLES = \
+6tisch/simple-node/z1 \
 hello-world/native \
 hello-world/native:MAKE_NET=MAKE_NET_NULLNET \
 hello-world/native:MAKE_ROUTING=MAKE_ROUTING_RPL_CLASSIC \


### PR DESCRIPTION
This is the first test that will cause
size issues on MSP430, so add it as
a compilation test to make it easier
to track how the sizes change across
commits.