### PR TITLE
nullradio: remove no-op call

### DIFF
--- a/os/dev/nullradio.c
+++ b/os/dev/nullradio.c
@@ -27,8 +27,7 @@ transmit(unsigned short transmit_len)
 static int
 send(const void *payload, unsigned short payload_len)
 {
-  prepare(payload, payload_len);
-  return transmit(payload_len);
+  return RADIO_TX_OK;
 }
 /*---------------------------------------------------------------------------*/
 static int


### PR DESCRIPTION
The prepare function does not do anything,
so remove the call to it.