### PR TITLE
tests/compile-arm-ports: switch gecko tests

### DIFF
--- a/examples/dev/button-hal/Makefile
+++ b/examples/dev/button-hal/Makefile
@@ -3,7 +3,7 @@ CONTIKI = ../../..
 
 all: $(CONTIKI_PROJECT)
 
-PLATFORMS_ONLY += cc26x0-cc13x0 cc2538dk openmote zoul simplelink
+PLATFORMS_ONLY += cc26x0-cc13x0 cc2538dk gecko openmote zoul simplelink
 PLATFORMS_ONLY += cooja native
 
 include $(CONTIKI)/Makefile.include

--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -67,9 +67,9 @@ EXAMPLES = \
 benchmarks/rpl-req-resp/zoul \
 coap/coap-example-client/zoul \
 coap/coap-example-server/zoul \
+dev/button-hal/gecko:BOARD=brd4162a \
+dev/button-hal/gecko:BOARD=brd4166a \
 dev/gpio-hal/zoul:BOARD=orion \
-dev/gpio-hal/gecko:BOARD=brd4162a \
-dev/gpio-hal/gecko:BOARD=brd4166a \
 dev/leds/simplelink:BOARD=srf06/cc26x0 \
 dev/leds/gecko:BOARD=brd4162a \
 dev/leds/gecko:BOARD=brd4166a \


### PR DESCRIPTION
The two Gecko boards that are supported only
have two leds, and the gpio-hal example requires
three leds.

Compile the button-hal example instead.