### PR TITLE
rpl-border-router: avoid starting serial-shell

### DIFF
--- a/os/services/rpl-border-router/native/Makefile.native
+++ b/os/services/rpl-border-router/native/Makefile.native
@@ -1,6 +1,8 @@
 MODULES += os/services/slip-cmd
 MODULES += os/services/shell
 
+MODULES_SOURCES_EXCLUDES += serial-shell.c
+
 MAKE_MAC = MAKE_MAC_OTHER
 MAKE_NET = MAKE_NET_IPV6
 

--- a/os/services/rpl-border-router/native/border-router-cmds.c
+++ b/os/services/rpl-border-router/native/border-router-cmds.c
@@ -217,6 +217,12 @@ serial_shell_output(const char *str)
   printf("%s", str);
 }
 /*---------------------------------------------------------------------------*/
+void
+serial_shell_init(void)
+{
+  /* avoid starting the normal serial-shell */
+}
+/*---------------------------------------------------------------------------*/
 
 PROCESS_THREAD(border_router_cmd_process, ev, data)
 {


### PR DESCRIPTION
Serial communication is handled by the native border-router and starting serial-shell will cause any shell commands to be executed twice.