### PR TITLE
CC2538: Fix compilation with Arm GNU Toolchain 14.2.Rel1

### DIFF
--- a/arch/cpu/cc2538/Makefile.cc2538
+++ b/arch/cpu/cc2538/Makefile.cc2538
@@ -31,7 +31,7 @@ CONTIKI_CPU_SOURCEFILES += dbg.c ieee-addr.c
 CONTIKI_CPU_SOURCEFILES += slip-arch.c
 CONTIKI_CPU_SOURCEFILES += i2c.c cc2538-temp-sensor.c vdd3-sensor.c
 CONTIKI_CPU_SOURCEFILES += cfs-coffee-arch.c pwm.c
-CONTIKI_CPU_SOURCEFILES += startup-gcc.c
+CONTIKI_CPU_SOURCEFILES += rom-util.c startup-gcc.c
 CONTIKI_CPU_SOURCEFILES += cc2538-sram-seeder.c
 
 USB_SOURCEFILES += usb-core.c cdc-acm.c usb-arch.c usb-serial.c cdc-acm-descriptors.c

--- a/arch/cpu/cc2538/dev/rom-util.c
+++ b/arch/cpu/cc2538/dev/rom-util.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, Siemens AG.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \addtogroup cc2538-rom-util
+ * @{
+ *
+ * \file
+ *         Implementation of the cc2538 ROM utility function library driver.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#include "rom-util.h"
+
+const struct rom_util_api *const rom_util_api =
+    (struct rom_util_api *)0x00000048;
+
+/**
+ * @}
+ */

--- a/arch/cpu/cc2538/dev/rom-util.h
+++ b/arch/cpu/cc2538/dev/rom-util.h
@@ -94,32 +94,32 @@ struct rom_util_api {
 /** \name Pointer to the ROM utility function library API table
  * @{
  */
-#define ROM_UTIL_API            ((struct rom_util_api *)0x00000048)
+extern const struct rom_util_api *const rom_util_api;
 /** @} */
 /*---------------------------------------------------------------------------*/
 /** \name ROM utility function library API accessor macros
  * @{
  */
 #define rom_util_crc32(data, byte_count) \
-  (ROM_UTIL_API->crc32((data), (byte_count)))
+  (rom_util_api->crc32((data), (byte_count)))
 #define rom_util_get_flash_size() \
-  (ROM_UTIL_API->get_flash_size())
+  (rom_util_api->get_flash_size())
 #define rom_util_get_chip_id() \
-  (ROM_UTIL_API->get_chip_id())
+  (rom_util_api->get_chip_id())
 #define rom_util_page_erase(flash_addr, size) \
-  (ROM_UTIL_API->page_erase((flash_addr), (size)))
+  (rom_util_api->page_erase((flash_addr), (size)))
 #define rom_util_program_flash(ram_data, flash_addr, byte_count) \
-  (ROM_UTIL_API->program_flash((ram_data), (flash_addr), (byte_count)))
+  (rom_util_api->program_flash((ram_data), (flash_addr), (byte_count)))
 #define rom_util_reset_device() \
-  (ROM_UTIL_API->reset_device())
+  (rom_util_api->reset_device())
 #define rom_util_memset(s, c, n) \
-  (ROM_UTIL_API->memset((s), (c), (n)))
+  (rom_util_api->memset((s), (c), (n)))
 #define rom_util_memcpy(dest, src, n) \
-  (ROM_UTIL_API->memcpy((dest), (src), (n)))
+  (rom_util_api->memcpy((dest), (src), (n)))
 #define rom_util_memcmp(s1, s2, n) \
-  (ROM_UTIL_API->memcmp((s1), (s2), (n)))
+  (rom_util_api->memcmp((s1), (s2), (n)))
 #define rom_util_memmove(dest, src, n) \
-  (ROM_UTIL_API->memmove((dest), (src), (n)))
+  (rom_util_api->memmove((dest), (src), (n)))
 /** @} */
 
 #endif /* ROM_UTIL_H_ */


### PR DESCRIPTION
This PR reorganizes `rom-util.ch` to resolve this compilation error:

```
rom-util.h:124:16: error: array subscript 0 is outside array bounds of 'const struct rom_util_api[0]'
```

This should also resolve [discussions/1567](https://github.com/contiki-ng/contiki-ng/discussions/1567).