### PR TITLE
stimer: make functions static inline

### DIFF
--- a/os/sys/stimer.c
+++ b/os/sys/stimer.c
@@ -112,22 +112,6 @@ stimer_expired(struct stimer *t)
 }
 /*---------------------------------------------------------------------------*/
 /**
- * The time until the timer expires
- *
- * This function returns the time until the timer expires.
- *
- * \param t A pointer to the timer
- *
- * \return The time until the timer expires
- *
- */
-unsigned long
-stimer_remaining(struct stimer *t)
-{
-  return t->start + t->interval - clock_seconds();
-}
-/*---------------------------------------------------------------------------*/
-/**
  * The time elapsed since the timer started
  *
  * This function returns the time elapsed.

--- a/os/sys/stimer.c
+++ b/os/sys/stimer.c
@@ -53,24 +53,6 @@
 
 /*---------------------------------------------------------------------------*/
 /**
- * Set a timer.
- *
- * This function is used to set a timer for a time sometime in the
- * future. The function stimer_expired() will evaluate to true after
- * the timer has expired.
- *
- * \param t A pointer to the timer
- * \param interval The interval before the timer expires.
- *
- */
-void
-stimer_set(struct stimer *t, unsigned long interval)
-{
-  t->interval = interval;
-  t->start = clock_seconds();
-}
-/*---------------------------------------------------------------------------*/
-/**
  * Reset the timer with the same interval.
  *
  * This function resets the timer with the same interval that was

--- a/os/sys/stimer.h
+++ b/os/sys/stimer.h
@@ -85,7 +85,24 @@ struct stimer {
   unsigned long interval;
 };
 
-void stimer_set(struct stimer *t, unsigned long interval);
+/**
+ * Set a timer.
+ *
+ * This function is used to set a timer for a time sometime in the
+ * future. The function stimer_expired() will evaluate to true after
+ * the timer has expired.
+ *
+ * \param t A pointer to the timer
+ * \param interval The interval before the timer expires.
+ *
+ */
+static inline void
+stimer_set(struct stimer *t, unsigned long interval)
+{
+  t->interval = interval;
+  t->start = clock_seconds();
+}
+
 void stimer_reset(struct stimer *t);
 void stimer_restart(struct stimer *t);
 bool stimer_expired(struct stimer *t);

--- a/os/sys/stimer.h
+++ b/os/sys/stimer.h
@@ -106,7 +106,24 @@ stimer_set(struct stimer *t, unsigned long interval)
 void stimer_reset(struct stimer *t);
 void stimer_restart(struct stimer *t);
 bool stimer_expired(struct stimer *t);
-unsigned long stimer_remaining(struct stimer *t);
+
+/**
+ * The time until the timer expires
+ *
+ * This function returns the time until the timer expires.
+ *
+ * \param t A pointer to the timer
+ *
+ * \return The time until the timer expires
+ *
+ */
+static inline unsigned long
+stimer_remaining(struct stimer *t)
+{
+  return t->start + t->interval - clock_seconds();
+}
+
+
 unsigned long stimer_elapsed(struct stimer *t);
 
 


### PR DESCRIPTION
This saves 16 bytes of text for all MSP430 tests, and another 12 bytes of text for slip-radio.sky.