### PR TITLE
border-router-mac: perform single init

### DIFF
--- a/os/services/rpl-border-router/native/border-router-mac.c
+++ b/os/services/rpl-border-router/native/border-router-mac.c
@@ -138,9 +138,10 @@ send_packet(mac_callback_t sent, void *ptr)
     mac_call_sent_callback(sent, ptr, MAC_TX_ERR_FATAL, 1);
   } else {
     /* here we send the data over SLIP to the radio-chip */
-    size = 0;
 #if SERIALIZE_ATTRIBUTES
     size = packetutils_serialize_atts(&buf[3], sizeof(buf) - 3);
+#else
+    size = 0;
 #endif
     if(size < 0 || size + packetbuf_totlen() + 3 > sizeof(buf)) {
       LOG_WARN("send failed, too large header\n");


### PR DESCRIPTION
The first value is never read, so put it
under an else in the ifdef to avoid
warnings.