### PR TITLE
border-router: share code with native

### DIFF
--- a/arch/cpu/native/net/tun6-net.c
+++ b/arch/cpu/native/net/tun6-net.c
@@ -51,6 +51,7 @@
 #include <sys/socket.h>
 #include <net/if.h>
 
+/*---------------------------------------------------------------------------*/
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "Tun6"
@@ -68,7 +69,6 @@
 static const char *config_ipaddr = "fd00::1/64";
 /* Allocate some bytes in RAM and copy the string */
 static char config_tundev[IFNAMSIZ + 1] = "tun0";
-
 
 static int tunfd = -1;
 
@@ -172,7 +172,7 @@ tun_alloc(char *dev, uint16_t devsize)
   struct ifreq ifr;
   int fd, err;
   LOG_INFO("Opening: %s\n", dev);
-  if( (fd = open("/dev/net/tun", O_RDWR)) < 0 ) {
+  if((fd = open("/dev/net/tun", O_RDWR)) < 0) {
     /* Error message handled by caller */
     return -1;
   }
@@ -186,12 +186,11 @@ tun_alloc(char *dev, uint16_t devsize)
   if(*dev != '\0') {
     memcpy(ifr.ifr_name, dev, MIN(sizeof(ifr.ifr_name), devsize));
   }
-  if((err = ioctl(fd, TUNSETIFF, (void *) &ifr)) < 0 ) {
+  if((err = ioctl(fd, TUNSETIFF, (void *)&ifr)) < 0) {
     /* Error message handled by caller */
     close(fd);
     return err;
   }
-
   LOG_INFO("Using '%s' vs '%s'\n", dev, ifr.ifr_name);
   strncpy(dev, ifr.ifr_name, MIN(devsize - 1, sizeof(ifr.ifr_name)));
   dev[devsize - 1] = '\0';
@@ -218,7 +217,6 @@ tun_init()
   tunfd = tun_alloc(config_tundev, sizeof(config_tundev));
   if(tunfd == -1) {
     LOG_WARN("Failed to open tun device (you may be lacking permission). Running without network.\n");
-    /* err(1, "failed to allocate tun device ``%s''", config_tundev); */
     return;
   }
 
@@ -235,12 +233,10 @@ tun_init()
   signal(SIGINT, sigcleanup);
   ifconf(config_tundev, config_ipaddr);
 }
-
 /*---------------------------------------------------------------------------*/
 static int
 tun_output(uint8_t *data, int len)
 {
-  /* fprintf(stderr, "*** Writing to tun...%d\n", len); */
   if(tunfd != -1 && write(tunfd, data, len) != len) {
     err(1, "serial_to_tun: write");
   }
@@ -262,7 +258,6 @@ tun_input(unsigned char *data, int maxlen)
   }
   return size;
 }
-
 /*---------------------------------------------------------------------------*/
 static uint8_t
 output(const linkaddr_t *localdest)
@@ -287,7 +282,6 @@ set_fd(fd_set *rset, fd_set *wset)
   FD_SET(tunfd, rset);
   return 1;
 }
-
 /*---------------------------------------------------------------------------*/
 
 static void
@@ -323,6 +317,4 @@ const struct network_driver tun6_net_driver ={
   input,
   output
 };
-
-
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/native/net/tun6-net.c
+++ b/arch/cpu/native/net/tun6-net.c
@@ -212,7 +212,7 @@ tun_init()
 {
   setvbuf(stdout, NULL, _IOLBF, 0); /* Line buffered output. */
 
-  LOG_INFO("Initializing tun interface\n");
+  LOG_INFO("Opening tun interface:%s\n", config_tundev);
 
   tunfd = tun_alloc(config_tundev, sizeof(config_tundev));
   if(tunfd == -1) {

--- a/arch/cpu/native/net/tun6-net.c
+++ b/arch/cpu/native/net/tun6-net.c
@@ -138,6 +138,15 @@ sigcleanup(int signo)
   _exit(0);
 }
 /*---------------------------------------------------------------------------*/
+int
+devopen(const char *dev, int flags)
+{
+  char t[32];
+  strcpy(t, "/dev/");
+  strncat(t, dev, sizeof(t) - 5);
+  return open(t, flags);
+}
+/*---------------------------------------------------------------------------*/
 void
 ifconf(const char *tundev, const char *ipaddr)
 {
@@ -190,14 +199,6 @@ tun_alloc(char *dev, uint16_t devsize)
   return fd;
 }
 #else
-static int
-devopen(const char *dev, int flags)
-{
-  char t[32];
-  strcpy(t, "/dev/");
-  strncat(t, dev, sizeof(t) - 5);
-  return open(t, flags);
-}
 /*---------------------------------------------------------------------------*/
 static int
 tun_alloc(char *dev, uint16_t devsize)

--- a/os/services/rpl-border-router/native/slip-config.c
+++ b/os/services/rpl-border-router/native/slip-config.c
@@ -43,6 +43,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <termios.h>
+#include <net/if.h>
 #include <sys/ioctl.h>
 #include <err.h>
 #include "contiki.h"
@@ -54,7 +55,7 @@ int slip_config_timestamp = 0;
 const char *slip_config_siodev = NULL;
 const char *slip_config_host = NULL;
 const char *slip_config_port = NULL;
-char slip_config_tundev[32] = { "" };
+char slip_config_tundev[IFNAMSIZ + 1] = { "" };
 uint16_t slip_config_basedelay = 0;
 
 #ifndef BAUDRATE

--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -173,7 +173,6 @@ tun_output(uint8_t *data, int len)
 {
   if(write(tunfd, data, len) != len) {
     err(1, "serial_to_tun: write");
-    return -1;
   }
   return 0;
 }

--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -95,7 +95,7 @@ cleanup(void)
   ifconf_cleanup(slip_config_tundev);
 }
 /*---------------------------------------------------------------------------*/
