### PR TITLE
CodeQL: decrease retention-days

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -143,4 +143,4 @@ jobs:
       with:
         name: codeql-results
         path: ${{ steps.step1.outputs.sarif-output }}
-        retention-days: 14
+        retention-days: 2


### PR DESCRIPTION
The reports in Security are created from
the results of this workflow, the reports
are not a display of the sarif file itself.

Decrease the retention days for the sarif
file since there is no direct use of it.