### PR TITLE
Dockerfile: handle orphans properly

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -24,6 +24,7 @@ USER root
 # python3: used by scripts.
 # snmp: used by the regression tests.
 # sudo: used by the regression tests.
+# tini: needed for cleaning up orphaned processes.
 # udev: needed for jlink deb postinst script.
 # unzip: required during docker image build for software installation.
 # valgrind: used by the regression tests.
@@ -57,6 +58,7 @@ RUN apt-get -qq update && \
     sudo \
     screen \
     srecord \
+    tini \
     udev \
     unzip \
     libusb-1.0-0 \

--- a/tools/docker/files/remap-user.sh
+++ b/tools/docker/files/remap-user.sh
@@ -9,4 +9,4 @@ GROUP_ID=${LOCAL_GID:-1000}
 
 [[ "$USER_ID" == "1000" ]] || usermod -u $USER_ID -o -m -d /home/user user
 [[ "$GROUP_ID" == "1000" ]] || groupmod -g $GROUP_ID user
-exec /usr/sbin/gosu user "$@"
+exec /usr/bin/tini -- /usr/sbin/gosu user "$@"


### PR DESCRIPTION
Use tini as init process so orphans
are handled properly on SIGINT/SIGTERM.