### PR TITLE
assert.h: provide static_assert macro

### DIFF
--- a/os/lib/assert.h
+++ b/os/lib/assert.h
@@ -57,4 +57,12 @@ void _xassert(const char *, int) CC_NORETURN;
 #define __CTASSERT(x, y)        typedef char __assert ## y[(x) ? 1 : -1]
 #endif
 
+/* Provide static_assert macro in C11-C17. */
+#if __STDC_VERSION__ >= 201112L && __STDC_VERSION__ < 202311L && \
+  !defined __cplusplus
+#ifndef static_assert
+#define static_assert _Static_assert
+#endif
+#endif
+
 #endif /* ASSERT_H_ */


### PR DESCRIPTION
Since Contiki-NG provides its own assert.h,
provide the static_assert macro for C11-C17
in that file.