### PR TITLE
doxygen: Move crypto-related files to the crypto group

### DIFF
--- a/os/lib/aes-128.c
+++ b/os/lib/aes-128.c
@@ -37,6 +37,8 @@
  */
 
 /**
+ * \addtogroup crypto
+ * @{
  * \file
  *         Wrapped AES-128 implementation from Texas Instruments.
  * \author
@@ -188,3 +190,5 @@ const struct aes_128_driver aes_128_driver = {
   encrypt
 };
 /*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/os/lib/aes-128.h
+++ b/os/lib/aes-128.h
@@ -31,6 +31,8 @@
  */
 
 /**
+ * \addtogroup crypto
+ * @{
  * \file
  *         AES-128.
  * \author
@@ -70,3 +72,5 @@ struct aes_128_driver {
 extern const struct aes_128_driver AES_128;
 
 #endif /* AES_128_H_ */
+
+/** @} */

--- a/os/lib/ccm-star.c
+++ b/os/lib/ccm-star.c
@@ -31,6 +31,8 @@
  */
 
 /**
+ * \addtogroup crypto
+ * @{
  * \file
  *         AES_128-based CCM* implementation.
  * \author
@@ -178,3 +180,5 @@ const struct ccm_star_driver ccm_star_driver = {
   aead
 };
 /*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/os/lib/ccm-star.h
+++ b/os/lib/ccm-star.h
@@ -31,6 +31,8 @@
  */
 
 /**
+ * \addtogroup crypto
+ * @{
  * \file
  *         CCM* header file.
  * \author
@@ -83,3 +85,5 @@ extern const struct ccm_star_driver ccm_star_driver;
 extern const struct ccm_star_driver CCM_STAR;
 
 #endif /* CCM_STAR_H_ */
+
+/** @} */

--- a/os/lib/csprng.c
+++ b/os/lib/csprng.c
@@ -31,15 +31,12 @@
  */
 
 /**
+ * \addtogroup csprng
+ * @{
  * \file
  *         An OFB-AES-128-based CSPRNG.
  * \author
  *         Konrad Krentz <konrad.krentz@gmail.com>
- */
-
-/**
- * \addtogroup csprng
- * @{
  */
 
 #include "lib/csprng.h"

--- a/os/lib/csprng.h
+++ b/os/lib/csprng.h
@@ -31,27 +31,22 @@
  */
 
 /**
+ * \addtogroup lib
+ * @{
+ *
+ * \defgroup crypto Cryptographic primitives
+ * @{
+ *
+ * \defgroup csprng Cryptographically-secure PRNG
+ * In contrast to a normal PRNG, a CSPRNG generates a stream of pseudo-random
+ * numbers that is indistinguishable from the uniform distribution to a
+ * computationally-bounded adversary who does not know the seed.
+ * @{
+ *
  * \file
  *         An OFB-AES-128-based CSPRNG.
  * \author
  *         Konrad Krentz <konrad.krentz@gmail.com>
- */
-
-/**
- * \addtogroup lib
- * @{
- */
-
-/**
- * \defgroup csprng Cryptographically-secure PRNG
- *
- * \brief Expands a truly random seed into a stream of pseudo-random numbers.
- *
- * In contrast to a normal PRNG, a CSPRNG generates a stream of pseudo-random
- * numbers that is indistinguishable from the uniform distribution to a
- * computationally-bounded adversary who does not know the seed.
- *
- * @{
  */
 
 #ifndef CSPRNG_H_
@@ -111,5 +106,6 @@ bool csprng_rand(uint8_t *result, unsigned len);
 
 #endif /* CSPRNG_H_ */
 
+/** @} */
 /** @} */
 /** @} */

--- a/os/lib/sha-256.c
+++ b/os/lib/sha-256.c
@@ -25,6 +25,13 @@
  * SUCH DAMAGE.
  */
 
+/**
+ * \addtogroup crypto
+ * @{
+ * \file
+ * Software implementation of SHA-256.
+ */
+
 #include "lib/sha-256.h"
 #include "net/ipv6/uip.h"
 #include "sys/cc.h"
@@ -459,3 +466,5 @@ const struct sha_256_driver sha_256_driver = {
   sha_256_hash,
 };
 /*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/os/lib/sha-256.h
+++ b/os/lib/sha-256.h
@@ -31,6 +31,8 @@
  */
 
 /**
+ * \addtogroup crypto
+ * @{
  * \file
  *         Platform-independent SHA-256 API.
  * \author
@@ -165,3 +167,5 @@ void sha_256_hkdf(const uint8_t *salt, size_t salt_len,
       uint8_t *okm, uint_fast16_t okm_len);
 
 #endif /* SHA_256_H_ */
+
+/** @} */


### PR DESCRIPTION
This PR moves crypto-related files into a common crypto group.