### PR TITLE
tests/script-base: enable full parallelism

### DIFF
--- a/tests/06-script-base/01-test-lc-switch.sh
+++ b/tests/06-script-base/01-test-lc-switch.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-./run-test-lc.sh 01-test-lc-switch

--- a/tests/06-script-base/02-test-lc-addrlabels.sh
+++ b/tests/06-script-base/02-test-lc-addrlabels.sh
@@ -1,2 +1,0 @@
-#!/bin/sh -e
-./run-test-lc.sh ${TESTNAME} 02-test-lc-addrlabels

--- a/tests/06-script-base/03-test-memb.sh
+++ b/tests/06-script-base/03-test-memb.sh
@@ -1,9 +1,0 @@
-#!/bin/sh -e
-
-TESTNAME=03-test-memb
-TEST_CODE_DIR=code-test-memb
-TARGET=test-memb
-
-make -C ${TEST_CODE_DIR} clean
-make -j4 -C ${TEST_CODE_DIR} ${TARGET}
-${TEST_CODE_DIR}/${TARGET}

--- a/tests/06-script-base/04-test-result-visualization.sh
+++ b/tests/06-script-base/04-test-result-visualization.sh
@@ -1,15 +1,6 @@
 #!/bin/sh -e
 
-TESTNAME=04-test-result-visualization
-
-CONTIKI=../..
-
-TEST_CODE_DIR=code-result-visualization
-
-make -C ${TEST_CODE_DIR} clean
-make -j4 -C ${TEST_CODE_DIR}
-
-${CONTIKI}/examples/benchmarks/result-visualization/run-analysis.py ${TEST_CODE_DIR}/COOJA.testlog > analysis.log
+../../examples/benchmarks/result-visualization/run-analysis.py code-result-visualization/COOJA.testlog > analysis.log
 
 # check that some packets were sent and all were received
 grep "PDR=100" analysis.log > /dev/null || exit 1

--- a/tests/06-script-base/Makefile
+++ b/tests/06-script-base/Makefile
@@ -1,1 +1,11 @@
-include ../Makefile.script-test
+RUN_FILE = 1
+
+EXAMPLESDIR = ./
+
+EXAMPLES = \
+code-test-lc/native:code-test-lc/test-lc-switch:test-lc-switch \
+code-test-lc/native:code-test-lc/test-lc-addrlabels:test-lc-addrlabels \
+code-test-memb/native:code-test-memb/test-memb \
+code-result-visualization/native:./04-test-result-visualization.sh
+
+include ../Makefile.compile-test

--- a/tests/06-script-base/run-test-lc.sh
+++ b/tests/06-script-base/run-test-lc.sh
@@ -1,9 +1,0 @@
-#!/bin/sh -e
-
-TEST_CODE_DIR=code-test-lc
-TESTNAME=$1
-TARGET=`echo ${TESTNAME} | sed -e 's/[0-9]*-\(.*\)/\1/'`
-
-make -C ${TEST_CODE_DIR} clean
-make -j4 -C ${TEST_CODE_DIR} ${TARGET}
-${TEST_CODE_DIR}/${TARGET}


### PR DESCRIPTION
Use Makefile.compile-tests to compile and run
the tests.

This will automatically clean each test, and
select the right number of cores for make -j.