### PR TITLE
CC2538: Avoid deadlock under jamming

### DIFF
--- a/arch/cpu/cc2538/dev/cc2538-rf.c
+++ b/arch/cpu/cc2538/dev/cc2538-rf.c
@@ -279,9 +279,6 @@ get_iq_lsbs(radio_value_t *value)
   /* Wait on RSSI_VALID */
   while((REG(RFCORE_XREG_RSSISTAT) & RFCORE_XREG_RSSISTAT_RSSI_VALID) == 0);
 
-  /* Wait until the channel seems clear for better randomness */
-  while(!(REG(RFCORE_XREG_FSMSTAT1) & RFCORE_XREG_FSMSTAT1_CCA));
-
   /* Read I/Q LSBs */
   *value = REG(RFCORE_XREG_RFRND)
       & (RFCORE_XREG_RFRND_IRND | RFCORE_XREG_RFRND_QRND);


### PR DESCRIPTION
This changes `get_iq_lsbs` to not wait until the channel is clear before reading I/Q LSBs. This is because the boot process otherwise gets stuck under jamming and moreover wastes much energy.