### PR TITLE
etimer: make etimer_expired static inline

### DIFF
--- a/os/sys/etimer.c
+++ b/os/sys/etimer.c
@@ -209,12 +209,6 @@ etimer_adjust(struct etimer *et, int timediff)
   update_time();
 }
 /*---------------------------------------------------------------------------*/
-bool
-etimer_expired(struct etimer *et)
-{
-  return et->p == PROCESS_NONE;
-}
-/*---------------------------------------------------------------------------*/
 clock_time_t
 etimer_expiration_time(struct etimer *et)
 {

--- a/os/sys/etimer.h
+++ b/os/sys/etimer.h
@@ -66,6 +66,7 @@
 #include "contiki.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 
 /**
  * A timer.
@@ -196,7 +197,11 @@ clock_time_t etimer_start_time(struct etimer *et);
  *             This function tests if an event timer has expired and
  *             returns true or false depending on its status.
  */
-bool etimer_expired(struct etimer *et);
+static inline bool
+etimer_expired(struct etimer *et)
+{
+  return et->p == PROCESS_NONE;
+}
 
 /**
  * \brief      Stop a pending event timer.


### PR DESCRIPTION
This saves 30-100+ bytes on MSP430 tests.