### PR TITLE
Make ringbuf_init static inline

### DIFF
--- a/os/lib/ringbuf.c
+++ b/os/lib/ringbuf.c
@@ -40,15 +40,6 @@
 #include "lib/ringbuf.h"
 #include <sys/cc.h>
 /*---------------------------------------------------------------------------*/
-void
-ringbuf_init(struct ringbuf *r, uint8_t *dataptr, uint8_t size)
-{
-  r->data = dataptr;
-  r->mask = size - 1;
-  r->put_ptr = 0;
-  r->get_ptr = 0;
-}
-/*---------------------------------------------------------------------------*/
 int
 ringbuf_put(struct ringbuf *r, uint8_t c)
 {

--- a/os/lib/ringbuf.h
+++ b/os/lib/ringbuf.h
@@ -86,8 +86,13 @@ struct ringbuf {
  *             bytes.
  *
  */
-void    ringbuf_init(struct ringbuf *r, uint8_t *a,
-		     uint8_t size_power_of_two);
+static inline void
+ringbuf_init(struct ringbuf *r, uint8_t *a, uint8_t size_power_of_two)
+{
+  r->data = a;
+  r->mask = size_power_of_two - 1;
+  r->put_ptr = r->get_ptr = 0;
+}
 
 /**
  * \brief      Insert a byte into the ring buffer


### PR DESCRIPTION
This saves 12 bytes on some MSP430 tests.