### PR TITLE
nrf: verify image programming

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -141,7 +141,7 @@ endif
 ifeq (, $(shell which $(NRFJPROG)))
 	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
 else
-	$(NRFJPROG) $(NRFJPROG_OPTIONS) $(NRFJPROG_FLAGS) --sectorerase --program $<
+	$(NRFJPROG) $(NRFJPROG_OPTIONS) $(NRFJPROG_FLAGS) --sectorerase --verify --program $<
 	$(NRFJPROG) $(NRFJPROG_OPTIONS) $(NRFJPROG_FLAGS) --reset
 endif
 
@@ -159,7 +159,7 @@ ifneq ($(filter nrf-upload-sequence,$(MAKECMDGOALS)),)
 endif
 
 nrf-upload-snr.%:
-	$(NRFJPROG) $(NRFJPROG_OPTIONS) --snr $* --sectorerase --program $(HEX_FILE)
+	$(NRFJPROG) $(NRFJPROG_OPTIONS) --snr $* --sectorerase --verify --program $(HEX_FILE)
 	$(NRFJPROG) $(NRFJPROG_OPTIONS) --snr $* --reset
 
 nrf-upload-sequence: $(foreach SNR, $(NRF_SNRS), nrf-upload-snr.$(SNR))

--- a/arch/cpu/nrf52840/Makefile.nrf52840
+++ b/arch/cpu/nrf52840/Makefile.nrf52840
@@ -137,7 +137,7 @@ endif
 ifeq (, $(shell which $(NRFJPROG)))
 	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
 else
-	$(NRFJPROG) -f nrf52 $(NRFJPROG_FLAGS) --sectorerase --program $<
+	$(NRFJPROG) -f nrf52 $(NRFJPROG_FLAGS) --sectorerase --verify --program $<
 	$(NRFJPROG) -f nrf52 $(NRFJPROG_FLAGS) --reset
 endif
 
@@ -155,7 +155,7 @@ ifneq ($(filter nrf-upload-sequence,$(MAKECMDGOALS)),)
 endif
 
 nrf-upload-snr.%:
-	$(NRFJPROG) -f nrf52 --snr $* --sectorerase --program $(HEX_FILE)
+	$(NRFJPROG) -f nrf52 --snr $* --sectorerase --verify --program $(HEX_FILE)
 	$(NRFJPROG) -f nrf52 --snr $* --reset
 
 nrf-upload-sequence: $(foreach SNR, $(NRF_SNRS), nrf-upload-snr.$(SNR))


### PR DESCRIPTION
Verify image after programming to avoid a warning when programming nrf devices.