### PR TITLE
border-router: only allow MAC address to be set once at startup

### DIFF
--- a/os/services/rpl-border-router/native/border-router-native.c
+++ b/os/services/rpl-border-router/native/border-router-native.c
@@ -79,6 +79,11 @@ request_mac(void)
 void
 border_router_set_mac(const uint8_t *data)
 {
+  if(is_mac_set) {
+    /* only set MAC address once */
+    return;
+  }
+
   memcpy(uip_lladdr.addr, data, sizeof(uip_lladdr.addr));
   linkaddr_set_node_addr((linkaddr_t *)uip_lladdr.addr);
 

--- a/os/services/rpl-border-router/native/border-router-native.c
+++ b/os/services/rpl-border-router/native/border-router-native.c
@@ -54,11 +54,12 @@
 #define LOG_LEVEL LOG_LEVEL_INFO
 
 #include <stdlib.h>
+#include <stdbool.h>
 
 extern long slip_sent;
 extern long slip_received;
 
-static uint8_t mac_set;
+static bool is_mac_set;
 
 extern int contiki_argc;
 extern char **contiki_argv;
@@ -88,7 +89,7 @@ border_router_set_mac(const uint8_t *data)
   NETSTACK_ROUTING.init();
   PROCESS_CONTEXT_END(&tcpip_process);
 
-  mac_set = 1;
+  is_mac_set = true;
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -103,6 +104,8 @@ PROCESS_THREAD(border_router_process, ev, data)
   static struct etimer et;
 
   PROCESS_BEGIN();
+
+  is_mac_set = false;
   prefix_set = 0;
 
   PROCESS_PAUSE();
@@ -116,7 +119,7 @@ PROCESS_THREAD(border_router_process, ev, data)
   /* tun init is also responsible for setting up the SLIP connection */
   tun_init();
 
-  while(!mac_set) {
+  while(!is_mac_set) {
     etimer_set(&et, CLOCK_SECOND);
     request_mac();
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));


### PR DESCRIPTION
Fix an issue where the border router could clear the network configuration by reinitializing the RPL network if the MAC address is received multiple times from the slip radio.