### PR TITLE
heapmem: keep track of peak heap usage

### DIFF
--- a/os/lib/heapmem.c
+++ b/os/lib/heapmem.c
@@ -367,10 +367,10 @@ heapmem_zone_register(const char *name, size_t zone_size)
  * a pointer to it in case of success, and NULL in case of failure.
  *
  * When allocating memory, heapmem_alloc() will first try to find a
- * free chunk of the same size and the requested one. If none can be
+ * free chunk of the same size as the requested one. If none can be
  * find, we pick a larger chunk that is as close in size as possible,
  * and possibly split it so that the remaining part becomes a chunk
- * available for allocation.  At most CHUNK_SEARCH_MAX chunks on the
+ * available for allocation. At most CHUNK_SEARCH_MAX chunks on the
  * free list will be examined.
  *
  * As a last resort, heapmem_alloc() will try to extend the heap
@@ -424,7 +424,6 @@ heapmem_zone_alloc(heapmem_zone_t zone, size_t size)
   zones[zone].allocated += sizeof(chunk_t) + size;
 
   return GET_PTR(chunk);
-
 }
 
 /*
@@ -474,14 +473,14 @@ heapmem_free(void *ptr)
 /*
  * heapmem_realloc: Reallocate an object with a different size,
  * possibly moving it in memory. In case of success, the function
- * returns a pointer to the objects new location. In case of failure,
+ * returns a pointer to the object's new location. In case of failure,
  * it returns NULL.
  *
  * If the size of the new chunk is larger than that of the allocated
  * chunk, heapmem_realloc() will first attempt to extend the currently
- * allocated chunk. If that memory is not free, heapmem_ralloc() will
- * attempt to allocate a completely new chunk, copy the old data to
- * the new chunk, and deallocate the old chunk.
+ * allocated chunk. If the adjacent memory is not free,
+ * heapmem_realloc() will attempt to allocate a completely new chunk,
+ * copy the old data to the new chunk, and deallocate the old chunk.
  *
  * If the size of the new chunk is smaller than the allocated one, we
  * split the allocated chunk if the remaining chunk would be large
@@ -545,7 +544,7 @@ heapmem_realloc(void *ptr, size_t size)
   /* Request to make the object larger. (size_adj > 0) */
   if(IS_LAST_CHUNK(chunk)) {
     /*
-     * If the object is within the last allocated chunk (i.e., the
+     * If the object belongs to the last allocated chunk (i.e., the
      * one before the end of the heap footprint, we just attempt to
      * extend the heap.
      */
@@ -588,7 +587,7 @@ heapmem_realloc(void *ptr, size_t size)
 }
 #endif /* HEAPMEM_REALLOC */
 
-/* heapmem_stats: Calculate statistics regarding memory usage. */
+/* heapmem_stats: Provides statistics regarding heap memory usage. */
 void
 heapmem_stats(heapmem_stats_t *stats)
 {
@@ -611,7 +610,7 @@ heapmem_stats(heapmem_stats_t *stats)
   stats->chunks = stats->overhead / sizeof(chunk_t);
 }
 
-/* heapmem_alignment: return the minimum alignment of allocated addresses. */
+/* heapmem_alignment: Returns the minimum alignment of allocated addresses. */
 size_t
 heapmem_alignment(void)
 {

--- a/os/lib/heapmem.c
+++ b/os/lib/heapmem.c
@@ -168,6 +168,7 @@ typedef struct chunk {
    statically allocated with a configurable size. */
 static char heap_base[HEAPMEM_ARENA_SIZE] CC_ALIGN(HEAPMEM_ALIGNMENT);
 static size_t heap_usage;
+static size_t max_heap_usage;
 
 static chunk_t *first_chunk = (chunk_t *)heap_base;
 static chunk_t *free_list;
@@ -187,6 +188,9 @@ extend_space(size_t size)
 
   char *old_usage = &heap_base[heap_usage];
   heap_usage += size;
+  if(heap_usage > max_heap_usage) {
+    max_heap_usage = heap_usage;
+  }
 
   return old_usage;
 }
@@ -603,6 +607,7 @@ heapmem_stats(heapmem_stats_t *stats)
   }
   stats->available += HEAPMEM_ARENA_SIZE - heap_usage;
   stats->footprint = heap_usage;
+  stats->max_footprint = max_heap_usage;
   stats->chunks = stats->overhead / sizeof(chunk_t);
 }
 

