### PR TITLE
linkaddr: make linkaddr_set_node_addr static inline

### DIFF
--- a/os/net/linkaddr.c
+++ b/os/net/linkaddr.c
@@ -71,10 +71,4 @@ linkaddr_cmp(const linkaddr_t *addr1, const linkaddr_t *addr2)
 	return (memcmp(addr1, addr2, LINKADDR_SIZE) == 0);
 }
 /*---------------------------------------------------------------------------*/
-void
-linkaddr_set_node_addr(linkaddr_t *t)
-{
-  linkaddr_copy(&linkaddr_node_addr, t);
-}
-/*---------------------------------------------------------------------------*/
 /** @} */

--- a/os/net/linkaddr.h
+++ b/os/net/linkaddr.h
@@ -91,15 +91,6 @@ bool linkaddr_cmp(const linkaddr_t *addr1, const linkaddr_t *addr2);
 
 
 /**
- * \brief      Set the address of the current node
- * \param addr The address
- *
- *             This function sets the link-layer address of the node.
- *
- */
-void linkaddr_set_node_addr(linkaddr_t *addr);
-
-/**
  * \brief      The link-layer address of the node
  *
  *             This variable contains the link-layer address of the
@@ -122,6 +113,18 @@ extern linkaddr_t linkaddr_node_addr;
  *
  */
 extern const linkaddr_t linkaddr_null;
+
+/**
+ * \brief      Set the address of the current node
+ * \param addr The address
+ *
+ *             This function sets the link-layer address of the node.
+ *
+ */
+static inline void linkaddr_set_node_addr(linkaddr_t *addr)
+{
+  linkaddr_copy(&linkaddr_node_addr, addr);
+}
 
 #endif /* LINKADDR_H_ */
 /** @} */


### PR DESCRIPTION
This saves 8 bytes of text on the MSP430 tests.