### PR TITLE
nrf: add mdk to LDFLAGS early

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -50,7 +50,6 @@ CFLAGS += -DNRFX_UARTE0_ENABLED
 ifeq ($(CLANG),0)
   LDFLAGS += --specs=nano.specs
 endif
-LDFLAGS += -L $(NRFX_ROOT)/mdk
 LDFLAGS += -Wl,--defsym=_stack=end
 LDFLAGS += -Wl,--defsym=_stack_origin=__stack
 LDFLAGS += -Wl,--defsym=_heap=end

--- a/arch/cpu/nrf/Makefile.nrf52840
+++ b/arch/cpu/nrf/Makefile.nrf52840
@@ -20,6 +20,7 @@ CFLAGS += -DCPU_DEF_PATH=\"nrf52840-def.h\"
 
 CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
+LDFLAGS += -L$(NRFX_ROOT)/mdk
 LDFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
 include $(CONTIKI)/$(CONTIKI_NG_CM4_DIR)/Makefile.cm4

--- a/arch/cpu/nrf/Makefile.nrf5340_application
+++ b/arch/cpu/nrf/Makefile.nrf5340_application
@@ -32,10 +32,7 @@ else
   SOURCE_LDSCRIPT ?= $(NRFX_ROOT)/mdk/nrf5340_xxaa_application.ld
 endif
 
-# GCC automatically invokes the linker with this flag, Clang does not.
-ifeq ($(CLANG),1)
-  LDFLAGS += -L$(NRFX_ROOT)/mdk
-endif
+LDFLAGS += -L$(NRFX_ROOT)/mdk
 LDFLAGS += -mfloat-abi=hard 
 LDFLAGS += -mfpu=fpv5-sp-d16
 

--- a/arch/cpu/nrf/Makefile.nrf5340_network
+++ b/arch/cpu/nrf/Makefile.nrf5340_network
@@ -14,6 +14,8 @@ NRFJPROG_OPTIONS=-f NRF53 --coprocessor CP_NETWORK
 CFLAGS += -DCPU_CONF_PATH=\"nrf5340-network-conf.h\"
 CFLAGS += -DCPU_DEF_PATH=\"nrf5340-network-def.h\"
 
+LDFLAGS += -L$(NRFX_ROOT)/mdk
+
 TARGET_LIBFILES += -lm
 
 ifeq ($(NRF_NATIVE_USB),1)


### PR DESCRIPTION
Makefile.cortex-m adds "-T $(LDSCRIPT)",
so add "-L $(NRFX_ROOT)/mdk" to LDFLAGS
before that.

This fixes a link issue with finding
nrf_common.ld for nrf52840 boards
when using Clang.