-void
+void CC_NORETURN
 sigcleanup(int signo)
 {
   fprintf(stderr, "signal %d\n", signo);

--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -107,8 +107,8 @@ tun_alloc(char *dev)
 {
   struct ifreq ifr;
   int fd, err;
-
   if((fd = open("/dev/net/tun", O_RDWR)) < 0) {
+    /* Error message handled by caller */
     return -1;
   }
 
@@ -121,8 +121,8 @@ tun_alloc(char *dev)
   if(*dev != 0) {
     strncpy(ifr.ifr_name, dev, IFNAMSIZ - 1);
   }
-
   if((err = ioctl(fd, TUNSETIFF, (void *)&ifr)) < 0) {
+    /* Error message handled by caller */
     close(fd);
     return err;
   }
@@ -130,6 +130,7 @@ tun_alloc(char *dev)
   return fd;
 }
 #else
+/*---------------------------------------------------------------------------*/
 int
 tun_alloc(char *dev)
 {
@@ -151,7 +152,6 @@ tun_init()
   LOG_INFO("Opening tun interface:%s\n", slip_config_tundev);
 
   tunfd = tun_alloc(slip_config_tundev);
-
   if(tunfd == -1) {
     err(1, "tun_init: tun_alloc failed");
   }
@@ -171,7 +171,6 @@ tun_init()
 static int
 tun_output(uint8_t *data, int len)
 {
-  /* fprintf(stderr, "*** Writing to tun...%d\n", len); */
   if(write(tunfd, data, len) != len) {
     err(1, "serial_to_tun: write");
     return -1;
@@ -242,7 +241,6 @@ handle_fd(fd_set *rset, fd_set *wset)
 
     if(FD_ISSET(tunfd, rset)) {
       size = tun_input(uip_buf, sizeof(uip_buf));
-      /* printf("TUN data incoming read:%d\n", size); */
       uip_len = size;
       tcpip_input();
 

--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -108,6 +108,7 @@ tun_alloc(char *dev, uint16_t devsize)
 {
   struct ifreq ifr;
   int fd, err;
+  LOG_INFO("Opening: %s\n", dev);
   if((fd = open("/dev/net/tun", O_RDWR)) < 0) {
     /* Error message handled by caller */
     return -1;
@@ -127,8 +128,10 @@ tun_alloc(char *dev, uint16_t devsize)
     close(fd);
     return err;
   }
+  LOG_INFO("Using '%s' vs '%s'\n", dev, ifr.ifr_name);
   strncpy(dev, ifr.ifr_name, MIN(devsize - 1, sizeof(ifr.ifr_name)));
   dev[devsize - 1] = '\0';
+  LOG_INFO("Using %s\n", dev);
   return fd;
 }
 #else
@@ -136,6 +139,7 @@ tun_alloc(char *dev, uint16_t devsize)
 int
 tun_alloc(char *dev, uint16_t devsize)
 {
+  LOG_INFO("Opening: %s\n", dev);
   return devopen(dev, O_RDWR);
 }
 #endif
@@ -157,6 +161,8 @@ tun_init()
   if(tunfd == -1) {
     err(1, "tun_init: tun_alloc failed");
   }
+
+  LOG_INFO("Tun open:%d\n", tunfd);
 
   select_set_callback(tunfd, &tun_select_callback);
 

--- a/os/services/rpl-border-router/native/tun-bridge.c
+++ b/os/services/rpl-border-router/native/tun-bridge.c
@@ -84,6 +84,8 @@ int ssystem(const char *fmt, ...)
      __attribute__((__format__ (__printf__, 1, 2)));
 void ifconf_cleanup(const char *dev);
 void ifconf(const char *tundev, const char *ipaddr);
+int devopen(const char *dev, int flags);
+
 
 /*---------------------------------------------------------------------------*/
 void
@@ -97,15 +99,6 @@ sigcleanup(int signo)
 {
   fprintf(stderr, "signal %d\n", signo);
   exit(0);			/* exit(0) will call cleanup() */
-}
-/*---------------------------------------------------------------------------*/
-int
-devopen(const char *dev, int flags)
-{
-  char t[32];
-  strcpy(t, "/dev/");
-  strncat(t, dev, sizeof(t) - 5);
-  return open(t, flags);
 }
 /*---------------------------------------------------------------------------*/
 #ifdef linux


### PR DESCRIPTION
The code in tun-bridge.c and tun6-net.c is nearly identical. Share the simple parts, and align the rest in preparation for sharing more code in the future.