### PR TITLE
CBOR library

### DIFF
--- a/os/lib/cbor.c
+++ b/os/lib/cbor.c
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2018, SICS, RISE AB
+ * Copyright (c) 2023, Uppsala universitet
+ * Copyright (c) 2024, Siemens AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * \addtogroup cbor
+ * @{
+ * \file
+ *         CBOR implementation.
+ */
+
+#include "lib/cbor.h"
+#include <string.h>
+
+/*---------------------------------------------------------------------------*/
+void
+cbor_init_writer(cbor_writer_state_t *state,
+                 uint8_t *buffer, size_t buffer_size)
+{
+  state->buffer_head = buffer;
+  state->buffer = buffer;
+  state->buffer_size = buffer_size;
+  state->nesting_depth = CBOR_MAX_NESTING;
+}
+/*---------------------------------------------------------------------------*/
+size_t
+cbor_end_writer(cbor_writer_state_t *state)
+{
+  return (state->nesting_depth == CBOR_MAX_NESTING) && state->buffer
+         ? (size_t)(state->buffer - state->buffer_head)
+         : 0;
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_break_writer(cbor_writer_state_t *state)
+{
+  state->buffer = NULL;
+  state->buffer_size = 0;
+}
+/*---------------------------------------------------------------------------*/
+static void
+increment(cbor_writer_state_t *state)
+{
+  if(state->nesting_depth == CBOR_MAX_NESTING) {
+    return;
+  }
+  state->records[state->nesting_depth].objects++;
+}
+/*---------------------------------------------------------------------------*/
+static void
+write_first_byte(cbor_writer_state_t *state, uint_fast8_t value)
+{
+  if(!state->buffer_size) {
+    cbor_break_writer(state);
+    return;
+  }
+  *state->buffer++ = value;
+  state->buffer_size--;
+  increment(state);
+}
+/*---------------------------------------------------------------------------*/
+static void
+write_object(cbor_writer_state_t *state,
+             const void *object, size_t object_size)
+{
+  if(!object_size) {
+    return;
+  }
+  if(state->buffer_size < object_size) {
+    cbor_break_writer(state);
+    return;
+  }
+  memcpy(state->buffer, object, object_size);
+  state->buffer += object_size;
+  state->buffer_size -= object_size;
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_write_object(cbor_writer_state_t *state,
+                  const void *object, size_t object_size)
+{
+  if(!object_size) {
+    return;
+  }
+  write_object(state, object, object_size);
+  increment(state);
+}
+/*---------------------------------------------------------------------------*/
+static void
+insert_unsigned(cbor_writer_state_t *state,
+                uint8_t *const destination,
+                uint64_t value)
+{
+  size_t length_to_copy;
+
+  if(!state->buffer) {
+    return;
+  }
+
+  /* update additional information */
+  if(value < CBOR_SIZE_1) {
+    destination[-1] |= value;
+    return;
+  }
+  if(value <= UINT8_MAX) {
+    length_to_copy = 1;
+    destination[-1] |= CBOR_SIZE_1;
+  } else if(value <= UINT16_MAX) {
+    length_to_copy = 2;
+    destination[-1] |= CBOR_SIZE_2;
+  } else if(value <= UINT32_MAX) {
+    length_to_copy = 4;
+    destination[-1] |= CBOR_SIZE_4;
+  } else {
+    length_to_copy = 8;
+    destination[-1] |= CBOR_SIZE_8;
+  }
+
+  /* check if there is enough space left */
+  if(state->buffer_size < length_to_copy) {
+    cbor_break_writer(state);
+    return;
+  }
+
+  /* move when inserting */
+  memmove(destination + length_to_copy,
+          destination,
+          state->buffer - destination);
+
+  /* update buffer variables */
+  state->buffer += length_to_copy;
+  state->buffer_size -= length_to_copy;
+
+  /* serialize value */
+  while(length_to_copy--) {
+    destination[length_to_copy] = value;
+    value >>= 8;
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_write_unsigned(cbor_writer_state_t *state, uint64_t value)
+{
+  write_first_byte(state, CBOR_MAJOR_TYPE_UNSIGNED);
+  insert_unsigned(state, state->buffer, value);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_write_data(cbor_writer_state_t *state,
+                const uint8_t *data, size_t data_size)
+{
+  write_first_byte(state, CBOR_MAJOR_TYPE_BYTE_STRING);
+  insert_unsigned(state, state->buffer, data_size);
+  write_object(state, data, data_size);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_write_text(cbor_writer_state_t *state,
+                const char *text, size_t text_size)
+{
+  write_first_byte(state, CBOR_MAJOR_TYPE_TEXT_STRING);
+  insert_unsigned(state, state->buffer, text_size);
+  write_object(state, text, text_size);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_write_null(cbor_writer_state_t *state)
+{
+  write_first_byte(state, CBOR_SIMPLE_VALUE_NULL);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_write_undefined(cbor_writer_state_t *state)
+{
+  write_first_byte(state, CBOR_SIMPLE_VALUE_UNDEFINED);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_write_bool(cbor_writer_state_t *state, bool boolean)
+{
+  write_first_byte(state,
+                   boolean ? CBOR_SIMPLE_VALUE_TRUE : CBOR_SIMPLE_VALUE_FALSE);
+}
+/*---------------------------------------------------------------------------*/
+static void
+generic_open(cbor_writer_state_t *state, cbor_major_type_t major_type)
+{
+  if(!state->nesting_depth) {
+    cbor_break_writer(state);
+    return;
+  }
+  write_first_byte(state, major_type);
+  state->records[--state->nesting_depth].start = state->buffer;
+  state->records[state->nesting_depth].objects = 0;
+}
+/*---------------------------------------------------------------------------*/
+static void
+generic_close(cbor_writer_state_t *state, size_t value)
+{
+  insert_unsigned(state, state->records[state->nesting_depth].start, value);
+  state->nesting_depth++;
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_open_data(cbor_writer_state_t *state)
+{
+  generic_open(state, CBOR_MAJOR_TYPE_BYTE_STRING);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_close_data(cbor_writer_state_t *state)
+{
+  if(state->nesting_depth == CBOR_MAX_NESTING) {
+    cbor_break_writer(state);
+    return;
+  }
+  generic_close(state,
+                state->buffer - state->records[state->nesting_depth].start);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_open_array(cbor_writer_state_t *state)
+{
+  generic_open(state, CBOR_MAJOR_TYPE_ARRAY);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_close_array(cbor_writer_state_t *state)
+{
+  if(state->nesting_depth == CBOR_MAX_NESTING) {
+    cbor_break_writer(state);
+    return;
+  }
+  generic_close(state, state->records[state->nesting_depth].objects);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_open_map(cbor_writer_state_t *state)
+{
+  generic_open(state, CBOR_MAJOR_TYPE_MAP);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_close_map(cbor_writer_state_t *state)
+{
+  if((state->nesting_depth == CBOR_MAX_NESTING)
+     || (state->records[state->nesting_depth].objects & 1)) {
+    cbor_break_writer(state);
+    return;
+  }
+  generic_close(state, state->records[state->nesting_depth].objects >> 1);
+}
+/*---------------------------------------------------------------------------*/
+void
+cbor_init_reader(cbor_reader_state_t *state,
+                 const uint8_t *cbor, size_t cbor_size)
+{
+  state->cbor = cbor;
+  state->cbor_size = cbor_size;
+}
+/*---------------------------------------------------------------------------*/
+cbor_major_type_t
+cbor_peek_next(cbor_reader_state_t *state)
+{
+  if(!state->cbor_size) {
+    return CBOR_MAJOR_TYPE_NONE;
+  }
+  return *state->cbor & 0xE0;
+}
+/*---------------------------------------------------------------------------*/
+bool
+cbor_end_reader(cbor_reader_state_t *state)
+{
+  return state->cbor_size == 0;
+}
+/*---------------------------------------------------------------------------*/
+cbor_size_t
+cbor_read_unsigned(cbor_reader_state_t *state, uint64_t *value)
+{
+  size_t bytes_to_read;
+
+  if(!state->cbor_size) {
+    return CBOR_SIZE_NONE;
+  }
+  cbor_size_t size = *state->cbor & ~0xE0;
+  state->cbor++;
+  state->cbor_size--;
+
+  if(size < CBOR_SIZE_1) {
+    *value = size;
+    return CBOR_SIZE_1;
+  }
+
+  switch(size) {
+  case CBOR_SIZE_1:
+    bytes_to_read = 1;
+    break;
+  case CBOR_SIZE_2:
+    bytes_to_read = 2;
+    break;
+  case CBOR_SIZE_4:
+    bytes_to_read = 4;
+    break;
+  case CBOR_SIZE_8:
+    bytes_to_read = 8;
+    break;
+  case CBOR_SIZE_NONE:
+  default:
+    return CBOR_SIZE_NONE;
+  }
+
+  if(bytes_to_read > state->cbor_size) {
+    return CBOR_SIZE_NONE;
+  }
+  state->cbor_size -= bytes_to_read;
+
+  *value = 0;
+  while(bytes_to_read--) {
+    *value <<= 8;
+    *value += *state->cbor++;
+  }
+  return size;
+}
+/*---------------------------------------------------------------------------*/
+static const uint8_t *
+read_byte_or_text_string(cbor_reader_state_t *state, size_t *size)
+{
+  uint64_t value;
+
+  if((CBOR_SIZE_NONE == cbor_read_unsigned(state, &value))
+     || (value > SIZE_MAX)
+     || (state->cbor_size < value)) {
+    return NULL;
+  }
+  *size = value;
+  const uint8_t *beginning = state->cbor;
+  state->cbor += *size;
+  state->cbor_size -= *size;
+  return beginning;
+}
+/*---------------------------------------------------------------------------*/
+const uint8_t *
+cbor_read_data(cbor_reader_state_t *state, size_t *data_size)
+{
+  if(cbor_peek_next(state) != CBOR_MAJOR_TYPE_BYTE_STRING) {
+    return NULL;
+  }
+  return read_byte_or_text_string(state, data_size);
+}
+/*---------------------------------------------------------------------------*/
+const char *
+cbor_read_text(cbor_reader_state_t *state, size_t *text_size)
+{
+  if(cbor_peek_next(state) != CBOR_MAJOR_TYPE_TEXT_STRING) {
+    return NULL;
+  }
+  return (const char *)read_byte_or_text_string(state, text_size);
+}
+/*---------------------------------------------------------------------------*/
+cbor_simple_value_t
+cbor_read_simple(cbor_reader_state_t *state)
+{
+  if(!state->cbor_size) {
+    return CBOR_SIMPLE_VALUE_NONE;
+  }
+  state->cbor_size--;
+  return *state->cbor++;
+}
+/*---------------------------------------------------------------------------*/
+static size_t
+read_array_or_map(cbor_reader_state_t *state)
+{
+  uint64_t value;
+
+  if((CBOR_SIZE_NONE == cbor_read_unsigned(state, &value))
+     || (value >= SIZE_MAX)) {
+    return SIZE_MAX;
+  }
+  return value;
+}
+/*---------------------------------------------------------------------------*/
+size_t
+cbor_read_array(cbor_reader_state_t *state)
+{
+  if(cbor_peek_next(state) != CBOR_MAJOR_TYPE_ARRAY) {
+    return SIZE_MAX;
+  }
+  return read_array_or_map(state);
+}
+/*---------------------------------------------------------------------------*/
+size_t
+cbor_read_map(cbor_reader_state_t *state)
+{
+  if(cbor_peek_next(state) != CBOR_MAJOR_TYPE_MAP) {
+    return SIZE_MAX;
+  }
+  return read_array_or_map(state);
+}
+/*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/os/lib/cbor.h
+++ b/os/lib/cbor.h
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2018, SICS, RISE AB
+ * Copyright (c) 2023, Uppsala universitet
+ * Copyright (c) 2024, Siemens AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef CBOR_H_
+#define CBOR_H_
+
+/**
+ * \addtogroup data
+ * @{
+ *
+ * \defgroup cbor CBOR
+ *
+ * Functions for reading and writing CBOR.
+ * @{
+ *
+ * \file
+ *         CBOR API.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Defines how many arrays and maps can be open simultaneously while writing.
+ */
+#ifdef CBOR_CONF_MAX_NESTING
+#define CBOR_MAX_NESTING CBOR_CONF_MAX_NESTING
+#else /* CBOR_CONF_MAX_NESTING */
+#define CBOR_MAX_NESTING (8)
+#endif /* CBOR_CONF_MAX_NESTING */
+
+#define CBOR_UNSIGNED_SIZE(uint) ((uint) < CBOR_SIZE_1 \
+                                  ? 1 \
+                                  : ((uint) <= UINT8_MAX \
+                                     ? 1 + 1 \
+                                     : ((uint) <= UINT16_MAX \
+                                        ? 1 + 2 \
+                                        : ((uint) <= UINT32_MAX \
+                                           ? 1 + 4 \
+                                           : 1 + 8))))
+#define CBOR_BYTE_STRING_SIZE(bytes) (CBOR_UNSIGNED_SIZE(bytes) + (bytes))
+
+/**
+ * Enumeration of major types.
+ */
+typedef enum cbor_major_type_t {
+  CBOR_MAJOR_TYPE_NONE = -1,
+  CBOR_MAJOR_TYPE_UNSIGNED = 0x00,
+  CBOR_MAJOR_TYPE_BYTE_STRING = 0x40,
+  CBOR_MAJOR_TYPE_TEXT_STRING = 0x60,
+  CBOR_MAJOR_TYPE_ARRAY = 0x80,
+  CBOR_MAJOR_TYPE_MAP = 0xA0,
+  CBOR_MAJOR_TYPE_SIMPLE = 0xE0,
+} cbor_major_type_t;
+
+/**
+ * Enumeration of simple values.
+ */
+typedef enum cbor_simple_value_t {
+  CBOR_SIMPLE_VALUE_NONE = -1,
+  CBOR_SIMPLE_VALUE_FALSE = 0xF4,
+  CBOR_SIMPLE_VALUE_TRUE = 0xF5,
+  CBOR_SIMPLE_VALUE_NULL = 0xF6,
+  CBOR_SIMPLE_VALUE_UNDEFINED = 0xF7,
+} cbor_simple_value_t;
+
+/**
+ * Enumeration of size information in various major types.
+ */
+typedef enum cbor_size_t {
+  CBOR_SIZE_NONE = -1, /**< error condition */
+  CBOR_SIZE_1 = 0x18,  /**< 1 byte */
+  CBOR_SIZE_2 = 0x19,  /**< 2 bytes */
+  CBOR_SIZE_4 = 0x1A,  /**< 4 bytes */
+  CBOR_SIZE_8 = 0x1B,  /**< 8 bytes */
+} cbor_size_t;
+
+/**
+ * Structure of a nesting record.
+ */
+typedef struct cbor_nesting_record_t {
+  uint8_t *start;
+  size_t objects;
+} cbor_nesting_record_t;
+
+/**
+ * Structure of the internal state of a CBOR writer.
+ */
+typedef struct cbor_writer_state_t {
+  const uint8_t *buffer_head;
+  uint8_t *buffer;
+  size_t buffer_size;
+  size_t nesting_depth;
+  cbor_nesting_record_t records[CBOR_MAX_NESTING];
+} cbor_writer_state_t;
+
+/**
+ * Structure of the internal state of a CBOR reader.
+ */
+typedef struct cbor_reader_state_t {
+  const uint8_t *cbor;
+  size_t cbor_size;
+} cbor_reader_state_t;
+
+/**
+ * Prepares for writing CBOR output.
+ *
+ * \param state       State of the CBOR writer.
+ * \param buffer      Buffer for holding CBOR output.
+ * \param buffer_size Size of \p buffer in bytes.
+ */
+void cbor_init_writer(cbor_writer_state_t *state,
+                      uint8_t *buffer, size_t buffer_size);
+
+/**
+ * Finishes writing CBOR output.
+ *
+ * \param state State of the CBOR writer.
+ *
+ * \return      Size of the CBOR output or \c 0 on error.
+ */
+size_t cbor_end_writer(cbor_writer_state_t *state);
+
+/**
+ * Marks the CBOR output as erroneous.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_break_writer(cbor_writer_state_t *state);
+
+/**
+ * Appends an arbitrary CBOR object.
+ *
+ * \param state       State of the CBOR writer.
+ * \param object      Location of the CBOR object.
+ * \param object_size Size of \p object in bytes.
+ */
+void cbor_write_object(cbor_writer_state_t *state,
+                       const void *object, size_t object_size);
+
+/**
+ * Appends an unsigned integer.
+ *
+ * \param state State of the CBOR writer.
+ * \param value Unsigned integer.
+ */
+void cbor_write_unsigned(cbor_writer_state_t *state, uint64_t value);
+
+/**
+ * Appends a byte string.
+ *
+ * \param state     State of the CBOR writer.
+ * \param data      The byte string.
+ * \param data_size Size of \p data in bytes.
+ */
+void cbor_write_data(cbor_writer_state_t *state,
+                     const uint8_t *data, size_t data_size);
+
+/**
+ * Appends a text string.
+ *
+ * \param state     State of the CBOR writer.
+ * \param text      The text string.
+ * \param text_size Number of characters in \p text.
+ */
+void cbor_write_text(cbor_writer_state_t *state,
+                     const char *text, size_t text_size);
+
+/**
+ * Appends the simple value \c null.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_write_null(cbor_writer_state_t *state);
+
+/**
+ * Appends the simple value \c undefined.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_write_undefined(cbor_writer_state_t *state);
+
+/**
+ * Appends a boolean simple value.
+ *
+ * \param state   State of the CBOR writer.
+ * \param boolean The boolean simple value to append.
+ */
+void cbor_write_bool(cbor_writer_state_t *state, bool boolean);
+
+/**
+ * Encloses subsequent CBOR objects in a byte string.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_open_data(cbor_writer_state_t *state);
+
+/**
+ * Stops enclosing subsequent CBOR objects in the innermost byte string.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_close_data(cbor_writer_state_t *state);
+
+/**
+ * Adds subsequent CBOR objects to an array.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_open_array(cbor_writer_state_t *state);
+
+/**
+ * Stops adding subsequent CBOR objects to the innermost array.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_close_array(cbor_writer_state_t *state);
+
+/**
+ * Adds subsequent entries to a map.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_open_map(cbor_writer_state_t *state);
+
+/**
+ * Stops adding subsequent entries to the innermost map.
+ *
+ * \param state State of the CBOR writer.
+ */
+void cbor_close_map(cbor_writer_state_t *state);
+
+/**
+ * Prepares for reading CBOR input.
+ *
+ * \param state     State of the CBOR reader.
+ * \param cbor      Buffer that holds the CBOR input.
+ * \param cbor_size Size of \p cbor in bytes.
+ */
+void cbor_init_reader(cbor_reader_state_t *state,
+                      const uint8_t *cbor, size_t cbor_size);
+
+/**
+ * Inspects the next major type.
+ *
+ * \param state State of the CBOR reader.
+ *
+ * \return      The next major type (could be \c CBOR_MAJOR_TYPE_NONE).
+ */
+cbor_major_type_t cbor_peek_next(cbor_reader_state_t *state);
+
+/**
+ * Ensures that no bytes remain unread.
+ *
+ * \param state State of the CBOR reader.
+ *
+ * \return      \c true if no unread bytes remain, or \c false otherwise.
+ */
+bool cbor_end_reader(cbor_reader_state_t *state);
+
+/**
+ * Reads an unsigned integer.
+ *
+ * \param state State of the CBOR reader.
+ * \param value Buffer to store the unsigned integer.
+ *
+ * \return      Size of the unsigned integer or \c CBOR_SIZE_NONE on error.
+ */
+cbor_size_t cbor_read_unsigned(cbor_reader_state_t *state, uint64_t *value);
+
+/**
+ * Reads a byte string.
+ *
+ * \param state     State of the CBOR reader.
+ * \param data_size Size of the byte string in bytes.
+ *
+ * \return          First byte of the byte string or \c NULL on error.
+ */
+const uint8_t *cbor_read_data(cbor_reader_state_t *state, size_t *data_size);
+
+/**
+ * Reads a text string.
+ *
+ * \param state     State of the CBOR reader.
+ * \param text_size Number of characters in the text string.
+ *
+ * \return          First character of the text string or \c NULL on error.
+ */
+const char *cbor_read_text(cbor_reader_state_t *state, size_t *text_size);
+
+/**
+ * Reads a simple value.
+ *
+ * \param state State of the CBOR reader.
+ *
+ * \return      The simple value or \c CBOR_SIMPLE_VALUE_NONE on error.
+ */
+cbor_simple_value_t cbor_read_simple(cbor_reader_state_t *state);
+
+/**
+ * Reads the number of elements of an array.
+ *
+ * \param state State of the CBOR reader.
+ *
+ * \return      Number of elements or \c SIZE_MAX on error.
+ */
+size_t cbor_read_array(cbor_reader_state_t *state);
+
+/**
+ * Reads the number of entries of a map.
+ *
+ * \param state State of the CBOR reader.
+ *
+ * \return      Number of entries or \c SIZE_MAX on error.
+ */
+size_t cbor_read_map(cbor_reader_state_t *state);
+
+/** @} */
+/** @} */
+
+#endif /* CBOR_H_ */

--- a/tests/08-native-runs/16-cbor.sh
+++ b/tests/08-native-runs/16-cbor.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+./run-one.sh 16-cbor

--- a/tests/08-native-runs/16-cbor/Makefile
+++ b/tests/08-native-runs/16-cbor/Makefile
@@ -1,0 +1,8 @@
+CONTIKI_PROJECT = test-cbor
+all: $(CONTIKI_PROJECT)
+
+TARGET = native
+
+MODULES += os/services/unit-test
+
+include ../../../Makefile.include

--- a/tests/08-native-runs/16-cbor/test-cbor.c
+++ b/tests/08-native-runs/16-cbor/test-cbor.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025, Siemens AG.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Unit test of the CBOR library.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#include "contiki.h"
+#include "lib/cbor.h"
+#include "unit-test.h"
+#include <stdio.h>
+#include <string.h>
+
+PROCESS(test_process, "test");
+AUTOSTART_PROCESSES(&test_process);
+
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_write_read, "Basic write read example");
+UNIT_TEST(test_write_read)
+{
+  static const uint8_t foo[] = { 0xA, 0xB, 0xC };
+  uint8_t buffer[128];
+  size_t cbor_size;
+
+  UNIT_TEST_BEGIN();
+
+  /* write a CBOR array that contains a byte array and an unsigned value */
+  {
+    cbor_writer_state_t writer;
+    cbor_init_writer(&writer, buffer, sizeof(buffer));
+    cbor_open_array(&writer);
+    cbor_write_data(&writer, foo, sizeof(foo));
+    cbor_write_unsigned(&writer, 123);
+    cbor_close_array(&writer);
+    cbor_size = cbor_end_writer(&writer);
+  }
+
+  UNIT_TEST_ASSERT(cbor_size);
+
+  /* read the CBOR array and compare with our inputs */
+  {
+    cbor_reader_state_t reader;
+    cbor_init_reader(&reader, buffer, cbor_size);
+    UNIT_TEST_ASSERT(CBOR_MAJOR_TYPE_ARRAY == cbor_peek_next(&reader));
+    UNIT_TEST_ASSERT(2 == cbor_read_array(&reader));
+    size_t data_size;
+    const uint8_t *data = cbor_read_data(&reader, &data_size);
+    UNIT_TEST_ASSERT(data);
+    UNIT_TEST_ASSERT(data_size == sizeof(foo));
+    UNIT_TEST_ASSERT(!memcmp(foo, data, data_size));
+    uint64_t value;
+    UNIT_TEST_ASSERT(CBOR_SIZE_NONE != cbor_read_unsigned(&reader, &value));
+    UNIT_TEST_ASSERT(123 == value);
+    UNIT_TEST_ASSERT(cbor_end_reader(&reader));
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(test_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(test_write_read);
+
+  if(!UNIT_TEST_PASSED(test_write_read)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
+  printf("=check-me= DONE\n");
+  printf("---\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -19,6 +19,7 @@ tests/08-native-runs/12-heapmem/native:./12-heapmem.sh:DEFINES=HEAPMEM_DEBUG=0 \
 tests/08-native-runs/12-heapmem/native:./12-heapmem.sh:DEFINES=HEAPMEM_DEBUG=1 \
 tests/08-native-runs/13-coffee/native:./13-coffee.sh \
 tests/08-native-runs/14-sha-256/native:./14-sha-256.sh \
-tests/08-native-runs/15-ieee802154-security/native:./15-ieee802154-security.sh
+tests/08-native-runs/15-ieee802154-security/native:./15-ieee802154-security.sh \
+tests/08-native-runs/16-cbor/native:./16-cbor.sh \
 
 include ../Makefile.compile-test


### PR DESCRIPTION
This PR adds a CBOR library. Unlike the CBOR library suggested in #2993, this one here supports parsing, checks for buffer overflows, and does not ask for the number of elements/entries when opening an array/map. Like in QCBOR, it is unnecessary to check for errors after each write operation. This is because once an error state is entered, subsequent write operations are being ignored. CBOR is written in reverse in order to avoid asking for the number of elements/entries, while also avoiding rearranging already written data.