### PR TITLE
CodeQL: filter out unimportant warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -110,6 +110,8 @@ jobs:
       uses: advanced-security/filter-sarif@v1
       with:
         patterns: |
+          -**:cpp/complex-block/*
+          -**:cpp/fixme-comment/*
           -**:cpp/path-injection
           -**:cpp/world-writable-file-creation
           -**:cpp/poorly-documented-function
@@ -118,6 +120,7 @@ jobs:
           -**:cpp/integer-multiplication-cast-to-long
           -**:cpp/comparison-with-wider-type
           -**:cpp/leap-year/*
+          -**:cpp/long-switch/*
           -**:cpp/ambiguously-signed-bit-field
           -**:cpp/suspicious-pointer-scaling
           -**:cpp/suspicious-pointer-scaling-void


### PR DESCRIPTION
These just create noise in the security tab.