### PR TITLE
Makefile.include: fix missing quotes

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -496,7 +496,7 @@ clean:
 	$(Q)rm -rf $(BUILD_DIR_TARGET)
 
 distclean:
-	$(Q)[ $(TARGETDIRS) = "" ] || for TARG in `ls $(TARGETDIRS)`; do \
+	$(Q)[ "$(TARGETDIRS)" = "" ] || for TARG in `ls $(TARGETDIRS)`; do \
 		$(MAKE) TARGET=$$TARG clean; \
 	done
 	$(Q)rm -rf $(BUILD_DIR)


### PR DESCRIPTION
This fixes:

$ make distclean
TARGET not defined, using target 'native'
/bin/sh: 1: [: =: unexpected operator

discovered by @kkrentz.