### PR TITLE
rtd_requirements.txt: install standard-imghdr

### DIFF
--- a/tools/docker/files/rtd_requirements.txt
+++ b/tools/docker/files/rtd_requirements.txt
@@ -4,3 +4,4 @@ sphinx==5.0.2
 sphinx_rtd_theme==1.0.0
 myst_parser==0.18.0
 linkify-it-py==2.0.0
+standard-imghdr ; python_version > '3.12'


### PR DESCRIPTION
This hopefully fixes the documentation
build failure on macOS.