### PR TITLE
nrf-clock: only request etimer poll when an etimer has expired

### DIFF
--- a/arch/cpu/nrf/sys/clock-arch.c
+++ b/arch/cpu/nrf/sys/clock-arch.c
@@ -51,6 +51,11 @@
 #include "nrfx_rtc.h"
 #include "nrfx_clock.h"
 
+#if CLOCK_SIZE != 4
+/* 64 bit variables may not be read atomically without extra handling */
+#error CLOCK_CONF_SIZE must be 4 (32 bit)
+#endif
+
 #ifdef NRF_CLOCK_CONF_RTC_INSTANCE
 #define NRF_CLOCK_RTC_INSTANCE NRF_CLOCK_CONF_RTC_INSTANCE
 #else
@@ -61,10 +66,10 @@
 /**< RTC instance used for platform clock */
 static const nrfx_rtc_t rtc = NRFX_RTC_INSTANCE(NRF_CLOCK_RTC_INSTANCE);
 /*---------------------------------------------------------------------------*/
-static volatile uint32_t ticks;
+static volatile clock_time_t ticks;
 void clock_update(void);
 /*---------------------------------------------------------------------------*/
-static void 
+static void
 clock_handler(nrfx_clock_evt_type_t event)
 {
   (void) event;
@@ -82,7 +87,7 @@ rtc_handler(nrfx_rtc_int_type_t int_type)
   }
 }
 /*---------------------------------------------------------------------------*/
-/** 
+/**
  * @brief Function starting the internal LFCLK XTAL oscillator.
  */
 static void
@@ -137,7 +142,7 @@ clock_init(void)
 clock_time_t
 clock_time(void)
 {
-  return (clock_time_t)(ticks & 0xFFFFFFFF);
+  return ticks;
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -152,7 +157,7 @@ clock_update(void)
 unsigned long
 clock_seconds(void)
 {
-  return (unsigned long)ticks / CLOCK_CONF_SECOND;
+  return (unsigned long)(ticks / CLOCK_SECOND);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/cpu/nrf/sys/clock-arch.c
+++ b/arch/cpu/nrf/sys/clock-arch.c
@@ -62,12 +62,13 @@
 #define NRF_CLOCK_RTC_INSTANCE 0
 #endif
 
+static void clock_update(void);
+
 /*---------------------------------------------------------------------------*/
 /**< RTC instance used for platform clock */
 static const nrfx_rtc_t rtc = NRFX_RTC_INSTANCE(NRF_CLOCK_RTC_INSTANCE);
 /*---------------------------------------------------------------------------*/
 static volatile clock_time_t ticks;
-void clock_update(void);
 /*---------------------------------------------------------------------------*/
 static void
 clock_handler(nrfx_clock_evt_type_t event)
@@ -145,11 +146,11 @@ clock_time(void)
   return ticks;
 }
 /*---------------------------------------------------------------------------*/
-void
+static void
 clock_update(void)
 {
   ticks++;
-  if(etimer_pending()) {
+  if(etimer_pending() && !CLOCK_LT(ticks, etimer_next_expiration_time())) {
     etimer_request_poll();
   }
 }

--- a/arch/cpu/nrf/sys/clock-arch.c
+++ b/arch/cpu/nrf/sys/clock-arch.c
@@ -163,9 +163,8 @@ clock_seconds(void)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start;
-  start = clock_time();
-  while(clock_time() - start < (clock_time_t)i) {
+  clock_time_t start = clock_time();
+  while(clock_time() - start < i) {
     __WFE();
   }
 }


### PR DESCRIPTION
This is an optimization in preparation for TrustZone support #2740 to avoid switching between secure and normal world for each clock tick.