### PR TITLE
tests: enable Clang warning checks for 01-compilation-base

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -136,6 +136,9 @@ ifneq ($(MAKECMDGOALS),clean)
     LD := $(CC)
     CFLAGS += $(CFLAGS_CLANG)
     LDFLAGS += $(LDFLAGS_CLANG)
+    ifdef NO_CLANG
+      PLATFORM_ACTION = skip
+    endif
   endif
 
   # Validate the toolchain.

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -42,6 +42,8 @@ CONTIKI_SOURCEFILES        += $(CONTIKI_TARGET_SOURCEFILES)
 
 ### Compiler definitions
 
+# Clang supports MSP430, but more Contiki-NG-work is required to use it.
+NO_CLANG = 1
 # LTO is available in GCC 4.7.2, but crashes for MSP430.
 NO_LTO_TARGET = 1
 

--- a/tests/01-compile-base/Makefile
+++ b/tests/01-compile-base/Makefile
@@ -1,6 +1,8 @@
 CURDIR := $(abspath $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST)))))
 BINARY_SIZE_LOGFILE = $(CURDIR)/sizes.log
 
+CLANG_WARNINGS = 1
+
 EXAMPLESDIR=../../examples
 
 EXAMPLES = \

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -72,10 +72,11 @@ $(EXAMPLES_TMP):
 
 examples:
 	@rm -f summary $(BINARY_SIZE_LOGFILE)
-	@$(MAKE) $(EXAMPLES_TMP)
 ifeq ($(CLANG_WARNINGS),1)
 	@$(MAKE) MAKE_EXTRA_OPTIONS=CLANG=1 $(EXAMPLES_TMP)
+	@rm -f $(BINARY_SIZE_LOGFILE)
 endif
+	@$(MAKE) $(EXAMPLES_TMP)
 
 summary: examples
 	@echo "========== Summary =========="

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -7,6 +7,7 @@ USER root
 
 # Tools
 # build-essential: development tools.
+# clang-15: additional warnings in tests.
 # gdb: development tools.
 # git: development tools.
 # git-lfs: development tools (used by Gecko SDK).
@@ -33,6 +34,7 @@ RUN apt-get -qq update && \
       ca-certificates > /dev/null && \
   apt-get -qq -y --no-install-recommends install \
     build-essential \
+    clang-15 \
     gdb \
     git \
     git-lfs \


### PR DESCRIPTION
This ensures that some parts of the code base remain warning-free with Clang. 