### PR TITLE
nbr-table: remove extra code

### DIFF
--- a/os/net/nbr-table.c
+++ b/os/net/nbr-table.c
@@ -141,7 +141,7 @@ nbr_get_bit(const uint8_t *bitmap, const nbr_table_t *table,
             const nbr_table_item_t *item)
 {
   int item_index = index_from_item(table, item);
-  if(table != NULL && item_index != -1) {
+  if(item_index != -1) {
     return (bitmap[item_index] & (1 << table->index)) != 0;
   } else {
     return 0;
@@ -156,7 +156,7 @@ nbr_set_bit(uint8_t *bitmap, const nbr_table_t *table,
 {
   int item_index = index_from_item(table, item);
 
-  if(table != NULL && item_index != -1) {
+  if(item_index != -1) {
     if(value) {
       bitmap[item_index] |= 1 << table->index;
     } else {

--- a/os/net/nbr-table.c
+++ b/os/net/nbr-table.c
@@ -143,8 +143,6 @@ nbr_get_bit(const uint8_t *bitmap, const nbr_table_t *table,
   int item_index = index_from_item(table, item);
   if(item_index != -1) {
     return (bitmap[item_index] & (1 << table->index)) != 0;
-  } else {
-    return 0;
   }
   return 0;
 }
@@ -163,8 +161,6 @@ nbr_set_bit(uint8_t *bitmap, const nbr_table_t *table,
       bitmap[item_index] &= ~(1 << table->index);
     }
     return 1;
-  } else {
-    return 0;
   }
   return 0;
 }


### PR DESCRIPTION
This saves 8 bytes on MSP430.