### PR TITLE
netstack: make netstack_init static inline

### DIFF
--- a/os/net/netstack.c
+++ b/os/net/netstack.c
@@ -81,13 +81,4 @@ uip_ds6_ip_packet_processor_rm(struct netstack_ip_packet_processor *p)
                                {
   list_remove(ip_processor_list, p);
 }
-
-/*---------------------------------------------------------------------------*/
-void
-netstack_init(void)
-{
-  NETSTACK_RADIO.init();
-  NETSTACK_MAC.init();
-  NETSTACK_NETWORK.init();
-}
 /*---------------------------------------------------------------------------*/

--- a/os/net/netstack.h
+++ b/os/net/netstack.h
@@ -27,8 +27,6 @@
  * SUCH DAMAGE.
  *
  * This file is part of the Contiki operating system.
- *
- * $Id: netstack.h,v 1.6 2010/10/03 20:37:32 adamdunkels Exp $
  */
 
 /**
@@ -133,7 +131,13 @@ extern const struct mac_driver NETSTACK_MAC;
 extern const struct radio_driver NETSTACK_RADIO;
 extern const struct framer NETSTACK_FRAMER;
 
-void netstack_init(void);
+static inline void
+netstack_init(void)
+{
+  NETSTACK_RADIO.init();
+  NETSTACK_MAC.init();
+  NETSTACK_NETWORK.init();
+}
 
 /* Netstack ip_packet_processor - for implementing packet filters, firewalls,
    debuggin info, etc */


### PR DESCRIPTION
This saves 6 bytes of text on the MSP430
tests.