### PR TITLE
Remove CC_CONF_INLINE

### DIFF
--- a/arch/cpu/msp430/dev/hwconf.h
+++ b/arch/cpu/msp430/dev/hwconf.h
@@ -35,22 +35,22 @@
 #include "sys/cc.h"
 
 #define HWCONF_PIN(name, port, bit)                                           \
-static CC_INLINE void name##_SELECT() {P##port##SEL &= ~(1 << bit);}          \
-static CC_INLINE void name##_SELECT_IO() {P##port##SEL &= ~(1 << bit);}       \
-static CC_INLINE void name##_SELECT_PM() {P##port##SEL |= 1 << bit;}          \
-static CC_INLINE void name##_SET() {P##port##OUT |= 1 << bit;}                \
-static CC_INLINE void name##_CLEAR() {P##port##OUT &= ~(1 << bit);}           \
-static CC_INLINE int  name##_READ() {return (P##port##IN & (1 << bit));}      \
-static CC_INLINE void name##_MAKE_OUTPUT() {P##port##DIR |= 1 << bit;}        \
-static CC_INLINE void name##_MAKE_INPUT() {P##port##DIR &= ~(1 << bit);}
+static inline void name##_SELECT() {P##port##SEL &= ~(1 << bit);}          \
+static inline void name##_SELECT_IO() {P##port##SEL &= ~(1 << bit);}       \
+static inline void name##_SELECT_PM() {P##port##SEL |= 1 << bit;}          \
+static inline void name##_SET() {P##port##OUT |= 1 << bit;}                \
+static inline void name##_CLEAR() {P##port##OUT &= ~(1 << bit);}           \
+static inline int  name##_READ() {return (P##port##IN & (1 << bit));}      \
+static inline void name##_MAKE_OUTPUT() {P##port##DIR |= 1 << bit;}        \
+static inline void name##_MAKE_INPUT() {P##port##DIR &= ~(1 << bit);}
 
 #define HWCONF_IRQ(name, port, bit)                                           \
-static CC_INLINE void name##_ENABLE_IRQ() {P##port##IE |= 1 << bit;}          \
-static CC_INLINE void name##_DISABLE_IRQ() {P##port##IE &= ~(1 << bit);}      \
-static CC_INLINE int  name##_IRQ_ENABLED() {return P##port##IE & (1 << bit);} \
-static CC_INLINE void name##_IRQ_EDGE_SELECTD() {P##port##IES |= 1 << bit;}   \
-static CC_INLINE void name##_IRQ_EDGE_SELECTU() {P##port##IES &= ~(1 << bit);}\
-static CC_INLINE int  name##_CHECK_IRQ() {return P##port##IFG & (1 << bit);} \
-static CC_INLINE int  name##_IRQ_PORT() {return port;}
+static inline void name##_ENABLE_IRQ() {P##port##IE |= 1 << bit;}          \
+static inline void name##_DISABLE_IRQ() {P##port##IE &= ~(1 << bit);}      \
+static inline int  name##_IRQ_ENABLED() {return P##port##IE & (1 << bit);} \
+static inline void name##_IRQ_EDGE_SELECTD() {P##port##IES |= 1 << bit;}   \
+static inline void name##_IRQ_EDGE_SELECTU() {P##port##IES &= ~(1 << bit);}\
+static inline int  name##_CHECK_IRQ() {return P##port##IFG & (1 << bit);} \
+static inline int  name##_IRQ_PORT() {return port;}
 
 #endif /* HWCONF_H_ */

--- a/arch/cpu/msp430/msp430-def.h
+++ b/arch/cpu/msp430/msp430-def.h
@@ -37,7 +37,6 @@
 #define dint() __disable_interrupt()
 #define eint() __enable_interrupt()
 #define __MSP430__ 1
-#define CC_CONF_INLINE
 
 #else /* __IAR_SYSTEMS_ICC__ */
 
@@ -56,8 +55,6 @@
 #define MSP430_MEMCPY_WORKAROUND 1
 #endif
 #endif /* __MSPGCC__ */
-
-#define CC_CONF_INLINE inline
 
 #endif /* __IAR_SYSTEMS_ICC__ */
 

--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -97,7 +97,6 @@
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
 #define CC_CONF_VA_ARGS                1
-#define CC_CONF_INLINE inline
 
 #include <inttypes.h>
 

