### PR TITLE
Makefile.cm3: avoid -nostartfiles with Clang

### DIFF
--- a/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
+++ b/arch/cpu/arm/cortex-m/cm3/Makefile.cm3
@@ -2,7 +2,12 @@ CONTIKI_ARM_DIRS += cortex-m/cm3
 
 CFLAGS += -mcpu=cortex-m3
 
-LDFLAGS += -mcpu=cortex-m3 -nostartfiles
+LDFLAGS += -mcpu=cortex-m3
+# Clang does not add crti.o and other start files when linking
+# with the Contiki-NG build system, so do not pass -nostartfiles.
+ifeq ($(CLANG), 0)
+  LDFLAGS += -nostartfiles
+endif
 
 TARGET_LIBFILES += -lm
 


### PR DESCRIPTION
Clang does not add crti.o and other files when
linking with the Contiki-NG build system, so
stop passing -nostartfiles to avoid a warning
about unused command line arguments.