### PR TITLE
Makefile: remove Makefile patterns

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -13,12 +13,6 @@ endif
 # of attempted matches from the implicit rules for SCCS.
 MAKEFLAGS += --no-builtin-rules
 
-# Despite --no-builtin-rules, make insists on "remaking" the included
-# Makefiles, so disable that with these empty rules. This saves 200+ lines
-# of rule matching on "make -d TARGET=native" on hello-world.
-Makefile: ;
-Makefile.%: ;
-
 # The target logic makes all build artifacts implicit, prevent make from
 # removing object files upon build completion.
 .SECONDARY:


### PR DESCRIPTION
These patterns removes the error checking
on include, despite include clearly working
to the level that it includes the makefiles
that do exist.