### PR TITLE
heapmem: Suppress warning when calling heapmem_free(NULL)

### DIFF
--- a/os/lib/heapmem.c
+++ b/os/lib/heapmem.c
@@ -442,7 +442,9 @@ heapmem_free(void *ptr)
 #endif
 {
   if(!IN_HEAP(ptr)) {
-    LOG_WARN("%s: ptr %p is not in the heap\n", __func__, ptr);
+    if(ptr) {
+      LOG_WARN("%s: ptr %p is not in the heap\n", __func__, ptr);
+    }
     return false;
   }
 


### PR DESCRIPTION
Though the [API documentation](https://docs.contiki-ng.org/en/develop/_api/group__heapmem.html) says that calling `heapmem_free` with a NULL argument is fine, heapmem prints warnings when doing so.