### PR TITLE
ctimer: make ctimer_set static inline

### DIFF
--- a/os/sys/ctimer.c
+++ b/os/sys/ctimer.c
@@ -95,12 +95,6 @@ ctimer_init(void)
   process_start(&ctimer_process, NULL);
 }
 /*---------------------------------------------------------------------------*/
-void
-ctimer_set(struct ctimer *c, clock_time_t t,
-           void (*f)(void *), void *ptr)
-{
-  ctimer_set_with_process(c, t, f, ptr, PROCESS_CURRENT());
-}
 /*---------------------------------------------------------------------------*/
 void
 ctimer_set_with_process(struct ctimer *c, clock_time_t t,

--- a/os/sys/ctimer.h
+++ b/os/sys/ctimer.h
@@ -109,23 +109,6 @@ void ctimer_restart(struct ctimer *c);
  * \param t    The interval before the timer expires.
  * \param f    A function to be called when the timer expires.
  * \param ptr  An opaque pointer that will be supplied as an argument to the callback function.
- *
- *             This function is used to set a callback timer for a time
- *             sometime in the future. When the callback timer expires,
- *             the callback function f will be called with ptr as argument.
- *
- *             This essentially does ctimer_set_process(c, t, f, ptr, PROCESS_CURRENT());
- *
- */
-void ctimer_set(struct ctimer *c, clock_time_t t,
-                void (*f)(void *), void *ptr);
-
-/**
- * \brief      Set a callback timer.
- * \param c    A pointer to the callback timer.
- * \param t    The interval before the timer expires.
- * \param f    A function to be called when the timer expires.
- * \param ptr  An opaque pointer that will be supplied as an argument to the callback function.
  * \param p    A pointer to the process the timer belongs to
  *
  *             This function is used to set a callback timer for a time
@@ -135,6 +118,26 @@ void ctimer_set(struct ctimer *c, clock_time_t t,
  */
 void ctimer_set_with_process(struct ctimer *c, clock_time_t t,
                              void (*f)(void *), void *ptr, struct process *p);
+
+/**
+ * \brief      Set a callback timer.
+ * \param c    A pointer to the callback timer.
+ * \param t    The interval before the timer expires.
+ * \param f    A function to be called when the timer expires.
+ * \param ptr  An opaque pointer that will be supplied as an argument to the callback function.
+ *
+ *             This function is used to set a callback timer for a time
+ *             sometime in the future. When the callback timer expires,
+ *             the callback function f will be called with ptr as argument.
+ *
+ *             This essentially does ctimer_set_process(c, t, f, ptr, PROCESS_CURRENT());
+ *
+ */
+static inline void
+ctimer_set(struct ctimer *c, clock_time_t t, void (*f)(void *), void *ptr)
+{
+  ctimer_set_with_process(c, t, f, ptr, PROCESS_CURRENT());
+}
 
 /**
  * \brief      Stop a pending callback timer.


### PR DESCRIPTION
This saves 46 bytes of text on all MSP430
tests.