### PR TITLE
cc26x0-web-demo: ensure null termination

### DIFF
--- a/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/Makefile
+++ b/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/Makefile
@@ -20,9 +20,4 @@ CONTIKI=../../../..
 include $(CONTIKI)/Makefile.dir-variables
 MODULES += $(CONTIKI_NG_APP_LAYER_DIR)/mqtt $(CONTIKI_NG_APP_LAYER_DIR)/coap
 
-# FIXME: Fix the code and remove the next line.
-ifneq ($(CLANG),1)
-  CFLAGS += -Wno-stringop-truncation
-endif
-
 include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/httpd-simple.c
+++ b/examples/platform-specific/cc26x0-cc13x0/cc26x0-web-demo/httpd-simple.c
@@ -1151,6 +1151,7 @@ PT_THREAD(handle_input(struct httpd_state *s))
     } else {
       s->inputbuf[PSOCK_DATALEN(&s->sin) - 1] = 0;
       strncpy(s->filename, s->inputbuf, sizeof(s->filename));
+      s->filename[HTTPD_PATHLEN - 1] = '\0';
     }
   } else if(strncasecmp(s->inputbuf, http_post, 5) == 0) {
     s->request_type = REQUEST_TYPE_POST;
@@ -1162,6 +1163,7 @@ PT_THREAD(handle_input(struct httpd_state *s))
 
     s->inputbuf[PSOCK_DATALEN(&s->sin) - 1] = 0;
     strncpy(s->filename, s->inputbuf, sizeof(s->filename));
+    s->filename[HTTPD_PATHLEN - 1] = '\0';
 
     /* POST: Read out the rest of the line and ignore it */
     PSOCK_READTO(&s->sin, ISO_nl);


### PR DESCRIPTION
The source string is potentially longer
than the destination, so ensure there
is a null termination of the resulting
string.