### PR TITLE
Makefile.compile-test: allow running tests

### DIFF
--- a/tests/04-renode-simulation/01-rpl-udp.sh
+++ b/tests/04-renode-simulation/01-rpl-udp.sh
@@ -1,9 +1,3 @@
 #!/bin/sh -e
 
-TESTNAME=01-rpl-udp
-TEST_CODE_DIR=../../examples/rpl-udp
-TARGET=cc2538dk
-
-make -C ${TEST_CODE_DIR} clean TARGET=${TARGET}
-make -C ${TEST_CODE_DIR} TARGET=${TARGET}
-renode-test --show-log ${TEST_CODE_DIR}/rpl-udp.robot
+renode-test --show-log ../../examples/rpl-udp/rpl-udp.robot

--- a/tests/04-renode-simulation/Makefile
+++ b/tests/04-renode-simulation/Makefile
@@ -1,1 +1,11 @@
-include ../Makefile.script-test
+CURDIR := $(abspath $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST)))))
+BINARY_SIZE_LOGFILE = $(CURDIR)/sizes.log
+
+RUN_FILE = 1
+
+EXAMPLESDIR = ../../examples
+
+EXAMPLES = \
+rpl-udp/cc2538dk:./01-rpl-udp.sh
+
+include ../Makefile.compile-test

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -53,6 +53,11 @@ PRINT_LOGFILE ?= true
 PRINT_DIR ?= --no-print-directory
 MAKEOPTIONS += $(PRINT_DIR) $(SIZE_LOGFILE) WERROR=1 $(MAKE_EXTRA_OPTIONS)
 
+ifdef RUN_FILE
+  DEFINE_START = 3
+endif
+DEFINE_START ?= 2
+
 # Rule for compiling examples.
 # EXAMPLES has the form directory/target:define1=value1:define2=value2:...
 # Mangle ":" to "_@_" and "=" to "@_@" to get a valid make rule name.
@@ -64,10 +69,16 @@ $(EXAMPLES_TMP):
 	$(eval _blob := $(firstword $(_exlist)))
 	$(eval _example := $(dir $(_blob)))
 	$(eval _target := $(notdir $(_blob)))
-	$(eval _defines := $(wordlist 2,15,$(_exlist)))
+ifdef RUN_FILE
+	$(eval _runfile := $(wordlist 2,2,$(_exlist)))
+else
+	$(eval _runfile := true)
+endif
+	$(eval _defines := $(wordlist $(DEFINE_START),16,$(_exlist)))
 	@echo Building: $(_example) $(_defines) for target $(_target)
 	$(Q)($(MAKE) -C $(EXAMPLESDIR)/$(_example) $(_defines) TARGET=$(_target) $(MAKEOPTIONS) clean && \
-          make -C $(EXAMPLESDIR)/$(_example) -j$(CPUS) $(_defines) TARGET=$(_target) $(MAKEOPTIONS)) || \
+          make -C $(EXAMPLESDIR)/$(_example) -j$(CPUS) $(_defines) TARGET=$(_target) $(MAKEOPTIONS) && \
+          $(_runfile)) || \
          printf "%-75s %-40s %-20s TEST FAIL\n" "$(_example)" "$(_defines)" "$(_target)" >> summary
 
 examples:


### PR DESCRIPTION
Add an option to run tests after they are
compiled, and switch the Renode tests to
use this functionality.

This puts the cleaning and error detection
in the Makefile, instead of duplicating the same
code in every test script.