### PR TITLE
zoul: add serial device pattern for motelist to search for Zolertia devices

### DIFF
--- a/arch/platform/zoul/Makefile.zoul
+++ b/arch/platform/zoul/Makefile.zoul
@@ -51,7 +51,7 @@ MODULES += $(CONTIKI_NG_STORAGE_DIR)/cfs
 
 BSL = $(CONTIKI_NG_TOOLS_DIR)/cc2538-bsl/cc2538-bsl.py
 
-MOTES := $(shell $(CONTIKI_NG_TOOLS_DIR)/motelist/motelist.py --omit-header \
+MOTES := $(shell $(CONTIKI_NG_TOOLS_DIR)/motelist/motelist.py -p "/dev/tty.usbserial*" --omit-header \
                  | grep $(MOTELIST_ZOLERTIA) | cut -f1 -d " ")
 
 ### If PORT is defined, override to keep backward compatibility


### PR DESCRIPTION
The Zolertia Firefly devices appear as `/dev/tty.usbserial*` on macOS.