### PR TITLE
CoAP minor improvements

### DIFF
--- a/os/net/app-layer/coap/coap-block1.c
+++ b/os/net/app-layer/coap/coap-block1.c
@@ -89,13 +89,17 @@ coap_block1_handler(coap_message_t *request, coap_message_t *response,
 
   if(!pay_len || !payload) {
     coap_status_code = BAD_REQUEST_4_00;
+#if COAP_MESSAGE_ON_ERROR
     coap_error_message = "NoPayload";
+#endif
     return -1;
   }
 
   if(request->block1_offset + pay_len > max_len) {
     coap_status_code = REQUEST_ENTITY_TOO_LARGE_4_13;
+#if COAP_MESSAGE_ON_ERROR
     coap_error_message = "Message to big";
+#endif
     return -1;
   }
 

--- a/os/net/app-layer/coap/coap-conf.h
+++ b/os/net/app-layer/coap/coap-conf.h
@@ -117,5 +117,12 @@
 #define COAP_WELL_KNOWN_RESOURCE_ENABLED  1
 #endif
 
+/* Add a human readable message to payload if an error occurs */
+#ifdef COAP_CONF_MESSAGE_ON_ERROR
+#define COAP_MESSAGE_ON_ERROR   COAP_CONF_MESSAGE_ON_ERROR
+#else
+#define COAP_MESSAGE_ON_ERROR   1
+#endif
+
 #endif /* COAP_CONF_H_ */
 /** @} */

--- a/os/net/app-layer/coap/coap-conf.h
+++ b/os/net/app-layer/coap/coap-conf.h
@@ -113,7 +113,9 @@
 #endif
 
 /* Enable the well-known resource (well-known/core) by default */
-#ifndef COAP_WELL_KNOWN_RESOURCE_ENABLED
+#ifdef COAP_CONF_WELL_KNOWN_RESOURCE_ENABLED
+#define COAP_WELL_KNOWN_RESOURCE_ENABLED  COAP_CONF_WELL_KNOWN_RESOURCE_ENABLED
+#else
 #define COAP_WELL_KNOWN_RESOURCE_ENABLED  1
 #endif
 

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -204,7 +204,9 @@ coap_receive(const coap_endpoint_t *src,
         if(new_offset < 0) {
           LOG_DBG("Blockwise: block request offset overflow\n");
           coap_status_code = BAD_OPTION_4_02;
+#if COAP_MESSAGE_ON_ERROR
           coap_error_message = "BlockOutOfScope";
+#endif
           status = COAP_HANDLER_STATUS_CONTINUE;
         } else {
           /* call CoAP framework and check if found and allowed */
@@ -226,7 +228,9 @@ coap_receive(const coap_endpoint_t *src,
                 LOG_DBG("Block1 NOT IMPLEMENTED\n");
 
                 coap_status_code = NOT_IMPLEMENTED_5_01;
+#if COAP_MESSAGE_ON_ERROR
                 coap_error_message = "NoBlock1Support";
+#endif
 
                 /* client requested Block2 transfer */
               } else if(coap_is_option(message, COAP_OPTION_BLOCK2)) {
@@ -291,7 +295,9 @@ coap_receive(const coap_endpoint_t *src,
           }
       } else {
         coap_status_code = SERVICE_UNAVAILABLE_5_03;
+#if COAP_MESSAGE_ON_ERROR
         coap_error_message = "NoFreeTraBuffer";
+#endif
       } /* if(transaction buffer) */
 
       /* handle responses */
@@ -346,7 +352,11 @@ coap_receive(const coap_endpoint_t *src,
   } else {
     coap_message_type_t reply_type = COAP_TYPE_ACK;
 
+#if COAP_MESSAGE_ON_ERROR
     LOG_WARN("ERROR %u: %s\n", coap_status_code, coap_error_message);
+#else
+    LOG_WARN("ERROR %u\n", coap_status_code);
+#endif
     coap_clear_transaction(transaction);
 
     if(coap_status_code == PING_RESPONSE) {
@@ -359,8 +369,10 @@ coap_receive(const coap_endpoint_t *src,
     }
     coap_init_message(message, reply_type, coap_status_code,
                       message->mid);
+#if COAP_MESSAGE_ON_ERROR
     coap_set_payload(message, coap_error_message,
                      strlen(coap_error_message));
+#endif
     coap_sendto(src, payload, coap_serialize_message(message, payload));
   }
 

--- a/os/net/app-layer/coap/coap-separate.c
+++ b/os/net/app-layer/coap/coap-separate.c
@@ -69,7 +69,9 @@ coap_separate_reject()
 {
   /* TODO: Accept string pointer for custom error message */
   coap_status_code = SERVICE_UNAVAILABLE_5_03;
+#if COAP_MESSAGE_ON_ERROR
   coap_error_message = "AlreadyInUse";
+#endif
 }
 /*----------------------------------------------------------------------------*/
 /**

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -65,7 +65,9 @@
 static uint16_t current_mid = 0;
 
 coap_status_t coap_status_code = NO_ERROR;
+#if COAP_MESSAGE_ON_ERROR
 const char *coap_error_message = "";
+#endif
 /*---------------------------------------------------------------------------*/
 /*- Local helper functions --------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -396,7 +398,9 @@ coap_serialize_message(coap_message_t *coap_pkt, uint8_t *buffer)
   } else {
     /* an error occurred: caller must check for !=0 */
     coap_pkt->buffer = NULL;
+#if COAP_MESSAGE_ON_ERROR
     coap_error_message = "Serialized header exceeds COAP_MAX_HEADER_SIZE";
+#endif
     return 0;
   }
 
@@ -439,12 +443,16 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
   coap_pkt->mid = coap_pkt->buffer[2] << 8 | coap_pkt->buffer[3];
 
   if(coap_pkt->version != 1) {
+#if COAP_MESSAGE_ON_ERROR
     coap_error_message = "CoAP version must be 1";
+#endif
     return BAD_REQUEST_4_00;
   }
 
   if(coap_pkt->token_len > COAP_TOKEN_LEN) {
+#if COAP_MESSAGE_ON_ERROR
     coap_error_message = "Token Length must not be more than 8";
+#endif
     return BAD_REQUEST_4_00;
   }
 
@@ -602,8 +610,9 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
       LOG_DBG_COAP_STRING(coap_pkt->proxy_uri, coap_pkt->proxy_uri_len);
       LOG_DBG_("]\n");
 #endif /* COAP_PROXY_OPTION_PROCESSING */
-
-      coap_error_message = "This is a constrained server (Contiki)";
+#if COAP_MESSAGE_ON_ERROR
+      coap_error_message = "This is a constrained server (Contiki-NG)";
+#endif
       return PROXYING_NOT_SUPPORTED_5_05;
       break;
     case COAP_OPTION_PROXY_SCHEME:
@@ -614,7 +623,9 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
       LOG_DBG_COAP_STRING(coap_pkt->proxy_scheme, coap_pkt->proxy_scheme_len);
       LOG_DBG_("]\n");
 #endif
-      coap_error_message = "This is a constrained server (Contiki)";
+#if COAP_MESSAGE_ON_ERROR
+      coap_error_message = "This is a constrained server (Contiki-NG)";
+#endif
       return PROXYING_NOT_SUPPORTED_5_05;
       break;
 
@@ -710,7 +721,9 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
       LOG_DBG_("unknown (%u)\n", option_number);
       /* check if critical (odd) */
       if(option_number & 1) {
+#if COAP_MESSAGE_ON_ERROR
         coap_error_message = "Unsupported critical option";
+#endif
         return BAD_OPTION_4_02;
       }
     }

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -725,7 +725,7 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
 /*- CoAP Engine API ---------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 int
-coap_get_query_variable(coap_message_t *coap_pkt,
+coap_get_query_variable(const coap_message_t *coap_pkt,
                         const char *name, const char **output)
 {
   if(coap_is_option(coap_pkt, COAP_OPTION_URI_QUERY)) {
@@ -735,7 +735,7 @@ coap_get_query_variable(coap_message_t *coap_pkt,
   return 0;
 }
 int
-coap_get_post_variable(coap_message_t *coap_pkt,
+coap_get_post_variable(const coap_message_t *coap_pkt,
                        const char *name, const char **output)
 {
   if(coap_pkt->payload_len) {
@@ -768,7 +768,8 @@ coap_set_token(coap_message_t *coap_pkt, const uint8_t *token, size_t token_len)
 /*- CoAP Implementation API -------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_content_format(coap_message_t *coap_pkt, unsigned int *format)
+coap_get_header_content_format(const coap_message_t *coap_pkt,
+                               unsigned int *format)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_CONTENT_FORMAT)) {
     return 0;
@@ -785,7 +786,7 @@ coap_set_header_content_format(coap_message_t *coap_pkt, unsigned int format)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_accept(coap_message_t *coap_pkt, unsigned int *accept)
+coap_get_header_accept(const coap_message_t *coap_pkt, unsigned int *accept)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_ACCEPT)) {
     return 0;
@@ -802,7 +803,7 @@ coap_set_header_accept(coap_message_t *coap_pkt, unsigned int accept)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_max_age(coap_message_t *coap_pkt, uint32_t *age)
+coap_get_header_max_age(const coap_message_t *coap_pkt, uint32_t *age)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_MAX_AGE)) {
     *age = COAP_DEFAULT_MAX_AGE;
@@ -819,7 +820,7 @@ coap_set_header_max_age(coap_message_t *coap_pkt, uint32_t age)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_etag(coap_message_t *coap_pkt, const uint8_t **etag)
+coap_get_header_etag(const coap_message_t *coap_pkt, const uint8_t **etag)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_ETAG)) {
     return 0;
@@ -839,7 +840,7 @@ coap_set_header_etag(coap_message_t *coap_pkt, const uint8_t *etag, size_t etag_
 /*---------------------------------------------------------------------------*/
 /*FIXME support multiple ETags */
 int
-coap_get_header_if_match(coap_message_t *coap_pkt, const uint8_t **etag)
+coap_get_header_if_match(const coap_message_t *coap_pkt, const uint8_t **etag)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_IF_MATCH)) {
     return 0;
@@ -858,7 +859,7 @@ coap_set_header_if_match(coap_message_t *coap_pkt, const uint8_t *etag, size_t e
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_if_none_match(coap_message_t *message)
+coap_get_header_if_none_match(const coap_message_t *message)
 {
   return coap_is_option(message, COAP_OPTION_IF_NONE_MATCH) ? 1 : 0;
 }
@@ -870,7 +871,7 @@ coap_set_header_if_none_match(coap_message_t *message)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_proxy_uri(coap_message_t *coap_pkt, const char **uri)
+coap_get_header_proxy_uri(const coap_message_t *coap_pkt, const char **uri)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_PROXY_URI)) {
     return 0;
@@ -891,7 +892,7 @@ coap_set_header_proxy_uri(coap_message_t *coap_pkt, const char *uri)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_uri_host(coap_message_t *coap_pkt, const char **host)
+coap_get_header_uri_host(const coap_message_t *coap_pkt, const char **host)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_URI_HOST)) {
     return 0;
@@ -910,7 +911,7 @@ coap_set_header_uri_host(coap_message_t *coap_pkt, const char *host)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_uri_path(coap_message_t *coap_pkt, const char **path)
+coap_get_header_uri_path(const coap_message_t *coap_pkt, const char **path)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_URI_PATH)) {
     return 0;
@@ -933,7 +934,8 @@ coap_set_header_uri_path(coap_message_t *coap_pkt, const char *path)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_uri_query(coap_message_t *coap_pkt, const char **query)
+coap_get_header_uri_query(const coap_message_t *coap_pkt,
+                          const char **query)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_URI_QUERY)) {
     return 0;
@@ -956,7 +958,8 @@ coap_set_header_uri_query(coap_message_t *coap_pkt, const char *query)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_location_path(coap_message_t *coap_pkt, const char **path)
+coap_get_header_location_path(const coap_message_t *coap_pkt,
+                              const char **path)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_LOCATION_PATH)) {
     return 0;
@@ -987,7 +990,8 @@ coap_set_header_location_path(coap_message_t *coap_pkt, const char *path)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_location_query(coap_message_t *coap_pkt, const char **query)
+coap_get_header_location_query(const coap_message_t *coap_pkt,
+                               const char **query)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_LOCATION_QUERY)) {
     return 0;
@@ -1010,7 +1014,7 @@ coap_set_header_location_query(coap_message_t *coap_pkt, const char *query)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_observe(coap_message_t *coap_pkt, uint32_t *observe)
+coap_get_header_observe(const coap_message_t *coap_pkt, uint32_t *observe)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_OBSERVE)) {
     return 0;
@@ -1027,8 +1031,8 @@ coap_set_header_observe(coap_message_t *coap_pkt, uint32_t observe)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_block2(coap_message_t *coap_pkt, uint32_t *num, uint8_t *more,
-                       uint16_t *size, uint32_t *offset)
+coap_get_header_block2(const coap_message_t *coap_pkt, uint32_t *num,
+                       uint8_t *more, uint16_t *size, uint32_t *offset)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_BLOCK2)) {
     return 0;
@@ -1070,8 +1074,8 @@ coap_set_header_block2(coap_message_t *coap_pkt, uint32_t num, uint8_t more,
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_block1(coap_message_t *coap_pkt, uint32_t *num, uint8_t *more,
-                       uint16_t *size, uint32_t *offset)
+coap_get_header_block1(const coap_message_t *coap_pkt, uint32_t *num,
+                       uint8_t *more, uint16_t *size, uint32_t *offset)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_BLOCK1)) {
     return 0;
@@ -1113,7 +1117,7 @@ coap_set_header_block1(coap_message_t *coap_pkt, uint32_t num, uint8_t more,
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_size2(coap_message_t *coap_pkt, uint32_t *size)
+coap_get_header_size2(const coap_message_t *coap_pkt, uint32_t *size)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_SIZE2)) {
     return 0;
@@ -1130,7 +1134,7 @@ coap_set_header_size2(coap_message_t *coap_pkt, uint32_t size)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_size1(coap_message_t *coap_pkt, uint32_t *size)
+coap_get_header_size1(const coap_message_t *coap_pkt, uint32_t *size)
 {
   if(!coap_is_option(coap_pkt, COAP_OPTION_SIZE1)) {
     return 0;
@@ -1147,7 +1151,7 @@ coap_set_header_size1(coap_message_t *coap_pkt, uint32_t size)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_payload(coap_message_t *coap_pkt, const uint8_t **payload)
+coap_get_payload(const coap_message_t *coap_pkt, const uint8_t **payload)
 {
   if(payload != NULL) {
     *payload = coap_pkt->payload;

--- a/os/net/app-layer/coap/coap.h
+++ b/os/net/app-layer/coap/coap.h
@@ -188,7 +188,9 @@ coap_is_option(const coap_message_t *message, unsigned int opt)
 
 /* to store error code and human-readable payload */
 extern coap_status_t coap_status_code;
+#if COAP_MESSAGE_ON_ERROR
 extern const char *coap_error_message;
+#endif
 
 void coap_init_connection(void);
 uint16_t coap_get_mid(void);

--- a/os/net/app-layer/coap/coap.h
+++ b/os/net/app-layer/coap/coap.h
@@ -199,19 +199,19 @@ size_t coap_serialize_message(coap_message_t *message, uint8_t *buffer);
 coap_status_t coap_parse_message(coap_message_t *request, uint8_t *data,
                                  uint16_t data_len);
 
-int coap_get_query_variable(coap_message_t *message, const char *name,
+int coap_get_query_variable(const coap_message_t *message, const char *name,
                             const char **output);
-int coap_get_post_variable(coap_message_t *message, const char *name,
+int coap_get_post_variable(const coap_message_t *message, const char *name,
                            const char **output);
 
 static inline coap_resource_flags_t
-coap_get_method_type(coap_message_t *message)
+coap_get_method_type(const coap_message_t *message)
 {
   return (coap_resource_flags_t)(1 << (message->code - 1));
 }
 
 static inline const coap_endpoint_t *
-coap_get_src_endpoint(coap_message_t *request)
+coap_get_src_endpoint(const coap_message_t *request)
 {
   return request->src_ep;
 }
@@ -228,76 +228,84 @@ int coap_set_status_code(coap_message_t *message, unsigned int code);
 int coap_set_token(coap_message_t *message, const uint8_t *token,
                    size_t token_len);
 
-int coap_get_header_content_format(coap_message_t *message, unsigned int *format);
+int coap_get_header_content_format(const coap_message_t *message,
+                                   unsigned int *format);
 int coap_set_header_content_format(coap_message_t *message, unsigned int format);
 
-int coap_get_header_accept(coap_message_t *message, unsigned int *accept);
+int coap_get_header_accept(const coap_message_t *message, unsigned int *accept);
 int coap_set_header_accept(coap_message_t *message, unsigned int accept);
 
-int coap_get_header_max_age(coap_message_t *message, uint32_t *age);
+int coap_get_header_max_age(const coap_message_t *message, uint32_t *age);
 int coap_set_header_max_age(coap_message_t *message, uint32_t age);
 
-int coap_get_header_etag(coap_message_t *message, const uint8_t **etag);
+int coap_get_header_etag(const coap_message_t *message, const uint8_t **etag);
 int coap_set_header_etag(coap_message_t *message, const uint8_t *etag,
                          size_t etag_len);
 
-int coap_get_header_if_match(coap_message_t *message, const uint8_t **etag);
+int coap_get_header_if_match(const coap_message_t *message,
+                             const uint8_t **etag);
 int coap_set_header_if_match(coap_message_t *message, const uint8_t *etag,
                              size_t etag_len);
 
-int coap_get_header_if_none_match(coap_message_t *message);
+int coap_get_header_if_none_match(const coap_message_t *message);
 int coap_set_header_if_none_match(coap_message_t *message);
 
 /* in-place string might not be 0-terminated. */
-int coap_get_header_proxy_uri(coap_message_t *message, const char **uri);
+int coap_get_header_proxy_uri(const coap_message_t *message, const char **uri);
 int coap_set_header_proxy_uri(coap_message_t *message, const char *uri);
 
-/* in-place string might not be 0-terminated. */
-int coap_get_header_proxy_scheme(coap_message_t *message, const char **scheme);
-int coap_set_header_proxy_scheme(coap_message_t *message, const char *scheme);
+/* in-place string might not be 0-terminated. FIXME not supported */
+/* int coap_get_header_proxy_scheme(const coap_message_t *message,
+                                    const char **scheme); */
+/* int coap_set_header_proxy_scheme(coap_message_t *message,
+                                    const char *scheme); */
 
 /* in-place string might not be 0-terminated. */
-int coap_get_header_uri_host(coap_message_t *message, const char **host);
+int coap_get_header_uri_host(const coap_message_t *message, const char **host);
 int coap_set_header_uri_host(coap_message_t *message, const char *host);
 
 /* in-place string might not be 0-terminated. */
-int coap_get_header_uri_path(coap_message_t *message, const char **path);
+int coap_get_header_uri_path(const coap_message_t *message, const char **path);
 int coap_set_header_uri_path(coap_message_t *message, const char *path);
 
 /* in-place string might not be 0-terminated. */
-int coap_get_header_uri_query(coap_message_t *message, const char **query);
+int coap_get_header_uri_query(const coap_message_t *message,
+                              const char **query);
 int coap_set_header_uri_query(coap_message_t *message, const char *query);
 
 /* in-place string might not be 0-terminated. */
-int coap_get_header_location_path(coap_message_t *message, const char **path);
+int coap_get_header_location_path(const coap_message_t *message,
+                                  const char **path);
 /* also splits optional query into Location-Query option. */
 int coap_set_header_location_path(coap_message_t *message, const char *path);
 
 /* in-place string might not be 0-terminated. */
-int coap_get_header_location_query(coap_message_t *message, const char **query);
+int coap_get_header_location_query(const coap_message_t *message,
+                                   const char **query);
 int coap_set_header_location_query(coap_message_t *message, const char *query);
 
-int coap_get_header_observe(coap_message_t *message, uint32_t *observe);
+int coap_get_header_observe(const coap_message_t *message, uint32_t *observe);
 int coap_set_header_observe(coap_message_t *message, uint32_t observe);
 
-int coap_get_header_block2(coap_message_t *message, uint32_t *num, uint8_t *more,
-                           uint16_t *size, uint32_t *offset);
+int coap_get_header_block2(const coap_message_t *message, uint32_t *num,
+                           uint8_t *more, uint16_t *size, uint32_t *offset);
 int coap_set_header_block2(coap_message_t *message, uint32_t num, uint8_t more,
                            uint16_t size);
 
-int coap_get_header_block1(coap_message_t *message, uint32_t *num, uint8_t *more,
-                           uint16_t *size, uint32_t *offset);
+int coap_get_header_block1(const coap_message_t *message, uint32_t *num,
+                           uint8_t *more, uint16_t *size, uint32_t *offset);
 int coap_set_header_block1(coap_message_t *message, uint32_t num, uint8_t more,
                            uint16_t size);
 
-int coap_get_header_size2(coap_message_t *message, uint32_t *size);
+int coap_get_header_size2(const coap_message_t *message, uint32_t *size);
 int coap_set_header_size2(coap_message_t *message, uint32_t size);
 
-int coap_get_header_size1(coap_message_t *message, uint32_t *size);
+int coap_get_header_size1(const coap_message_t *message, uint32_t *size);
 int coap_set_header_size1(coap_message_t *message, uint32_t size);
 
-int coap_get_payload(coap_message_t *message, const uint8_t **payload);
-int coap_set_payload(coap_message_t *message, const void *payload, size_t length);
+int coap_get_payload(const coap_message_t *message, const uint8_t **payload);
+int coap_set_payload(coap_message_t *message, const void *payload,
+                     size_t length);
 
 #endif /* COAP_H_ */
 /** @} */


### PR DESCRIPTION
A set of minor improvements to CoAP:
* Make the inclusion of error-messages in payload optional. This saves ~300 bytes on cc13xx-cc26xx platform when disabled. By default it is still enabled, thus no changes in behavior after this PR.
* Add missing `const` for some CoAP APIs
* Use `_CONF_` for the recently added `WELL_KNOWN_RESOURCE_ENABLED` option