### PR TITLE
udp-socket: only memcpy when required

### DIFF
--- a/os/net/ipv6/udp-socket.c
+++ b/os/net/ipv6/udp-socket.c
@@ -167,7 +167,7 @@ PROCESS_THREAD(udp_socket_process, ev, data)
 
         /* If we were called because of incoming data, we should call
            the reception callback. */
-        if(uip_newdata()) {
+        if(uip_newdata() && c->input_callback != NULL) {
           /* Copy the data from the uIP data buffer into our own
              buffer to avoid the uIP buffer being messed with by the
              callee. */
@@ -176,16 +176,14 @@ PROCESS_THREAD(udp_socket_process, ev, data)
           /* Call the client process. We use the PROCESS_CONTEXT
              mechanism to temporarily switch process context to the
              client process. */
-          if(c->input_callback != NULL) {
-            PROCESS_CONTEXT_BEGIN(c->p);
-            c->input_callback(c, c->ptr,
-                              &(UIP_IP_BUF->srcipaddr),
-                              UIP_HTONS(UIP_UDP_BUF->srcport),
-                              &(UIP_IP_BUF->destipaddr),
-                              UIP_HTONS(UIP_UDP_BUF->destport),
-                              buf, uip_datalen());
-            PROCESS_CONTEXT_END();
-          }
+          PROCESS_CONTEXT_BEGIN(c->p);
+          c->input_callback(c, c->ptr,
+                            &(UIP_IP_BUF->srcipaddr),
+                            UIP_HTONS(UIP_UDP_BUF->srcport),
+                            &(UIP_IP_BUF->destipaddr),
+                            UIP_HTONS(UIP_UDP_BUF->destport),
+                            buf, uip_datalen());
+          PROCESS_CONTEXT_END();
         }
       }
     }


### PR DESCRIPTION
The buffer is only used when there is a callback,
so only perform the memcpy under the same
circumstances.