### PR TITLE
Make node_id_init static inline

### DIFF
--- a/examples/benchmarks/rpl-req-resp/node.c
+++ b/examples/benchmarks/rpl-req-resp/node.c
@@ -40,6 +40,7 @@
 
 #include "contiki.h"
 #include "contiki-net.h"
+#include "sys/node-id.h"
 #include "services/deployment/deployment.h"
 
 #include <inttypes.h>

--- a/examples/libs/deployment/node.c
+++ b/examples/libs/deployment/node.c
@@ -40,6 +40,7 @@
 
 #include "contiki.h"
 #include "contiki-net.h"
+#include "sys/node-id.h"
 #include "services/deployment/deployment.h"
 
 /* Log configuration */

--- a/os/services/deployment/deployment.h
+++ b/os/services/deployment/deployment.h
@@ -44,7 +44,6 @@
 #define DEPLOYMENT_H_
 
 #include "contiki-conf.h"
-#include "sys/node-id.h"
 #include "net/ipv6/uip.h"
 #include "net/linkaddr.h"
 

--- a/os/sys/node-id.c
+++ b/os/sys/node-id.c
@@ -39,18 +39,6 @@
 
 #include "contiki.h"
 #include "sys/node-id.h"
-#include "net/linkaddr.h"
-#include "services/deployment/deployment.h"
 
 uint16_t node_id = 0;
 
-void
-node_id_init(void) {
-#if BUILD_WITH_DEPLOYMENT
-  deployment_init();
-#else /* BUILD_WITH_DEPLOYMENT */
-  /* Initialize with a default value derived from linkaddr */
-  node_id = linkaddr_node_addr.u8[LINKADDR_SIZE - 1]
-            + (linkaddr_node_addr.u8[LINKADDR_SIZE - 2] << 8);
-#endif /* BUILD_WITH_DEPLOYMENT */
-}

--- a/os/sys/node-id.h
+++ b/os/sys/node-id.h
@@ -46,12 +46,28 @@
 #ifndef NODE_ID_H_
 #define NODE_ID_H_
 
+#include "contiki.h"
+#include "net/linkaddr.h"
+#if BUILD_WITH_DEPLOYMENT
+#include "services/deployment/deployment.h"
+#endif
+
 /* A global variable that hosts the node ID */
 extern uint16_t node_id;
 /**
  * Initialize the node ID. Must be called after initialized of linkaddr
  */
-void node_id_init(void);
+static inline void
+node_id_init(void)
+{
+#if BUILD_WITH_DEPLOYMENT
+  deployment_init();
+#else /* BUILD_WITH_DEPLOYMENT */
+  /* Initialize with a default value derived from linkaddr */
+  node_id = linkaddr_node_addr.u8[LINKADDR_SIZE - 1]
+            + (linkaddr_node_addr.u8[LINKADDR_SIZE - 2] << 8);
+#endif /* BUILD_WITH_DEPLOYMENT */
+}
 
 #endif /* NODE_ID_H_ */
 /**


### PR DESCRIPTION
There is a single use of this code
in contiki-main, make it static inline
in the header instead.

This saves 8 bytes of text on all MSP430
tests.