### PR TITLE
lpm: use RTIMER_CLOCK_DIFF to allow for wrap-arounds

### DIFF
--- a/arch/cpu/cc2538/lpm.c
+++ b/arch/cpu/cc2538/lpm.c
@@ -248,7 +248,7 @@ lpm_enter()
    * Choose the most suitable PM based on anticipated deep sleep duration
    */
   lpm_exit_time = rtimer_arch_next_trigger();
-  duration = lpm_exit_time - RTIMER_NOW();
+  duration = RTIMER_CLOCK_DIFF(lpm_exit_time, RTIMER_NOW());
 
   if(duration < DEEP_SLEEP_PM1_THRESHOLD || lpm_exit_time == 0) {
     /* Anticipated duration too short or no scheduled rtimer task. Use PM0 */
@@ -267,7 +267,7 @@ lpm_enter()
    * Switching the System Clock from the 32MHz XOSC to the 16MHz RC OSC may
    * have taken a while. Re-estimate sleep duration.
    */
-  duration = lpm_exit_time - RTIMER_NOW();
+  duration = RTIMER_CLOCK_DIFF(lpm_exit_time, RTIMER_NOW());
 
   if(duration < DEEP_SLEEP_PM1_THRESHOLD) {
     /*


### PR DESCRIPTION
On CC2538-based platforms, `rtimer` timestamps wrap around after about 36 hours. In most places, `RTIMER_CLOCK_DIFF` is already being used to allow for wrap-arounds when computing durations. This PR fixes an unprotected occurrence in `lpm.c`.