### PR TITLE
Fix issue #2943 : Be able to reassociate to a new network if neighbor table was full (and the node we try to associate was not known)

### DIFF
--- a/os/net/routing/rpl-classic/rpl-nbr-policy.c
+++ b/os/net/routing/rpl-classic/rpl-nbr-policy.c
@@ -97,6 +97,10 @@ can_accept_new_parent(const linkaddr_t *candidate_for_removal, rpl_dio_t *dio)
   }
 }
 /*---------------------------------------------------------------------------*/
+#if MAC_CONF_WITH_TSCH
+extern int tsch_is_associated;
+#endif
+/*---------------------------------------------------------------------------*/
 bool
 rpl_nbr_can_accept_new(const linkaddr_t *new,
                        const linkaddr_t *candidate_for_removal,
@@ -124,6 +128,12 @@ rpl_nbr_can_accept_new(const linkaddr_t *new,
     /* Behavior for all but new RPL parents/children: accept anything
        until table is full. */
     accept = (candidate_for_removal == NULL);
+    #if MAC_CONF_WITH_TSCH
+    if(!tsch_is_associated)
+    {
+      accept = true;
+    }
+    #endif
     break;
   }
   LOG_DBG("%s new neighbor ", accept ? "accept" : "reject");

--- a/os/net/routing/rpl-classic/rpl-nbr-policy.c
+++ b/os/net/routing/rpl-classic/rpl-nbr-policy.c
@@ -129,8 +129,7 @@ rpl_nbr_can_accept_new(const linkaddr_t *new,
        until table is full. */
     accept = (candidate_for_removal == NULL);
     #if MAC_CONF_WITH_TSCH
-    if(!tsch_is_associated)
-    {
+    if(!tsch_is_associated) {
       accept = true;
     }
     #endif


### PR DESCRIPTION
This fixes the issue. I am open to other ways of doing it which would be better.