### PR TITLE
tests/packet-injector: enable full parallelism

### DIFF
--- a/tests/20-packet-parsing/Makefile
+++ b/tests/20-packet-parsing/Makefile
@@ -1,1 +1,18 @@
-include ../Makefile.script-test
+CURDIR := $(abspath $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST)))))
+HOST_OS := $(shell uname)
+
+ifneq ($(HOST_OS),Darwin)
+  BINARY_SIZE_LOGFILE = $(CURDIR)/sizes.log
+endif
+
+RUN_FILE = 1
+
+EXAMPLESDIR = ./
+
+EXAMPLES = \
+packet-injector/native:./01-test-uip.sh \
+packet-injector/native:./02-test-sicslowpan.sh \
+packet-injector/native:./03-test-ble-l2cap.sh \
+packet-injector/native:./04-test-tcpip.sh \
+
+include ../Makefile.compile-test

--- a/tests/20-packet-parsing/packet-injector.sh
+++ b/tests/20-packet-parsing/packet-injector.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 source ../utils.sh
 
-# Contiki directory
-CONTIKI=$1
-
 # Basic statistics for packet parsing results.
 SUCCEEDED=0
 FAILED=0
@@ -17,8 +14,6 @@ echo packet dir = $PACKET_DIR
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-make -j4 -C $CODE_DIR TARGET=native || exit 1
-
 for i in $PACKET_DIR/*
 do
   if [ -d "$i" ]; then


### PR DESCRIPTION
Use Makefile.compile-tests to compile and run
the tests.

This will automatically clean each test, and
select the right number of cores for make -j.