### PR TITLE
tests/native-runs: enable full parallelism

### DIFF
--- a/tests/08-native-runs/01-test-data-structures.sh
+++ b/tests/08-native-runs/01-test-data-structures.sh
@@ -2,7 +2,7 @@
 source ../utils.sh
 
 # Contiki directory
-CONTIKI=$1
+CONTIKI=../..
 
 # Example code directory
 CODE_DIR=$CONTIKI/tests/07-simulation-base/code-data-structures/
@@ -10,7 +10,6 @@ CODE=test-data-structures
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-make -j4 -C $CODE_DIR TARGET=native || exit 1
 $CODE_DIR/$CODE.native > $CODE.log 2> $CODE.err &
 CPID=$!
 

--- a/tests/08-native-runs/08-native-ping.sh
+++ b/tests/08-native-runs/08-native-ping.sh
@@ -2,7 +2,7 @@
 source ../utils.sh
 
 # Contiki directory
-CONTIKI=$1
+CONTIKI=../..
 # Test basename
 BASENAME=$(basename $0 .sh)
 
@@ -10,7 +10,6 @@ IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-make -j4 -C $CONTIKI/examples/hello-world || exit 1
 sudo $CONTIKI/examples/hello-world/hello-world.native &
 CPID=$!
 sleep 2

--- a/tests/08-native-runs/09-native-coap.sh
+++ b/tests/08-native-runs/09-native-coap.sh
@@ -2,7 +2,7 @@
 source ../utils.sh
 
 # Contiki directory
-CONTIKI=$1
+CONTIKI=../..
 # Test basename
 BASENAME=$(basename $0 .sh)
 
@@ -13,7 +13,6 @@ declare -i TESTCOUNT=0
 
 # Starting Contiki-NG native node
 echo "Starting native CoAP server"
-make -j4 -C $CONTIKI/examples/coap/coap-example-server || exit 1
 sudo $CONTIKI/examples/coap/coap-example-server/coap-example-server.native &
 CPID=$!
 sleep 2

--- a/tests/08-native-runs/10-snmp-server.sh
+++ b/tests/08-native-runs/10-snmp-server.sh
@@ -2,30 +2,30 @@
 source ../utils.sh
 
 # Contiki directory
-CONTIKI=$1
+CONTIKI=../..
 # Test basename
 BASENAME=$(basename $0 .sh)
 
 IPADDR=fd00::302:304:506:708
 
 # Starting Contiki-NG native node
-make -j4 -C $CONTIKI/examples/snmp-server
 sudo $CONTIKI/examples/snmp-server/snmp-server.native &
 CPID=$!
+printf "\r\n"
 
 test_handler () {
   sleep 2
-  $1 2>&1 | tee $BASENAME.log
-  grep -z -E "$2" $BASENAME.log
+  $1 > $BASENAME.log 2>&1
+  grep -q -z -E "$2" $BASENAME.log
   STATUS=$?
 
   if [ $STATUS -eq 0 ] ; then
-    printf "%-32s TEST OK\n" "$BASENAME" | tee $BASENAME.testlog;
+    printf "%-32s TEST OK\r\n" "$BASENAME" | tee $BASENAME.testlog;
   else
     kill_bg $CPID
     echo $1
     echo $2
-    printf "%-32s TEST FAIL\n" "$BASENAME" | tee $BASENAME.testlog;
+    printf "%-32s TEST FAIL\r\n" "$BASENAME" | tee $BASENAME.testlog;
     exit 1
   fi
 }

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -1,1 +1,22 @@
-include ../Makefile.script-test
+RUN_FILE = 1
+
+EXAMPLESDIR = ../../
+
+
+EXAMPLES = \
+tests/07-simulation-base/code-data-structures/native:./01-test-data-structures.sh \
+examples/mqtt-client/native:./02-mqtt-client-31.sh:DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG,MQTT_CONF_VERSION=MQTT_PROTOCOL_VERSION_3_1 \
+examples/mqtt-client/native:./03-mqtt-client-31-valgrind.sh:DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG,MQTT_CONF_VERSION=MQTT_PROTOCOL_VERSION_3_1 \
+examples/mqtt-client/native:./04-mqtt-client-311.sh:DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG,MQTT_CONF_VERSION=MQTT_PROTOCOL_VERSION_3_1_1 \
+examples/mqtt-client/native:./05-mqtt-client-311-valgrind.sh:DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG,MQTT_CONF_VERSION=MQTT_PROTOCOL_VERSION_3_1_1 \
+examples/mqtt-client/native:./06-mqtt-client-5.sh:DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG,MQTT_CONF_VERSION=MQTT_PROTOCOL_VERSION_5 \
+examples/mqtt-client/native:./07-mqtt-client-5-valgrind.sh:DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG,MQTT_CONF_VERSION=MQTT_PROTOCOL_VERSION_5 \
+examples/hello-world/native:./08-native-ping.sh \
+examples/coap/coap-example-server/native:./09-native-coap.sh \
+examples/snmp-server/native:./10-snmp-server.sh \
+tests/08-native-runs/11-aes-ccm/native:./11-aes-ccm.sh \
+tests/08-native-runs/12-heapmem/native:./12-heapmem.sh \
+tests/08-native-runs/13-coffee/native:./13-coffee.sh
+
+
+include ../Makefile.compile-test

