### PR TITLE
Makefile.include: fix for ARM GCC 13

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -164,8 +164,15 @@ ifneq ($(MAKECMDGOALS),clean)
   ifeq ("$(CC)","arm-none-eabi-gcc")
     # Silence some warnings when using GCC 12.
     ifeq (12,$(GCC_MAJOR_VERSION))
-      # Disable -Warray-bounds false positives in GCC 12, GCC 13 has better
-      # precision (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578).
+      # Disable -Warray-bounds false positives.
+      CFLAGS += --param=min-pagesize=0
+      # FIXME: Investigate if the warning can be re-enabled.
+      # https://www.redhat.com/en/blog/linkers-warnings-about-executable-stacks-and-segments
+      LDFLAGS += -Wl,--no-warn-rwx-segments
+    endif
+    ifeq (13,$(GCC_MAJOR_VERSION))
+      # Disable -Warray-bounds false positives. Supposed to be improved
+      # in GCC 13 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578).
       CFLAGS += --param=min-pagesize=0
       # FIXME: Investigate if the warning can be re-enabled.
       # https://www.redhat.com/en/blog/linkers-warnings-about-executable-stacks-and-segments


### PR DESCRIPTION
Disable the same warnings for ARM GCC 13
as for 12, and update the comments to reflect
the still insufficient precision of
the underlying analysis.