### PR TITLE
CI: cancel jobs when updating PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,13 @@ on:
   pull_request:
     branches: [ master, develop, release-* ]
 
+
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 # We use a single job with a matrix with elements corresponding to our tests
 # The job will be replicated as many times as there are elements in the matrix
 jobs:


### PR DESCRIPTION
When a PR gets updated, cancel any CI jobs
from the previous run. Let merge jobs complete
their runs, even if more PRs are merged after.