### PR TITLE
Allow disabling CoAP well known resource

### DIFF
--- a/os/net/app-layer/coap/coap-conf.h
+++ b/os/net/app-layer/coap/coap-conf.h
@@ -112,5 +112,10 @@
 #define COAP_OBSERVER_URL_LEN 20
 #endif
 
+/* Enable the well-known resource (well-known/core) by default */
+#ifndef COAP_WELL_KNOWN_RESOURCE_ENABLED
+#define COAP_WELL_KNOWN_RESOURCE_ENABLED  1
+#endif
+
 #endif /* COAP_CONF_H_ */
 /** @} */

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -134,8 +134,10 @@ call_service(coap_message_t *request, coap_message_t *response,
 /*- Server Part -------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
-/* the discover resource is automatically included for CoAP */
+#if COAP_WELL_KNOWN_RESOURCE_ENABLED
+/* The discover resource is included by default for CoAP */
 extern coap_resource_t res_well_known_core;
+#endif
 
 /*---------------------------------------------------------------------------*/
 /*- Internal API ------------------------------------------------------------*/
@@ -380,7 +382,9 @@ coap_engine_init(void)
   list_init(coap_handlers);
   list_init(coap_resource_services);
 
+#if COAP_WELL_KNOWN_RESOURCE_ENABLED
   coap_activate_resource(&res_well_known_core, ".well-known/core");
+#endif
 
   coap_transport_init();
   coap_init_connection();


### PR DESCRIPTION
As in title. The resource is still enabled by default. Disabling saves almost 500 bytes code space on cc13xx-cc26xx. 