### PR TITLE
timers: change *_expired() to return bool

### DIFF
--- a/os/sys/ctimer.c
+++ b/os/sys/ctimer.c
@@ -157,7 +157,7 @@ ctimer_stop(struct ctimer *c)
   list_remove(ctimer_list, c);
 }
 /*---------------------------------------------------------------------------*/
-int
+bool
 ctimer_expired(struct ctimer *c)
 {
   struct ctimer *t;
@@ -166,10 +166,10 @@ ctimer_expired(struct ctimer *c)
   }
   for(t = list_head(ctimer_list); t != NULL; t = t->next) {
     if(t == c) {
-      return 0;
+      return false;
     }
   }
-  return 1;
+  return true;
 }
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/os/sys/ctimer.h
+++ b/os/sys/ctimer.h
@@ -58,6 +58,8 @@
 #include "contiki.h"
 #include "sys/etimer.h"
 
+#include <stdbool.h>
+
 struct ctimer {
   struct ctimer *next;
   struct etimer etimer;
@@ -149,12 +151,12 @@ void ctimer_stop(struct ctimer *c);
 /**
  * \brief      Check if a callback timer has expired.
  * \param c    A pointer to the callback timer
- * \return     Non-zero if the timer has expired, zero otherwise.
+ * \return     True if the timer has expired.
  *
  *             This function tests if a callback timer has expired and
  *             returns true or false depending on its status.
  */
-int ctimer_expired(struct ctimer *c);
+bool ctimer_expired(struct ctimer *c);
 
 /**
  * \brief      Initialize the callback timer library.

--- a/os/sys/etimer.c
+++ b/os/sys/etimer.c
@@ -209,7 +209,7 @@ etimer_adjust(struct etimer *et, int timediff)
   update_time();
 }
 /*---------------------------------------------------------------------------*/
-int
+bool
 etimer_expired(struct etimer *et)
 {
   return et->p == PROCESS_NONE;

--- a/os/sys/etimer.h
+++ b/os/sys/etimer.h
@@ -65,6 +65,8 @@
 
 #include "contiki.h"
 
+#include <stdbool.h>
+
 /**
  * A timer.
  *
@@ -189,12 +191,12 @@ clock_time_t etimer_start_time(struct etimer *et);
 /**
  * \brief      Check if an event timer has expired.
  * \param et   A pointer to the event timer
- * \return     Non-zero if the timer has expired, zero otherwise.
+ * \return     True if the timer has expired.
  *
  *             This function tests if an event timer has expired and
  *             returns true or false depending on its status.
  */
-int etimer_expired(struct etimer *et);
+bool etimer_expired(struct etimer *et);
 
 /**
  * \brief      Stop a pending event timer.

--- a/os/sys/stimer.c
+++ b/os/sys/stimer.c
@@ -120,10 +120,10 @@ stimer_restart(struct stimer *t)
  *
  * \param t A pointer to the timer
  *
- * \return Non-zero if the timer has expired, zero otherwise.
+ * \return True if the timer has expired.
  *
  */
-int
+bool
 stimer_expired(struct stimer *t)
 {
   return SCLOCK_GEQ(clock_seconds(), t->start + t->interval);

--- a/os/sys/stimer.h
+++ b/os/sys/stimer.h
@@ -70,6 +70,8 @@
 
 #include "sys/clock.h"
 
+#include <stdbool.h>
+
 /**
  * A timer.
  *
@@ -86,7 +88,7 @@ struct stimer {
 void stimer_set(struct stimer *t, unsigned long interval);
 void stimer_reset(struct stimer *t);
 void stimer_restart(struct stimer *t);
-int stimer_expired(struct stimer *t);
+bool stimer_expired(struct stimer *t);
 unsigned long stimer_remaining(struct stimer *t);
 unsigned long stimer_elapsed(struct stimer *t);
 

--- a/os/sys/timer.c
+++ b/os/sys/timer.c
@@ -116,10 +116,10 @@ timer_restart(struct timer *t)
  *
  * \param t A pointer to the timer
  *
- * \return Non-zero if the timer has expired, zero otherwise.
+ * \return True if the timer has expired.
  *
  */
-int
+bool
 timer_expired(struct timer *t)
 {
   /* Note: Can not return diff >= t->interval so we add 1 to diff and return

--- a/os/sys/timer.h
+++ b/os/sys/timer.h
@@ -71,6 +71,8 @@
 
 #include "sys/clock.h"
 
+#include <stdbool.h>
+
 /**
  * A timer.
  *
@@ -87,7 +89,7 @@ struct timer {
 void timer_set(struct timer *t, clock_time_t interval);
 void timer_reset(struct timer *t);
 void timer_restart(struct timer *t);
-int timer_expired(struct timer *t);
+bool timer_expired(struct timer *t);
 clock_time_t timer_remaining(struct timer *t);
 
 


### PR DESCRIPTION
If a timer has expired is clearly a boolean
question, so change the return type to reflect
that.

As a bonus, this saves 10-20 bytes of
text on the MSP430 tests.