### PR TITLE
Process mutexes

### DIFF
--- a/os/sys/process-mutex.c
+++ b/os/sys/process-mutex.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Siemens AG.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \addtogroup process
+ * @{
+ *
+ * \file
+ *         Implementation of Process mutexes.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#include "sys/process-mutex.h"
+#include <string.h>
+
+/*---------------------------------------------------------------------------*/
+void
+process_mutex_init(process_mutex_t *mutex)
+{
+  memset(mutex, 0, sizeof(*mutex));
+}
+/*---------------------------------------------------------------------------*/
+bool
+process_mutex_try_lock(process_mutex_t *mutex)
+{
+  if(mutex->is_locked) {
+    if(!mutex->waiting_process && !mutex->has_more_waiting_processes) {
+      mutex->waiting_process = PROCESS_CURRENT();
+    } else if(mutex->waiting_process != PROCESS_CURRENT()) {
+      mutex->has_more_waiting_processes = true;
+      mutex->waiting_process = PROCESS_BROADCAST;
+    }
+    return false;
+  } else {
+    mutex->is_locked = true;
+    return true;
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+process_mutex_unlock(process_mutex_t *mutex)
+{
+  if(mutex->waiting_process || mutex->has_more_waiting_processes) {
+    process_post(mutex->waiting_process, PROCESS_EVENT_UNLOCKED, NULL);
+    mutex->has_more_waiting_processes = false;
+    mutex->waiting_process = NULL;
+  }
+  mutex->is_locked = false;
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/os/sys/process-mutex.h
+++ b/os/sys/process-mutex.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024, Siemens AG.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \addtogroup process
+ * @{
+ *
+ * \file
+ *         Header file for Process mutexes.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#ifndef PROCESS_MUTEX_H_
+#define PROCESS_MUTEX_H_
+
+#include "contiki.h"
+#include <stdbool.h>
+
+/**
+ * Structure of a process mutex.
+ */
+typedef struct process_mutex_t {
+  struct process *waiting_process;
+  bool has_more_waiting_processes;
+  bool is_locked;
+} process_mutex_t;
+
+/**
+ * \brief       Initializes a process mutex.
+ * \param mutex The process mutex.
+ */
+void process_mutex_init(process_mutex_t *mutex);
+
+/**
+ * \brief       Tries to acquire a process mutex.
+ * \param mutex The process mutex.
+ * \return      True if the process mutex was locked.
+ */
+bool process_mutex_try_lock(process_mutex_t *mutex);
+
+/**
+ * \brief       Unlocks a process mutex.
+ * \param mutex The process mutex.
+ */
+void process_mutex_unlock(process_mutex_t *mutex);
+
+#endif /* PROCESS_MUTEX_H_ */
+
+/** @} */

--- a/os/sys/process.h
+++ b/os/sys/process.h
@@ -100,7 +100,8 @@ typedef uint8_t       process_num_events_t;
 #define PROCESS_EVENT_EXITED          0x87
 #define PROCESS_EVENT_TIMER           0x88
 #define PROCESS_EVENT_COM             0x89
-#define PROCESS_EVENT_MAX             0x8a
+#define PROCESS_EVENT_UNLOCKED        0x8a
+#define PROCESS_EVENT_MAX             0x8b
 
 #define PROCESS_BROADCAST NULL
 

--- a/tests/08-native-runs/17-process-mutex.sh
+++ b/tests/08-native-runs/17-process-mutex.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+./run-one.sh 17-process-mutex

--- a/tests/08-native-runs/17-process-mutex/Makefile
+++ b/tests/08-native-runs/17-process-mutex/Makefile
@@ -1,0 +1,8 @@
+CONTIKI_PROJECT = test-process-mutex
+all: $(CONTIKI_PROJECT)
+
+TARGET = native
+
+MODULES += os/services/unit-test
+
+include ../../../Makefile.include

--- a/tests/08-native-runs/17-process-mutex/test-process-mutex.c
+++ b/tests/08-native-runs/17-process-mutex/test-process-mutex.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024, Siemens AG.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "contiki.h"
+#include "unit-test.h"
+#include "sys/process-mutex.h"
+#include <stdio.h>
+
+static process_mutex_t mutex;
+PROCESS(contender_1, "contender_1");
+PROCESS(contender_2, "contender_2");
+PROCESS(test_process, "test");
+AUTOSTART_PROCESSES(&test_process);
+
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(contender_1, ev, data)
+{
+  PROCESS_BEGIN();
+
+  PROCESS_WAIT_UNTIL(process_mutex_try_lock(&mutex));
+  process_mutex_unlock(&mutex);
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(contender_2, ev, data)
+{
+  PROCESS_BEGIN();
+
+  PROCESS_WAIT_UNTIL(process_mutex_try_lock(&mutex));
+  process_mutex_unlock(&mutex);
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(process_mutex_one_contender, "one contender");
+UNIT_TEST(process_mutex_one_contender)
+{
+  UNIT_TEST_BEGIN();
+
+  process_mutex_init(&mutex);
+  PT_WAIT_UNTIL(&unit_test_pt, process_mutex_try_lock(&mutex));
+  process_start(&contender_1, NULL);
+  UNIT_TEST_ASSERT(process_is_running(&contender_1));
+  process_mutex_unlock(&mutex);
+  PT_YIELD_UNTIL(&unit_test_pt, !process_is_running(&contender_1));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(process_mutex_two_contenders, "two contenders");
+UNIT_TEST(process_mutex_two_contenders)
+{
+  UNIT_TEST_BEGIN();
+
+  process_mutex_init(&mutex);
+  PT_WAIT_UNTIL(&unit_test_pt, process_mutex_try_lock(&mutex));
+  process_start(&contender_1, NULL);
+  UNIT_TEST_ASSERT(process_is_running(&contender_1));
+  process_start(&contender_2, NULL);
+  UNIT_TEST_ASSERT(process_is_running(&contender_2));
+  process_mutex_unlock(&mutex);
+  PT_YIELD_UNTIL(&unit_test_pt, !process_is_running(&contender_1));
+  PT_WAIT_UNTIL(&unit_test_pt, !process_is_running(&contender_2));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(test_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(process_mutex_one_contender);
+  UNIT_TEST_RUN(process_mutex_two_contenders);
+
+  if(!UNIT_TEST_PASSED(process_mutex_one_contender)
+     || !UNIT_TEST_PASSED(process_mutex_two_contenders)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
+  printf("=check-me= DONE\n");
+  printf("---\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -21,5 +21,6 @@ tests/08-native-runs/13-coffee/native:./13-coffee.sh \
 tests/08-native-runs/14-sha-256/native:./14-sha-256.sh \
 tests/08-native-runs/15-ieee802154-security/native:./15-ieee802154-security.sh \
 tests/08-native-runs/16-cbor/native:./16-cbor.sh \
+tests/08-native-runs/17-process-mutex/native:./17-process-mutex.sh
 
 include ../Makefile.compile-test


### PR DESCRIPTION
To ensure exclusive access to a common resource, such as ECC in #2898, this PR introduces "process mutexes". Unlike `sys/pt-sem.h`, waiting protothreads automatically continue when a process mutex is unlocked.