### PR TITLE
Cooja platform: append to CONTIKI_TARGET_SOURCEFILES rather than set them

### DIFF
--- a/arch/platform/cooja/Makefile.cooja
+++ b/arch/platform/cooja/Makefile.cooja
@@ -67,7 +67,7 @@ COOJA_INTFS	= beep.c ip.c leds-arch.c moteid.c \
 COOJA_CORE = platform.c mtype.c random.c sensors.c leds.c gpio-hal-arch.c buttons.c
 
 # (COOJA_SOURCEFILES contains additional sources set from simulator)
-CONTIKI_TARGET_SOURCEFILES = \
+CONTIKI_TARGET_SOURCEFILES += \
 $(COOJA_BASE) $(COOJA_INTFS) $(COOJA_CORE) $(COOJA_NET) $(COOJA_SOURCEFILES)
 
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)


### PR DESCRIPTION
Other Contiki-NG platforms add to `CONTIKI_TARGET_SOURCEFILES`  in their own Makefile.

Cooja simply sets the variable `CONTIKI_TARGET_SOURCEFILES`. 

This breaks user application code that sets `CONTIKI_TARGET_SOURCEFILES` from the application Makefiles.