### PR TITLE
clock: Add format specifier for printing clock_time_t

### DIFF
--- a/os/sys/clock.h
+++ b/os/sys/clock.h
@@ -69,7 +69,7 @@
 #ifndef CLOCK_H_
 #define CLOCK_H_
 
-#include <stdint.h>
+#include <inttypes.h>
 
 /** \brief The clock size (in bytes). */
 #ifdef CLOCK_CONF_SIZE
@@ -83,9 +83,11 @@
 #if CLOCK_SIZE == 4
 typedef uint32_t clock_time_t;
 #define CLOCK_LT(a, b)  ((int32_t)((a) - (b)) < 0)
+#define CLOCK_PRI PRIu32
 #elif CLOCK_SIZE == 8
 typedef uint64_t clock_time_t;
 #define CLOCK_LT(a, b)  ((int64_t)((a) - (b)) < 0)
+#define CLOCK_PRI PRIu64
 #else
 #error Unsupported clock_time_t size (check CLOCK_CONF_SIZE)
 #endif


### PR DESCRIPTION
This adds a preprocessor macro for printing values of type `clock_time_t` in a platform-independent and secure manner. Here is a usage example:

```c
      LOG_INFO("I=%" CLOCK_PRI "s t=%" CLOCK_PRI "s\n",
               trickle->interval_size / CLOCK_SECOND,
               trickle->timer.etimer.timer.interval / CLOCK_SECOND);
```