### PR TITLE
tests/compile-all: limit parallelism

### DIFF
--- a/tests/compile-all/Makefile
+++ b/tests/compile-all/Makefile
@@ -1,5 +1,4 @@
-all:
-	./build.sh all
+all clean:
+	MAKE="$(MAKE)" MAKEFLAGS="$(MAKEFLAGS)" ./build.sh $@
 
-clean:
-	./build.sh clean
+.PHONY: all clean

--- a/tests/compile-all/build.sh
+++ b/tests/compile-all/build.sh
@@ -34,6 +34,9 @@
 # example and platform combinations that are marked as impossible in the Makefiles
 # by using PLATFORMS_EXCLUDE and PLATFORMS_ONLY variables.
 #
+# To build with gmake and 8 cores, invoke with:
+# MAKE="gmake" MAKEFLAGS="-j8" ./build.sh all
+#
 # This script can also clean all targets. To do that, run:
 # ./build.sh clean
 #
@@ -52,6 +55,8 @@ if [[ "$MAKEFILES" == "" ]]
 then
     MAKEFILES=`find $EXAMPLES_DIR -name Makefile`
 fi
+
+[[ "$MAKE" != "" ]] || MAKE="make"
 
 HELLO_WORLD=$EXAMPLES_DIR/hello-world
 
@@ -107,7 +112,7 @@ do
     # Detect all boards for the current platform by calling
     # make TARGET=$platform boards
     # in the hello-world dir.
-    BOARDS=`make -s -C $HELLO_WORLD TARGET=$platform boards \
+    BOARDS=`$MAKE -s -C $HELLO_WORLD TARGET=$platform boards \
             | grep -v "no boards" | rev | cut -f3- -d" " | rev`
 
     if [[ -z $BOARDS ]]
@@ -126,7 +131,7 @@ do
             example_dir=`dirname "$example"`
 
             # Clean it before building
-            make -C "$example_dir" TARGET=$platform BOARD=$board clean 2>&1 >/dev/null
+            $MAKE -C "$example_dir" TARGET=$platform BOARD=$board clean 2>&1 >/dev/null
             if [[ "$GOAL" == "clean" ]]
             then
                # do this just for the first board
@@ -134,8 +139,8 @@ do
             fi
 
             # Build the goal
-            $LOG_INFO "make -C \"$example_dir\" -j TARGET=$platform BOARD=$board $GOAL"
-            if make -C "$example_dir" -j TARGET=$platform BOARD=$board $GOAL >build.log 2>&1
+            $LOG_INFO "$MAKE -C \"$example_dir\" $MAKEFLAGS TARGET=$platform BOARD=$board $GOAL"
+            if $MAKE -C "$example_dir" $MAKEFLAGS TARGET=$platform BOARD=$board $GOAL >build.log 2>&1
             then
                 $LOG_INFO "..done"
                 $CAT_DEBUG build.log
@@ -157,7 +162,7 @@ do
             fi
 
             # Clean it after building
-            make -C "$example_dir" TARGET=$platform BOARD=$board clean 2>&1 >/dev/null
+            $MAKE -C "$example_dir" TARGET=$platform BOARD=$board clean 2>&1 >/dev/null
         done
     done
 done


### PR DESCRIPTION
Spawning 40+ compilers on a small machine
is slow, so limit the parallelism to
the -j argument that make is invoked with.