### PR TITLE
simple-node: remove double variable initialization

### DIFF
--- a/examples/6tisch/simple-node/node.c
+++ b/examples/6tisch/simple-node/node.c
@@ -54,19 +54,12 @@ AUTOSTART_PROCESSES(&node_process);
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(node_process, ev, data)
 {
-  int is_coordinator;
-
   PROCESS_BEGIN();
-
-  is_coordinator = 0;
-
 #if CONTIKI_TARGET_COOJA || CONTIKI_TARGET_Z1
-  is_coordinator = (node_id == 1);
-#endif
-
-  if(is_coordinator) {
+  if(node_id == 1) { /* Coordinator node. */
     NETSTACK_ROUTING.root_start();
   }
+#endif
   NETSTACK_MAC.on();
 
 #if WITH_PERIODIC_ROUTES_PRINT

--- a/examples/6tisch/simple-node/node.c
+++ b/examples/6tisch/simple-node/node.c
@@ -63,21 +63,19 @@ PROCESS_THREAD(node_process, ev, data)
   NETSTACK_MAC.on();
 
 #if WITH_PERIODIC_ROUTES_PRINT
-  {
-    static struct etimer et;
-    /* Print out routing tables every minute */
-    etimer_set(&et, CLOCK_SECOND * 60);
-    while(1) {
-      /* Used for non-regression testing */
-      #if (UIP_MAX_ROUTES != 0)
-        PRINTF("Routing entries: %u\n", uip_ds6_route_num_routes());
-      #endif
-      #if (UIP_SR_LINK_NUM != 0)
-        PRINTF("Routing links: %u\n", uip_sr_num_nodes());
-      #endif
-      PROCESS_YIELD_UNTIL(etimer_expired(&et));
-      etimer_reset(&et);
-    }
+  static struct etimer et;
+  /* Print out routing tables every minute */
+  etimer_set(&et, CLOCK_SECOND * 60);
+  while(1) {
+    /* Used for non-regression testing */
+    #if (UIP_MAX_ROUTES != 0)
+      PRINTF("Routing entries: %u\n", uip_ds6_route_num_routes());
+    #endif
+    #if (UIP_SR_LINK_NUM != 0)
+      PRINTF("Routing links: %u\n", uip_sr_num_nodes());
+    #endif
+    PROCESS_YIELD_UNTIL(etimer_expired(&et));
+    etimer_reset(&et);
   }
 #endif /* WITH_PERIODIC_ROUTES_PRINT */
 


### PR DESCRIPTION
Remove the double variable initialization to avoid a warning from Clang static analyzer. Also remove a block+indentation level since we now use C99.