### PR TITLE
anti-replay: Doxygen fix

### DIFF
--- a/os/net/mac/anti-replay.c
+++ b/os/net/mac/anti-replay.c
@@ -31,16 +31,14 @@
  */
 
 /**
+ * \addtogroup llsec802154
+ * @{
+ *
  * \file
  *         Protects against replay attacks by comparing with the last
  *         unicast or broadcast frame counter of the sender.
  * \author
  *         Konrad Krentz <konrad.krentz@gmail.com>
- */
-
-/**
- * \addtogroup llsec802154
- * @{
  */
 
 #include "net/mac/anti-replay.h"

--- a/os/net/mac/anti-replay.h
+++ b/os/net/mac/anti-replay.h
@@ -31,15 +31,13 @@
  */
 
 /**
+ * \addtogroup llsec802154
+ * @{
+ *
  * \file
  *         Interface to anti-replay mechanisms.
  * \author
  *         Konrad Krentz <konrad.krentz@gmail.com>
- */
-
-/**
- * \addtogroup llsec802154
- * @{
  */
 
 #ifndef ANTI_REPLAY_H


### PR DESCRIPTION
This makes `anti-replay.ch` appear in the file list of the doxygen group `llsec802154`.

Which style is actually preferred?
```c
/**
 * \addtogroup llsec802154
 * @{
 *
 * \file
 *         Interface to anti-replay mechanisms.
 * \author
 *         Konrad Krentz <konrad.krentz@gmail.com>
 */
```
or
```c
/**
 * \addtogroup llsec802154
 * @{
 */

/**
 * \file
 *         Interface to anti-replay mechanisms.
 * \author
 *         Konrad Krentz <konrad.krentz@gmail.com>
 */
```
or anything else?