### PR TITLE
frame802154e.ch: Declare ies parameter as const in frame802154e_create_*

### DIFF
--- a/os/net/mac/framer/frame802154e-ie.c
+++ b/os/net/mac/framer/frame802154e-ie.c
@@ -137,7 +137,7 @@ create_mlme_long_ie_descriptor(uint8_t *buf, uint8_t sub_id, int ie_len)
 /* Header IE. ACK/NACK time correction. Used in enhanced ACKs */
 int
 frame80215e_create_ie_header_ack_nack_time_correction(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   int ie_len = 2;
   if(len >= 2 + ie_len && ies != NULL) {
@@ -203,7 +203,8 @@ frame80215e_create_ie_payload_list_termination(uint8_t *buf, int len,
 #if TSCH_WITH_SIXTOP
 /* Payload IE. 6top. Used to nest sub-IEs */
 int
-frame80215e_create_ie_ietf(uint8_t *buf, int len, struct ieee802154_ies *ies)
+frame80215e_create_ie_ietf(uint8_t *buf, int len,
+    const struct ieee802154_ies *ies)
 {
   if(len >= 2 && ies != NULL) {
     create_payload_ie_descriptor(buf,
@@ -218,7 +219,7 @@ frame80215e_create_ie_ietf(uint8_t *buf, int len, struct ieee802154_ies *ies)
 /* Payload IE. MLME. Used to nest sub-IEs */
 int
 frame80215e_create_ie_mlme(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   int ie_len = 0;
   if(len >= 2 + ie_len && ies != NULL) {
@@ -233,7 +234,7 @@ frame80215e_create_ie_mlme(uint8_t *buf, int len,
 /* MLME sub-IE. TSCH synchronization. Used in EBs: ASN and join priority */
 int
 frame80215e_create_ie_tsch_synchronization(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   int ie_len = 6;
   if(len >= 2 + ie_len && ies != NULL) {
@@ -253,7 +254,7 @@ frame80215e_create_ie_tsch_synchronization(uint8_t *buf, int len,
 /* MLME sub-IE. TSCH slotframe and link. Used in EBs: initial schedule */
 int
 frame80215e_create_ie_tsch_slotframe_and_link(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   if(ies != NULL) {
     int i;
@@ -290,7 +291,7 @@ frame80215e_create_ie_tsch_slotframe_and_link(uint8_t *buf, int len,
 /* MLME sub-IE. TSCH timeslot. Used in EBs: timeslot template (timing) */
 int
 frame80215e_create_ie_tsch_timeslot(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   int ie_len;
   if(ies == NULL) {
@@ -316,7 +317,7 @@ frame80215e_create_ie_tsch_timeslot(uint8_t *buf, int len,
 /* MLME sub-IE. TSCH channel hopping sequence. Used in EBs: hopping sequence */
 int
 frame80215e_create_ie_tsch_channel_hopping_sequence(uint8_t *buf, int len,
-    struct ieee802154_ies *ies)
+    const struct ieee802154_ies *ies)
 {
   int ie_len;
   if(ies == NULL || ies->ie_hopping_sequence_len > sizeof(ies->ie_hopping_sequence_list)) {

--- a/os/net/mac/framer/frame802154e-ie.h
+++ b/os/net/mac/framer/frame802154e-ie.h
@@ -95,7 +95,7 @@ struct ieee802154_ies {
 /** Insert various Information Elements **/
 /* Header IE. ACK/NACK time correction. Used in enhanced ACKs */
 int frame80215e_create_ie_header_ack_nack_time_correction(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 /* Header IE. List termination 1 (Signals the end of the Header IEs when
  * followed by payload IEs) */
 int frame80215e_create_ie_header_list_termination_1(uint8_t *buf, int len,
@@ -110,23 +110,23 @@ int frame80215e_create_ie_payload_list_termination(uint8_t *buf, int len,
 #if TSCH_WITH_SIXTOP
 /* Payload IE. 6top. Used to nest sub-IEs */
 int frame80215e_create_ie_ietf(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 #endif /* TSCH_WITH_SIXTOP */
 /* Payload IE. MLME. Used to nest sub-IEs */
 int frame80215e_create_ie_mlme(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 /* MLME sub-IE. TSCH synchronization. Used in EBs: ASN and join priority */
 int frame80215e_create_ie_tsch_synchronization(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 /* MLME sub-IE. TSCH slotframe and link. Used in EBs: initial schedule */
 int frame80215e_create_ie_tsch_slotframe_and_link(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 /* MLME sub-IE. TSCH timeslot. Used in EBs: timeslot template (timing) */
 int frame80215e_create_ie_tsch_timeslot(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 /* MLME sub-IE. TSCH channel hopping sequence. Used in EBs: hopping sequence */
 int frame80215e_create_ie_tsch_channel_hopping_sequence(uint8_t *buf, int len,
-    struct ieee802154_ies *ies);
+    const struct ieee802154_ies *ies);
 
 /* Parse all Information Elements of a frame */
 int frame802154e_parse_information_elements(const uint8_t *buf, uint8_t buf_size,


### PR DESCRIPTION
As discussed in #2713, information element (IE) structs should remain constant during serialization.