### PR TITLE
native: use safe functions in signal handler

### DIFF
--- a/arch/cpu/native/net/tun6-net.c
+++ b/arch/cpu/native/net/tun6-net.c
@@ -115,8 +115,13 @@ cleanup(void)
 static void CC_NORETURN
 sigcleanup(int signo)
 {
-  fprintf(stderr, "signal %d\n", signo);
-  exit(0);			/* exit(0) will call cleanup() */
+  const char *prefix = "signal ";
+  const char *sig =
+    signo == SIGHUP ? "HUP\n" : signo == SIGTERM ? "TERM\n" : "INT\n";
+  write(fileno(stderr), prefix, strlen(prefix));
+  write(fileno(stderr), sig, strlen(sig));
+  cleanup();
+  _exit(0);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The printf family of functions are not safe to use in a signal handler, so switch to using write and strcpy/strncat instead.