### PR TITLE
CCM*: Revise sanity checks

### DIFF
--- a/os/lib/ccm-star.c
+++ b/os/lib/ccm-star.c
@@ -47,9 +47,6 @@
     | ((((mic_len) - 2u) >> 1) << 3) \
     | 1u)
 #define CCM_STAR_ENCRYPTION_FLAGS 1
-/* The auth data can have a variable length, but this implementation supports
- * only the case of 0 < l(a) < (2^16 - 2^8) */
-#define MAX_A_LEN 0xfeff
 /* Valid values are 4, 6, 8, 10, 12, 14, and 16 octets */
 #define MIC_LEN_VALID(x) ((x) >= 4 && (x) <= 16 && (x) % 2 == 0)
 
@@ -155,7 +152,7 @@ aead(const uint8_t* nonce,
     uint8_t *result, uint8_t mic_len,
     int forward)
 {
-  if(a_len > MAX_A_LEN || !MIC_LEN_VALID(mic_len)) {
+  if(!MIC_LEN_VALID(mic_len)) {
     return;
   }
 


### PR DESCRIPTION
This PR revises both sanity checks in the `aead` function. One of them presumably remained from an older version. The other hinders the reuse of the implementation. The changes build upon #2754.