### PR TITLE
tests/coap-lwm2m: enable full parallelism

### DIFF
--- a/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
+++ b/tests/18-coap-lwm2m/06-lwm2m-ipso-test.sh
@@ -2,7 +2,7 @@
 source ../utils.sh
 
 # Contiki directory
-CONTIKI=$1
+CONTIKI=../..
 # Test basename
 BASENAME=06-lwm2m-ipso-test
 
@@ -10,8 +10,6 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node - lwm2m/ipso objects"
-make -C $CONTIKI/examples/lwm2m-ipso-objects clean || exit 1
-make -j4 -C $CONTIKI/examples/lwm2m-ipso-objects || exit 1
 sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native &
 CPID=$!
 
@@ -43,8 +41,6 @@ kill_bg $LESHID
 if ! grep -q 'OK' leshan.err ; then
   echo "==== leshan.log ====" ; cat leshan.log;
   echo "==== leshan.err ====" ; cat leshan.err;
-  echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
-
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
   rm -f leshan.log leshan.err
   exit 1

--- a/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
+++ b/tests/18-coap-lwm2m/07-lwm2m-standalone-test.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 source ../utils.sh
 
-# Contiki directory
-CONTIKI=$1
 # Test basename
 BASENAME=07-lwm2m-standalone-test
-
-# Building standalone posix example
-echo "Compiling standalone posix example"
-make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m clean || exit 1
-make -j4 CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m || exit 1
 
 echo "Downloading leshan"
 LESHAN_JAR=leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar
@@ -44,8 +37,6 @@ kill_bg $LESHID
 if ! grep -q 'OK' leshan.err ; then
   echo "==== leshan.log ====" ; cat leshan.log;
   echo "==== leshan.err ====" ; cat leshan.err;
-  echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
-
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
   rm -f leshan.log leshan.err
   exit 1

--- a/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
+++ b/tests/18-coap-lwm2m/08-lwm2m-qmode-ipso-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Contiki directory
-CONTIKI=$1
+CONTIKI=../..
 # Test basename
 BASENAME=08-lwm2m-qmode-ipso-test
 
@@ -9,8 +9,6 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node - lwm2m/ipso objects with Q-Mode"
-make -C $CONTIKI/examples/lwm2m-ipso-objects clean || exit 1
-make -j4 -C $CONTIKI/examples/lwm2m-ipso-objects DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 || exit 1
 sudo $CONTIKI/examples/lwm2m-ipso-objects/example-ipso-objects.native &
 CPID=$!
 
@@ -48,8 +46,6 @@ then
 else
   echo "==== leshan.log ====" ; cat leshan.log;
   echo "==== leshan.err ====" ; cat leshan.err;
-  echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
-
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
   rm -f leshan.log leshan.err
   exit 1

--- a/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
+++ b/tests/18-coap-lwm2m/09-lwm2m-qmode-standalone-test.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 
-# Contiki directory
-CONTIKI=$1
 # Test basename
 BASENAME=09-lwm2m-qmode-standalone-test
-
-# Building standalone posix example
-echo "Compiling standalone posix example"
-make CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m clean || exit 1
-make -j4 CONTIKI_NG=$CONTIKI -C example-lwm2m-standalone/lwm2m DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 || exit 1
 
 echo "Downloading leshan with Q-Mode support"
 LESHAN_JAR=leshan-server-demo-qmode-support1.0.0-SNAPSHOT-jar-with-dependencies.jar
@@ -47,8 +40,6 @@ then
 else
   echo "==== leshan.log ====" ; cat leshan.log;
   echo "==== leshan.err ====" ; cat leshan.err;
-  echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
-
   printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
   rm -f leshan.log leshan.err
   exit 1

--- a/tests/18-coap-lwm2m/Makefile
+++ b/tests/18-coap-lwm2m/Makefile
@@ -1,1 +1,11 @@
-include ../Makefile.script-test
+RUN_FILE = 1
+
+EXAMPLESDIR := $(abspath ../..)
+
+EXAMPLES = \
+examples/lwm2m-ipso-objects/native:./06-lwm2m-ipso-test.sh \
+tests/18-coap-lwm2m/example-lwm2m-standalone/lwm2m/native:./07-lwm2m-standalone-test.sh:CONTIKI_NG=$(EXAMPLESDIR) \
+examples/lwm2m-ipso-objects/native:./08-lwm2m-qmode-ipso-test.sh:DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1 \
+tests/18-coap-lwm2m/example-lwm2m-standalone/lwm2m/native:./09-lwm2m-qmode-standalone-test.sh:CONTIKI_NG=$(EXAMPLESDIR):DEFINES=LWM2M_QUEUE_MODE_CONF_ENABLED=1,LWM2M_QUEUE_MODE_CONF_INCLUDE_DYNAMIC_ADAPTATION=1,LWM2M_QUEUE_MODE_OBJECT_CONF_ENABLED=1
+
+include ../Makefile.compile-test


### PR DESCRIPTION
Use Makefile.compile-tests to compile and run
the tests.

This will automatically clean each test, and
select the right number of cores for make -j.