### PR TITLE
antelope-shell: cast void argument

### DIFF
--- a/examples/storage/antelope-shell/shell-db.c
+++ b/examples/storage/antelope-shell/shell-db.c
@@ -58,7 +58,7 @@ PROCESS_THREAD(db_shell, ev, data)
   for(;;) {
     PROCESS_WAIT_EVENT_UNTIL(ev == serial_line_event_message && data != NULL);
 
-    result = db_query(&handle, "%s", data);
+    result = db_query(&handle, "%s", (char *)data);
     if(DB_ERROR(result)) {
       printf("Query \"%s\" failed: %s\n",
              (char *)data, db_get_result_message(result));


### PR DESCRIPTION
This is similar to the cast required
for printf a couple of lines below.