### PR TITLE
cc.h: move static_assert from lib/assert.h

### DIFF
--- a/os/lib/assert.h
+++ b/os/lib/assert.h
@@ -57,12 +57,4 @@ void _xassert(const char *, int) CC_NORETURN;
 #define __CTASSERT(x, y)        typedef char __assert ## y[(x) ? 1 : -1]
 #endif
 
-/* Provide static_assert macro in C11-C17. */
-#if __STDC_VERSION__ >= 201112L && __STDC_VERSION__ < 202311L && \
-  !defined __cplusplus
-#ifndef static_assert
-#define static_assert _Static_assert
-#endif
-#endif
-
 #endif /* ASSERT_H_ */

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -181,4 +181,12 @@
 #define CC_CONCAT3(s1, s2, s3) s1##s2##s3
 #define CC_CONCAT_EXT_3(s1, s2, s3) CC_CONCAT3(s1, s2, s3)
 
+/* Provide static_assert macro in C11-C17. */
+#if __STDC_VERSION__ >= 201112L && __STDC_VERSION__ < 202311L && \
+  !defined __cplusplus
+#ifndef static_assert
+#define static_assert _Static_assert
+#endif
+#endif
+
 #endif /* CC_H_ */


### PR DESCRIPTION
This avoids the risk of circular includes when using static_assert() in certain header files.