### PR TITLE
rtimer: enable optimizing return value check

### DIFF
--- a/os/sys/rtimer.c
+++ b/os/sys/rtimer.c
@@ -90,7 +90,6 @@ rtimer_run_next(void)
   if(next_rtimer != NULL) {
     rtimer_arch_schedule(next_rtimer->time);
   }
-  return;
 }
 /*---------------------------------------------------------------------------*/
 

--- a/os/sys/rtimer.c
+++ b/os/sys/rtimer.c
@@ -57,10 +57,10 @@
 static struct rtimer *next_rtimer;
 
 /*---------------------------------------------------------------------------*/
-int
-rtimer_set(struct rtimer *rtimer, rtimer_clock_t time,
-	   rtimer_clock_t duration,
-	   rtimer_callback_t func, void *ptr)
+void
+rtimer_set_internal(struct rtimer *rtimer, rtimer_clock_t time,
+                    rtimer_clock_t duration, rtimer_callback_t func,
+                    void *ptr)
 {
   bool first = next_rtimer == NULL;
 
@@ -75,7 +75,6 @@ rtimer_set(struct rtimer *rtimer, rtimer_clock_t time,
   if(first) {
     rtimer_arch_schedule(time);
   }
-  return RTIMER_OK;
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/os/sys/rtimer.c
+++ b/os/sys/rtimer.c
@@ -62,13 +62,9 @@ rtimer_set(struct rtimer *rtimer, rtimer_clock_t time,
 	   rtimer_clock_t duration,
 	   rtimer_callback_t func, void *ptr)
 {
-  int first = 0;
+  bool first = next_rtimer == NULL;
 
   PRINTF("rtimer_set time %d\n", time);
-
-  if(next_rtimer == NULL) {
-    first = 1;
-  }
 
   rtimer->func = func;
   rtimer->ptr = ptr;
@@ -76,7 +72,7 @@ rtimer_set(struct rtimer *rtimer, rtimer_clock_t time,
   rtimer->time = time;
   next_rtimer = rtimer;
 
-  if(first == 1) {
+  if(first) {
     rtimer_arch_schedule(time);
   }
   return RTIMER_OK;

--- a/os/sys/rtimer.h
+++ b/os/sys/rtimer.h
@@ -162,8 +162,14 @@ enum {
  *             time in the future.
  *
  */
-int rtimer_set(struct rtimer *task, rtimer_clock_t time,
-	       rtimer_clock_t duration, rtimer_callback_t func, void *ptr);
+static inline int
+rtimer_set(struct rtimer *task, rtimer_clock_t time,
+	   rtimer_clock_t duration, rtimer_callback_t func, void *ptr) {
+  void rtimer_set_internal(struct rtimer *, rtimer_clock_t, rtimer_clock_t,
+                           rtimer_callback_t, void *);
+  rtimer_set_internal(task, time, duration, func, ptr);
+  return RTIMER_OK;
+}
 
 /**
  * \brief      Execute the next real-time task and schedule the next task, if any


### PR DESCRIPTION
The current function always returns
the same value, so make that part
static inline in the header.

This preserves the interface, so future
changes can extend the function with
more return values.

This saves 5 bytes on MSP430.