### PR TITLE
CSPRNG: Use size_t

### DIFF
--- a/os/lib/csprng.c
+++ b/os/lib/csprng.c
@@ -50,14 +50,14 @@
 #define LOG_LEVEL LOG_LEVEL_NONE
 
 static struct csprng_seed seed;
-static unsigned read_state_bytes;
+static size_t read_state_bytes;
 static bool seeded;
 
 /*---------------------------------------------------------------------------*/
 void
 csprng_feed(struct csprng_seed *new_seed)
 {
-  uint8_t i;
+  size_t i;
 
   /*
    * By XORing the current seed with the new seed, the seed of this CSPRNG
@@ -78,9 +78,9 @@ csprng_feed(struct csprng_seed *new_seed)
 }
 /*---------------------------------------------------------------------------*/
 bool
-csprng_rand(uint8_t *result, unsigned len)
+csprng_rand(uint8_t *result, size_t len)
 {
-  unsigned pos;
+  size_t pos;
 
   if(!seeded) {
     return false;

--- a/os/lib/csprng.h
+++ b/os/lib/csprng.h
@@ -54,6 +54,7 @@
 
 #include "contiki.h"
 #include "lib/aes-128.h"
+#include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -102,7 +103,7 @@ void csprng_feed(struct csprng_seed *new_seed);
  *               Cycle Size of The Key Stream in Output Feedback Encipherment].
  * \return       Returns true on success and false otherwise.
  */
-bool csprng_rand(uint8_t *result, unsigned len);
+bool csprng_rand(uint8_t *result, size_t len);
 
 #endif /* CSPRNG_H_ */
 


### PR DESCRIPTION
This PR changes the CSPRNG to use size_t, which is more appropriate.