--- a/arch/platform/native/contiki-conf.h
+++ b/arch/platform/native/contiki-conf.h
@@ -50,7 +50,6 @@ struct select_callback {
 int select_set_callback(int fd, const struct select_callback *callback);
 
 #define CC_CONF_VA_ARGS                1
-/*#define CC_CONF_INLINE                 inline*/
 
 #ifndef EEPROM_CONF_SIZE
 #define EEPROM_CONF_SIZE				1024

--- a/arch/platform/sky/dev/sky-sensors.c
+++ b/arch/platform/sky/dev/sky-sensors.c
@@ -44,7 +44,7 @@
 static uint16_t adc_on;
 static uint16_t ready;
 /*---------------------------------------------------------------------------*/
-static CC_INLINE void
+static inline void
 start(void)
 {
   uint16_t c, last;
@@ -81,7 +81,7 @@ start(void)
   ADC12CTL0 |= ADC12SC;               /* sample & convert */
 }
 /*---------------------------------------------------------------------------*/
-static CC_INLINE void
+static inline void
 stop(void)
 {
   /* stop converting immediately, turn off reference voltage, etc. */

--- a/arch/platform/z1/dev/sky-sensors.c
+++ b/arch/platform/z1/dev/sky-sensors.c
@@ -44,7 +44,7 @@
 static uint16_t adc_on;
 static uint16_t ready;
 /*---------------------------------------------------------------------------*/
-static CC_INLINE void
+static inline void
 start(void)
 {
   uint16_t c, last;
@@ -81,7 +81,7 @@ start(void)
   ADC12CTL0 |= ADC12SC;               /* sample & convert */
 }
 /*---------------------------------------------------------------------------*/
-static CC_INLINE void
+static inline void
 stop(void)
 {
   /* stop converting immediately, turn off reference voltage, etc. */

--- a/os/lib/hexconv.c
+++ b/os/lib/hexconv.c
@@ -38,7 +38,7 @@
 #include "sys/cc.h"
 #include <stdio.h>
 /*---------------------------------------------------------------------------*/
-static CC_INLINE int
+static inline int
 fromhex(char c)
 {
   if(c >= '0' && c <= '9') {

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -111,7 +111,7 @@ coap_call_handlers(coap_message_t *request, coap_message_t *response,
   return COAP_HANDLER_STATUS_CONTINUE;
 }
 /*---------------------------------------------------------------------------*/
-static CC_INLINE coap_handler_status_t
+static inline coap_handler_status_t
 call_service(coap_message_t *request, coap_message_t *response,
              uint8_t *buffer, uint16_t buffer_size, int32_t *offset)
 {

--- a/os/net/ipv6/uip-nameserver.c
+++ b/os/net/ipv6/uip-nameserver.c
@@ -86,7 +86,7 @@ static uint32_t serverlifetime;
  * Initialize the module variables
  */
 #if UIP_NAMESERVER_POOL_SIZE > 1
-static CC_INLINE void
+static inline void
 init(void)
 {
   list_init(dns);

--- a/os/net/mac/framer/frame802154.c
+++ b/os/net/mac/framer/frame802154.c
@@ -89,7 +89,7 @@ typedef struct {
 } field_length_t;
 
 /*----------------------------------------------------------------------------*/
-CC_INLINE static uint8_t
+static inline uint8_t
 addr_len(uint8_t mode)
 {
   switch(mode) {

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -67,7 +67,7 @@
 
 #ifdef CC_CONF_ALIGN
 #define CC_ALIGN(n) CC_CONF_ALIGN(n)
-#endif /* CC_CONF_INLINE */
+#endif /* CC_CONF_ALIGN */
 
 /**
  * Configure if the C compiler supports functions that are not meant to return

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -49,11 +49,6 @@
 
 #ifdef __GNUC__
 
-#ifndef CC_CONF_INLINE
-/* use __inline__ in case "inline" is not available for any reason */
-#define CC_CONF_INLINE __inline__
-#endif
-
 #define CC_CONF_ALIGN(n) __attribute__((__aligned__(n)))
 
 #ifndef CC_CONF_CONSTRUCTOR
@@ -69,12 +64,6 @@
 #define CC_CONF_NORETURN __attribute__((__noreturn__))
 
 #endif /* __GNUC__ */
-
-#ifdef CC_CONF_INLINE
-#define CC_INLINE CC_CONF_INLINE
-#else /* CC_CONF_INLINE */
-#define CC_INLINE
-#endif /* CC_CONF_INLINE */
 
 #ifdef CC_CONF_ALIGN
 #define CC_ALIGN(n) CC_CONF_ALIGN(n)


### PR DESCRIPTION
The inline keyword is available in C99,
so use that instead.