### PR TITLE
CSPRNG: Support for native platform on Linux and macOS

### DIFF
--- a/arch/cpu/native/Makefile.native
+++ b/arch/cpu/native/Makefile.native
@@ -49,6 +49,7 @@ endif
 ifeq ($(HOST_OS),Darwin)
 LDFLAGS_WERROR := -Wl,-fatal_warnings
 LDFLAGS += -Wl,-flat_namespace
+LDFLAGS += -framework Security
 CFLAGS += -DHAVE_SNPRINTF=1 -U__ASSERT_USE_STDERR
 endif
 


### PR DESCRIPTION
This PR adds functionality for seeding the CSPRNG on the native platform, at least when run on Linux or macOS.