### PR TITLE
Added additional source data check in input_l2cap_frame_flow_channel

### DIFF
--- a/os/net/mac/ble/ble-l2cap.c
+++ b/os/net/mac/ble/ble-l2cap.c
@@ -429,7 +429,7 @@ input_l2cap_frame_flow_channel(l2cap_channel_t *channel, uint8_t *data, uint16_t
     memcpy(&frame_len, &data[0], 2);
     payload_len = frame_len - 2;
 
-    if(payload_len > BLE_L2CAP_NODE_MTU) {
+    if(payload_len > BLE_L2CAP_NODE_MTU || payload_len > data_len - 6) {
     	LOG_WARN("l2cap_frame: illegal L2CAP frame payload_len: %d\n", payload_len);
     	/* the payload length may not be larger than the destination buffer */
     	return;
@@ -444,7 +444,7 @@ input_l2cap_frame_flow_channel(l2cap_channel_t *channel, uint8_t *data, uint16_t
     memcpy(&frame_len, &data[0], 2);
     payload_len = frame_len;
     
-    if(payload_len > BLE_L2CAP_NODE_MTU - channel->rx_buffer.current_index) {
+    if(payload_len > BLE_L2CAP_NODE_MTU - channel->rx_buffer.current_index || payload_len > data_len - 4) {
     	LOG_WARN("l2cap_frame: illegal L2CAP frame payload_len: %d\n", payload_len);
     	/* the current index plus the payload length may not be larger than 
 	 * the destination buffer */


### PR DESCRIPTION
The `input_l2cap_frame_flow_channel` does not properly verify the size of the provided source buffer when copying data into the `l2cap_channel_t` struct. This could lead to out of bounds reads using a crafted packet.

This PR fixes the issue by adding two checks before each copy that ensures the source data buffer has enough size to preform the copy.