### PR TITLE
tests: avoid Java ServiceLoader mechanism

### DIFF
--- a/tests/Makefile.simulation-test
+++ b/tests/Makefile.simulation-test
@@ -63,7 +63,7 @@ endif
 # Successful simulations do nothing, failures appends test+seed to summary.
 tests: $(TESTS)
 	@for (( SEED=$(BASESEED); SEED < $$(( $(BASESEED) + $(RUNCOUNT) )); SEED++ )); do \
-          $(GRADLE) --no-watch-fs --parallel --build-cache -p $(CONTIKI)/tools/cooja run --args="--no-gui --contiki=$(realpath $(CONTIKI)) --logdir=$(dir $(realpath $<)) --random-seed=$$SEED $(realpath $^)" || \
+          $(GRADLE) --no-watch-fs --parallel --build-cache -p $(CONTIKI)/tools/cooja run -Dslf4j.provider=ch.qos.logback.classic.spi.LogbackServiceProvider --args="--no-gui --contiki=$(realpath $(CONTIKI)) --logdir=$(dir $(realpath $<)) --random-seed=$$SEED $(realpath $^)" || \
             echo "TEST FAIL: $^ seed $$SEED" >> summary; \
          done
 


### PR DESCRIPTION
Set the slf4j.provider property so the ServiceLoader mechanism in Java can be avoided.

This saves 1 second for 07-simulation-base on
my machine, and it probably saves more on slower
machines.