### PR TITLE
Makefile.include: error on faulty BOARD argument

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -143,6 +143,13 @@ ifneq ($(MAKECMDGOALS),clean)
     endif
   endif
 
+  ifdef BOARD
+    ifeq ("$(filter $(BOARD), $(BOARDS))", "")
+      $(info Available boards: $(BOARDS))
+      $(error Board '$(BOARD)' not available for target '$(TARGET)'.)
+    endif
+  endif
+
   # Validate the toolchain.
   ifeq (, $(shell which $(CC)))
     $(error Target "$(TARGET)" compiler "$(CC)" cannot be found)


### PR DESCRIPTION
Give a readable error message when passing
a non-existent BOARD argument to make.

Without this, nrf (and other targets) will error
out with a cryptic error message along the lines of:

../../../arch/cpu/nrf/Makefile.: No such file or directory