### PR TITLE
mqtt: remove sign check warning

### DIFF
--- a/os/net/app-layer/mqtt/mqtt.c
+++ b/os/net/app-layer/mqtt/mqtt.c
@@ -1171,7 +1171,7 @@ handle_publish(struct mqtt_connection *conn)
 
   DBG("MQTT - This chunk is %i bytes\n", conn->in_publish_msg.payload_chunk_length);
 
-  if(((conn->in_packet.fhdr & 0x09) >> 1) > 0) {
+  if(((conn->in_packet.fhdr & 0x09) >> 1) != 0) {
     PRINTF("MQTT - Error, got incoming PUBLISH with QoS > 0, not supported atm!\n");
   }
 


### PR DESCRIPTION
CodeQL flags sign checks of bitwise operations,
and suggests comparing with != 0 instead of > 0.
Since all the types are unsigned, that should
give the same result, but without CodeQL warnings