### PR TITLE
ringbufindex: make accessors static inline

### DIFF
--- a/os/lib/ringbufindex.c
+++ b/os/lib/ringbufindex.c
@@ -123,27 +123,3 @@ ringbufindex_peek_get(const struct ringbufindex *r)
     return -1;
   }
 }
-/* Return the ring buffer size */
-int
-ringbufindex_size(const struct ringbufindex *r)
-{
-  return r->mask + 1;
-}
-/* Return the number of elements currently in the ring buffer */
-int
-ringbufindex_elements(const struct ringbufindex *r)
-{
-  return (r->put_ptr - r->get_ptr) & r->mask;
-}
-/* Is the ring buffer full? */
-int
-ringbufindex_full(const struct ringbufindex *r)
-{
-  return ((r->put_ptr - r->get_ptr) & r->mask) == r->mask;
-}
-/* Is the ring buffer empty? */
-int
-ringbufindex_empty(const struct ringbufindex *r)
-{
-  return ringbufindex_elements(r) == 0;
-}

--- a/os/lib/ringbufindex.h
+++ b/os/lib/ringbufindex.h
@@ -93,27 +93,43 @@ int ringbufindex_peek_get(const struct ringbufindex *r);
  * \param r Pinter to ringbufindex
  * \return The size of the ring buffer
  */
-int ringbufindex_size(const struct ringbufindex *r);
+static inline int
+ringbufindex_size(const struct ringbufindex *r)
+{
+  return r->mask + 1;
+}
 
 /**
  * \brief Return the number of elements currently in the ring buffer.
  * \param r Pinter to ringbufindex
  * \return The number of elements in the ring buffer
  */
-int ringbufindex_elements(const struct ringbufindex *r);
+static inline int
+ringbufindex_elements(const struct ringbufindex *r)
+{
+  return (r->put_ptr - r->get_ptr) & r->mask;
+}
 
 /**
  * \brief Is the ring buffer full?
  * \retval 0 Not full
  * \retval 1 Full
  */
-int ringbufindex_full(const struct ringbufindex *r);
+static inline int
+ringbufindex_full(const struct ringbufindex *r)
+{
+  return ((r->put_ptr - r->get_ptr) & r->mask) == r->mask;
+}
 
 /**
  * \brief Is the ring buffer empty?
  * \retval 0 Not empty
  * \retval 1 Empty
  */
-int ringbufindex_empty(const struct ringbufindex *r);
+static inline int
+ringbufindex_empty(const struct ringbufindex *r)
+{
+  return ringbufindex_elements(r) == 0;
+}
 
 #endif /* RINGBUFINDEX_H_ */


### PR DESCRIPTION
This saves 18 bytes of text on simple-node
on Z1, which is the example that frequently
runs out of space.