--- a/os/lib/heapmem.h
+++ b/os/lib/heapmem.h
@@ -89,6 +89,7 @@ typedef struct heapmem_stats {
   size_t overhead;
   size_t available;
   size_t footprint;
+  size_t max_footprint;
   size_t chunks;
 } heapmem_stats_t;
 /*****************************************************************************/

--- a/os/lib/heapmem.h
+++ b/os/lib/heapmem.h
@@ -119,7 +119,7 @@ heapmem_zone_t heapmem_zone_register(const char *name, size_t zone_size);
 
 void *heapmem_alloc_debug(size_t size,
 			  const char *file, const unsigned line);
-void *heapmem_zone_alloc_debug(heapmem_zone_t, size_t size,
+void *heapmem_zone_alloc_debug(heapmem_zone_t zone, size_t size,
 			  const char *file, const unsigned line);
 void *heapmem_realloc_debug(void *ptr, size_t size,
 			    const char *file, const unsigned line);
@@ -198,7 +198,6 @@ bool heapmem_free(void *ptr);
  * the amount of memory allocated, overhead used for memory management,
  * and the number of chunks allocated. By using this information, developers
  * can tune their software to use the heapmem allocator more efficiently.
- *
  */
 
 void heapmem_stats(heapmem_stats_t *stats);

--- a/tests/08-native-runs/12-heapmem/test-heapmem.c
+++ b/tests/08-native-runs/12-heapmem/test-heapmem.c
@@ -168,20 +168,28 @@ UNIT_TEST(max_alloc)
 
   heapmem_stats_t stats_before;
   heapmem_stats(&stats_before);
+  printf("Old max footprint: %zu\n", stats_before.max_footprint);
 
   /* The test uses a much smaller size than the theoretical maximum because
      the heapmem module is not yet supporting such large allocations. */
-  printf("Allocate %zu bytes\n", stats_before.available / 2);
-  char *ptr = heapmem_alloc(stats_before.available / 2);
+  size_t test_alloc_size = stats_before.available / 2;
+  printf("Allocate %zu bytes\n", test_alloc_size);
+  char *ptr = heapmem_alloc(test_alloc_size);
 
   UNIT_TEST_ASSERT(ptr != NULL);
   UNIT_TEST_ASSERT(heapmem_free(ptr) == true);
 
   heapmem_stats_t stats_after;
   heapmem_stats(&stats_after);
+  printf("New max footprint: %zu\n", stats_after.max_footprint);
 
-  UNIT_TEST_ASSERT(memcmp(&stats_before, &stats_after,
-                          sizeof(heapmem_stats_t)) == 0);
+  UNIT_TEST_ASSERT(stats_before.allocated == stats_after.allocated);
+  UNIT_TEST_ASSERT(stats_before.overhead == stats_after.overhead);
+  UNIT_TEST_ASSERT(stats_before.available == stats_after.available);
+  UNIT_TEST_ASSERT(stats_before.footprint == stats_after.footprint);
+  UNIT_TEST_ASSERT(stats_before.max_footprint < stats_after.max_footprint);
+  UNIT_TEST_ASSERT(stats_before.chunks == stats_after.chunks);
+  UNIT_TEST_ASSERT(stats_after.max_footprint >= test_alloc_size);
 
   UNIT_TEST_END();
 }
@@ -239,14 +247,15 @@ UNIT_TEST(stats_check)
   heapmem_stats(&stats);
 
   printf("* allocated %zu\n* overhead %zu\n* available %zu\n"
-	 "* footprint %zu\n* chunks %zu\n",
+	 "* footprint %zu\n* max footprint %zu\n* chunks %zu\n",
          stats.allocated, stats.overhead, stats.available,
-         stats.footprint, stats.chunks);
+         stats.footprint, stats.max_footprint, stats.chunks);
 
   UNIT_TEST_ASSERT(stats.allocated == 0);
   UNIT_TEST_ASSERT(stats.overhead == 0);
   UNIT_TEST_ASSERT(stats.available == HEAPMEM_CONF_ARENA_SIZE);
   UNIT_TEST_ASSERT(stats.footprint == 0);
+  UNIT_TEST_ASSERT(stats.max_footprint > stats.available / 2);
   UNIT_TEST_ASSERT(stats.chunks == 0);
 
   UNIT_TEST_END();


### PR DESCRIPTION
Beside keeping track of the peak heap usage, this PR also includes an extended test for the maximum heap usage, and some minor style and documentation fixes.