### PR TITLE
cooja: stop calling eeprom_init

### DIFF
--- a/arch/platform/cooja/dev/eeprom.c
+++ b/arch/platform/cooja/dev/eeprom.c
@@ -40,12 +40,6 @@ int simEEPROMRead = 0;
 int simEEPROMWritten = 0;
 
 bool
-eeprom_init(void)
-{
-  return true;
-}
-
-bool
 eeprom_read(eeprom_addr_t addr, unsigned char *buf, size_t len)
 {
   if(addr >= EEPROM_BUF_SIZE) {

--- a/arch/platform/cooja/platform.c
+++ b/arch/platform/cooja/platform.c
@@ -116,8 +116,6 @@ platform_init_stage_two()
 void
 platform_init_stage_three()
 {
-  /* Initialize eeprom */
-  eeprom_init();
   /* Start serial process */
   serial_line_init();
 }


### PR DESCRIPTION
This is an empty function on the Cooja target,
so remove the function.