### PR TITLE
Compile as C11

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -390,7 +390,7 @@ ifneq ($(MODULES_IMACROS),)
   CFLAGS += ${foreach d, $(MODULES_IMACROS), -imacros $(d)}
 endif
 
-CXXFLAGS += $(subst -std=c99,-std=gnu++11,$(CFLAGS))
+CXXFLAGS += $(subst -std=c11,-std=gnu++11,$(CFLAGS))
 CXXFLAGS += -fpermissive -fno-exceptions -fno-unwind-tables
 CXXFLAGS += -fno-threadsafe-statics -fno-rtti -fno-use-cxa-atexit
 

--- a/arch/cpu/arm/Makefile.arm
+++ b/arch/cpu/arm/Makefile.arm
@@ -20,7 +20,7 @@ SREC_CAT = srec_cat
 
 CFLAGS += -mthumb -mabi=aapcs -mlittle-endian
 CFLAGS += -Wall
-CFLAGS += -std=c99
+CFLAGS += -std=c11
 CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
 CFLAGS += -fshort-enums -fomit-frame-pointer
 ifeq ($(TRUSTZONE_SECURE_BUILD),1)

--- a/arch/cpu/msp430/Makefile.msp430
+++ b/arch/cpu/msp430/Makefile.msp430
@@ -82,7 +82,7 @@ endif
 ifndef CFLAGSNO
 CFLAGSNO = -Wall -mmcu=$(MCU) $(CFLAGSWERROR)
 endif
-CFLAGS  += -Os -fno-strict-aliasing -std=gnu99
+CFLAGS  += -Os -fno-strict-aliasing -std=gnu11
 LDFLAGS += -mmcu=$(MCU) -Wl,-Map=$(CONTIKI_NG_PROJECT_MAP)
 LDFLAGS += -Wl,--sort-section=alignment
 

--- a/doc/project/Contributing.md
+++ b/doc/project/Contributing.md
@@ -24,7 +24,7 @@ Please adhere to the following guidelines:
 * For new features, GitHub Action tests are mandatory. For bug fixes, they are strongly encouraged.
 * For new protocols, platforms, or major modules, we will ask for documentation, as a wiki page.
 * Doxygen comments are strongly encouraged.
-* Ensure that all contributed files have a valid copyright statement, open-source license, and follow the required code style and naming conventions (see [doc:code-style]). Adhere to ISO C99 in all C language source files.
+* Ensure that all contributed files have a valid copyright statement, open-source license, and follow the required code style and naming conventions (see [doc:code-style]). Adhere to the subset of ISO C11 that is supported in GCC 4.7 in all C language source files.
 * Write a descriptive pull request message. Explain the advantages and disadvantages of your proposed changes.
 * If your PR introduces changes that need reflected in some pages in the wiki, make sure to point out which wiki pages are affected as part of your PR message. Providing updated text for those pages is always welcome.
  

--- a/doc/project/Release-Notes-next.md
+++ b/doc/project/Release-Notes-next.md
@@ -1,6 +1,7 @@
 # Press release
 
-We are releasing version 5.0 of Contiki-NG. This release adds XXX.
+We are releasing version 5.0 of Contiki-NG. This release adds C11 support,
+XXX.
 
 ## Find out more at:
 
@@ -13,7 +14,6 @@ We are releasing version 5.0 of Contiki-NG. This release adds XXX.
 
 * Contiki-NG tag on Stack Overflow: https://stackoverflow.com/questions/tagged/contiki-ng
 * Github Discussions: https://github.com/contiki-ng/contiki-ng/discussions
-* Gitter: https://gitter.im/contiki-ng
 * Twitter: https://twitter.com/contiki_ng
 
 The Contiki-NG team


### PR DESCRIPTION
GCC 5.5 and later default to -std=gnu11, and
only MSP430-based targets are compiled with
an older GCC. There is partial C11 support
in GCC 4.7.x though, so enable that on all
platforms.

In practice, this means generic code is
limited to the C11 features supported
by GCC 4.7.x, but platform specific
code for non-MSP430-based targets can use
any feature available in C11.