### PR TITLE
tests: remove sleep statements

### DIFF
--- a/tests/20-packet-parsing/packet-injector.sh
+++ b/tests/20-packet-parsing/packet-injector.sh
@@ -52,9 +52,5 @@ if [ $((TIMEDOUT + FAILED)) -gt 0 ]; then
   echo "Succeeded: " $SUCCEEDED
   echo "Timed out: " $TIMEDOUT
   echo "Failed   : " $FAILED
-
-  sleep 3
   exit 1
 fi
-
-sleep 3


### PR DESCRIPTION
These are not required, so remove them
to speed up the tests.