### PR TITLE
Minor improvements in packetqueue

### DIFF
--- a/os/net/ipv6/uip-packetqueue.c
+++ b/os/net/ipv6/uip-packetqueue.c
@@ -1,14 +1,11 @@
-#include <stdio.h>
-
-#include "net/ipv6/uip.h"
-
-#include "lib/memb.h"
-
 #include "net/ipv6/uip-packetqueue.h"
+#include "lib/memb.h"
+#include <stdio.h>
 
 #define MAX_NUM_QUEUED_PACKETS 2
 MEMB(packets_memb, struct uip_packetqueue_packet, MAX_NUM_QUEUED_PACKETS);
 
+/*---------------------------------------------------------------------------*/
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>
@@ -16,7 +13,6 @@ MEMB(packets_memb, struct uip_packetqueue_packet, MAX_NUM_QUEUED_PACKETS);
 #else
 #define PRINTF(...)
 #endif
-
 /*---------------------------------------------------------------------------*/
 static void
 packet_timedout(void *ptr)
@@ -36,7 +32,8 @@ uip_packetqueue_new(struct uip_packetqueue_handle *handle)
 }
 /*---------------------------------------------------------------------------*/
 struct uip_packetqueue_packet *
-uip_packetqueue_alloc(struct uip_packetqueue_handle *handle, clock_time_t lifetime)
+uip_packetqueue_alloc(struct uip_packetqueue_handle *handle,
+                      clock_time_t lifetime)
 {
   PRINTF("uip_packetqueue_alloc %p\n", handle);
   if(handle->packet != NULL) {
@@ -67,13 +64,13 @@ uip_packetqueue_free(struct uip_packetqueue_handle *handle)
 uint8_t *
 uip_packetqueue_buf(struct uip_packetqueue_handle *h)
 {
-  return h->packet != NULL? h->packet->queue_buf: NULL;
+  return h->packet != NULL ? h->packet->queue_buf: NULL;
 }
 /*---------------------------------------------------------------------------*/
 uint16_t
 uip_packetqueue_buflen(struct uip_packetqueue_handle *h)
 {
-  return h->packet != NULL? h->packet->queue_buf_len: 0;
+  return h->packet != NULL ? h->packet->queue_buf_len: 0;
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/os/net/ipv6/uip-packetqueue.c
+++ b/os/net/ipv6/uip-packetqueue.c
@@ -6,20 +6,16 @@
 MEMB(packets_memb, struct uip_packetqueue_packet, MAX_NUM_QUEUED_PACKETS);
 
 /*---------------------------------------------------------------------------*/
-#define DEBUG 0
-#if DEBUG
-#include <stdio.h>
-#define PRINTF(...) printf(__VA_ARGS__)
-#else
-#define PRINTF(...)
-#endif
+#include "sys/log.h"
+#define LOG_MODULE  "Packet-Q"
+#define LOG_LEVEL   LOG_LEVEL_NONE
 /*---------------------------------------------------------------------------*/
 static void
 packet_timedout(void *ptr)
 {
   struct uip_packetqueue_handle *h = ptr;
 
-  PRINTF("uip_packetqueue_free timed out %p\n", h);
+  LOG_INFO("Timed out %p\n", h);
   memb_free(&packets_memb, h->packet);
   h->packet = NULL;
 }
@@ -27,7 +23,7 @@ packet_timedout(void *ptr)
 void
 uip_packetqueue_new(struct uip_packetqueue_handle *handle)
 {
-  PRINTF("uip_packetqueue_new %p\n", handle);
+  LOG_DBG("New %p\n", handle);
   handle->packet = NULL;
 }
 /*---------------------------------------------------------------------------*/
@@ -35,9 +31,9 @@ struct uip_packetqueue_packet *
 uip_packetqueue_alloc(struct uip_packetqueue_handle *handle,
                       clock_time_t lifetime)
 {
-  PRINTF("uip_packetqueue_alloc %p\n", handle);
+  LOG_DBG("Alloc %p\n", handle);
   if(handle->packet != NULL) {
-    PRINTF("alloced\n");
+    LOG_DBG("Alloced\n");
     return NULL;
   }
   handle->packet = memb_alloc(&packets_memb);
@@ -45,7 +41,7 @@ uip_packetqueue_alloc(struct uip_packetqueue_handle *handle,
     ctimer_set(&handle->packet->lifetimer, lifetime,
                packet_timedout, handle);
   } else {
-    PRINTF("uip_packetqueue_alloc failed\n");
+    LOG_ERR("Alloc failed\n");
   }
   return handle->packet;
 }
@@ -53,7 +49,7 @@ uip_packetqueue_alloc(struct uip_packetqueue_handle *handle,
 void
 uip_packetqueue_free(struct uip_packetqueue_handle *handle)
 {
-  PRINTF("uip_packetqueue_free %p\n", handle);
+  LOG_DBG("Free %p\n", handle);
   if(handle->packet != NULL) {
     ctimer_stop(&handle->packet->lifetimer);
     memb_free(&packets_memb, handle->packet);

--- a/os/net/ipv6/uip-packetqueue.c
+++ b/os/net/ipv6/uip-packetqueue.c
@@ -58,13 +58,13 @@ uip_packetqueue_free(struct uip_packetqueue_handle *handle)
 }
 /*---------------------------------------------------------------------------*/
 uint8_t *
-uip_packetqueue_buf(struct uip_packetqueue_handle *h)
+uip_packetqueue_buf(const struct uip_packetqueue_handle *h)
 {
   return h->packet != NULL ? h->packet->queue_buf: NULL;
 }
 /*---------------------------------------------------------------------------*/
 uint16_t
-uip_packetqueue_buflen(struct uip_packetqueue_handle *h)
+uip_packetqueue_buflen(const struct uip_packetqueue_handle *h)
 {
   return h->packet != NULL ? h->packet->queue_buf_len: 0;
 }

--- a/os/net/ipv6/uip-packetqueue.h
+++ b/os/net/ipv6/uip-packetqueue.h
@@ -6,11 +6,9 @@
 struct uip_packetqueue_handle;
 
 struct uip_packetqueue_packet {
-  struct uip_ds6_queued_packet *next;
   uint8_t queue_buf[UIP_BUFSIZE];
   uint16_t queue_buf_len;
   struct ctimer lifetimer;
-  struct uip_packetqueue_handle *handle;
 };
 
 struct uip_packetqueue_handle {

--- a/os/net/ipv6/uip-packetqueue.h
+++ b/os/net/ipv6/uip-packetqueue.h
@@ -2,7 +2,10 @@
 #define UIP_PACKETQUEUE_H
 
 #include "sys/ctimer.h"
+#include "net/ipv6/uip.h"
+#include <stdint.h>
 
+/*---------------------------------------------------------------------------*/
 struct uip_packetqueue_handle;
 
 struct uip_packetqueue_packet {
@@ -15,19 +18,13 @@ struct uip_packetqueue_handle {
   struct uip_packetqueue_packet *packet;
 };
 
+/*---------------------------------------------------------------------------*/
 void uip_packetqueue_new(struct uip_packetqueue_handle *handle);
-
-
-struct uip_packetqueue_packet *
-uip_packetqueue_alloc(struct uip_packetqueue_handle *handle, clock_time_t lifetime);
-
-
-void
-uip_packetqueue_free(struct uip_packetqueue_handle *handle);
-
+struct uip_packetqueue_packet *uip_packetqueue_alloc(
+    struct uip_packetqueue_handle *handle, clock_time_t lifetime);
+void uip_packetqueue_free(struct uip_packetqueue_handle *handle);
 uint8_t *uip_packetqueue_buf(struct uip_packetqueue_handle *h);
 uint16_t uip_packetqueue_buflen(struct uip_packetqueue_handle *h);
 void uip_packetqueue_set_buflen(struct uip_packetqueue_handle *h, uint16_t len);
-
-
+/*---------------------------------------------------------------------------*/
 #endif /* UIP_PACKETQUEUE_H */

--- a/os/net/ipv6/uip-packetqueue.h
+++ b/os/net/ipv6/uip-packetqueue.h
@@ -23,8 +23,8 @@ void uip_packetqueue_new(struct uip_packetqueue_handle *handle);
 struct uip_packetqueue_packet *uip_packetqueue_alloc(
     struct uip_packetqueue_handle *handle, clock_time_t lifetime);
 void uip_packetqueue_free(struct uip_packetqueue_handle *handle);
-uint8_t *uip_packetqueue_buf(struct uip_packetqueue_handle *h);
-uint16_t uip_packetqueue_buflen(struct uip_packetqueue_handle *h);
+uint8_t *uip_packetqueue_buf(const struct uip_packetqueue_handle *h);
+uint16_t uip_packetqueue_buflen(const struct uip_packetqueue_handle *h);
 void uip_packetqueue_set_buflen(struct uip_packetqueue_handle *h, uint16_t len);
 /*---------------------------------------------------------------------------*/
 #endif /* UIP_PACKETQUEUE_H */


### PR DESCRIPTION
~~The `next`-field in `struct uip_packetqueue_packet` is a pointer to `struct uip_ds6_queued_packet`. This datatype is not declared or defined anywhere. Seems straight-forward that this should be a pointer to a `struct uip_packetqueue_packet`.~~

A set of minor improvements:
* Remove unused `next` and `handle` from `struct uip_packetqueue_packet`
* Modernize logging, code-style
* Fix inclusions and missing consts

Closes https://github.com/contiki-ng/contiki-ng/issues/1186