### PR TITLE
sicslowpan.c: fix -fanalyzer warning

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -622,7 +622,7 @@ uncompress_addr(uip_ipaddr_t *ipaddr, uint8_t const prefix[],
 
   LOG_DBG("uncompression: address %d %d ", prefcount, postcount);
 
-  if(prefcount > 0) {
+  if(prefix != NULL) {
     memcpy(ipaddr, prefix, prefcount);
   }
   if(prefcount + postcount < 16) {


### PR DESCRIPTION
Add an assert so gcc -fanalyzer understands
that prefix is only null when prefcount is 0.
