### PR TITLE
Add support for static analysis

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -125,6 +125,8 @@ include $(target_makefile)
 
 ifneq ($(MAKECMDGOALS),clean)
   ifeq ($(CLANG),1)
+    # Clang Static Analyzer ignores -Werror, run through clang-tidy instead.
+    override ANALYZER = 0
     # Use GCC sysroot unless user specified something else.
     ifndef SYSROOT
       SYSROOT := $(shell $(CC) $(CFLAGS) --print-sysroot)
@@ -188,6 +190,15 @@ CFLAGS_DEBUG ?= -ggdb
 
 ifeq ($(DEBUG),1)
   CFLAGS += $(CFLAGS_DEBUG)
+endif
+
+# Default to not use static analysis.
+ANALYZE ?= 0
+ifeq ($(ANALYZE),1)
+  # Define something corresponding to __clang_analyzer__ for GCC as well.
+  CFLAGS += -fanalyzer -D__gcc_analyzer__ $(CFLAGS_FANALYZER)
+  # FIXME: poor -fanalyzer results with GCC 13 according to documentation.
+  #        Add ANALYZE support to CXXFLAGS when GCC supports it better.
 endif
 
 # Configure link-time-optimization (LTO).

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -46,6 +46,8 @@ CONTIKI_SOURCEFILES        += $(CONTIKI_TARGET_SOURCEFILES)
 NO_CLANG = 1
 # LTO is available in GCC 4.7.2, but crashes for MSP430.
 NO_LTO_TARGET = 1
+# No -fanalyzer before GCC 10.
+override ANALYZE = 0
 
 ifeq ($(WERROR),1)
   CFLAGSWERROR = -Werror

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -49,6 +49,16 @@
 
 #ifdef __GNUC__
 
+#ifndef CC_CONF_ASSUME
+  #ifdef __clang__
+    #define CC_CONF_ASSUME(c) do { __builtin_assume((c)); } while(0)
+  #elif __GNUC__ >= 13
+    #define CC_CONF_ASSUME(c) __attribute__((__assume__(c)))
+  #else
+    #define CC_CONF_ASSUME(c) do { if (!(c)) __builtin_unreachable(); } while(0)
+  #endif
+#endif
+
 #define CC_CONF_ALIGN(n) __attribute__((__aligned__(n)))
 
 #ifndef CC_CONF_CONSTRUCTOR
@@ -64,6 +74,16 @@
 #define CC_CONF_NORETURN __attribute__((__noreturn__))
 
 #endif /* __GNUC__ */
+
+/**
+ * Configure if the C compiler supports taking hints from the user about
+ * invariants, e.g. with __attribute__((__assume__(hint))).
+ */
+#ifdef CC_CONF_ASSUME
+#define ASSUME(c) CC_CONF_ASSUME(c)
+#else
+#define ASSUME(c)
+#endif /* CC_CONF_ASSUME */
 
 #ifdef CC_CONF_ALIGN
 #define CC_ALIGN(n) CC_CONF_ALIGN(n)


### PR DESCRIPTION
GCC can perform static analysis on code.
Add support to the build system for
using that.

Run with:

make ANALYZE=1