### PR TITLE
rtimer: make rtimer_init a macro

### DIFF
--- a/os/sys/rtimer.c
+++ b/os/sys/rtimer.c
@@ -57,12 +57,6 @@
 static struct rtimer *next_rtimer;
 
 /*---------------------------------------------------------------------------*/
-void
-rtimer_init(void)
-{
-  rtimer_arch_init();
-}
-/*---------------------------------------------------------------------------*/
 int
 rtimer_set(struct rtimer *rtimer, rtimer_clock_t time,
 	   rtimer_clock_t duration,

--- a/os/sys/rtimer.h
+++ b/os/sys/rtimer.h
@@ -117,8 +117,10 @@ typedef uint64_t rtimer_clock_t;
  *             This function initializes the real-time scheduler and
  *             must be called at boot-up, before any other functions
  *             from the real-time scheduler is called.
+ *
+ * \hideinitializer
  */
-void rtimer_init(void);
+#define rtimer_init() rtimer_arch_init()
 
 struct rtimer;
 typedef void (* rtimer_callback_t)(struct rtimer *t, void *ptr);


### PR DESCRIPTION
This is a single-statement function,
so make it a macro instead.

This saves 6 bytes of text on all
MSP430 tests.