### PR TITLE
examples/cplusplus: exclude MSP430 platforms

### DIFF
--- a/examples/cplusplus/Makefile
+++ b/examples/cplusplus/Makefile
@@ -1,6 +1,8 @@
 CONTIKI_PROJECT = node
 all: $(CONTIKI_PROJECT)
 
+PLATFORMS_EXCLUDE += sky z1
+
 PROJECT_SOURCEFILES += module.cpp
 
 CONTIKI = ../..


### PR DESCRIPTION
There is no C++ compiler with the GCC used
by Contiki-NG.