### PR TITLE
ctimer: Simplification of ctimer_expired

### DIFF
--- a/os/sys/ctimer.c
+++ b/os/sys/ctimer.c
@@ -149,16 +149,10 @@ ctimer_stop(struct ctimer *c)
 bool
 ctimer_expired(struct ctimer *c)
 {
-  struct ctimer *t;
   if(initialized) {
     return etimer_expired(&c->etimer);
   }
-  for(t = list_head(ctimer_list); t != NULL; t = t->next) {
-    if(t == c) {
-      return false;
-    }
-  }
-  return true;
+  return !list_contains(ctimer_list, c);
 }
 /*---------------------------------------------------------------------------*/
 /** @} */


### PR DESCRIPTION
Shortens `ctimer_expired` by using `list_contains`