### PR TITLE
Update tools/cooja submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,12 +208,12 @@ jobs:
         # Check outcome of the test
         ./tests/check-test.sh `pwd`/tests/??-${{ matrix.test }}
 
-    # Pre-install a Java 20 on macOS to avoid 503 responses in Gradle.
-    - name: Setup Java 20
+    # Pre-install a Java 21 on macOS to avoid 503 responses in Gradle.
+    - name: Setup Java 21
       if: matrix.os == 'macos-latest'
       uses: actions/setup-java@v3
       with:
-        java-version: 20
+        java-version: 21
         distribution: 'zulu'
 
     - name: Execute tests

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get -qq update && \
     > /dev/null && \
   apt-get -qq clean
 
-ARG JAVA_VERSION=20
+ARG JAVA_VERSION=21
 RUN wget -nv https://download.oracle.com/graalvm/${JAVA_VERSION}/latest/graalvm-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz && \
   tar xf graalvm-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz -C /usr/local --strip-components=1 --no-same-owner && \
   rm -f graalvm*gz


### PR DESCRIPTION
This also requires updating the CI
and Dockerfile for Java 21.

Commits:
733049a57 CI: override Contiki-NG version check
d93cf5c87 Update to Java 21
4ce84ba65 SectionMoteMemory: avoid re-adding symbols 9da8402a0 Remove Windows settings
f0789a9e3 ContikiMoteType: pass through COOJA_CI
1794e5e8d CI: stop installing gawk
16e8d5135 Cooja: add option for using FlatLaf