### PR TITLE
frame802154: support for CSL frames

### DIFF
--- a/os/net/mac/framer/frame802154.c
+++ b/os/net/mac/framer/frame802154.c
@@ -80,6 +80,7 @@ static uint16_t mac_pan_id = IEEE802154_PANID;
  *  in the 802.15.4 header.  This structure is used in \ref frame802154_create()
  */
 typedef struct {
+  uint8_t frame_ctrl_len;  /**<  Length (in bytes) of the frame control field */
   uint8_t seqno_len;       /**<  Length (in bytes) of sequence number field */
   uint8_t dest_pid_len;    /**<  Length (in bytes) of destination PAN ID field */
   uint8_t dest_addr_len;   /**<  Length (in bytes) of destination address field */
@@ -146,6 +147,12 @@ frame802154_has_panid(frame802154_fcf_t *fcf, int *has_src_pan_id, int *has_dest
   }
 
   if(fcf->frame_version == FRAME802154_IEEE802154_2015) {
+    if(fcf->frame_type == FRAME802154_MPFRAME) {
+      *has_src_pan_id = 0;
+      *has_dest_pan_id = !fcf->panid_compression;
+      return;
+    }
+
     /*
      * IEEE 802.15.4-2015
      * Table 7-2, PAN ID Compression value for frame version 0b10
@@ -294,6 +301,11 @@ field_len(frame802154_t *p, field_length_t *flen)
   /* init flen to zeros */
   memset(flen, 0, sizeof(field_length_t));
 
+  flen->frame_ctrl_len =
+      (p->fcf.frame_type == FRAME802154_MPFRAME) && !p->fcf.long_frame_control
+      ? 1
+      : 2;
+
   /* Determine lengths of each field based on fcf and other args */
   if((p->fcf.sequence_number_suppression & 1) == 0) {
     flen->seqno_len = 1;
@@ -354,12 +366,38 @@ frame802154_hdrlen(frame802154_t *p)
 {
   field_length_t flen;
   field_len(p, &flen);
-  return 2 + flen.seqno_len + flen.dest_pid_len + flen.dest_addr_len +
-         flen.src_pid_len + flen.src_addr_len + flen.aux_sec_len;
+  return flen.frame_ctrl_len
+         + flen.seqno_len
+         + flen.dest_pid_len
+         + flen.dest_addr_len
+         + flen.src_pid_len
+         + flen.src_addr_len
+         + flen.aux_sec_len;
 }
-void
+/*----------------------------------------------------------------------------*/
+int
 frame802154_create_fcf(frame802154_fcf_t *fcf, uint8_t *buf)
 {
+#if FRAME802154_VERSION == FRAME802154_IEEE802154_2015
+  if(fcf->frame_type == FRAME802154_MPFRAME) {
+    /* create MP Frame Control field */
+    buf[0] = FRAME802154_MPFRAME
+             | ((fcf->long_frame_control) << 3)
+             | ((fcf->dest_addr_mode & 3) << 4)
+             | ((fcf->src_addr_mode & 3) << 6);
+    if(!fcf->long_frame_control) {
+      return 1;
+    }
+    buf[1] = ((!fcf->panid_compression) & 1)
+             | ((fcf->security_enabled & 1) << 1)
+             | ((fcf->sequence_number_suppression & 1) << 2)
+             | ((fcf->frame_pending & 1) << 3)
+             | ((fcf->ack_required & 1) << 6)
+             | ((fcf->ie_list_present & 1) << 7);
+    return 2;
+  }
+#endif /* FRAME802154_VERSION == FRAME802154_IEEE802154_2015 */
+  /* create Frame Control field */
   buf[0] = (fcf->frame_type & 7) |
     ((fcf->security_enabled & 1) << 3) |
     ((fcf->frame_pending & 1) << 4) |
@@ -370,6 +408,7 @@ frame802154_create_fcf(frame802154_fcf_t *fcf, uint8_t *buf)
     ((fcf->dest_addr_mode & 3) << 2) |
     ((fcf->frame_version & 3) << 4) |
     ((fcf->src_addr_mode & 3) << 6);
+  return 2;
 }
 /*----------------------------------------------------------------------------*/
 /**
@@ -396,8 +435,7 @@ frame802154_create(frame802154_t *p, uint8_t *buf)
 
   /* OK, now we have field lengths.  Time to actually construct */
   /* the outgoing frame, and store it in buf */
-  frame802154_create_fcf(&p->fcf, buf);
-  unsigned int pos = 2;
+  unsigned int pos = frame802154_create_fcf(&p->fcf, buf);
 
   /* Sequence number */
   if(flen.seqno_len == 1) {
@@ -458,27 +496,45 @@ frame802154_create(frame802154_t *p, uint8_t *buf)
 
   return (int)pos;
 }
-
-void
+/*----------------------------------------------------------------------------*/
+int
 frame802154_parse_fcf(const uint8_t *data, frame802154_fcf_t *pfcf)
 {
-  frame802154_fcf_t fcf;
+  /* parse Frame Type field */
+  pfcf->frame_type = data[0] & 7;
 
-  /* decode the FCF */
-  fcf.frame_type = data[0] & 7;
-  fcf.security_enabled = (data[0] >> 3) & 1;
-  fcf.frame_pending = (data[0] >> 4) & 1;
-  fcf.ack_required = (data[0] >> 5) & 1;
-  fcf.panid_compression = (data[0] >> 6) & 1;
+  switch(pfcf->frame_type) {
+  case FRAME802154_MPFRAME:
+    /* parse MP Frame Control field */
+    pfcf->long_frame_control = (data[0] >> 3) & 1;
+    pfcf->dest_addr_mode = (data[0] >> 4) & 3;
+    pfcf->src_addr_mode = (data[0] >> 6) & 3;
 
-  fcf.sequence_number_suppression = data[1] & 1;
-  fcf.ie_list_present = (data[1] >> 1) & 1;
-  fcf.dest_addr_mode = (data[1] >> 2) & 3;
-  fcf.frame_version = (data[1] >> 4) & 3;
-  fcf.src_addr_mode = (data[1] >> 6) & 3;
+    if(!pfcf->long_frame_control) {
+      return 1;
+    }
+    pfcf->panid_compression = !(data[1] & 1);
+    pfcf->security_enabled = (data[1] >> 1) & 1;
+    pfcf->sequence_number_suppression = (data[1] >> 2) & 1;
+    pfcf->frame_pending = (data[1] >> 3) & 1;
+    pfcf->frame_version = (data[1] >> 4) & 3;
+    pfcf->ack_required = (data[1] >> 6) & 1;
+    pfcf->ie_list_present = (data[1] >> 7) & 1;
+    return 2;
+  default:
+    /* parse Frame Control field */
+    pfcf->security_enabled = (data[0] >> 3) & 1;
+    pfcf->frame_pending = (data[0] >> 4) & 1;
+    pfcf->ack_required = (data[0] >> 5) & 1;
+    pfcf->panid_compression = (data[0] >> 6) & 1;
 
-  /* copy fcf */
-  memcpy(pfcf, &fcf, sizeof(frame802154_fcf_t));
+    pfcf->sequence_number_suppression = data[1] & 1;
+    pfcf->ie_list_present = (data[1] >> 1) & 1;
+    pfcf->dest_addr_mode = (data[1] >> 2) & 3;
+    pfcf->frame_version = (data[1] >> 4) & 3;
+    pfcf->src_addr_mode = (data[1] >> 6) & 3;
+    return 2;
+  }
 }
 /*----------------------------------------------------------------------------*/
 /**
@@ -494,7 +550,6 @@ int
 frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
 {
   uint8_t *p;
-  frame802154_fcf_t fcf;
   int c;
   int has_src_panid;
   int has_dest_panid;
@@ -509,19 +564,17 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
   p = data;
 
   /* decode the FCF */
-  frame802154_parse_fcf(p, &fcf);
-  memcpy(&pf->fcf, &fcf, sizeof(frame802154_fcf_t));
-  p += 2;                             /* Skip first two bytes */
+  p += frame802154_parse_fcf(p, &pf->fcf);
 
-  if(fcf.sequence_number_suppression == 0) {
+  if(pf->fcf.sequence_number_suppression == 0) {
     pf->seq = p[0];
     p++;
   }
 
-  frame802154_has_panid(&fcf, &has_src_panid, &has_dest_panid);
+  frame802154_has_panid(&pf->fcf, &has_src_panid, &has_dest_panid);
 
   /* Destination address, if any */
-  if(fcf.dest_addr_mode) {
+  if(pf->fcf.dest_addr_mode) {
     if(has_dest_panid) {
       /* Destination PAN */
       pf->dest_pid = p[0] + (p[1] << 8);
@@ -531,12 +584,12 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
     }
 
     /* Destination address */
-    if(fcf.dest_addr_mode == FRAME802154_SHORTADDRMODE) {
+    if(pf->fcf.dest_addr_mode == FRAME802154_SHORTADDRMODE) {
       linkaddr_copy((linkaddr_t *)&(pf->dest_addr), &linkaddr_null);
       pf->dest_addr[0] = p[1];
       pf->dest_addr[1] = p[0];
       p += 2;
-    } else if(fcf.dest_addr_mode == FRAME802154_LONGADDRMODE) {
+    } else if(pf->fcf.dest_addr_mode == FRAME802154_LONGADDRMODE) {
       for(c = 0; c < 8; c++) {
         pf->dest_addr[c] = p[7 - c];
       }
@@ -548,7 +601,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
   }
 
   /* Source address, if any */
-  if(fcf.src_addr_mode) {
+  if(pf->fcf.src_addr_mode) {
     /* Source PAN */
     if(has_src_panid) {
       pf->src_pid = p[0] + (p[1] << 8);
@@ -561,12 +614,12 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
     }
 
     /* Source address */
-    if(fcf.src_addr_mode == FRAME802154_SHORTADDRMODE) {
+    if(pf->fcf.src_addr_mode == FRAME802154_SHORTADDRMODE) {
       linkaddr_copy((linkaddr_t *)&(pf->src_addr), &linkaddr_null);
       pf->src_addr[0] = p[1];
       pf->src_addr[1] = p[0];
       p += 2;
-    } else if(fcf.src_addr_mode == FRAME802154_LONGADDRMODE) {
+    } else if(pf->fcf.src_addr_mode == FRAME802154_LONGADDRMODE) {
       for(c = 0; c < 8; c++) {
         pf->src_addr[c] = p[7 - c];
       }
@@ -578,7 +631,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
   }
 
 #if LLSEC802154_USES_AUX_HEADER
-  if(fcf.security_enabled) {
+  if(pf->fcf.security_enabled) {
     pf->aux_hdr.security_control.security_level = p[0] & 7;
 #if LLSEC802154_USES_EXPLICIT_KEYS
     pf->aux_hdr.security_control.key_id_mode = (p[0] >> 3) & 3;

--- a/os/net/mac/framer/frame802154.h
+++ b/os/net/mac/framer/frame802154.h
@@ -103,6 +103,7 @@ frame-filtering-friendly on some platforms) */
 #define FRAME802154_DATAFRAME       (0x01)
 #define FRAME802154_ACKFRAME        (0x02)
 #define FRAME802154_CMDFRAME        (0x03)
+#define FRAME802154_MPFRAME         (0x05)
 
 #define FRAME802154_BEACONREQ       (0x07)
 
@@ -162,6 +163,7 @@ typedef struct {
   uint8_t dest_addr_mode;    /**< 2 bit. Destination address mode, see 802.15.4 */
   uint8_t frame_version;     /**< 2 bit. 802.15.4 frame version */
   uint8_t src_addr_mode;     /**< 2 bit. Source address mode, see 802.15.4 */
+  uint8_t long_frame_control;/**< 1 bit. True if the Long Frame Control field is set */
 } frame802154_fcf_t;
 
 /** \brief 802.15.4 security control bitfield.  See section 7.6.2.2.1 in 802.15.4 specification */
@@ -214,10 +216,10 @@ typedef struct {
 /* Prototypes */
 
 int frame802154_hdrlen(frame802154_t *p);
-void frame802154_create_fcf(frame802154_fcf_t *fcf, uint8_t *buf);
+int frame802154_create_fcf(frame802154_fcf_t *fcf, uint8_t *buf);
 int frame802154_create(frame802154_t *p, uint8_t *buf);
 int frame802154_parse(uint8_t *data, int length, frame802154_t *pf);
-void frame802154_parse_fcf(const uint8_t *data, frame802154_fcf_t *pfcf);
+int frame802154_parse_fcf(const uint8_t *data, frame802154_fcf_t *pfcf);
 
 /* Get current PAN ID */
 uint16_t frame802154_get_pan_id(void);

--- a/os/net/mac/framer/frame802154e-ie.c
+++ b/os/net/mac/framer/frame802154e-ie.c
@@ -134,6 +134,35 @@ create_mlme_long_ie_descriptor(uint8_t *buf, uint8_t sub_id, int ie_len)
   WRITE16(buf, ie_desc);
 }
 
+#if MAC_CONF_WITH_CSL
+int
+frame802154e_create_ie_rendezvous_time(uint8_t *buf, int len,
+                                       const struct ieee802154_ies *ies)
+{
+  if(!ies || (len < 4)) {
+    return -1;
+  }
+
+  WRITE16(buf + 2, ies->rendezvous_time);
+  create_header_ie_descriptor(buf, HEADER_IE_RZ_TIME, 2);
+  return 4;
+}
+
+int
+frame802154e_create_ie_csl(uint8_t *buf, int len,
+                           const struct ieee802154_ies *ies)
+{
+  if(!ies || (len < 6)) {
+    return -1;
+  }
+
+  WRITE16(buf + 2, ies->csl_phase);
+  WRITE16(buf + 4, ies->csl_period);
+  create_header_ie_descriptor(buf, HEADER_IE_LE_CSL, 4);
+  return 6;
+}
+#endif /* MAC_CONF_WITH_CSL */
+
 /* Header IE. ACK/NACK time correction. Used in enhanced ACKs */
 int
 frame80215e_create_ie_header_ack_nack_time_correction(uint8_t *buf, int len,
@@ -372,6 +401,21 @@ frame802154e_parse_header_ie(const uint8_t *buf, int len,
         return len;
       }
       break;
+#if MAC_CONF_WITH_CSL
+    case HEADER_IE_RZ_TIME:
+      if((len == 2) && ies) {
+        READ16(buf, ies->rendezvous_time);
+        return len;
+      }
+      break;
+    case HEADER_IE_LE_CSL:
+      if(ies && (len == 4)) {
+        READ16(buf, ies->csl_phase);
+        READ16(buf + 2, ies->csl_period);
+        return len;
+      }
+      break;
+#endif /* MAC_CONF_WITH_CSL */
   }
   return -1;
 }

--- a/os/net/mac/framer/frame802154e-ie.h
+++ b/os/net/mac/framer/frame802154e-ie.h
@@ -68,6 +68,11 @@ struct tsch_slotframe_and_links {
 /* The information elements that we currently support */
 struct ieee802154_ies {
   /* Header IEs */
+#if MAC_CONF_WITH_CSL
+  uint16_t rendezvous_time;
+  uint16_t csl_period;
+  uint16_t csl_phase;
+#endif /* MAC_CONF_WITH_CSL */
   int16_t ie_time_correction;
   uint8_t ie_is_nack;
   /* Payload MLME */
@@ -93,6 +98,17 @@ struct ieee802154_ies {
 };
 
 /** Insert various Information Elements **/
+#if MAC_CONF_WITH_CSL
+/* Header IE. Time until the transmission of a payload frame. Used in wake-up
+ * frames */
+int frame802154e_create_ie_rendezvous_time(uint8_t *buf, int len,
+                                           const struct ieee802154_ies *ies);
+/* Header IE. Carries the time from the first symbol of the frame containing
+ * the CSL IE until the next duty cycle. Used in Enh-Acks. */
+int frame802154e_create_ie_csl(uint8_t *buf, int len,
+                               const struct ieee802154_ies *ies);
+#endif /* MAC_CONF_WITH_CSL */
+
 /* Header IE. ACK/NACK time correction. Used in enhanced ACKs */
 int frame80215e_create_ie_header_ack_nack_time_correction(uint8_t *buf, int len,
     const struct ieee802154_ies *ies);


### PR DESCRIPTION
The `frame802154` modules lacks support for creating and parsing CSL frames. This PR fills these gaps and hence takes a step toward a CSL implementation as conceived in #21.