### PR TITLE
Add pre-commit hook for artistic style (astyle)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+-   repo: https://github.com/igrr/astyle_py.git
+    rev: v1.0.5
+    hooks:
+    -   id: astyle_py
+        args: ['--style=1tbs',
+               '--align-pointer=name',
+               '--align-reference=name',
+               '--attach-closing-while',
+               '--attach-return-type-decl',
+               '--break-one-line-headers',
+               '--break-return-type',
+               '--convert-tabs',
+               '--indent-continuation=2',
+               '--indent-preproc-define',
+               '--indent=spaces=2',
+               '--max-code-length=80',
+               '--min-conditional-indent=0',
+               '--unpad-paren']


### PR DESCRIPTION
For auto-formatting code, we already have the uncrustify scripts in `tools/code-style`, but uncrustify often handles pointer stars `*` incorrectly.

This PR adds an astyle config, which yields better results. It can be envoked via `pre-commit run --files <path to file>`.

I set the indentation level after a line that ends with `=` or `(` to 2, i.e., 4 spaces. While the uncrustify config inserts only 2 spaces, 4 spaces seems to be more common in Contiki-NG, as well as other C projects.

Deviating from the uncrustify config, I enabled the alignment of assignments like so
```c
very_long_variable_name = very_long_function_name()
                          + 123;
```
Otherwise, we would have a strange exception.