### PR TITLE
ringbufindex: remove sign check warning

### DIFF
--- a/os/lib/ringbufindex.c
+++ b/os/lib/ringbufindex.c
@@ -101,7 +101,7 @@ ringbufindex_get(struct ringbufindex *r)
      be atomic. We use an uint8_t type, which makes access atomic on
      most platforms, but C does not guarantee this.
    */
-  if(((r->put_ptr - r->get_ptr) & r->mask) > 0) {
+  if(((r->put_ptr - r->get_ptr) & r->mask) != 0) {
     get_ptr = r->get_ptr;
     r->get_ptr = (r->get_ptr + 1) & r->mask;
     return get_ptr;
@@ -117,7 +117,7 @@ ringbufindex_peek_get(const struct ringbufindex *r)
   /* Check if there are bytes in the buffer. If so, we return the
      first one. If there are no bytes left, we return -1.
    */
-  if(((r->put_ptr - r->get_ptr) & r->mask) > 0) {
+  if(((r->put_ptr - r->get_ptr) & r->mask) != 0) {
     return r->get_ptr;
   } else {
     return -1;


### PR DESCRIPTION
CodeQL flags sign checks of bitwise operations,
and suggests comparing with != 0 instead of > 0.
Since all the types are unsigned, that should
give the same result, but without CodeQL warnings.