--- a/tests/08-native-runs/mqtt-client.sh
+++ b/tests/08-native-runs/mqtt-client.sh
@@ -2,7 +2,7 @@
 source ../utils.sh
 
 # Contiki directory
-CONTIKI=$1
+CONTIKI=../..
 
 # 3_1, 3_1_1, or 5
 # default: 3_1
@@ -41,9 +41,6 @@ sleep 2
 
 # Starting Contiki-NG native node
 echo "Starting native node"
-make -C $CODE_DIR -B TARGET=native clean || exit 1
-make -j4 -C $CODE_DIR -B TARGET=native \
-  DEFINES=MQTT_CLIENT_CONF_ORG_ID=\\\"travis-test\\\",MQTT_CLIENT_CONF_LOG_LEVEL=LOG_LEVEL_DBG,MQTT_CONF_VERSION=MQTT_PROTOCOL_VERSION_$MQTT_VERSION || exit 1
 sudo $VALGRIND_CMD $CODE_DIR/$CODE.native > $CLIENT_LOG 2> $CLIENT_ERR &
 CPID=$!
 

--- a/tests/08-native-runs/run-one.sh
+++ b/tests/08-native-runs/run-one.sh
@@ -3,17 +3,11 @@
 source ../utils.sh
 
 BASENAME=$(basename $1)
-BUILDLOG=$BASENAME.build.log
 
 cd ${1}
 test_init
 
-register_logfile $BUILDLOG
-
 echo "-- Starting test $1"
-# Clean and build
-assert "clean" "make clean &> $BUILDLOG"
-assert "compile" "make -j >> $BUILDLOG 2>&1"
 
 for TEST in ./test*.native; do
   RUNLOG=$(basename $TEST .native).run.log

--- a/tests/Makefile.compile-test
+++ b/tests/Makefile.compile-test
@@ -60,12 +60,16 @@ DEFINE_START ?= 2
 
 # Rule for compiling examples.
 # EXAMPLES has the form directory/target:define1=value1:define2=value2:...
-# Mangle ":" to "_@_" and "=" to "@_@" to get a valid make rule name.
-DELIMIT1 := _@_
-DELIMIT2 := @_@
-EXAMPLES_TMP := $(subst =,$(DELIMIT2), $(subst :,$(DELIMIT1),$(EXAMPLES)))
+# Mangle :, =, \, and '"' to get valid rule name.
+DELIMIT1 := __@__
+DELIMIT2 := _@-@_
+DELIMIT3 := _@_@_
+DELIMIT4 := _@@@_
+QUOTE := "
+EXAMPLES_TMP := $(subst \,$(DELIMIT4), $(subst $(QUOTE),$(DELIMIT3), $(subst =,$(DELIMIT2), $(subst :,$(DELIMIT1),$(EXAMPLES)))))
+
 $(EXAMPLES_TMP):
-	$(eval _exlist := $(subst $(DELIMIT1), ,$(subst $(DELIMIT2),=,$@)))
+	$(eval _exlist := $(subst $(DELIMIT1), ,$(subst $(DELIMIT2),=,$(subst $(DELIMIT3),$(QUOTE),$(subst $(DELIMIT4),\,$@)))))
 	$(eval _blob := $(firstword $(_exlist)))
 	$(eval _example := $(dir $(_blob)))
 	$(eval _target := $(notdir $(_blob)))


### PR DESCRIPTION
Use Makefile.compile-tests to compile and run
the tests.

This will automatically clean each test, and
select the right number of cores for make -j.