### PR TITLE
unit-test.ch: Enable tests to use protothread functions

### DIFF
--- a/os/services/unit-test/unit-test.c
+++ b/os/services/unit-test/unit-test.c
@@ -39,6 +39,8 @@
 
 #include "unit-test.h"
 
+struct pt unit_test_pt;
+
 /*---------------------------------------------------------------------------*/
 /**
  * Print the results of a unit test.


### PR DESCRIPTION
This PR turns unit test functions into protothreads. This allows unit tests to call protothreads and wait for them to finish.