### PR TITLE
rpl-lite: remove duplicate initialization

### DIFF
--- a/os/net/routing/rpl-lite/rpl-neighbor.c
+++ b/os/net/routing/rpl-lite/rpl-neighbor.c
@@ -168,8 +168,7 @@ int
 rpl_neighbor_count(void)
 {
   int count = 0;
-  rpl_nbr_t *nbr = nbr_table_head(rpl_neighbors);
-  for(nbr = nbr_table_head(rpl_neighbors);
+  for(rpl_nbr_t *nbr = nbr_table_head(rpl_neighbors);
       nbr != NULL;
       nbr = nbr_table_next(rpl_neighbors, nbr)) {
     count++;


### PR DESCRIPTION
Initialize the variable once, pick the the init
in the for-loop since that is a smaller scope.