### PR TITLE
uip6: Avoid duplicate processing of HBH extension header options

### DIFF
--- a/os/net/ipv6/uip6.c
+++ b/os/net/ipv6/uip6.c
@@ -1355,14 +1355,18 @@ uip_process(uint8_t flag)
         uip_ext_bitmap |= UIP_EXT_HDR_BITMAP_HBHO;
       }
 #endif /*UIP_CONF_IPV6_CHECKS*/
-      switch(ext_hdr_options_process(next_header)) {
-      case 0:
-        break; /* done */
-      case 1:
-        goto drop; /* silently discard */
-      case 2:
-        goto send; /* send icmp error message (created in
-                      ext_hdr_options_process) and discard */
+      /* HBH options should have been processed already if
+         UIP_CONF_ROUTER != 0. */
+      if(!UIP_CONF_ROUTER) {
+        switch(ext_hdr_options_process(next_header)) {
+        case 0:
+          break; /* done */
+        case 1:
+          goto drop; /* silently discard */
+        case 2:
+          goto send; /* send icmp error message (created in
+                        ext_hdr_options_process) and discard */
+        }
       }
       break;
     case UIP_PROTO_DESTO:

--- a/tests/15-rpl-classic/js/12-rpl-rank-error.js
+++ b/tests/15-rpl-classic/js/12-rpl-rank-error.js
@@ -5,13 +5,11 @@ while(true) {
 
   if(msg.contains("RPL Option Error: Dropping Packet")) {
     log.log(time + " " + "node-" + id + " "+ msg + "\n");
-    // FIXME Logic inverted to showcase issue. Revert when implementing fix.
-    log.testOK();
+    log.testFailed();
   }
 
   if(msg.contains("Received all packets")) {
     log.log(time + " " + "node-" + id + " "+ msg + "\n");
-    // FIXME Logic inverted to showcase issue. Revert when implementing fix.
-    log.testFailed();
+    log.testOK();
   }
 }


### PR DESCRIPTION
This is an alternative fix for the workaround of the problem with duplicate extension header processing.

References: PR #2446 and issue #2285.