### PR TITLE
CI: shorten job name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,10 @@ jobs:
               - os: macos-latest
                 test: ieee802154
 
+    # Default job name is too long to be visible in the "Checks" tab.
+    name: ${{ matrix.test }}/${{ matrix.os }}
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
-
     # Checks-out the contiki-ng $GITHUB_WORKSPACE, so your job can access it
     steps:
 


### PR DESCRIPTION
The default job name is too long
to be visible in the "Checks" tab.
Set the job name to "$TESTNAME/$OS"
so the test results for each test
on different operating systems
are adjacent.