### PR TITLE
rpl-border-router: enable tunslip6 args

### DIFF
--- a/os/services/rpl-border-router/embedded/Makefile.embedded
+++ b/os/services/rpl-border-router/embedded/Makefile.embedded
@@ -1,6 +1,6 @@
 PREFIX ?= fd00::1/64
 
-ifdef PORT
+ifneq ($(PORT),)
 	TUNSLIP6_ARGS = -s $(PORT) $(PREFIX)
 else
 	TUNSLIP6_ARGS = $(PREFIX)
@@ -10,4 +10,4 @@ connect-router: $(TUNSLIP6)
 	sudo $(TUNSLIP6) $(TUNSLIP6_ARGS)
 
 connect-router-cooja: $(TUNSLIP6)
-	sudo $(TUNSLIP6) -a 127.0.0.1 $(PREFIX)
+	sudo $(TUNSLIP6) -a 127.0.0.1 $(TUNSLIP6_ARGS)


### PR DESCRIPTION
The "connect-router" target allows arguments,
so use the same mechanism for connect-router-cooja.