### PR TITLE
simplelink: pass --entry to linker

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -110,7 +110,7 @@ CFLAGS += -fno-common
 ### Linker configuration
 
 # Linker flags
-LDFLAGS += --entry resetISR
+LDFLAGS += -Wl,--entry=resetISR
 ifeq ($(CLANG),0)
   LDFLAGS += --specs=nano.specs
 endif


### PR DESCRIPTION
GCC documents the flag as "interpreted by the linker", so pass the flag directly to the linker instead.

This fixes a number of compilation errors
in the ARM tests for Clang.