### PR TITLE
packetbuf: remove unused return values

### DIFF
--- a/os/net/packetbuf.c
+++ b/os/net/packetbuf.c
@@ -201,11 +201,10 @@ packetbuf_attr_copyfrom(struct packetbuf_attr *attrs,
   memcpy(packetbuf_addrs, addrs, sizeof(packetbuf_addrs));
 }
 /*---------------------------------------------------------------------------*/
-int
+void
 packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val)
 {
   packetbuf_attrs[type].val = val;
-  return 1;
 }
 /*---------------------------------------------------------------------------*/
 packetbuf_attr_t

--- a/os/net/packetbuf.c
+++ b/os/net/packetbuf.c
@@ -213,11 +213,10 @@ packetbuf_attr(uint8_t type)
   return packetbuf_attrs[type].val;
 }
 /*---------------------------------------------------------------------------*/
-int
+void
 packetbuf_set_addr(uint8_t type, const linkaddr_t *addr)
 {
   linkaddr_copy(&packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr, addr);
-  return 1;
 }
 /*---------------------------------------------------------------------------*/
 const linkaddr_t *

--- a/os/net/packetbuf.h
+++ b/os/net/packetbuf.h
@@ -252,7 +252,7 @@ enum {
 
 #define PACKETBUF_IS_ADDR(type) ((type) >= PACKETBUF_ADDR_FIRST)
 
-int               packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val);
+void              packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val);
 packetbuf_attr_t packetbuf_attr(uint8_t type);
 int               packetbuf_set_addr(uint8_t type, const linkaddr_t *addr);
 const linkaddr_t *packetbuf_addr(uint8_t type);

--- a/os/net/packetbuf.h
+++ b/os/net/packetbuf.h
@@ -254,7 +254,7 @@ enum {
 
 void              packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val);
 packetbuf_attr_t packetbuf_attr(uint8_t type);
-int               packetbuf_set_addr(uint8_t type, const linkaddr_t *addr);
+void              packetbuf_set_addr(uint8_t type, const linkaddr_t *addr);
 const linkaddr_t *packetbuf_addr(uint8_t type);
 
 /**


### PR DESCRIPTION
Each commit saves 2 bytes of text on MSP430, a bit more on ARM.