### PR TITLE
Remove CC_NO_VA_ARGS

### DIFF
--- a/os/sys/autostart.h
+++ b/os/sys/autostart.h
@@ -43,12 +43,8 @@
 #include "contiki.h"
 #include "sys/process.h"
 
-#if ! CC_NO_VA_ARGS
 #define AUTOSTART_PROCESSES(...)					\
 struct process * const autostart_processes[] = {__VA_ARGS__, NULL}
-#else
-#error "C compiler must support __VA_ARGS__ macro"
-#endif
 
 extern struct process * const autostart_processes[];
 

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -124,10 +124,6 @@
 #define CC_DEPRECATED(msg)
 #endif /* CC_CONF_DEPRECATED */
 
-#if CC_CONF_NO_VA_ARGS
-#define CC_NO_VA_ARGS CC_CONF_VA_ARGS
-#endif
-
 /** \def CC_ACCESS_NOW(x)
  * This macro ensures that the access to a non-volatile variable can
  * not be reordered or optimized by the compiler.


### PR DESCRIPTION
Variadic arguments to macros is a part of C99,
so this is no longer required.