### PR TITLE
Modernising SimpleLink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,9 @@
 [submodule "tools/motelist"]
 	path = tools/motelist
 	url = https://github.com/contiki-ng/motelist
-[submodule "arch/cpu/simplelink-cc13xx-cc26xx/lib/coresdk_cc13xx_cc26xx"]
-	path = arch/cpu/simplelink-cc13xx-cc26xx/lib/coresdk_cc13xx_cc26xx
-	url = https://github.com/contiki-ng/coresdk_cc13xx_cc26xx.git
+[submodule "arch/cpu/simplelink-cc13xx-cc26xx/lib/simplelink-lowpower-f2-sdk"]
+	path = arch/cpu/simplelink-cc13xx-cc26xx/lib/simplelink-lowpower-f2-sdk
+	url = https://github.com/TexasInstruments/simplelink-lowpower-f2-sdk.git
 [submodule "arch/cpu/cc26xx-cc13xx/lib/cc2640r2-sdk"]
 	path = arch/cpu/cc26x0-cc13x0/lib/cc2640r2-sdk
 	url = https://github.com/contiki-ng/cc2640r2-sdk.git

--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -6,7 +6,7 @@ CC13x2_CC26x2_PRE_RTM ?= 1
 # Core SDK is placed as a submodule under arch/cpu/simplelink-cc13xx-cc26xx/lib.
 # Do a sanity check that Core SDK submodule has been initialized.
 ifndef CORE_SDK
- CORE_SDK := $(CONTIKI_CPU)/lib/coresdk_cc13xx_cc26xx
+ CORE_SDK := $(CONTIKI_CPU)/lib/simplelink-lowpower-f2-sdk
  CORE_SDK_INIT := $(shell [ -f $(CORE_SDK)/.git ] && echo 1)
 
  ifneq ($(CORE_SDK_INIT),1)
@@ -39,7 +39,7 @@ ifeq ($(SUBFAMILY),cc13x2-cc26x2)
 # CC13x0/CC26x0 does not have this, with both its devices name and library
 # name the same as its own device family name.
 else
- SDK_DEVICES_NAME := $(DEVICE_FAMILY_LC)
+ SDK_DEVICES_NAME := $(SUBFAMILY_LC)
  SDK_LIB_NAME := $(DEVICE_FAMILY_LC)
 endif
 

--- a/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -48,7 +48,12 @@ endif
 
 # Both ccfg-conf.c and startup_cc13xx_cc26xx_gcc.c is located locally in
 # the arch/cpu/cc13xx-cc26xx folder.
-CONTIKI_CPU_SOURCEFILES += ccfg-conf.c startup_cc13xx_cc26xx_gcc.c
+CONTIKI_CPU_SOURCEFILES += ccfg-conf.c
+ifeq ($(SUBFAMILY),cc13x4-cc26x4)
+  CONTIKI_CPU_SOURCEFILES += startup_gcc.c
+else
+  CONTIKI_CPU_SOURCEFILES += startup_cc13xx_cc26xx_gcc.c
+endif
 
 # CPU-dependent source files
 CONTIKI_CPU_SOURCEFILES += rtimer-arch.c    clock-arch.c
@@ -153,26 +158,5 @@ $(OBJECTDIR)/ieee-addr.o: $(GENDIR)/ieee-addr-id.h
 include $(CONTIKI_CPU)/$(SUBFAMILY)/Makefile.$(SUBFAMILY)
 
 ################################################################################
-### For the .upload make target
-BSL_FLAGS += -e -w -v
-
-ifdef PORT
-  BSL_FLAGS += -p $(PORT)
-endif
-
-BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
-
-ifeq ($(BOARD_SUPPORTS_BSL),1)
-%.upload: $(OUT_BIN)
-ifeq ($(wildcard $(BSL)), )
-	$(error Could not find "$(BSL)". Did you run 'git submodule update --init'?)
-else
-	$(BSL) $(BSL_FLAGS) $<
-endif
-else
-%.upload:
-	@echo "This board cannot be programmed through the ROM bootloader and therefore does not support the .upload target."
-endif
-
 ### For the login etc targets
 BAUDRATE ?= 115200

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/Makefile.cc13x4-cc26x4
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/Makefile.cc13x4-cc26x4
@@ -1,0 +1,10 @@
+################################################################################
+### CC13x4/CC26x4 CPU makefile
+
+TARGET_LIBFILES += $(SDK_NORTOS)/lib/gcc/m33f/nortos_$(SDK_LIB_NAME).a
+TARGET_LIBFILES += $(SDK_DRIVERS)/rf/lib/gcc/m33f/rf_multiMode_$(SDK_LIB_NAME).a
+TARGET_LIBFILES += $(SDK_DRIVERS)/lib/gcc/m33f/drivers_$(SDK_LIB_NAME).a
+TARGET_LIBFILES += $(SDK_DEVICES)/driverlib/bin/gcc/driverlib.lib
+
+# CC13x4/CC26x4 is a Cortex-M33 architecture
+include $(CONTIKI)/$(CONTIKI_NG_CM33_DIR)/Makefile.cm33

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/README.md
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/README.md
@@ -1,0 +1,3 @@
+ - `startup_gcc.c` is copied from `../lib/simplelink-lowpower-f2-sdk/kernel/nortos/startup/startup_cc13x4_cc26x4_gcc.c`.
+ - `cc13x4-cc26x4.*` are copied from `../lib/simplelink-lowpower-f2-sdk/source/ti/boards/cc13x4_cc26x4/cc13x4_cc26x4_nortos.*`.
+ 

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/cc13x4-cc26x4-cm33.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/cc13x4-cc26x4-cm33.h
@@ -1,0 +1,61 @@
+/*
+ * Template:
+ * Copyright (c) 2012 ARM LIMITED
+ * All rights reserved.
+ *
+ * CC13xx-CC26xx:
+ * Copyright (c) 2017, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup cc26xx
+ * @{
+ *
+ * \defgroup cc26xx-cm33 CC13x4/CC26x4 CMSIS
+ *
+ * CC13x4/CC26x4 Cortex-M33 CMSIS definitions
+ * @{
+ *
+ * \file
+ * CMSIS Cortex-M3 core peripheral access layer header file for CC13x4/CC26x4
+ */
+
+#ifndef CC13X4_CC26X4_CM33_H_
+#define CC13X4_CC26X4_CM33_H_
+
+#include DeviceFamily_constructPath(cmsis/cc26x4.h)
+#include "core_cm33.h" /* Cortex-M33 processor and core peripherals */
+
+#endif /* CC13X4_CC26X4_CM33_H_ */
+
+/**
+ * @}
+ * @}
+ */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/cc13x4-cc26x4.icf
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/cc13x4-cc26x4.icf
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020-2022, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+define symbol __intvec_start__ = 0x00000000;
+/*-Memory Regions-*/
+define symbol ROM_start__ = 0x00000000;
+define symbol ROM_end__   = 0x000FFFFF;
+define symbol RAM_start__ = 0x20000000;
+define symbol RAM_end__   = 0x2003FFFF;
+define symbol GPRAM_start__ = 0x11000000;
+define symbol GPRAM_end__   = 0x11001FFF;
+define symbol CCFG_START__ = 0x50000000;
+define symbol CCFG_END__   = 0x500007FF;
+
+/* Define a memory region that covers the entire 4 GB addressable space */
+define memory mem with size = 4G;
+
+/* Define a region for the on-chip flash */
+define region FLASH_region = mem:[from ROM_start__ to ROM_end__];
+
+/* Define a region for the on-chip SRAM */
+define region RAM_region = mem:[from RAM_start__ to RAM_end__];
+
+/* Define a region for the on-chip GPRAM */
+define region GPRAM_region = mem:[from GPRAM_start__ to GPRAM_end__];
+
+/* Place the interrupt vectors at the start of flash */
+place at address mem:__intvec_start__ { readonly section .resetVecs };
+keep { section .resetVecs};
+
+/* Define a region for CCFG */
+define region CCFG_region = mem:[from CCFG_START__ to CCFG_END__];
+place in CCFG_region {section .ccfg};
+keep { section .ccfg };
+
+/* Place remaining 'read only' in Flash */
+place in FLASH_region { readonly };
+
+/* Place all read/write items into RAM */
+place in RAM_region   { readwrite, section .ramVecs };
+initialize by copy { readwrite };
+do not initialize { section .ramVecs };
+
+/*
+ * Define CSTACK block to contain .stack section. This enables the IAR IDE
+ * to properly show the stack content during debug. Place stack at end of
+ * retention RAM, do not initialize (initializing the stack will destroy the
+ * return address from the initialization code, causing the processor to branch
+ * to zero and fault)
+ */
+define block CSTACK with alignment = 8, size = 0x400 { section .stack };
+place at end of RAM_region { block CSTACK };
+do not initialize { section .stack, section .noinit};
+
+/* Export stack top symbol. Used by startup file */
+define exported symbol STACK_TOP = RAM_end__ + 1;
+
+/* Primary Heap configuration */
+define symbol HEAPSIZE = 16384;
+define block HEAP with alignment = 8, size = HEAPSIZE { };
+
+/* Place heap just before CSTACK */
+place in RAM_region { block HEAP };
+
+/* Explicitly placed off target for the storage of logging data.
+ * The data placed here is NOT  loaded ont the target device.
+ * This is part of 1 GB of external memory from 0x60000000 - 0x9FFFFFFF.
+ * ARM memory map can be found here:
+ * https://developer.arm.com/documentation/ddi0337/e/memory-map/about-the-memory-map
+ */
+define region LOG_DATA = mem:[from 0x90000000 to 0x9003FFFF];
+define region LOG_PTR = mem:[from 0x94000008 to 0x94040007];
+define block LOG_DATA  with size = 0x40000 { readonly section .log_data  };
+define block LOG_PTR   with size = 0x40000 { readonly section .log_ptr* };
+".log_data": place noload in LOG_DATA { block LOG_DATA };
+".log_ptr": place noload in LOG_PTR { block LOG_PTR };

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/cc13x4-cc26x4.lds
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/cc13x4-cc26x4.lds
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2020-2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+STACKSIZE = 1024;
+HEAPSIZE = 16384; /* Size of heap buffer used by HeapMem */
+
+MEMORY
+{
+    FLASH (RX)      : ORIGIN = 0x00000000, LENGTH = 0x00100000
+    /*
+     * Customer Configuration Area and Bootloader Backdoor configuration in
+     * flash
+     */
+    FLASH_CCFG (R)  : ORIGIN = 0x50000000, LENGTH = 0x00000800
+    SRAM (RWX)      : ORIGIN = 0x20000000, LENGTH = 0x00040000
+    GPRAM (RWX)     : ORIGIN = 0x11000000, LENGTH = 0x00002000
+    /* Explicitly placed off target for the storage of logging data.
+     * The data placed here is NOT loaded onto the target device.
+     * This is part of 1 GB of external memory from 0x60000000 - 0x9FFFFFFF.
+     * ARM memory map can be found here:
+     * https://developer.arm.com/documentation/ddi0337/e/memory-map/about-the-memory-map
+     */
+    LOG_DATA     (R) : ORIGIN = 0x90000000, LENGTH = 0x40000
+    LOG_PTR      (R) : ORIGIN = 0x94000008, LENGTH = 0x40000
+}
+
+REGION_ALIAS("REGION_TEXT", FLASH);
+REGION_ALIAS("REGION_BSS", SRAM);
+REGION_ALIAS("REGION_DATA", SRAM);
+REGION_ALIAS("REGION_STACK", SRAM);
+REGION_ALIAS("REGION_HEAP", SRAM);
+REGION_ALIAS("REGION_LOG", LOG_DATA);
+REGION_ALIAS("REGION_ARM_EXIDX", FLASH);
+REGION_ALIAS("REGION_ARM_EXTAB", FLASH);
+
+SECTIONS {
+
+    PROVIDE (_resetVecs_base_address =
+        DEFINED(_resetVecs_base_address) ? _resetVecs_base_address : 0x0);
+
+    .resetVecs (_resetVecs_base_address) : AT (_resetVecs_base_address) {
+        KEEP (*(.resetVecs))
+    } > REGION_TEXT
+
+    .ramVecs (NOLOAD) : {
+        KEEP (*(.ramVecs)) /* Section from interrupt.c (driverlib) */
+    } > REGION_DATA
+
+    /*
+     * UDMACC26XX_CONFIG_BASE below must match UDMACC26XX_CONFIG_BASE defined
+     * by ti/drivers/dma/UDMACC26XX.h
+     * The user is allowed to change UDMACC26XX_CONFIG_BASE to move it away from
+     * the default address 0x2000_0400, but remember it must be 1024 bytes aligned.
+     */
+    UDMACC26XX_CONFIG_BASE = 0x20000400;
+
+    /*
+     * Define absolute addresses for the DMA channels.
+     * DMA channels must always be allocated at a fixed offset from the DMA base address.
+     * --------- DO NOT MODIFY -----------
+     */
+    DMA_UART0_RX_CONTROL_TABLE_ENTRY_ADDRESS  = (UDMACC26XX_CONFIG_BASE + 0x10);
+    DMA_UART0_TX_CONTROL_TABLE_ENTRY_ADDRESS  = (UDMACC26XX_CONFIG_BASE + 0x20);
+    DMA_SPI0_RX_CONTROL_TABLE_ENTRY_ADDRESS   = (UDMACC26XX_CONFIG_BASE + 0x30);
+    DMA_SPI0_TX_CONTROL_TABLE_ENTRY_ADDRESS   = (UDMACC26XX_CONFIG_BASE + 0x40);
+    DMA_UART1_RX_CONTROL_TABLE_ENTRY_ADDRESS  = (UDMACC26XX_CONFIG_BASE + 0x50);
+    DMA_UART1_TX_CONTROL_TABLE_ENTRY_ADDRESS  = (UDMACC26XX_CONFIG_BASE + 0x60);
+    DMA_ADC_PRI_CONTROL_TABLE_ENTRY_ADDRESS   = (UDMACC26XX_CONFIG_BASE + 0x70);
+    DMA_GPT0A_PRI_CONTROL_TABLE_ENTRY_ADDRESS = (UDMACC26XX_CONFIG_BASE + 0x90);
+    DMA_SPI1_RX_CONTROL_TABLE_ENTRY_ADDRESS   = (UDMACC26XX_CONFIG_BASE + 0x100);
+    DMA_SPI1_TX_CONTROL_TABLE_ENTRY_ADDRESS   = (UDMACC26XX_CONFIG_BASE + 0x110);
+
+    DMA_UART0_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS = (UDMACC26XX_CONFIG_BASE + 0x210);
+    DMA_UART0_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS = (UDMACC26XX_CONFIG_BASE + 0x220);
+    DMA_SPI0_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS  = (UDMACC26XX_CONFIG_BASE + 0x230);
+    DMA_SPI0_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS  = (UDMACC26XX_CONFIG_BASE + 0x240);
+    DMA_UART1_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS = (UDMACC26XX_CONFIG_BASE + 0x250);
+    DMA_UART1_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS = (UDMACC26XX_CONFIG_BASE + 0x260);
+    DMA_ADC_ALT_CONTROL_TABLE_ENTRY_ADDRESS      = (UDMACC26XX_CONFIG_BASE + 0x270);
+    DMA_GPT0A_ALT_CONTROL_TABLE_ENTRY_ADDRESS    = (UDMACC26XX_CONFIG_BASE + 0x290);
+    DMA_SPI1_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS  = (UDMACC26XX_CONFIG_BASE + 0x300);
+    DMA_SPI1_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS  = (UDMACC26XX_CONFIG_BASE + 0x310);
+
+    /*
+     * Allocate UART0, UART1, SPI0, SPI1, ADC, and GPTimer0 DMA descriptors at absolute addresses.
+     * --------- DO NOT MODIFY -----------
+     */
+    UDMACC26XX_uart0RxControlTableEntry_is_placed = 0;
+    .dmaUart0RxControlTableEntry DMA_UART0_RX_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_UART0_RX_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaUart0RxControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_uart0TxControlTableEntry_is_placed = 0;
+    .dmaUart0TxControlTableEntry DMA_UART0_TX_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_UART0_TX_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaUart0TxControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaSpi0RxControlTableEntry_is_placed = 0;
+    .dmaSpi0RxControlTableEntry DMA_SPI0_RX_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_SPI0_RX_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaSpi0RxControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaSpi0TxControlTableEntry_is_placed = 0;
+    .dmaSpi0TxControlTableEntry DMA_SPI0_TX_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_SPI0_TX_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaSpi0TxControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_uart1RxControlTableEntry_is_placed = 0;
+    .dmaUart1RxControlTableEntry DMA_UART1_RX_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_UART1_RX_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaUart1RxControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_uart1TxControlTableEntry_is_placed = 0;
+    .dmaUart1TxControlTableEntry DMA_UART1_TX_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_UART1_TX_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaUart1TxControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaADCPriControlTableEntry_is_placed = 0;
+    .dmaADCPriControlTableEntry DMA_ADC_PRI_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_ADC_PRI_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaADCPriControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaGPT0APriControlTableEntry_is_placed = 0;
+    .dmaGPT0APriControlTableEntry DMA_GPT0A_PRI_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_GPT0A_PRI_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaGPT0APriControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaSpi1RxControlTableEntry_is_placed = 0;
+    .dmaSpi1RxControlTableEntry DMA_SPI1_RX_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_SPI1_RX_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaSpi1RxControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaSpi1TxControlTableEntry_is_placed = 0;
+    .dmaSpi1TxControlTableEntry DMA_SPI1_TX_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_SPI1_TX_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaSpi1TxControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_uart0RxAltControlTableEntry_is_placed = 0;
+    .dmaUart0RxAltControlTableEntry DMA_UART0_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_UART0_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaUart0RxAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_uart0TxAltControlTableEntry_is_placed = 0;
+    .dmaUart0TxAltControlTableEntry DMA_UART0_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_UART0_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaUart0TxAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaSpi0RxAltControlTableEntry_is_placed = 0;
+    .dmaSpi0RxAltControlTableEntry DMA_SPI0_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_SPI0_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaSpi0RxAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaSpi0TxAltControlTableEntry_is_placed = 0;
+    .dmaSpi0TxAltControlTableEntry DMA_SPI0_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_SPI0_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaSpi0TxAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_uart1RxAltControlTableEntry_is_placed = 0;
+    .dmaUart1RxAltControlTableEntry DMA_UART1_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_UART1_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaUart1RxAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_uart1TxAltControlTableEntry_is_placed = 0;
+    .dmaUart1TxAltControlTableEntry DMA_UART1_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_UART1_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaUart1TxAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaADCAltControlTableEntry_is_placed = 0;
+    .dmaADCAltControlTableEntry DMA_ADC_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_ADC_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaADCAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaGPT0AAltControlTableEntry_is_placed = 0;
+    .dmaGPT0AAltControlTableEntry DMA_GPT0A_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_GPT0A_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaGPT0AAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaSpi1RxAltControlTableEntry_is_placed = 0;
+    .dmaSpi1RxAltControlTableEntry DMA_SPI1_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_SPI1_RX_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaSpi1RxAltControlTableEntry)} > REGION_DATA
+
+    UDMACC26XX_dmaSpi1TxAltControlTableEntry_is_placed = 0;
+    .dmaSpi1TxAltControlTableEntry DMA_SPI1_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS (NOLOAD) : AT (DMA_SPI1_TX_ALT_CONTROL_TABLE_ENTRY_ADDRESS) {*(.dmaSpi1TxAltControlTableEntry)} > REGION_DATA
+
+    .text : {
+        CREATE_OBJECT_SYMBOLS
+        *(.text)
+        *(.text.*)
+        . = ALIGN(0x4);
+        KEEP (*(.ctors))
+        . = ALIGN(0x4);
+        KEEP (*(.dtors))
+        . = ALIGN(0x4);
+        __init_array_start = .;
+        KEEP (*(.init_array*))
+        __init_array_end = .;
+        *(.init)
+        *(.fini*)
+    } > REGION_TEXT AT> REGION_TEXT
+
+    PROVIDE (__etext = .);
+    PROVIDE (_etext = .);
+    PROVIDE (etext = .);
+
+    .rodata : {
+        *(.rodata)
+        *(.rodata.*)
+        *(.rodata_*)
+        KEEP (*(.timestampPFormat))
+    } > REGION_TEXT AT> REGION_TEXT
+
+    .data : ALIGN(4) {
+        __data_load__ = LOADADDR (.data);
+        __data_start__ = .;
+        *(.data)
+        *(.data.*)
+        . = ALIGN (4);
+        __data_end__ = .;
+    } > REGION_DATA AT> REGION_TEXT
+
+    .ARM.exidx : {
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+    } > REGION_ARM_EXIDX AT> REGION_ARM_EXIDX
+
+    .ARM.extab : {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > REGION_ARM_EXTAB AT> REGION_ARM_EXTAB
+
+    .nvs (NOLOAD) : ALIGN(0x2000) {
+        *(.nvs)
+    } > REGION_TEXT
+
+    .ccfg : {
+        KEEP (*(.ccfg))
+    } > FLASH_CCFG AT> FLASH_CCFG
+
+    .bss : {
+        __bss_start__ = .;
+        *(.shbss)
+        *(.bss)
+        *(.bss.*)
+        *(COMMON)
+        . = ALIGN (4);
+        __bss_end__ = .;
+    } > REGION_BSS AT> REGION_BSS
+
+    .heap : {
+        __heap_start__ = .;
+        end = __heap_start__;
+        _end = end;
+        __end = end;
+        . = . + HEAPSIZE;
+        KEEP(*(.heap))
+        __heap_end__ = .;
+        __HeapLimit = __heap_end__;
+    } > REGION_HEAP AT> REGION_HEAP
+
+    .stack (NOLOAD) : ALIGN(0x8) {
+        _stack = .;
+        __stack = .;
+        KEEP(*(.stack))
+        . += STACKSIZE;
+        _stack_end = .;
+        __stack_end = .;
+        PROVIDE(_stack_origin = _stack_end);
+    } > REGION_STACK AT> REGION_STACK
+
+    .log_data (COPY) : {
+        KEEP (*(.log_data))
+    } > REGION_LOG
+    .log_ptr (COPY) : {
+        KEEP (*(.log_ptr*))
+    } > LOG_PTR
+}
+
+ENTRY(resetISR)

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/startup_gcc.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13x4-cc26x4/startup_gcc.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2022-2023, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+//*****************************************************************************
+//
+// Check if compiler is GNU Compiler
+//
+//*****************************************************************************
+#if !(defined(__GNUC__))
+    #error "startup_cc13x4_cc26x4_gcc.c: Unsupported compiler!"
+#endif
+
+#include <string.h>
+
+#include <ti/devices/DeviceFamily.h>
+#include DeviceFamily_constructPath(inc/hw_types.h)
+#include DeviceFamily_constructPath(driverlib/interrupt.h)
+#include DeviceFamily_constructPath(driverlib/setup.h)
+#include DeviceFamily_constructPath(inc/hw_ints.h)
+
+//*****************************************************************************
+//
+// Forward declaration of the default fault handlers.
+//
+//*****************************************************************************
+void resetISR(void);
+static void nmiISR(void);
+static void faultISR(void);
+static void defaultHandler(void);
+static void busFaultHandler(void);
+static void secureFaultHandler(void);
+
+//*****************************************************************************
+//
+// External declaration for the reset handler that is to be called when the
+// processor is started
+//
+//*****************************************************************************
+extern void _c_int00(void);
+
+//*****************************************************************************
+//
+// The entry point for the application.
+//
+//*****************************************************************************
+extern int main(void);
+
+//*****************************************************************************
+//
+// linker variable that marks the top of stack.
+//
+//*****************************************************************************
+extern unsigned long _stack_end;
+
+//*****************************************************************************
+//
+// The vector table in Flash. Note that the proper constructs must be placed
+// on this to ensure that it ends up at physical address 0x0000.0000 or at the
+// start of the program if located at a start address other than 0.
+//
+//*****************************************************************************
+__attribute__((section(".resetVecs"), used)) static void (*const resetVectors[16])(void) = {
+    (void (*)(void))((uint32_t)&_stack_end), // 0 The initial stack pointer
+    resetISR,                                // 1 The reset handler
+    nmiISR,                                  // 2 The NMI handler
+    faultISR,                                // 3 The hard fault handler
+    defaultHandler,                          // 4 The MPU fault handler
+    busFaultHandler,                         // 5 The bus fault handler
+    defaultHandler,                          // 6 The usage fault handler
+    secureFaultHandler,                      // 7 The secure fault handler
+    0,                                       // 8 Reserved
+    0,                                       // 9 Reserved
+    0,                                       // 10 Reserved
+    defaultHandler,                          // 11 SVCall handler
+    defaultHandler,                          // 12 Debug monitor handler
+    0,                                       // 13 Reserved
+    defaultHandler,                          // 14 The PendSV handler
+    defaultHandler                           // 15 The SysTick handler
+};
+
+//*****************************************************************************
+//
+// The following are arrays of pointers to constructor functions that need to
+// be called during startup to initialize global objects.
+//
+//*****************************************************************************
+extern void (*__init_array_start[])(void);
+extern void (*__init_array_end[])(void);
+
+//*****************************************************************************
+//
+// The following global variable is required for C++ support.
+//
+//*****************************************************************************
+void *__dso_handle = (void *)&__dso_handle;
+
+//*****************************************************************************
+//
+// The following are constructs created by the linker, indicating where the
+// the "data" and "bss" segments reside in memory.  The initializers for the
+// for the "data" segment resides immediately following the "text" segment.
+//
+//*****************************************************************************
+extern uint32_t __bss_start__, __bss_end__;
+extern uint32_t __data_load__, __data_start__, __data_end__;
+
+//
+//*****************************************************************************
+//
+// Initialize the .data and .bss sections and copy the first 16 vectors from
+// the read-only/reset table to the runtime RAM table. Fill the remaining
+// vectors with a stub. This vector table will be updated at runtime.
+//
+//*****************************************************************************
+//
+__attribute__((used)) void localProgramStart(void)
+{
+    uint32_t *bs;
+    uint32_t *be;
+    uint32_t *dl;
+    uint32_t *ds;
+    uint32_t *de;
+    uint32_t count;
+    uint32_t i;
+
+#if defined(__VFP_FP__) && !defined(__SOFTFP__)
+    volatile uint32_t *pui32Cpacr = (uint32_t *)0xE000ED88;
+
+    /* Enable Coprocessor Access Control (CPAC) */
+    *pui32Cpacr |= (0xF << 20);
+#endif
+
+    IntMasterDisable();
+
+    /* Final trim of device */
+    SetupTrimDevice();
+
+    /* initiailize .bss to zero */
+    bs = &__bss_start__;
+    be = &__bss_end__;
+    while (bs < be)
+    {
+        *bs = 0;
+        bs++;
+    }
+
+    /* relocate the .data section */
+    dl = &__data_load__;
+    ds = &__data_start__;
+    de = &__data_end__;
+    if (dl != ds)
+    {
+        while (ds < de)
+        {
+            *ds = *dl;
+            dl++;
+            ds++;
+        }
+    }
+
+    /* Run any constructors */
+    count = (uint32_t)(__init_array_end - __init_array_start);
+    for (i = 0; i < count; i++)
+    {
+        __init_array_start[i]();
+    }
+
+    /* Call the application's entry point. */
+    main();
+
+    /* If we ever return signal Error */
+    faultISR();
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor first starts execution
+// following a reset event.  Only the absolutely necessary set is performed,
+// after which the application supplied entry() routine is called.  Any fancy
+// actions (such as making decisions based on the reset cause register, and
+// resetting the bits in that register) are left solely in the hands of the
+// application.
+//
+//*****************************************************************************
+void __attribute__((naked)) resetISR(void)
+{
+    __asm__ __volatile__(" movw r0, #:lower16:resetVectors\n"
+                         " movt r0, #:upper16:resetVectors\n"
+                         " ldr r0, [r0]\n"
+                         " mov sp, r0\n"
+                         " bl localProgramStart");
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives an NMI. This
+// simply enters an infinite loop, preserving the system state for examination
+// by a debugger.
+//
+//*****************************************************************************
+static void nmiISR(void)
+{
+    /* Enter an infinite loop. */
+    while (1) {}
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives a fault
+// interrupt. This simply enters an infinite loop, preserving the system state
+// for examination by a debugger.
+//
+//*****************************************************************************
+static void faultISR(void)
+{
+    /* Enter an infinite loop. */
+    while (1) {}
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives a bus fault.
+// This simply enters an infinite loop, preserving the system state for
+// examination by a debugger.
+//
+//*****************************************************************************
+static void busFaultHandler(void)
+{
+    /* Enter an infinite loop. */
+    while (1) {}
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives an unexpected
+// interrupt. This simply enters an infinite loop, preserving the system state
+// for examination by a debugger.
+//
+//*****************************************************************************
+static void defaultHandler(void)
+{
+    /* Enter an infinite loop. */
+    while (1) {}
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives a secure fault.
+// This simply enters an infinite loop, preserving the system state for
+// examination by a debugger.
+//
+//*****************************************************************************
+static void secureFaultHandler(void)
+{
+    /* Enter an infinite loop. */
+    while (1) {}
+}
+
+//*****************************************************************************
+//
+// This function is called by __libc_fini_array which gets called when exit()
+// is called. In order to support exit(), an empty _fini() stub function is
+// required.
+//
+//*****************************************************************************
+void _fini(void)
+{
+    /* Function body left empty intentionally */
+}

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-def.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-def.h
@@ -46,6 +46,8 @@
 #include <cm3/cm3-def.h>
 #elif (DeviceFamily_PARENT == DeviceFamily_PARENT_CC13X2_CC26X2)
 #include <cm4/cm4-def.h>
+#elif (DeviceFamily_PARENT == DeviceFamily_PARENT_CC13X4_CC26X3_CC26X4)
+#include <cm33/cm33-def.h>
 #endif
 /*---------------------------------------------------------------------------*/
 #include <stddef.h>
@@ -172,6 +174,8 @@
 #define CMSIS_CONF_HEADER_PATH              "cc13x0-cc26x0-cm3.h"
 #elif (DeviceFamily_PARENT == DeviceFamily_PARENT_CC13X2_CC26X2)
 #define CMSIS_CONF_HEADER_PATH              "cc13x2-cc26x2-cm4.h"
+#elif (DeviceFamily_PARENT == DeviceFamily_PARENT_CC13X4_CC26X3_CC26X4)
+#define CMSIS_CONF_HEADER_PATH              "cc13x4-cc26x4-cm33.h"
 #endif
 /*---------------------------------------------------------------------------*/
 /* Path to headers with implementation of mutexes, atomic and memory barriers */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/ccfg-conf.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/ccfg-conf.c
@@ -51,6 +51,10 @@
  * to secure deployed images.
  * @{
  */
+#ifndef CCFG_CONF_JTAG_INTERFACE_DISABLE
+#define CCFG_CONF_JTAG_INTERFACE_DISABLE             0
+#endif /* CCFG_CONF_JTAG_INTERFACE_DISABLE */
+
 #if CCFG_CONF_JTAG_INTERFACE_DISABLE
 #define SET_CCFG_CCFG_TI_OPTIONS_TI_FA_ENABLE        0x00
 #define SET_CCFG_CCFG_TAP_DAP_0_CPU_DAP_ENABLE       0x00
@@ -59,6 +63,9 @@
 #define SET_CCFG_CCFG_TAP_DAP_1_PBIST2_TAP_ENABLE    0x00
 #define SET_CCFG_CCFG_TAP_DAP_1_PBIST1_TAP_ENABLE    0x00
 #define SET_CCFG_CCFG_TAP_DAP_1_WUC_TAP_ENABLE       0x00
+#define SET_CCFG_CCFG_TI_OPTIONS_C_FA_DIS            0xC5
+#define SET_CCFG_CCFG_TAP_DAP_0_PWRPROF_TAP_ENABLE   0x00
+#define SET_CCFG_CCFG_TAP_DAP_1_AON_TAP_ENABLE       0x00
 #endif /* CCFG_CONF_JTAG_INTERFACE_DISABLE */
 /** @} */
 /*---------------------------------------------------------------------------*/
@@ -95,6 +102,21 @@
 #define SET_CCFG_BL_CONFIG_BL_ENABLE                 0xC5
 #endif /* CCFG_CONF_ROM_BOOTLOADER_ENABLE */
 /** @} */
+/*---------------------------------------------------------------------------*/
+/* Cache is enabled and GPRAM is disabled (unavailable) */
+#define SET_CCFG_SIZE_AND_DIS_FLAGS_DIS_GPRAM           0x1
+
+#ifndef CCFG_CONF_TRUSTZONE_ENABLE
+#define CCFG_CONF_TRUSTZONE_ENABLE                      0
+#endif /* CCFG_CONF_TRUSTZONE_ENABLE */
+
+#if CCFG_CONF_TRUSTZONE_ENABLE
+/* Set all of flash to secure-only access, using the special value of 0 */
+#define SET_CCFG_TRUSTZONE_FLASH_CFG_NSADDR_BOUNDARY    0x0
+#else /* CCFG_CONF_TRUSTZONE_ENABLE */
+/* Set all of flash to non-secure, except the lowest 8 KB */
+#define SET_CCFG_TRUSTZONE_FLASH_CFG_NSADDR_BOUNDARY    0x1
+#endif /* CCFG_CONF_TRUSTZONE_ENABLE */
 /*---------------------------------------------------------------------------*/
 /**
  * \name Include the device-specific CCFG file from the SDK.

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/clock-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/clock-arch.c
@@ -70,6 +70,13 @@ static ClockP_Struct wakeup_clk;
     (clock_time_t)(((uint64_t)(t) * CLOCK_SECOND * ClockP_getSystemTickPeriod()) / (1000 * 1000))
 
 #define RTC_SUBSEC_FRAC  ((uint64_t)1 << 32)  /* Important to cast to 64-bit */
+
+/* Bit-band access to address x bit number b using word access (32 bit) */
+#ifndef HWREGBITW
+#define HWREGBITW(x, b) \
+  HWREG(((unsigned long)(x) & 0xF0000000) | 0x02000000 | \
+        (((unsigned long)(x) & 0x000FFFFF) << 5) | ((b) << 2))
+#endif
 /*---------------------------------------------------------------------------*/
 static void
 check_etimer(void)

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.c
@@ -45,115 +45,25 @@
 #include <ti/devices/DeviceFamily.h>
 #include DeviceFamily_constructPath(driverlib/gpio.h)
 
-#include <ti/drivers/PIN.h>
-#include <ti/drivers/pin/PINCC26XX.h>
+#include <ti/drivers/GPIO.h>
 /*---------------------------------------------------------------------------*/
 #include <stdint.h>
 /*---------------------------------------------------------------------------*/
-static PIN_Config pin_config[] = { PIN_TERMINATE };
-static PIN_State pin_state;
-static PIN_Handle pin_handle;
-/*---------------------------------------------------------------------------*/
-/**< PIN standard input configuration mimicking IOC_STD_INPUT */
-#define GPIO_HAL_PIN_STD_INPUT      (PIN_INPUT_EN | PIN_GPIO_OUTPUT_DIS | \
-                                     PIN_NOPULL | PIN_DRVSTR_MIN | PIN_IRQ_DIS)
-
-/**< PIN standard input configuration bitmask */
-#define GPIO_HAL_PIN_STD_INPUT_BM   (PIN_BM_INPUT_EN | PIN_BM_GPIO_OUTPUT_EN | \
-                                     PIN_BM_PULLING | PIN_BM_INV_INOUT | \
-                                     PIN_BM_DRVSTR | PIN_BM_SLEWCTRL | \
-                                     PIN_BM_HYSTERESIS | PIN_BM_IRQ)
-
-/**< PIN standard input configuration mimicking IOC_STD_OUTPUT */
-#define GPIO_HAL_PIN_STD_OUTPUT     (PIN_INPUT_DIS | PIN_GPIO_OUTPUT_EN | \
-                                     PIN_NOPULL | PIN_DRVSTR_MIN | PIN_IRQ_DIS)
-
-/**< PIN standard output configuration bitmask */
-#define GPIO_HAL_PIN_STD_OUTPUT_BM  (PIN_BM_INPUT_EN | PIN_BM_GPIO_OUTPUT_EN | \
-                                     PIN_BM_PULLING | PIN_BM_INV_INOUT | \
-                                     PIN_BM_DRVSTR | PIN_BM_SLEWCTRL | \
-                                     PIN_BM_HYSTERESIS | PIN_BM_IRQ)
-/*---------------------------------------------------------------------------*/
 static void
-from_hal_cfg(gpio_hal_pin_cfg_t cfg, PIN_Config *pin_cfg, PIN_Config *pin_mask)
+from_hal_cfg(gpio_hal_pin_cfg_t cfg, GPIO_PinConfig *pin_cfg)
 {
-  /* Pulling config */
-  *pin_mask |= PIN_BM_PULLING;
-
-  switch(cfg & GPIO_HAL_PIN_CFG_PULL_MASK) {
-  default: /* Default to no pullup/pulldown */
-  case GPIO_HAL_PIN_CFG_PULL_NONE: *pin_cfg |= PIN_NOPULL;   break;
-  case GPIO_HAL_PIN_CFG_PULL_UP:   *pin_cfg |= PIN_PULLUP;   break;
-  case GPIO_HAL_PIN_CFG_PULL_DOWN: *pin_cfg |= PIN_PULLDOWN; break;
-  }
-
-  /* Hysteresis config */
-  *pin_mask |= PIN_BM_HYSTERESIS;
-
-  if(cfg & GPIO_HAL_PIN_CFG_HYSTERESIS) {
-    *pin_cfg |= PIN_HYSTERESIS;
-  }
-
-  /* Interrupt config */
-  *pin_mask |= PIN_BM_IRQ;
-
-  if((cfg & GPIO_HAL_PIN_CFG_INT_MASK) == GPIO_HAL_PIN_CFG_INT_ENABLE) {
-    /* Interrupt edge config */
-    switch(cfg & GPIO_HAL_PIN_CFG_EDGE_BOTH) {
-    case GPIO_HAL_PIN_CFG_EDGE_NONE:    *pin_cfg |= PIN_IRQ_DIS;       break;
-    case GPIO_HAL_PIN_CFG_EDGE_FALLING: *pin_cfg |= PIN_IRQ_NEGEDGE;   break;
-    case GPIO_HAL_PIN_CFG_EDGE_RISING:  *pin_cfg |= PIN_IRQ_POSEDGE;   break;
-    case GPIO_HAL_PIN_CFG_EDGE_BOTH:    *pin_cfg |= PIN_IRQ_BOTHEDGES; break;
-    }
-  } else {
-    *pin_cfg |= PIN_IRQ_DIS;
-  }
+  /* TODO */
 }
 /*---------------------------------------------------------------------------*/
 static void
-to_hal_cfg(PIN_Config pin_cfg, gpio_hal_pin_cfg_t *cfg)
+to_hal_cfg(GPIO_PinConfig pin_cfg, gpio_hal_pin_cfg_t *cfg)
 {
-  /* Input config */
-  if(pin_cfg & PIN_BM_INPUT_MODE) {
-    /* Hysteresis config */
-    if((pin_cfg & PIN_BM_HYSTERESIS) == PIN_BM_HYSTERESIS) {
-      *cfg |= GPIO_HAL_PIN_CFG_HYSTERESIS;
-    }
-
-    /* Pulling config */
-    switch(pin_cfg & (PIN_GEN | PIN_BM_PULLING)) {
-    case PIN_NOPULL:   *cfg |= GPIO_HAL_PIN_CFG_PULL_NONE; break;
-    case PIN_PULLUP:   *cfg |= GPIO_HAL_PIN_CFG_PULL_UP;   break;
-    case PIN_PULLDOWN: *cfg |= GPIO_HAL_PIN_CFG_PULL_DOWN; break;
-    }
-  }
-
-  /* Interrupt config */
-  if(pin_cfg & PIN_BM_IRQ) {
-    /* Interrupt edge config */
-    switch(pin_cfg & (PIN_GEN | PIN_BM_IRQ)) {
-    case PIN_IRQ_DIS:       *cfg |= GPIO_HAL_PIN_CFG_EDGE_NONE;
-                            *cfg |= GPIO_HAL_PIN_CFG_INT_DISABLE;
-                            break;
-    case PIN_IRQ_NEGEDGE:   *cfg |= GPIO_HAL_PIN_CFG_EDGE_FALLING;
-                            *cfg |= GPIO_HAL_PIN_CFG_INT_ENABLE;
-                            break;
-    case PIN_IRQ_POSEDGE:   *cfg |= GPIO_HAL_PIN_CFG_EDGE_RISING;
-                            *cfg |= GPIO_HAL_PIN_CFG_INT_ENABLE;
-                            break;
-    case PIN_IRQ_BOTHEDGES: *cfg |= GPIO_HAL_PIN_CFG_EDGE_BOTH;
-                            *cfg |= GPIO_HAL_PIN_CFG_INT_ENABLE;
-                            break;
-    }
-  }
+  /* TODO */
 }
 /*---------------------------------------------------------------------------*/
 static void
-gpio_int_cb(PIN_Handle handle, PIN_Id pin_id)
+gpio_int_cb(uint_least8_t pin_id)
 {
-  /* Unused args */
-  (void)handle;
-
   /* Notify the GPIO HAL driver */
   gpio_hal_event_handler(gpio_hal_pin_to_mask(pin_id));
 }
@@ -161,107 +71,68 @@ gpio_int_cb(PIN_Handle handle, PIN_Id pin_id)
 void
 gpio_hal_arch_init(void)
 {
-  /* No error checking */
-  pin_handle = PIN_open(&pin_state, pin_config);
-  PIN_registerIntCb(pin_handle, gpio_int_cb);
 }
 /*---------------------------------------------------------------------------*/
 
 void
 gpio_hal_arch_no_port_pin_set_input(gpio_hal_pin_t pin)
 {
-  PIN_add(pin_handle, PIN_getConfig(pin));
-
-  /* Configure pin as standard input */
-  PIN_Config pin_cfg = GPIO_HAL_PIN_STD_INPUT | pin;
-  PIN_Config pin_mask = GPIO_HAL_PIN_STD_INPUT_BM;
-
-  PIN_setConfig(pin_handle, pin_mask, pin_cfg);
+  GPIO_setConfig(pin, GPIO_CFG_INPUT);
 }
 /*---------------------------------------------------------------------------*/
-void gpio_hal_arch_no_port_pin_set_output(gpio_hal_pin_t pin)
+void
+gpio_hal_arch_no_port_pin_set_output(gpio_hal_pin_t pin)
 {
-  PIN_add(pin_handle, PIN_getConfig(pin));
-
-  /* Configure pin as standard output */
-  PIN_Config pin_cfg = GPIO_HAL_PIN_STD_OUTPUT | pin;
-  PIN_Config pin_mask = GPIO_HAL_PIN_STD_OUTPUT_BM;
-  PIN_setConfig(pin_handle, pin_mask, pin_cfg);
+  GPIO_setConfig(pin, GPIO_CFG_OUTPUT);
 }
 /*---------------------------------------------------------------------------*/
 void
 gpio_hal_arch_no_port_interrupt_enable(gpio_hal_pin_t pin)
 {
-  /*
-   * This requires pin cfg already set with GPIO_HAL_PIN_CFG_INT_ENABLE,
-   * i.e. enabled interrupts, thus making this function redundant.
-   * Might be fixed if switching to GPIO or GPIO++ lib. instead of PIN.
-   */
-  PIN_Config pin_cfg;
-  PIN_Config irq_cfg;
-
-  pin_cfg = PIN_getConfig(pin);
-  PIN_add(pin_handle, pin_cfg);
-
-  irq_cfg = pin_cfg & PIN_BM_IRQ;
-  PIN_setInterrupt(pin_handle, pin | irq_cfg);
+  GPIO_setCallback(pin, gpio_int_cb);
+  GPIO_enableInt(pin);
 }
 /*---------------------------------------------------------------------------*/
 void
 gpio_hal_arch_no_port_interrupt_disable(gpio_hal_pin_t pin)
 {
-  PIN_add(pin_handle, PIN_getConfig(pin));
-
-  /*
-   * This removes all IRQ config., thus pin cfg must be set again to
-   * re-enable interrupts.
-   */
-  PIN_setInterrupt(pin_handle, pin | PIN_IRQ_DIS);
+  GPIO_disableInt(pin);
 }
 /*---------------------------------------------------------------------------*/
 void
 gpio_hal_arch_no_port_pin_cfg_set(gpio_hal_pin_t pin, gpio_hal_pin_cfg_t cfg)
 {
-  PIN_add(pin_handle, PIN_getConfig(pin));
-
-  /* Clear settings that we are about to change, keep everything else. */
-  PIN_Config pin_cfg = 0;
-  PIN_Config pin_mask = 0;
-
-  from_hal_cfg(cfg, &pin_cfg, &pin_mask);
-
-  PIN_setConfig(pin_handle, pin_mask, pin | pin_cfg);
+  GPIO_PinConfig pin_cfg = 0;
+  from_hal_cfg(cfg, &pin_cfg);
+  GPIO_setConfig(pin, pin_cfg);
 }
 /*---------------------------------------------------------------------------*/
 gpio_hal_pin_cfg_t
 gpio_hal_arch_no_port_pin_cfg_get(gpio_hal_pin_t pin)
 {
-  PIN_Config pin_cfg = PIN_getConfig(pin);
+  GPIO_PinConfig pin_cfg;
+  GPIO_getConfig(pin, &pin_cfg);
   gpio_hal_pin_cfg_t cfg = 0;
-
   to_hal_cfg(pin_cfg, &cfg);
-
   return cfg;
 }
 /*---------------------------------------------------------------------------*/
 gpio_hal_pin_mask_t
 gpio_hal_arch_no_port_read_pins(gpio_hal_pin_mask_t pins)
 {
-  /* For pins configured as output we need to read DOUT31_0 */
-  gpio_hal_pin_mask_t oe_pins = GPIO_getOutputEnableMultiDio(pins);
-
-  pins &= ~oe_pins;
-
-  return (HWREG(GPIO_BASE + GPIO_O_DOUT31_0) & oe_pins) |
-         GPIO_readMultiDio(pins);
+  gpio_hal_pin_mask_t result = 0;
+  for(gpio_hal_pin_t pin = 0; pin < (sizeof(gpio_hal_pin_mask_t) * 8); pin++) {
+    if(pins & (1 << pin)) {
+      result |= gpio_hal_arch_no_port_read_pin(pin);
+    }
+  }
+  return result;
 }
 /*---------------------------------------------------------------------------*/
 uint8_t
 gpio_hal_arch_no_port_read_pin(gpio_hal_pin_t pin)
 {
-  return (GPIO_getOutputEnableDio(pin))
-         ? PINCC26XX_getOutputValue(pin)
-         : PINCC26XX_getInputValue(pin);
+  return GPIO_read(pin);
 }
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/gpio-hal-arch.h
@@ -50,20 +50,11 @@
 /*---------------------------------------------------------------------------*/
 #include <ti/devices/DeviceFamily.h>
 #include DeviceFamily_constructPath(driverlib/gpio.h)
-
-#include <ti/drivers/pin/PINCC26XX.h>
 /*---------------------------------------------------------------------------*/
-#define gpio_hal_arch_set_pin(port, pin)        PINCC26XX_setOutputValue(pin, 1)
-#define gpio_hal_arch_clear_pin(port, pin)      PINCC26XX_setOutputValue(pin, 0)
-#define gpio_hal_arch_toggle_pin(port, pin)     PINCC26XX_setOutputValue(pin, \
-                                                  PINCC26XX_getOutputValue(pin) \
-                                                  ? 0 : 1)
-#define gpio_hal_arch_write_pin(port, pin, v)   PINCC26XX_setOutputValue(pin, v)
-
-#define gpio_hal_arch_set_pins(port, pin)       GPIO_setMultiDio(pin)
-#define gpio_hal_arch_clear_pins(port, pin)     GPIO_clearMultiDio(pin)
-#define gpio_hal_arch_toggle_pins(port, pin)    GPIO_toggleMultiDio(pin)
-#define gpio_hal_arch_write_pins(port, pin, v)  GPIO_writeMultiDio(pin, v)
+#define gpio_hal_arch_set_pin(port, pin)        GPIO_setDio(pin)
+#define gpio_hal_arch_clear_pin(port, pin)      GPIO_clearDio(pin)
+#define gpio_hal_arch_toggle_pin(port, pin)     GPIO_toggleDio(pin)
+#define gpio_hal_arch_write_pin(port, pin, v)   GPIO_writeDio(pin, v)
 /*---------------------------------------------------------------------------*/
 #endif /* GPIO_HAL_ARCH_H_ */
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/i2c-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/i2c-arch.c
@@ -59,7 +59,7 @@ i2c_arch_write_read(I2C_Handle i2c_handle, uint_least8_t slave_addr,
     .writeCount = wcount,
     .readBuf = rbuf,
     .readCount = rcount,
-    .slaveAddress = slave_addr,
+    .targetAddress = slave_addr,
   };
 
   if(!i2c_handle) {

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/spi-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/spi-arch.c
@@ -46,7 +46,6 @@
 /*---------------------------------------------------------------------------*/
 #include <ti/drivers/SPI.h>
 #include <ti/drivers/dpl/HwiP.h>
-#include <ti/drivers/pin/PINCC26XX.h>
 /*---------------------------------------------------------------------------*/
 #include <stdbool.h>
 #include <stddef.h>
@@ -144,7 +143,7 @@ spi_arch_lock_and_open(const spi_device_t *dev)
   SPI_Params_init(&spi_params);
 
   spi_params.transferMode = SPI_MODE_BLOCKING;
-  spi_params.mode = SPI_MASTER;
+  spi_params.mode = SPI_CONTROLLER;
   spi_params.bitRate = dev->spi_bit_rate;
   spi_params.dataSize = 8;
   spi_params.frameFormat = convert_frame_format(dev->spi_pol, dev->spi_pha);

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/uart0-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/uart0-arch.c
@@ -43,12 +43,12 @@
 /*---------------------------------------------------------------------------*/
 #include <Board.h>
 
-#include <ti/drivers/UART.h>
+#include <ti/drivers/UART2.h>
 /*---------------------------------------------------------------------------*/
 #include <stdint.h>
 #include <stdbool.h>
 /*---------------------------------------------------------------------------*/
-static UART_Handle uart_handle;
+static UART2_Handle uart_handle;
 
 static volatile uart0_input_fxn_t curr_input_cb;
 static unsigned char char_buf;
@@ -56,7 +56,10 @@ static unsigned char char_buf;
 static bool initialized;
 /*---------------------------------------------------------------------------*/
 static void
-uart0_cb(UART_Handle handle, void *buf, size_t count)
+uart0_cb(UART2_Handle handle,
+         void *buf, size_t count,
+         void *userArg,
+         int_fast16_t status)
 {
   /* Simply return if the current callback is NULL. */
   if(!curr_input_cb) {
@@ -75,7 +78,7 @@ uart0_cb(UART_Handle handle, void *buf, size_t count)
    * and triggered an another read.
    */
   if(curr_cb == curr_input_cb) {
-    UART_read(uart_handle, &char_buf, 1);
+    UART2_read(uart_handle, &char_buf, 1, NULL);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -86,18 +89,17 @@ uart0_init(void)
     return;
   }
 
-  UART_Params uart_params;
-  UART_Params_init(&uart_params);
+  UART2_Params uart_params;
+  UART2_Params_init(&uart_params);
 
   uart_params.baudRate = TI_UART_CONF_BAUD_RATE;
-  uart_params.readMode = UART_MODE_CALLBACK;
-  uart_params.writeMode = UART_MODE_BLOCKING;
+  uart_params.readMode = UART2_Mode_CALLBACK;
+  uart_params.writeMode = UART2_Mode_BLOCKING;
   uart_params.readCallback = uart0_cb;
-  uart_params.readDataMode = UART_DATA_TEXT;
-  uart_params.readReturnMode = UART_RETURN_NEWLINE;
+  uart_params.readReturnMode = UART2_ReadReturnMode_PARTIAL;
 
   /* No error handling. */
-  uart_handle = UART_open(Board_UART0, &uart_params);
+  uart_handle = UART2_open(Board_UART0, &uart_params);
 
   initialized = true;
 }
@@ -106,37 +108,37 @@ int_fast32_t
 uart0_write(const void *buf, size_t buf_size)
 {
   if(!initialized) {
-    return UART_STATUS_ERROR;
+    return UART2_STATUS_ENOTOPEN;
   }
-  return UART_write(uart_handle, buf, buf_size);
+  return UART2_write(uart_handle, buf, buf_size, NULL);
 }
 /*---------------------------------------------------------------------------*/
 int_fast32_t
 uart0_write_byte(uint8_t byte)
 {
   if(!initialized) {
-    return UART_STATUS_ERROR;
+    return UART2_STATUS_ENOTOPEN;
   }
-  return UART_write(uart_handle, &byte, 1);
+  return UART2_write(uart_handle, &byte, 1, NULL);
 }
 /*---------------------------------------------------------------------------*/
 int_fast32_t
 uart0_set_callback(uart0_input_fxn_t input_cb)
 {
   if(!initialized) {
-    return UART_STATUS_ERROR;
+    return UART2_STATUS_ENOTOPEN;
   }
 
   if(curr_input_cb == input_cb) {
-    return UART_STATUS_SUCCESS;
+    return UART2_STATUS_SUCCESS;
   }
 
   curr_input_cb = input_cb;
   if(input_cb) {
-    return UART_read(uart_handle, &char_buf, 1);
+    return UART2_read(uart_handle, &char_buf, 1, NULL);
   } else {
-    UART_readCancel(uart_handle);
-    return UART_STATUS_SUCCESS;
+    UART2_readCancel(uart_handle);
+    return UART2_STATUS_SUCCESS;
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/watchdog-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/watchdog-arch.c
@@ -58,6 +58,19 @@
 static Watchdog_Handle wdt_handle;
 #endif
 /*---------------------------------------------------------------------------*/
+static void
+watchdog_callback(uintptr_t watchdog_handle)
+{
+    /*
+     * If the Watchdog Non-Maskable Interrupt (NMI) is called,
+     * loop until the device resets. Some devices will invoke
+     * this callback upon watchdog expiration while others will
+     * reset. See the device specific watchdog driver documentation
+     * for your device.
+     */
+    while (1) {}
+}
+/*---------------------------------------------------------------------------*/
 /**
  * \brief  Initialises the Watchdog module.
  *
@@ -75,6 +88,7 @@ watchdog_init(void)
 
   wdt_params.resetMode = Watchdog_RESET_ON;
   wdt_params.debugStallMode = Watchdog_DEBUG_STALL_ON;
+  wdt_params.callbackFxn = watchdog_callback;
 
   wdt_handle = Watchdog_open(Board_WATCHDOG0, &wdt_params);
 #endif
@@ -112,7 +126,9 @@ void
 watchdog_start(void)
 {
 #if (WATCHDOG_DISABLE == 0)
-  watchdog_periodic();
+  uint32_t timeout_ticks = Watchdog_convertMsToTicks(wdt_handle,
+                                                     WATCHDOG_TIMEOUT_MS);
+  Watchdog_setReload(wdt_handle, timeout_ticks);
 #endif
 }
 /*---------------------------------------------------------------------------*/
@@ -123,8 +139,7 @@ void
 watchdog_periodic(void)
 {
 #if (WATCHDOG_DISABLE == 0)
-  uint32_t timeout_ticks = Watchdog_convertMsToTicks(wdt_handle, WATCHDOG_TIMEOUT_MS);
-  Watchdog_setReload(wdt_handle, timeout_ticks);
+  Watchdog_clear(wdt_handle);
 #endif
 }
 /*---------------------------------------------------------------------------*/
@@ -136,7 +151,7 @@ void
 watchdog_stop(void)
 {
 #if (WATCHDOG_DISABLE == 0)
-  Watchdog_clear(wdt_handle);
+  Watchdog_close(wdt_handle);
 #endif
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x4/ieee-settings.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x4/ieee-settings.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sys/cc.h"
+#include <ti/devices/DeviceFamily.h>
+#include DeviceFamily_constructPath(driverlib/rf_mailbox.h)
+#include DeviceFamily_constructPath(driverlib/rf_common_cmd.h)
+#include DeviceFamily_constructPath(driverlib/rf_ieee_cmd.h)
+#include DeviceFamily_constructPath(rf_patches/rf_patch_cpe_multi_protocol.h)
+
+#include <ti/drivers/rf/RF.h>
+#include "ieee-settings.h"
+
+//*********************************************************************************
+//  RF Setting:   IEEE 802.15.4-2006, 250 kbps, OQPSK, DSSS = 1:8
+//
+//  PHY:          ieee154
+//  Setting file: setting_ieee_802_15_4.json
+//*********************************************************************************
+
+// PARAMETER SUMMARY
+// Channel - Frequency (MHz): 2405
+// TX Power (dBm): 0
+
+// TI-RTOS RF Mode Object
+RF_Mode rf_ieee_mode =
+{
+    .rfMode = RF_MODE_AUTO,
+    .cpePatchFxn = &rf_patch_cpe_multi_protocol,
+    .mcePatchFxn = 0,
+    .rfePatchFxn = 0
+};
+
+// Overrides for CMD_RADIO_SETUP_PA
+uint32_t pOverrides_ieee154[] =
+{
+    // override_ieee_802_15_4.json
+    // Rx: Set DCDC settings drive strength and deadtime trim
+    (uint32_t)0x00C188C3,
+    // IEEE 802.15.4: Set pilot tone length to 35 us
+    HW_REG_OVERRIDE(0x5334,0x0690),
+    // IEEE 802.15.4: Set pilot tone length to 35 us
+    HW_REG_OVERRIDE(0x6024,0x5B20),
+    // IEEE 802.15.4: Enable fast settling during pilot tone
+    (uint32_t)0x10108413,
+    // IEEE 802.15.4: Compensate for modified pilot tone length
+    (uint32_t)0x037B02A3,
+    (uint32_t)0xFFFFFFFF
+};
+
+
+
+// CMD_RADIO_SETUP_PA
+// Radio Setup Command for Pre-Defined Schemes
+rfc_CMD_RADIO_SETUP_PA_t rf_cmd_ieee_radio_setup =
+{
+    .commandNo = 0x0802,
+    .status = 0x0000,
+    .pNextOp = 0,
+    .startTime = 0x00000000,
+    .startTrigger.triggerType = 0x0,
+    .startTrigger.bEnaCmd = 0x0,
+    .startTrigger.triggerNo = 0x0,
+    .startTrigger.pastTrig = 0x0,
+    .condition.rule = 0x1,
+    .condition.nSkip = 0x0,
+    .mode = 0x01,
+    .loDivider = 0x00,
+    .config.frontEndMode = 0x0, /* set by driver */
+    .config.biasMode = 0x0, /* set by driver */
+    .config.analogCfgMode = 0x0,
+    .config.bNoFsPowerUp = 0x0,
+    .config.bSynthNarrowBand = 0x0,
+    .txPower = 0x2A5E,
+    .pRegOverride = pOverrides_ieee154,
+    .pRegOverrideTxStd = 0,
+    .pRegOverrideTx20 = 0
+};
+
+// CMD_FS
+// Frequency Synthesizer Programming Command
+rfc_CMD_FS_t rf_cmd_ieee_fs =
+{
+    .commandNo = 0x0803,
+    .status = 0x0000,
+    .pNextOp = 0,
+    .startTime = 0x00000000,
+    .startTrigger.triggerType = 0x0,
+    .startTrigger.bEnaCmd = 0x0,
+    .startTrigger.triggerNo = 0x0,
+    .startTrigger.pastTrig = 0x0,
+    .condition.rule = 0x1,
+    .condition.nSkip = 0x0,
+    .frequency = 0x0965,
+    .fractFreq = 0x0000,
+    .synthConf.bTxMode = 0x0,
+    .synthConf.refFreq = 0x0,
+    .__dummy0 = 0x00,
+    .__dummy1 = 0x00,
+    .__dummy2 = 0x00,
+    .__dummy3 = 0x0000
+};
+
+// CMD_IEEE_TX
+// IEEE 802.15.4 Transmit Command
+rfc_CMD_IEEE_TX_t rf_cmd_ieee_tx =
+{
+    .commandNo = 0x2C01,
+    .status = 0x0000,
+    .pNextOp = 0,
+    .startTime = 0x00000000,
+    .startTrigger.triggerType = 0x0,
+    .startTrigger.bEnaCmd = 0x0,
+    .startTrigger.triggerNo = 0x0,
+    .startTrigger.pastTrig = 0x0,
+    .condition.rule = 0x1,
+    .condition.nSkip = 0x0,
+    .txOpt.bIncludePhyHdr = 0x0,
+    .txOpt.bIncludeCrc = 0x0,
+    .txOpt.payloadLenMsb = 0x0,
+    .payloadLen = 0x1E,
+    .pPayload = 0,
+    .timeStamp = 0x00000000
+};
+
+// CMD_IEEE_RX
+// IEEE 802.15.4 Receive Command
+rfc_CMD_IEEE_RX_t rf_cmd_ieee_rx =
+{
+    .commandNo = 0x2801,
+    .status = 0x0000,
+    .pNextOp = 0,
+    .startTime = 0x00000000,
+    .startTrigger.triggerType = 0x0,
+    .startTrigger.bEnaCmd = 0x0,
+    .startTrigger.triggerNo = 0x0,
+    .startTrigger.pastTrig = 0x0,
+    .condition.rule = 0x1,
+    .condition.nSkip = 0x0,
+    .channel = 0x00,
+    .rxConfig.bAutoFlushCrc = 0x0,
+    .rxConfig.bAutoFlushIgn = 0x0,
+    .rxConfig.bIncludePhyHdr = 0x0,
+    .rxConfig.bIncludeCrc = 0x0,
+    .rxConfig.bAppendRssi = 0x1,
+    .rxConfig.bAppendCorrCrc = 0x1,
+    .rxConfig.bAppendSrcInd = 0x0,
+    .rxConfig.bAppendTimestamp = 0x0,
+    .pRxQ = 0,
+    .pOutput = 0,
+    .frameFiltOpt.frameFiltEn = 0x0,
+    .frameFiltOpt.frameFiltStop = 0x0,
+    .frameFiltOpt.autoAckEn = 0x0,
+    .frameFiltOpt.slottedAckEn = 0x0,
+    .frameFiltOpt.autoPendEn = 0x0,
+    .frameFiltOpt.defaultPend = 0x0,
+    .frameFiltOpt.bPendDataReqOnly = 0x0,
+    .frameFiltOpt.bPanCoord = 0x0,
+    .frameFiltOpt.maxFrameVersion = 0x3,
+    .frameFiltOpt.fcfReservedMask = 0x0,
+    .frameFiltOpt.modifyFtFilter = 0x0,
+    .frameFiltOpt.bStrictLenFilter = 0x0,
+    .frameTypes.bAcceptFt0Beacon = 0x1,
+    .frameTypes.bAcceptFt1Data = 0x1,
+    .frameTypes.bAcceptFt2Ack = 0x1,
+    .frameTypes.bAcceptFt3MacCmd = 0x1,
+    .frameTypes.bAcceptFt4Reserved = 0x1,
+    .frameTypes.bAcceptFt5Reserved = 0x1,
+    .frameTypes.bAcceptFt6Reserved = 0x1,
+    .frameTypes.bAcceptFt7Reserved = 0x1,
+    .ccaOpt.ccaEnEnergy = 0x0,
+    .ccaOpt.ccaEnCorr = 0x0,
+    .ccaOpt.ccaEnSync = 0x0,
+    .ccaOpt.ccaCorrOp = 0x1,
+    .ccaOpt.ccaSyncOp = 0x1,
+    .ccaOpt.ccaCorrThr = 0x0,
+    .ccaRssiThr = 0x64,
+    .__dummy0 = 0x00,
+    .numExtEntries = 0x00,
+    .numShortEntries = 0x00,
+    .pExtEntryList = 0,
+    .pShortEntryList = 0,
+    .localExtAddr = 0x12345678,
+    .localShortAddr = 0xABBA,
+    .localPanID = 0x0000,
+    .__dummy1 = 0x000000,
+    .endTrigger.triggerType = 0x1,
+    .endTrigger.bEnaCmd = 0x0,
+    .endTrigger.triggerNo = 0x0,
+    .endTrigger.pastTrig = 0x0,
+    .endTime = 0x00000000
+};
+
+// CMD_IEEE_CSMA
+// IEEE 802.15.4 CSMA-CA Command
+const rfc_CMD_IEEE_CSMA_t RF_cmdIeeeCsma_ieee154 =
+{
+    .commandNo = 0x2C02,
+    .status = 0x0000,
+    .pNextOp = 0,
+    .startTime = 0x00000000,
+    .startTrigger.triggerType = 0x0,
+    .startTrigger.bEnaCmd = 0x0,
+    .startTrigger.triggerNo = 0x0,
+    .startTrigger.pastTrig = 0x0,
+    .condition.rule = 0x0,
+    .condition.nSkip = 0x0,
+    .randomState = 0x0000,
+    .macMaxBE = 0x00,
+    .macMaxCSMABackoffs = 0x00,
+    .csmaConfig.initCW = 0x0,
+    .csmaConfig.bSlotted = 0x0,
+    .csmaConfig.rxOffMode = 0x0,
+    .NB = 0x00,
+    .BE = 0x00,
+    .remainingPeriods = 0x00,
+    .lastRssi = 0x00,
+    .endTrigger.triggerType = 0x0,
+    .endTrigger.bEnaCmd = 0x0,
+    .endTrigger.triggerNo = 0x0,
+    .endTrigger.pastTrig = 0x0,
+    .lastTimeStamp = 0x00000000,
+    .endTime = 0x00000000
+};
+
+// CMD_IEEE_RX_ACK
+// IEEE 802.15.4 Receive Acknowledgement Command
+rfc_CMD_IEEE_RX_ACK_t rf_cmd_ieee_rx_ack =
+{
+    .commandNo = 0x2C03,
+    .status = 0x0000,
+    .pNextOp = 0,
+    .startTime = 0x00000000,
+    .startTrigger.triggerType = 0x0,
+    .startTrigger.bEnaCmd = 0x0,
+    .startTrigger.triggerNo = 0x0,
+    .startTrigger.pastTrig = 0x0,
+    .condition.rule = 0x0,
+    .condition.nSkip = 0x0,
+    .seqNo = 0x00,
+    .endTrigger.triggerType = 0x0,
+    .endTrigger.bEnaCmd = 0x0,
+    .endTrigger.triggerNo = 0x0,
+    .endTrigger.pastTrig = 0x0,
+    .endTime = 0x00000000
+};

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x4/ieee-settings.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x4/ieee-settings.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef IEEE_SETTINGS_H_
+#define IEEE_SETTINGS_H_
+
+#include "contiki-conf.h"
+
+#include <ti/devices/DeviceFamily.h>
+#include DeviceFamily_constructPath(driverlib/rf_mailbox.h)
+#include DeviceFamily_constructPath(driverlib/rf_common_cmd.h)
+#include DeviceFamily_constructPath(driverlib/rf_ieee_cmd.h)
+#include <ti/drivers/rf/RF.h>
+
+extern RF_Mode rf_ieee_mode;
+extern rfc_CMD_RADIO_SETUP_PA_t rf_cmd_ieee_radio_setup;
+extern rfc_CMD_FS_t rf_cmd_ieee_fs;
+extern rfc_CMD_IEEE_TX_t rf_cmd_ieee_tx;
+extern rfc_CMD_IEEE_RX_t rf_cmd_ieee_rx;
+extern rfc_CMD_IEEE_RX_ACK_t rf_cmd_ieee_rx_ack;
+extern uint32_t pOverrides_ieee154[];
+
+#endif /* IEEE_SETTINGS_H_ */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x4/ieee-tx-power.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf-settings/cc13x4/ieee-tx-power.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \addtogroup cc13xx-cc26xx-rf-tx-power
+ * @{
+ *
+ * \file
+ *        Source file for IEEE-mode TX power tables for LP-EM-CC1354P10-1.
+ * \author
+ *        Edvard Pettersen <e.pettersen@ti.com>
+ */
+
+#include "contiki.h"
+#include "rf/tx-power.h"
+
+/*
+ * TX Power table for 2400 MHz, 5 dBm
+ * The RF_TxPowerTable_DEFAULT_PA_ENTRY and RF_TxPowerTable_HIGH_PA_ENTRY macro is defined in RF.h.
+ * The following arguments are required:
+ * RF_TxPowerTable_DEFAULT_PA_ENTRY(bias, gain, boost coefficient)
+ * RF_TxPowerTable_HIGH_PA_ENTRY(bias, ibboost, boost, coefficient, ldoTrim)
+ * See the Technical Reference Manual for further details about the "txPower" Command field.
+ * The PA settings require the CCFG_FORCE_VDDR_HH = 0 unless stated otherwise.
+ */
+tx_power_table_t txPowerTable_2400_pa5[] =
+{
+    {-20, RF_TxPowerTable_DEFAULT_PA_ENTRY(7, 3, 0, 0) }, // 0x00C7
+    {-18, RF_TxPowerTable_DEFAULT_PA_ENTRY(9, 3, 0, 0) }, // 0x00C9
+    {-15, RF_TxPowerTable_DEFAULT_PA_ENTRY(12, 3, 0, 4) }, // 0x08CC
+    {-12, RF_TxPowerTable_DEFAULT_PA_ENTRY(10, 2, 0, 4) }, // 0x088A
+    {-10, RF_TxPowerTable_DEFAULT_PA_ENTRY(18, 3, 0, 0) }, // 0x00D2
+    {-9, RF_TxPowerTable_DEFAULT_PA_ENTRY(14, 2, 0, 7) }, // 0x0E8E
+    {-6, RF_TxPowerTable_DEFAULT_PA_ENTRY(19, 2, 0, 11) }, // 0x1693
+    {-5, RF_TxPowerTable_DEFAULT_PA_ENTRY(21, 2, 0, 11) }, // 0x1695
+    {-3, RF_TxPowerTable_DEFAULT_PA_ENTRY(38, 3, 0, 14) }, // 0x1CE6
+    {0, RF_TxPowerTable_DEFAULT_PA_ENTRY(30, 1, 0, 21) }, // 0x2A5E
+    {1, RF_TxPowerTable_DEFAULT_PA_ENTRY(35, 1, 0, 25) }, // 0x3263
+    {2, RF_TxPowerTable_DEFAULT_PA_ENTRY(22, 0, 0, 35) }, // 0x4616
+    {3, RF_TxPowerTable_DEFAULT_PA_ENTRY(29, 0, 0, 46) }, // 0x5C1D
+    {4, RF_TxPowerTable_DEFAULT_PA_ENTRY(41, 0, 0, 64) }, // 0x8029
+    {5, RF_TxPowerTable_DEFAULT_PA_ENTRY(63, 0, 0, 0) }, // 0x003F
+    RF_TxPowerTable_TERMINATION_ENTRY
+};
+
+/*
+ * Define symbols for both the TX power table and its size. The TX power
+ * table size is with one less entry by excluding the termination entry.
+ */
+#if RF_MODE == RF_MODE_2_4_GHZ
+#define TX_POWER_TABLE  txPowerTable_2400_pa5
+tx_power_table_t *const rf_tx_power_table = TX_POWER_TABLE;
+const size_t rf_tx_power_table_size = (sizeof(TX_POWER_TABLE) / sizeof(TX_POWER_TABLE[0])) - 1;
+#endif /* RF_MODE == RF_MODE_2_4_GHZ */
+
+/* @} */

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/sched.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/sched.c
@@ -194,7 +194,7 @@ cmd_rx_restore(uint_fast8_t rx_key)
   RF_ScheduleCmdParams sched_params;
   RF_ScheduleCmdParams_init(&sched_params);
 
-  sched_params.priority = RF_PriorityNormal;
+  sched_params.coexPriority = RF_PriorityCoexDefault;
   sched_params.endTime = 0;
   sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -229,7 +229,7 @@ rf_yield(void)
   RF_ScheduleCmdParams sched_params;
   RF_ScheduleCmdParams_init(&sched_params);
 
-  sched_params.priority = RF_PriorityNormal;
+  sched_params.coexPriority = RF_PriorityCoexDefault;
   sched_params.endTime = 0;
   sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -262,7 +262,7 @@ rf_restart_rat(void)
   /* Stop SYNC RAT */
   RF_ScheduleCmdParams_init(&sched_params);
 
-  sched_params.priority = RF_PriorityNormal;
+  sched_params.coexPriority = RF_PriorityCoexDefault;
   sched_params.endTime = 0;
   sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -278,7 +278,7 @@ rf_restart_rat(void)
   /* Start SYNC RAT */
   RF_ScheduleCmdParams_init(&sched_params);
 
-  sched_params.priority = RF_PriorityNormal;
+  sched_params.coexPriority = RF_PriorityCoexDefault;
   sched_params.endTime = 0;
   sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -354,7 +354,7 @@ netstack_sched_fs(void)
     RF_ScheduleCmdParams sched_params;
     RF_ScheduleCmdParams_init(&sched_params);
 
-    sched_params.priority = RF_PriorityNormal;
+    sched_params.coexPriority = RF_PriorityCoexDefault;
     sched_params.endTime = 0;
     sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -392,7 +392,7 @@ netstack_sched_fs(void)
       events = RF_runCmd(
           &rf_netstack,
           (RF_Op *)&netstack_cmd_fs,
-          RF_PriorityNormal,
+          RF_PriorityCoexDefault,
           NULL,
           0);
 
@@ -417,7 +417,7 @@ netstack_sched_ieee_tx(uint16_t payload_length, bool ack_request)
   RF_ScheduleCmdParams sched_params;
   RF_ScheduleCmdParams_init(&sched_params);
 
-  sched_params.priority = RF_PriorityNormal;
+  sched_params.coexPriority = RF_PriorityCoexDefault;
   sched_params.endTime = 0;
   sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -502,7 +502,7 @@ netstack_sched_prop_tx(uint16_t payload_length)
   RF_ScheduleCmdParams sched_params;
   RF_ScheduleCmdParams_init(&sched_params);
 
-  sched_params.priority = RF_PriorityNormal;
+  sched_params.coexPriority = RF_PriorityCoexDefault;
   sched_params.endTime = 0;
   sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -580,7 +580,7 @@ netstack_sched_rx(bool start)
     /* Start SYNC RAT */
     RF_ScheduleCmdParams_init(&sched_params);
 
-    sched_params.priority = RF_PriorityNormal;
+    sched_params.coexPriority = RF_PriorityCoexDefault;
     sched_params.endTime = 0;
     sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -597,7 +597,7 @@ netstack_sched_rx(bool start)
 
   RF_ScheduleCmdParams_init(&sched_params);
 
-  sched_params.priority = RF_PriorityNormal;
+  sched_params.coexPriority = RF_PriorityCoexDefault;
   sched_params.endTime = 0;
   sched_params.allowDelay = RF_AllowDelayAny;
 
@@ -779,7 +779,7 @@ ble_sched_beacons(uint8_t bm_channel)
   }
 
   RF_ScheduleCmdParams_init(&sched_params);
-  sched_params.priority = RF_PriorityNormal;
+  sched_params.coexPriority = RF_PriorityCoexDefault;
   sched_params.endTime = 0;
   sched_params.allowDelay = RF_AllowDelayAny;
 

--- a/arch/platform/simplelink/cc13xx-cc26xx/Makefile.cc13xx-cc26xx
+++ b/arch/platform/simplelink/cc13xx-cc26xx/Makefile.cc13xx-cc26xx
@@ -18,6 +18,7 @@ include $(BOARD_PATH)/Makefile.$(notdir $(BOARD))
 
 DEVICE_LC        := $(shell echo "$(DEVICE)" | tr A-Z a-z)
 DEVICE_FAMILY_LC := $(shell echo "$(DEVICE_FAMILY)" | tr A-Z a-z)
+SUBFAMILY_LC     := $(shell echo "$(SUBFAMILY)" | tr - _)
 
 # Add to the source dirs
 TARGET_FAMILY_DIRS += common

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/Board.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/Board.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017-2019, Texas Instruments Incorporated
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * *  Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * *  Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __BOARD_H
+#define __BOARD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <ti/drivers/Board.h>
+
+#define BOARD_STRING            "LP-EM-CC1354P10-1"
+#define Board_WATCHDOG0         0
+#define Board_TRNG0             0
+#define Board_UART0             0
+#define Board_PIN_LED0          6
+#define Board_PIN_LED1          7
+#define Board_PIN_BTN1          15
+#define Board_PIN_BTN2          14
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARD_H */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/Makefile.cc1354p10
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/Makefile.cc1354p10
@@ -1,0 +1,37 @@
+################################################################################
+# SimpleLink Device makefile
+
+SUBFAMILY     = cc13x4-cc26x4
+DEVICE_FAMILY = CC13X4
+DEVICE_LINE   = CC13XX
+DEVICE        = CC1354P
+
+BOARD_SOURCEFILES += ti_drivers_config.c
+
+SUPPORTS_PROP_MODE  = 0
+SUPPORTS_IEEE_MODE  = 1
+SUPPORTS_BLE_BEACON = 0
+
+SUPPORTS_HIGH_PA = 1
+
+# Include the common board makefile
+include $(FAMILY_PATH)/launchpad/Makefile.launchpad
+
+################################################################################
+### For the login etc targets
+BAUDRATE ?= 115200
+PORT ?= /dev/ttyACM0
+
+################################################################################
+### For the .upload make target
+CCXML ?= $(realpath $(CONTIKI_NG_RELOC_PLATFORM_DIR)/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/cc1354p10.ccxml)
+UFSETTINGS ?= $(realpath $(CONTIKI_NG_RELOC_PLATFORM_DIR)/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/generated.ufsettings)
+UNIFLASH_FLAGS += --config=$(CCXML) --load-settings $(UFSETTINGS) -b Erase -r 0
+
+UNIFLASH = ~/ti/uniflash_9.0.0/dslite.sh
+
+%.upload: $(BUILD_DIR_BOARD)/%.$(TARGET)
+	perl -MPOSIX -e 'tcflush(0, TCIFLUSH)' < $(PORT)
+	$(UNIFLASH) $(UNIFLASH_FLAGS) -f $(realpath $(BUILD_DIR_BOARD)/$*.$(TARGET))
+
+

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/cc1354p10.ccxml
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/cc1354p10.ccxml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configurations XML_version="1.2" id="configurations_0">
+<configuration XML_version="1.2" id="configuration_0">
+        <instance XML_version="1.2" desc="Texas Instruments XDS110 USB Debug Probe" href="connections/TIXDS110_Connection.xml" id="Texas Instruments XDS110 USB Debug Probe" xml="TIXDS110_Connection.xml" xmlpath="connections"/>
+        <connection XML_version="1.2" id="Texas Instruments XDS110 USB Debug Probe">
+        	
+        		   <instance XML_version="1.2" href="drivers/tixds510icepick_c.xml" id="drivers" xml="tixds510icepick_c.xml" xmlpath="drivers"/>
+        	
+        		   <instance XML_version="1.2" href="drivers/tixds510cs_dap.xml" id="drivers" xml="tixds510cs_dap.xml" xmlpath="drivers"/>
+        	
+        		   <instance XML_version="1.2" href="drivers/tixds510cortexM33.xml" id="drivers" xml="tixds510cortexM33.xml" xmlpath="drivers"/>
+        	
+            
+                  <property Type="choicelist" id="dataFileRequired" desc="Board Data File" Value="0">
+  <choice value="auto generate with extra config file">
+    <property Type="filepathfield" Value="0" id="dataFileExtraConfig" desc="Extra Config File" Extensions="Config Files (*.dat)|*.dat|All Files (*.*)|*.*||"/>
+  </choice>
+  <choice value="specify custom">
+    <property Type="filepathfield" Value="0" id="dataFile" desc="Custom Board.dat file" Extensions="Config Files (*.dat)|*.dat|All Files (*.*)|*.*||"/>
+  </choice>
+</property>
+            
+            
+                  <property id="Power Selection" Type="choicelist" Value="1">
+  <choice Name="Target supplied power" value="0">
+    <property id="Voltage Selection" Type="choicelist" Value="1">
+      <choice Name="User specified value" value="1">
+        <property id="Voltage Level" Type="stringfield" Value="3.3"/>
+      </choice>
+    </property>
+  </choice>
+  <choice Name="Probe supplied power" value="1">
+    <property id="Voltage Level" Type="stringfield" Value="3.3"/>
+  </choice>
+</property>
+            
+                  <property Type="choicelist" Value="0" id="JTAG Signal Isolation"/>
+            
+                  <property id="SWD Mode Settings" desc="JTAG / SWD / cJTAG Mode" Type="choicelist" Value="4">
+  <choice Name="cJTAG (1149.7) 2-pin advanced modes" value="enable">
+    <property id="XDS110 Aux Port" desc="Auxiliary COM Port Connection" Type="choicelist" Value="1"/>
+  </choice>
+</property>
+            
+            <platform XML_version="1.2" id="platform_0">
+                <instance XML_version="1.2" desc="CC1354P10" href="devices/cc1354p10.xml" id="CC1354P10" xml="cc1354p10.xml" xmlpath="devices"/>
+            </platform>
+        </connection>
+    </configuration>
+</configurations>

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/generated.ufsettings
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/generated.ufsettings
@@ -1,0 +1,1 @@
+{"Texas Instruments XDS110 USB Debug Probe/Cortex_M33_0":{"FlashEraseSetting":"Necessary Sectors Only (Retain untouched content within sector)"}}

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/rf-conf.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/rf-conf.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \addtogroup launchpad-peripherals
+ * @{
+ *
+ * \file
+ *        Header file with board-specific RF configurations.
+ * \author
+ *        Texas Instruments <e2e.ti.com>
+ * \note
+ *        This file should not be included directly
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef RF_CONF_H_
+#define RF_CONF_H_
+/*---------------------------------------------------------------------------*/
+#include "rf/rf.h"
+/*---------------------------------------------------------------------------*/
+/**
+ * \name  Board-specific front-end mode configurations for both the Sub-1 GHz
+ *        path and the 2.4 GHz path on the radio.
+ *
+ * These are the following front-end mode configurations for the
+ * CC1354P10 LaunchPad board:
+ *  - Sub-1 GHz: differential and external bias
+ *  - 2.4 GHz: differential and external bias
+ *
+ * @{
+ */
+#define RF_SUB_1_GHZ_CONF_FRONT_END_MODE  RF_FRONT_END_MODE_DIFFERENTIAL
+#define RF_SUB_1_GHZ_CONF_BIAS_MODE       RF_BIAS_MODE_EXTERNAL
+
+#define RF_2_4_GHZ_CONF_FRONT_END_MODE    RF_FRONT_END_MODE_DIFFERENTIAL
+#define RF_2_4_GHZ_CONF_BIAS_MODE         RF_BIAS_MODE_EXTERNAL
+/** @} */
+
+#define RF_MODE                           RF_MODE_2_4_GHZ
+/*---------------------------------------------------------------------------*/
+#endif /* RF_CONF_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/ti_drivers_config.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/ti_drivers_config.c
@@ -1,0 +1,698 @@
+/*
+ *  ======== ti_drivers_config.c ========
+ *  Configured TI-Drivers module definitions
+ *
+ *  DO NOT EDIT - This file is generated for the LP_EM_CC1354P10_1
+ *  by the SysConfig tool.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef DeviceFamily_CC13X4
+#define DeviceFamily_CC13X4
+#endif
+
+#include <ti/devices/DeviceFamily.h>
+
+#include "ti_drivers_config.h"
+
+/*
+ *  =============================== DMA ===============================
+ */
+
+#include <ti/drivers/dma/UDMACC26XX.h>
+#include <ti/devices/cc13x4_cc26x4/driverlib/udma.h>
+#include <ti/devices/cc13x4_cc26x4/inc/hw_memmap.h>
+
+UDMACC26XX_Object udmaCC26XXObject;
+
+const UDMACC26XX_HWAttrs udmaCC26XXHWAttrs = {
+    .baseAddr        = UDMA0_BASE,
+    .powerMngrId     = PowerCC26XX_PERIPH_UDMA,
+    .intNum          = INT_DMA_ERR,
+    .intPriority     = (~0)
+};
+
+const UDMACC26XX_Config UDMACC26XX_config[1] = {
+    {
+        .object         = &udmaCC26XXObject,
+        .hwAttrs        = &udmaCC26XXHWAttrs,
+    },
+};
+
+/*
+ *  =============================== GPIO ===============================
+ */
+
+#include <ti/drivers/GPIO.h>
+
+/* The range of pins available on this device */
+const uint_least8_t GPIO_pinLowerBound = 3;
+const uint_least8_t GPIO_pinUpperBound = 47;
+
+/*
+ *  ======== gpioPinConfigs ========
+ *  Array of Pin configurations
+ */
+GPIO_PinConfig gpioPinConfigs[48] = {
+    0, /* Pin is not available on this device */
+    0, /* Pin is not available on this device */
+    0, /* Pin is not available on this device */
+    /* Owned by /ti/drivers/RF as RF Antenna Pin 1 */
+    GPIO_CFG_OUTPUT_INTERNAL | GPIO_CFG_OUT_STR_HIGH | GPIO_CFG_OUT_LOW, /* CONFIG_RF_HIGH_PA */
+    GPIO_CFG_NO_DIR, /* DIO_4 */
+    GPIO_CFG_NO_DIR, /* DIO_5 */
+    GPIO_CFG_OUTPUT_INTERNAL | GPIO_CFG_OUT_STR_MED | GPIO_CFG_OUT_LOW, /* CONFIG_GPIO_LED_0 */
+    GPIO_CFG_OUTPUT_INTERNAL | GPIO_CFG_OUT_STR_MED | GPIO_CFG_OUT_LOW, /* CONFIG_GPIO_LED_1 */
+    GPIO_CFG_NO_DIR, /* DIO_8 */
+    GPIO_CFG_NO_DIR, /* DIO_9 */
+    GPIO_CFG_NO_DIR, /* DIO_10 */
+    GPIO_CFG_NO_DIR, /* DIO_11 */
+    /* Owned by CONFIG_UART2_0 as RX */
+    GPIO_CFG_INPUT_INTERNAL | GPIO_CFG_IN_INT_NONE | GPIO_CFG_PULL_DOWN_INTERNAL, /* CONFIG_PIN_UART_RX */
+    /* Owned by CONFIG_UART2_0 as TX */
+    GPIO_CFG_OUTPUT_INTERNAL | GPIO_CFG_OUT_STR_MED | GPIO_CFG_OUT_HIGH, /* CONFIG_PIN_UART_TX */
+    GPIO_CFG_INPUT_INTERNAL | GPIO_CFG_IN_INT_NONE | GPIO_CFG_PULL_NONE_INTERNAL, /* CONFIG_GPIO_BTN_2 */
+    GPIO_CFG_INPUT_INTERNAL | GPIO_CFG_IN_INT_NONE | GPIO_CFG_PULL_NONE_INTERNAL, /* CONFIG_GPIO_BTN_1 */
+    /* Owned by CONFIG_SPI_0 as PICO */
+    GPIO_CFG_OUTPUT_INTERNAL | GPIO_CFG_OUT_STR_MED | GPIO_CFG_OUT_LOW, /* CONFIG_GPIO_SPI_0_PICO */
+    /* Owned by CONFIG_SPI_0 as POCI */
+    GPIO_CFG_INPUT_INTERNAL | GPIO_CFG_IN_INT_NONE | GPIO_CFG_PULL_NONE_INTERNAL, /* CONFIG_GPIO_SPI_0_POCI */
+    /* Owned by CONFIG_SPI_0 as SCLK */
+    GPIO_CFG_OUTPUT_INTERNAL | GPIO_CFG_OUT_STR_MED | GPIO_CFG_OUT_LOW, /* CONFIG_GPIO_SPI_0_SCLK */
+    GPIO_CFG_NO_DIR, /* DIO_19 */
+    GPIO_CFG_NO_DIR, /* DIO_20 */
+    GPIO_CFG_NO_DIR, /* DIO_21 */
+    GPIO_CFG_NO_DIR, /* DIO_22 */
+    GPIO_CFG_NO_DIR, /* DIO_23 */
+    GPIO_CFG_NO_DIR, /* DIO_24 */
+    GPIO_CFG_NO_DIR, /* DIO_25 */
+    GPIO_CFG_NO_DIR, /* DIO_26 */
+    GPIO_CFG_NO_DIR, /* DIO_27 */
+    GPIO_CFG_NO_DIR, /* DIO_28 */
+    GPIO_CFG_NO_DIR, /* DIO_29 */
+    GPIO_CFG_NO_DIR, /* DIO_30 */
+    GPIO_CFG_NO_DIR, /* DIO_31 */
+    GPIO_CFG_NO_DIR, /* DIO_32 */
+    GPIO_CFG_NO_DIR, /* DIO_33 */
+    /* Owned by /ti/drivers/RF as RF Antenna Pin 0 */
+    GPIO_CFG_OUTPUT_INTERNAL | GPIO_CFG_OUT_STR_HIGH | GPIO_CFG_OUT_LOW, /* CONFIG_RF_24GHZ */
+    /* Owned by /ti/drivers/RF as RF Antenna Pin 2 */
+    GPIO_CFG_OUTPUT_INTERNAL | GPIO_CFG_OUT_STR_HIGH | GPIO_CFG_OUT_LOW, /* CONFIG_RF_SUB1GHZ */
+    GPIO_CFG_NO_DIR, /* DIO_36 */
+    GPIO_CFG_NO_DIR, /* DIO_37 */
+    GPIO_CFG_NO_DIR, /* DIO_38 */
+    GPIO_CFG_NO_DIR, /* DIO_39 */
+    GPIO_CFG_NO_DIR, /* DIO_40 */
+    GPIO_CFG_NO_DIR, /* DIO_41 */
+    GPIO_CFG_NO_DIR, /* DIO_42 */
+    GPIO_CFG_NO_DIR, /* DIO_43 */
+    GPIO_CFG_NO_DIR, /* DIO_44 */
+    GPIO_CFG_NO_DIR, /* DIO_45 */
+    GPIO_CFG_NO_DIR, /* DIO_46 */
+    GPIO_CFG_NO_DIR, /* DIO_47 */
+};
+
+/*
+ *  ======== gpioCallbackFunctions ========
+ *  Array of callback function pointers
+ *  Change at runtime with GPIO_setCallback()
+ */
+GPIO_CallbackFxn gpioCallbackFunctions[48];
+
+/*
+ *  ======== gpioUserArgs ========
+ *  Array of user argument pointers
+ *  Change at runtime with GPIO_setUserArg()
+ *  Get values with GPIO_getUserArg()
+ */
+void* gpioUserArgs[48];
+
+const uint_least8_t CONFIG_GPIO_LED_0_CONST = CONFIG_GPIO_LED_0;
+const uint_least8_t CONFIG_GPIO_LED_1_CONST = CONFIG_GPIO_LED_1;
+const uint_least8_t CONFIG_GPIO_BTN_1_CONST = CONFIG_GPIO_BTN_1;
+const uint_least8_t CONFIG_GPIO_BTN_2_CONST = CONFIG_GPIO_BTN_2;
+const uint_least8_t CONFIG_RF_24GHZ_CONST = CONFIG_RF_24GHZ;
+const uint_least8_t CONFIG_RF_HIGH_PA_CONST = CONFIG_RF_HIGH_PA;
+const uint_least8_t CONFIG_RF_SUB1GHZ_CONST = CONFIG_RF_SUB1GHZ;
+const uint_least8_t CONFIG_PIN_UART_TX_CONST = CONFIG_PIN_UART_TX;
+const uint_least8_t CONFIG_PIN_UART_RX_CONST = CONFIG_PIN_UART_RX;
+const uint_least8_t CONFIG_GPIO_SPI_0_SCLK_CONST = CONFIG_GPIO_SPI_0_SCLK;
+const uint_least8_t CONFIG_GPIO_SPI_0_POCI_CONST = CONFIG_GPIO_SPI_0_POCI;
+const uint_least8_t CONFIG_GPIO_SPI_0_PICO_CONST = CONFIG_GPIO_SPI_0_PICO;
+
+/*
+ *  ======== GPIO_config ========
+ */
+const GPIO_Config GPIO_config = {
+    .configs = (GPIO_PinConfig *)gpioPinConfigs,
+    .callbacks = (GPIO_CallbackFxn *)gpioCallbackFunctions,
+    .userArgs = gpioUserArgs,
+    .intPriority = (~0)
+};
+
+/*
+ *  =============================== Power ===============================
+ */
+#include <ti/drivers/Power.h>
+#include <ti/drivers/power/PowerCC26X2.h>
+#include "ti_drivers_config.h"
+
+extern void PowerCC26XX_standbyPolicy(void);
+extern bool PowerCC26XX_calibrate(unsigned int);
+
+const PowerCC26X2_Config PowerCC26X2_config = {
+    .enablePolicy             = true,
+    .policyInitFxn            = NULL,
+    .policyFxn                = PowerCC26XX_standbyPolicy,
+    .calibrateFxn             = PowerCC26XX_calibrate,
+    .calibrateRCOSC_LF        = true,
+    .calibrateRCOSC_HF        = true,
+    .enableTCXOFxn            = NULL
+};
+
+/*
+ *  =============================== RF Driver ===============================
+ */
+#include <ti/drivers/GPIO.h>
+#include <ti/devices/DeviceFamily.h>
+#include DeviceFamily_constructPath(driverlib/ioc.h)
+#include <ti/drivers/rf/RF.h>
+
+/*
+ * RF driver callback function, called by the driver on global driver events.
+ */
+static void RF_globalCallbackFunction (RF_Handle client, RF_GlobalEvent events, void* arg);
+
+/*
+ * Callback function to handle custom / application specific behavior
+ */
+extern void __attribute__((weak)) rfDriverCallback (RF_Handle client, RF_GlobalEvent events, void *arg);
+
+/*
+ * Callback function to handle antenna switching
+ */
+extern void __attribute__((weak)) rfDriverCallbackAntennaSwitching (RF_Handle client, RF_GlobalEvent events, void *arg);
+
+/*
+ * Platform-specific driver configuration
+ */
+const RFCC26XX_HWAttrsV2 RFCC26XX_hwAttrs = {
+    .hwiPriority        = (~0),
+    .swiPriority        = (uint8_t)0,
+    .xoscHfAlwaysNeeded = true,
+    .globalCallback     = &RF_globalCallbackFunction,
+    .globalEventMask    = RF_GlobalEventInit | RF_GlobalEventRadioPowerDown | RF_GlobalEventRadioSetup
+};
+
+/*
+ *  ======== RF_globalCallbackFunction ========
+ *  This function is called by the driver on global driver events.
+ *  It will call specific callback functions to further handle the triggering events.
+ */
+static void RF_globalCallbackFunction(RF_Handle client, RF_GlobalEvent events, void *arg)
+{
+    rfDriverCallback(client, events, arg);
+    rfDriverCallbackAntennaSwitching(client, events, arg);
+}
+
+/*
+ *  ======== rfDriverCallback ========
+ *  Handle events triggered by the RF driver for custom / application specific behavior.
+ */
+void __attribute__((weak)) rfDriverCallback(RF_Handle client, RF_GlobalEvent events, void *arg)
+{
+    /* ======== PLEASE READ THIS ========
+    *
+    * This function is declared weak for the application to override it.
+    * A new definition of 'rfDriverCallback' is required if you want to
+    * handle the events listed in '.globalEventMask'.
+    *
+    * Please copy this function definition to create your own, but make
+    * sure to remove '__attribute__((weak))' for your definition.
+    *
+    * According to '.globalEventMask', this function will be triggered by:
+    *   - RF_GlobalEventInit
+    *   - RF_GlobalEventRadioPowerDown
+    *   - RF_GlobalEventRadioSetup
+    *
+    * An example of how to handle these events would be:
+    *
+    *   --- Code snippet begin ---
+    *
+    *   if(events & RF_GlobalEventInit) {
+    *       // Perform action for this event
+    *   }
+    *   else if (events & RF_GlobalEventRadioPowerDown) {
+    *       // Perform action for this event
+    *   }
+    *   else if (events & RF_GlobalEventRadioSetup) {
+    *       // Perform action for this event
+    *   }
+    *
+    *   --- Code snippet end ---
+    */
+}
+
+
+
+/*
+ * ======== Antenna switching ========
+ */
+/*
+ * ======== rfDriverCallbackAntennaSwitching ========
+ * Sets up the antenna switch depending on the current PHY configuration.
+ *
+ * Truth table:
+ *
+ * Path       DIO34 DIO3  DIO35
+ * ========== ===== ===== =====
+ * Off        0     0     0
+ * 2.4 GHZ    1     0     0
+ * HIGH PA    0     1     0
+ * SUB1 GHZ   0     0     1
+ */
+void __attribute__((weak)) rfDriverCallbackAntennaSwitching(RF_Handle client, RF_GlobalEvent events, void *arg)
+{
+
+    if (events & RF_GlobalEventRadioSetup) {
+        bool    sub1GHz   = false;
+        uint8_t loDivider = 0;
+
+        /* Switch off all paths. */
+        GPIO_write(CONFIG_RF_24GHZ, 0);
+        GPIO_write(CONFIG_RF_HIGH_PA, 0);
+        GPIO_write(CONFIG_RF_SUB1GHZ, 0);
+
+        /* Decode the current PA configuration. */
+        RF_TxPowerTable_PAType paType = (RF_TxPowerTable_PAType)RF_getTxPower(client).paType;
+
+        /* Decode the generic argument as a setup command. */
+        RF_RadioSetup* setupCommand = (RF_RadioSetup*)arg;
+
+        switch (setupCommand->common.commandNo) {
+            case (CMD_RADIO_SETUP):
+            case (CMD_BLE5_RADIO_SETUP):
+                    loDivider = RF_LODIVIDER_MASK & setupCommand->common.loDivider;
+
+                    /* Sub-1GHz front-end. */
+                    if (loDivider != 0) {
+                        sub1GHz = true;
+                    }
+                    break;
+            case (CMD_PROP_RADIO_DIV_SETUP):
+                    loDivider = RF_LODIVIDER_MASK & setupCommand->prop_div.loDivider;
+
+                    /* Sub-1GHz front-end. */
+                    if (loDivider != 0) {
+                        sub1GHz = true;
+                    }
+                    break;
+            default:break;
+        }
+
+        if (sub1GHz) {
+            /* Sub-1 GHz */
+            if (paType == RF_TxPowerTable_HighPA) {
+                /* PA enable --> HIGH PA
+                 * LNA enable --> Sub-1 GHz
+                 */
+                GPIO_setConfigAndMux(CONFIG_RF_24GHZ, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+                /* Note: RFC_GPO3 is a work-around because the RFC_GPO1 (PA enable signal) is sometimes not
+                         de-asserted on CC1352 Rev A. */
+                GPIO_setConfigAndMux(CONFIG_RF_HIGH_PA, GPIO_CFG_OUTPUT, IOC_PORT_RFC_GPO3);
+                GPIO_setConfigAndMux(CONFIG_RF_SUB1GHZ, GPIO_CFG_OUTPUT, IOC_PORT_RFC_GPO0);
+            } else {
+                /* RF core active --> Sub-1 GHz */
+                GPIO_setConfigAndMux(CONFIG_RF_24GHZ, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+                GPIO_setConfigAndMux(CONFIG_RF_HIGH_PA, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+                GPIO_setConfigAndMux(CONFIG_RF_SUB1GHZ, GPIO_CFG_OUTPUT | GPIO_CFG_OUT_HIGH, IOC_PORT_GPIO);
+            }
+        } else {
+            /* 2.4 GHz */
+            if (paType == RF_TxPowerTable_HighPA)
+            {
+                /* PA enable --> HIGH PA
+                 * LNA enable --> 2.4 GHz
+                 */
+                GPIO_setConfigAndMux(CONFIG_RF_24GHZ, GPIO_CFG_OUTPUT, IOC_PORT_RFC_GPO0);
+                /* Note: RFC_GPO3 is a work-around because the RFC_GPO1 (PA enable signal) is sometimes not
+                         de-asserted on CC1352 Rev A. */
+                GPIO_setConfigAndMux(CONFIG_RF_HIGH_PA, GPIO_CFG_OUTPUT, IOC_PORT_RFC_GPO3);
+                GPIO_setConfigAndMux(CONFIG_RF_SUB1GHZ, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+            } else {
+                /* RF core active --> 2.4 GHz */
+                GPIO_setConfigAndMux(CONFIG_RF_24GHZ, GPIO_CFG_OUTPUT | GPIO_CFG_OUT_HIGH, IOC_PORT_GPIO);
+                GPIO_setConfigAndMux(CONFIG_RF_HIGH_PA, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+                GPIO_setConfigAndMux(CONFIG_RF_SUB1GHZ, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+            }
+        }
+    }
+    else if (events & RF_GlobalEventRadioPowerDown) {
+        /* Switch off all paths. */
+        GPIO_write(CONFIG_RF_24GHZ, 0);
+        GPIO_write(CONFIG_RF_HIGH_PA, 0);
+        GPIO_write(CONFIG_RF_SUB1GHZ, 0);
+
+        /* Reset the IO multiplexer to GPIO functionality */
+        GPIO_setConfigAndMux(CONFIG_RF_24GHZ, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+        GPIO_setConfigAndMux(CONFIG_RF_HIGH_PA, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+        GPIO_setConfigAndMux(CONFIG_RF_SUB1GHZ, GPIO_CFG_OUTPUT, IOC_PORT_GPIO);
+    }
+}
+
+/*
+ *  =============================== UART2 ===============================
+ */
+
+#include <ti/drivers/UART2.h>
+#include <ti/drivers/uart2/UART2CC26X2.h>
+#include <ti/drivers/GPIO.h>
+#include <ti/drivers/Power.h>
+#include <ti/drivers/dma/UDMACC26XX.h>
+#include <ti/drivers/power/PowerCC26X2.h>
+#include <ti/devices/cc13x4_cc26x4/driverlib/ioc.h>
+#include <ti/devices/cc13x4_cc26x4/inc/hw_memmap.h>
+#include <ti/devices/cc13x4_cc26x4/inc/hw_ints.h>
+
+#define CONFIG_UART2_COUNT 1
+
+UART2CC26X2_Object uart2CC26X2Objects[CONFIG_UART2_COUNT];
+
+static unsigned char uart2RxRingBuffer0[32];
+/* TX ring buffer allocated to be used for nonblocking mode */
+static unsigned char uart2TxRingBuffer0[32];
+
+ALLOCATE_CONTROL_TABLE_ENTRY(dmaUart0RxControlTableEntry, UDMA_CHAN_UART0_RX);
+ALLOCATE_CONTROL_TABLE_ENTRY(dmaUart0TxControlTableEntry, UDMA_CHAN_UART0_TX);
+
+static const UART2CC26X2_HWAttrs uart2CC26X2HWAttrs[CONFIG_UART2_COUNT] = {
+  {
+    .baseAddr           = UART0_BASE,
+    .intNum             = INT_UART0_COMB,
+    .intPriority        = (~0),
+    .rxPin              = CONFIG_PIN_UART_RX,
+    .txPin              = CONFIG_PIN_UART_TX,
+    .ctsPin             = GPIO_INVALID_INDEX,
+    .rtsPin             = GPIO_INVALID_INDEX,
+    .flowControl        = UART2_FLOWCTRL_NONE,
+    .powerId            = PowerCC26XX_PERIPH_UART0,
+    .rxBufPtr           = uart2RxRingBuffer0,
+    .rxBufSize          = sizeof(uart2RxRingBuffer0),
+    .txBufPtr           = uart2TxRingBuffer0,
+    .txBufSize          = sizeof(uart2TxRingBuffer0),
+    .txPinMux           = IOC_PORT_MCU_UART0_TX,
+    .rxPinMux           = IOC_PORT_MCU_UART0_RX,
+    .ctsPinMux          = IOC_PORT_MCU_UART0_CTS,
+    .rtsPinMux          = IOC_PORT_MCU_UART0_RTS,
+    .dmaTxTableEntryPri = &dmaUart0TxControlTableEntry,
+    .dmaRxTableEntryPri = &dmaUart0RxControlTableEntry,
+    .rxChannelMask      = 1 << UDMA_CHAN_UART0_RX,
+    .txChannelMask      = 1 << UDMA_CHAN_UART0_TX,
+    .txIntFifoThr       = UART2CC26X2_FIFO_THRESHOLD_1_8,
+    .rxIntFifoThr       = UART2CC26X2_FIFO_THRESHOLD_4_8
+  },
+};
+
+const UART2_Config UART2_config[CONFIG_UART2_COUNT] = {
+    {   /* CONFIG_UART2_0 */
+        .object      = &uart2CC26X2Objects[CONFIG_UART2_0],
+        .hwAttrs     = &uart2CC26X2HWAttrs[CONFIG_UART2_0]
+    },
+};
+
+const uint_least8_t CONFIG_UART2_0_CONST = CONFIG_UART2_0;
+const uint_least8_t UART2_count = CONFIG_UART2_COUNT;
+
+/*
+ *  =============================== SPI DMA ===============================
+ */
+#include <ti/drivers/SPI.h>
+#include <ti/drivers/spi/SPICC26X4DMA.h>
+#include <ti/drivers/dma/UDMACC26XX.h>
+
+#include <ti/devices/DeviceFamily.h>
+#include DeviceFamily_constructPath(driverlib/ioc.h)
+
+#define CONFIG_SPI_COUNT 1
+
+/*
+ *  ======== spiCC26X4DMAObjects ========
+ */
+SPICC26X4DMA_Object spiCC26X4DMAObjects[CONFIG_SPI_COUNT];
+
+/*
+ * ======== spiCC26X4DMA uDMA Table Entries  ========
+ */
+ALLOCATE_CONTROL_TABLE_ENTRY(dmaSpi0TxControlTableEntry, UDMA_CHAN_SPI0_TX);
+ALLOCATE_CONTROL_TABLE_ENTRY(dmaSpi0RxControlTableEntry, UDMA_CHAN_SPI0_RX);
+ALLOCATE_CONTROL_TABLE_ENTRY(dmaSpi0TxAltControlTableEntry, (UDMA_CHAN_SPI0_TX | UDMA_ALT_SELECT));
+ALLOCATE_CONTROL_TABLE_ENTRY(dmaSpi0RxAltControlTableEntry, (UDMA_CHAN_SPI0_RX | UDMA_ALT_SELECT));
+
+
+/*
+ *  ======== spiCC26X4DMAHWAttrs ========
+ */
+const SPICC26X4DMA_HWAttrs spiCC26X4DMAHWAttrs[CONFIG_SPI_COUNT] = {
+    /* CONFIG_SPI_0 */
+    {
+        .baseAddr = SPI0_BASE,
+        .intNum = INT_SPI0_COMB,
+        .intPriority = (~0),
+        .swiPriority = 0,
+        .powerMngrId = PowerCC26XX_PERIPH_SSI0,
+        .defaultTxBufValue = ~0,
+        .rxChannelBitMask = 1<<UDMA_CHAN_SPI0_RX,
+        .txChannelBitMask = 1<<UDMA_CHAN_SPI0_TX,
+        .dmaTxTableEntryPri = &dmaSpi0TxControlTableEntry,
+        .dmaRxTableEntryPri = &dmaSpi0RxControlTableEntry,
+        .dmaTxTableEntryAlt = &dmaSpi0TxAltControlTableEntry,
+        .dmaRxTableEntryAlt = &dmaSpi0RxAltControlTableEntry,
+        .minDmaTransferSize = 10,
+        .txPinMux    = IOC_PORT_MCU_SPI0_TX,
+        .rxPinMux    = IOC_PORT_MCU_SPI0_RX,
+        .clkPinMux   = IOC_PORT_MCU_SPI0_CLK,
+        .csnPinMux   = IOC_PORT_MCU_SPI0_FSS,
+        .picoPin = CONFIG_GPIO_SPI_0_PICO,
+        .pociPin = CONFIG_GPIO_SPI_0_POCI,
+        .clkPin  = CONFIG_GPIO_SPI_0_SCLK,
+        .csnPin  = GPIO_INVALID_INDEX
+    },
+};
+
+/*
+ *  ======== SPI_config ========
+ */
+const SPI_Config SPI_config[CONFIG_SPI_COUNT] = {
+    /* CONFIG_SPI_0 */
+    {
+        .fxnTablePtr = &SPICC26X4DMA_fxnTable,
+        .object = &spiCC26X4DMAObjects[CONFIG_SPI_0],
+        .hwAttrs = &spiCC26X4DMAHWAttrs[CONFIG_SPI_0]
+    },
+};
+
+const uint_least8_t CONFIG_SPI_0_CONST = CONFIG_SPI_0;
+const uint_least8_t SPI_count = CONFIG_SPI_COUNT;
+
+/*
+ *  =============================== TRNG ===============================
+ */
+
+#include <ti/drivers/TRNG.h>
+#include <ti/drivers/trng/TRNGCC26XX.h>
+
+#define CONFIG_TRNG_COUNT 1
+
+
+TRNGCC26XX_Object trngCC26XXObjects[CONFIG_TRNG_COUNT];
+
+/*
+ *  ======== trngCC26XXHWAttrs ========
+ */
+static const TRNGCC26XX_HWAttrs trngCC26XXHWAttrs[CONFIG_TRNG_COUNT] = {
+    {
+        .intPriority = (~0),
+        .swiPriority = 0,
+        .samplesPerCycle = 240000
+    },
+};
+
+const TRNG_Config TRNG_config[CONFIG_TRNG_COUNT] = {
+    {   /* CONFIG_TRNG_0 */
+        .object         = &trngCC26XXObjects[CONFIG_TRNG_0],
+        .hwAttrs        = &trngCC26XXHWAttrs[CONFIG_TRNG_0]
+    },
+};
+
+const uint_least8_t CONFIG_TRNG_0_CONST = CONFIG_TRNG_0;
+const uint_least8_t TRNG_count = CONFIG_TRNG_COUNT;
+
+/*
+ *  =============================== Watchdog ===============================
+ */
+
+#include <ti/drivers/Watchdog.h>
+#include <ti/drivers/watchdog/WatchdogCC26X4.h>
+
+#define CONFIG_WATCHDOG_COUNT 1
+
+
+WatchdogCC26X4_Object watchdogCC26X4Objects[CONFIG_WATCHDOG_COUNT];
+
+const WatchdogCC26X4_HWAttrs watchdogCC26X4HWAttrs[CONFIG_WATCHDOG_COUNT] = {
+    /* CONFIG_WATCHDOG_0: period = 1000 */
+    {
+        .reloadValue = 1000
+    },
+};
+
+const Watchdog_Config Watchdog_config[CONFIG_WATCHDOG_COUNT] = {
+    /* CONFIG_WATCHDOG_0 */
+    {
+        .fxnTablePtr = &WatchdogCC26X4_fxnTable,
+        .object      = &watchdogCC26X4Objects[CONFIG_WATCHDOG_0],
+        .hwAttrs     = &watchdogCC26X4HWAttrs[CONFIG_WATCHDOG_0]
+    }
+};
+
+const uint_least8_t CONFIG_WATCHDOG_0_CONST = CONFIG_WATCHDOG_0;
+const uint_least8_t Watchdog_count = CONFIG_WATCHDOG_COUNT;
+
+#include <stdbool.h>
+
+#include <ti/devices/cc13x4_cc26x4/driverlib/ioc.h>
+#include <ti/devices/cc13x4_cc26x4/driverlib/cpu.h>
+
+#include <ti/drivers/GPIO.h>
+
+/* Board GPIO defines */
+#define BOARD_EXT_FLASH_SPI_CS      38
+#define BOARD_EXT_FLASH_SPI_CLK     39
+#define BOARD_EXT_FLASH_SPI_PICO    36
+#define BOARD_EXT_FLASH_SPI_POCI    37
+
+
+/*
+ *  ======== Board_sendExtFlashByte ========
+ */
+void Board_sendExtFlashByte(uint8_t byte)
+{
+    uint8_t i;
+
+    /* SPI Flash CS */
+    GPIO_write(BOARD_EXT_FLASH_SPI_CS, 0);
+
+    for (i = 0; i < 8; i++) {
+        GPIO_write(BOARD_EXT_FLASH_SPI_CLK, 0); /* SPI Flash CLK */
+
+        /* SPI Flash PICO */
+        GPIO_write(BOARD_EXT_FLASH_SPI_PICO, (byte >> (7 - i)) & 0x01);
+        GPIO_write(BOARD_EXT_FLASH_SPI_CLK, 1);  /* SPI Flash CLK */
+
+        /*
+         * Waste a few cycles to keep the CLK high for at
+         * least 45% of the period.
+         * 3 cycles per loop: 8 loops @ 48 Mhz = 0.5 us.
+         */
+        CPUdelay(8);
+    }
+
+    GPIO_write(BOARD_EXT_FLASH_SPI_CLK, 0);  /* CLK */
+    GPIO_write(BOARD_EXT_FLASH_SPI_CS, 1);  /* CS */
+
+    /*
+     * Keep CS high at least 40 us
+     * 3 cycles per loop: 700 loops @ 48 Mhz ~= 44 us
+     */
+    CPUdelay(700);
+}
+
+/*
+ *  ======== Board_wakeUpExtFlash ========
+ */
+void Board_wakeUpExtFlash(void)
+{
+    /* SPI Flash CS*/
+    GPIO_setConfig(BOARD_EXT_FLASH_SPI_CS, GPIO_CFG_OUTPUT | GPIO_CFG_OUT_HIGH | GPIO_CFG_OUT_STR_MED);
+
+    /*
+     *  To wake up we need to toggle the chip select at
+     *  least 20 ns and ten wait at least 35 us.
+     */
+
+    /* Toggle chip select for ~20ns to wake ext. flash */
+    GPIO_write(BOARD_EXT_FLASH_SPI_CS, 0);
+    /* 3 cycles per loop: 1 loop @ 48 Mhz ~= 62 ns */
+    CPUdelay(1);
+    GPIO_write(BOARD_EXT_FLASH_SPI_CS, 1);
+    /* 3 cycles per loop: 560 loops @ 48 Mhz ~= 35 us */
+    CPUdelay(560);
+}
+
+/*
+ *  ======== Board_shutDownExtFlash ========
+ */
+void Board_shutDownExtFlash(void)
+{
+    /*
+     *  To be sure we are putting the flash into sleep and not waking it,
+     *  we first have to make a wake up call
+     */
+    Board_wakeUpExtFlash();
+
+    /* SPI Flash CS*/
+    GPIO_setConfig(BOARD_EXT_FLASH_SPI_CS, GPIO_CFG_OUTPUT | GPIO_CFG_OUT_HIGH | GPIO_CFG_OUT_STR_MED);
+    /* SPI Flash CLK */
+    GPIO_setConfig(BOARD_EXT_FLASH_SPI_CLK, GPIO_CFG_OUTPUT | GPIO_CFG_OUT_LOW | GPIO_CFG_OUT_STR_MED);
+    /* SPI Flash PICO */
+    GPIO_setConfig(BOARD_EXT_FLASH_SPI_PICO, GPIO_CFG_OUTPUT | GPIO_CFG_OUT_LOW | GPIO_CFG_OUT_STR_MED);
+    /* SPI Flash POCI */
+    GPIO_setConfig(BOARD_EXT_FLASH_SPI_POCI, GPIO_CFG_IN_PD);
+
+    uint8_t extFlashShutdown = 0xB9;
+
+    Board_sendExtFlashByte(extFlashShutdown);
+
+    GPIO_resetConfig(BOARD_EXT_FLASH_SPI_CS);
+    GPIO_resetConfig(BOARD_EXT_FLASH_SPI_CLK);
+    GPIO_resetConfig(BOARD_EXT_FLASH_SPI_PICO);
+    GPIO_resetConfig(BOARD_EXT_FLASH_SPI_POCI);
+}
+
+
+#include <ti/drivers/Board.h>
+
+/*
+ *  ======== Board_initHook ========
+ *  Perform any board-specific initialization needed at startup.  This
+ *  function is declared weak to allow applications to override it if needed.
+ */
+void __attribute__((weak)) Board_initHook(void)
+{
+}
+
+/*
+ *  ======== Board_init ========
+ *  Perform any initialization needed before using any board APIs
+ */
+void Board_init(void)
+{
+    /* ==== /ti/drivers/Power initialization ==== */
+    Power_init();
+
+    /* ==== /ti/devices/CCFG initialization ==== */
+
+    /* ==== /ti/drivers/GPIO initialization ==== */
+    /* Setup GPIO module and default-initialise pins */
+    GPIO_init();
+
+    /* ==== /ti/drivers/RF initialization ==== */
+
+
+    Board_shutDownExtFlash();
+
+    Board_initHook();
+}
+

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/ti_drivers_config.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1354p10/ti_drivers_config.h
@@ -1,0 +1,175 @@
+/*
+ *  ======== ti_drivers_config.h ========
+ *  Configured TI-Drivers module declarations
+ *
+ *  The macros defines herein are intended for use by applications which
+ *  directly include this header. These macros should NOT be hard coded or
+ *  copied into library source code.
+ *
+ *  Symbols declared as const are intended for use with libraries.
+ *  Library source code must extern the correct symbol--which is resolved
+ *  when the application is linked.
+ *
+ *  DO NOT EDIT - This file is generated for the LP_EM_CC1354P10_1
+ *  by the SysConfig tool.
+ */
+#ifndef ti_drivers_config_h
+#define ti_drivers_config_h
+
+#define CONFIG_SYSCONFIG_PREVIEW
+
+#define CONFIG_LP_EM_CC1354P10_1
+#ifndef DeviceFamily_CC13X4
+#define DeviceFamily_CC13X4
+#endif
+
+#include <ti/devices/DeviceFamily.h>
+
+#include <stdint.h>
+
+/* support C++ sources */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*
+ *  ======== CCFG ========
+ */
+
+
+/*
+ *  ======== GPIO ========
+ */
+extern const uint_least8_t CONFIG_GPIO_LED_0_CONST;
+#define CONFIG_GPIO_LED_0 6
+
+extern const uint_least8_t CONFIG_GPIO_LED_1_CONST;
+#define CONFIG_GPIO_LED_1 7
+
+extern const uint_least8_t CONFIG_GPIO_BTN_1_CONST;
+#define CONFIG_GPIO_BTN_1 15
+
+extern const uint_least8_t CONFIG_GPIO_BTN_2_CONST;
+#define CONFIG_GPIO_BTN_2 14
+ 
+/* Owned by /ti/drivers/RF as  */
+extern const uint_least8_t CONFIG_RF_24GHZ_CONST;
+#define CONFIG_RF_24GHZ 34
+
+/* Owned by /ti/drivers/RF as  */
+extern const uint_least8_t CONFIG_RF_HIGH_PA_CONST;
+#define CONFIG_RF_HIGH_PA 3
+
+/* Owned by /ti/drivers/RF as  */
+extern const uint_least8_t CONFIG_RF_SUB1GHZ_CONST;
+#define CONFIG_RF_SUB1GHZ 35
+
+/* Owned by CONFIG_UART2_0 as  */
+extern const uint_least8_t CONFIG_PIN_UART_TX_CONST;
+#define CONFIG_PIN_UART_TX 13
+
+/* Owned by CONFIG_UART2_0 as  */
+extern const uint_least8_t CONFIG_PIN_UART_RX_CONST;
+#define CONFIG_PIN_UART_RX 12
+
+/* Owned by CONFIG_SPI_0 as  */
+extern const uint_least8_t CONFIG_GPIO_SPI_0_SCLK_CONST;
+#define CONFIG_GPIO_SPI_0_SCLK 18
+
+/* Owned by CONFIG_SPI_0 as  */
+extern const uint_least8_t CONFIG_GPIO_SPI_0_POCI_CONST;
+#define CONFIG_GPIO_SPI_0_POCI 17
+
+/* Owned by CONFIG_SPI_0 as  */
+extern const uint_least8_t CONFIG_GPIO_SPI_0_PICO_CONST;
+#define CONFIG_GPIO_SPI_0_PICO 16
+
+/* The range of pins available on this device */
+extern const uint_least8_t GPIO_pinLowerBound;
+extern const uint_least8_t GPIO_pinUpperBound;
+
+/* LEDs are active high */
+#define CONFIG_GPIO_LED_ON  (1)
+#define CONFIG_GPIO_LED_OFF (0)
+
+#define CONFIG_LED_ON  (CONFIG_GPIO_LED_ON)
+#define CONFIG_LED_OFF (CONFIG_GPIO_LED_OFF)
+
+
+/*
+ *  ======== RF ========
+ */
+#define Board_DIO_35_RFSW 0x00000023
+
+
+/*
+ *  ======== UART2 ========
+ */
+
+/*
+ *  TX: DIO13
+ *  RX: DIO12
+ *  XDS110 UART
+ */
+extern const uint_least8_t                  CONFIG_UART2_0_CONST;
+#define CONFIG_UART2_0                      0
+#define CONFIG_TI_DRIVERS_UART2_COUNT       1
+
+/*
+ *  ======== SPI ========
+ */
+
+/*
+ *  PICO: DIO16
+ *  POCI: DIO17
+ *  SCLK: DIO18
+ */
+extern const uint_least8_t              CONFIG_SPI_0_CONST;
+#define CONFIG_SPI_0                    0
+#define CONFIG_TI_DRIVERS_SPI_COUNT     1
+
+/*
+ *  ======== TRNG ========
+ */
+
+extern const uint_least8_t              CONFIG_TRNG_0_CONST;
+#define CONFIG_TRNG_0                   0
+#define CONFIG_TI_DRIVERS_TRNG_COUNT    1
+
+
+/*
+ *  ======== Watchdog ========
+ */
+
+extern const uint_least8_t                  CONFIG_WATCHDOG_0_CONST;
+#define CONFIG_WATCHDOG_0                   0
+#define CONFIG_TI_DRIVERS_WATCHDOG_COUNT    1
+
+/*
+ *  ======== Board_init ========
+ *  Perform all required TI-Drivers initialization
+ *
+ *  This function should be called once at a point before any use of
+ *  TI-Drivers.
+ */
+extern void Board_init(void);
+
+/*
+ *  ======== Board_initGeneral ========
+ *  (deprecated)
+ *
+ *  Board_initGeneral() is defined purely for backward compatibility.
+ *
+ *  All new code should use Board_init() to do any required TI-Drivers
+ *  initialization _and_ use <Driver>_init() for only where specific drivers
+ *  are explicitly referenced by the application.  <Driver>_init() functions
+ *  are idempotent.
+ */
+#define Board_initGeneral Board_init
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* include guard */

--- a/arch/platform/simplelink/cc13xx-cc26xx/platform.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/platform.c
@@ -58,19 +58,17 @@
 #include <NoRTOS.h>
 
 #include <ti/devices/DeviceFamily.h>
-#include DeviceFamily_constructPath(driverlib/driverlib_release.h)
 #include DeviceFamily_constructPath(driverlib/chipinfo.h)
 #include DeviceFamily_constructPath(driverlib/vims.h)
 
 #include <ti/drivers/dpl/HwiP.h>
 #include <ti/drivers/I2C.h>
 #include <ti/drivers/NVS.h>
-#include <ti/drivers/PIN.h>
-#include <ti/drivers/pin/PINCC26XX.h>
+#include <ti/drivers/GPIO.h>
 #include <ti/drivers/Power.h>
 #include <ti/drivers/SPI.h>
 #include <ti/drivers/TRNG.h>
-#include <ti/drivers/UART.h>
+#include <ti/drivers/UART2.h>
 /*---------------------------------------------------------------------------*/
 #include "board-peripherals.h"
 #include "clock-arch.h"
@@ -99,7 +97,7 @@ extern void Board_initHook(void);
  * \brief  Fade a specified LED.
  */
 static void
-fade(PIN_Id pin)
+fade(uint_least8_t pin)
 {
   volatile uint32_t i;
   uint32_t k;
@@ -110,11 +108,11 @@ fade(PIN_Id pin)
   for(k = 0; k < pivot; ++k) {
     j = (k > pivot_half) ? pivot - k : k;
 
-    PINCC26XX_setOutputValue(pin, 1);
+    GPIO_write(pin, 1);
     for(i = 0; i < j; ++i) {
       __asm__ __volatile__ ("nop");
     }
-    PINCC26XX_setOutputValue(pin, 0);
+    GPIO_write(pin, 0);
     for(i = 0; i < pivot_half - j; ++i) {
       __asm__ __volatile__ ("nop");
     }
@@ -146,26 +144,7 @@ set_rf_params(void)
 void
 platform_init_stage_one(void)
 {
-  DRIVERLIB_ASSERT_CURR_RELEASE();
-
-  /* Enable flash cache */
-  VIMSModeSet(VIMS_BASE, VIMS_MODE_ENABLED);
-  /* Configure round robin arbitration and prefetching */
-  VIMSConfigure(VIMS_BASE, true, true);
-
-  Power_init();
-
-  /* BoardGpioInitTable declared in Board.h */
-  if(PIN_init(BoardGpioInitTable) != PIN_SUCCESS) {
-    /*
-     * Something is seriously wrong if PIN initialization of the Board GPIO
-     * table fails.
-     */
-    for(;;) { /* hang */ }
-  }
-
-  /* Perform board-specific initialization */
-  Board_initHook();
+  Board_init();
 
   /* Contiki drivers init */
   gpio_hal_init();
@@ -174,9 +153,6 @@ platform_init_stage_one(void)
   fade(Board_PIN_LED0);
 
   /* TI Drivers init */
-#if TI_UART_CONF_ENABLE
-  UART_init();
-#endif
 #if TI_I2C_CONF_ENABLE
   I2C_init();
 #endif
@@ -236,8 +212,6 @@ platform_init_stage_three(void)
 
   set_rf_params();
 
-  LOG_DBG("With DriverLib v%u.%u\n", DRIVERLIB_RELEASE_GROUP,
-          DRIVERLIB_RELEASE_BUILD);
   LOG_DBG("IEEE 802.15.4: %s, Sub-1 GHz: %s, BLE: %s\n",
           ChipInfo_SupportsIEEE_802_15_4() ? "Yes" : "No",
           ChipInfo_SupportsPROPRIETARY() ? "Yes" : "No",


### PR DESCRIPTION
This is an incomplete effort to update the SimpleLink targets to the latest SDK. So far, I only tested the `hello-world` example on the LP-EM-CC1354P10. All other boards will need similar adjustments. Any help is appreciated.

These commands flash the LP-EM-CC1354P10 with the `hello-world` example:
```c
make TARGET=simplelink BOARD=launchpad/cc1354p10 savetarget
make hello-world.upload -j${nproc} && make login
```

For compilation, it is first necessary to compile the SDK libraries:
1. `cd arch/cpu/simplelink-cc13xx-cc26xx/lib/simplelink-lowpower-f2-sdk`
2. Open the `imports.mak` file and set `CMAKE` and `GCC_ARMCOMPILER` in there
3. Run `make build-gcc`

For flashing, I installed [Uniflash 9.0.0](https://www.ti.com/tool/download/UNIFLASH/9.0.0). Uniflash 9.1.0 crashes due to an issue with its Cortex-M33 drivers. On Ubuntu 24.04, these packages may have to be retrieved manually:
- https://packages.ubuntu.com/jammy/all/gconf2-common
- https://packages.ubuntu.com/jammy/amd64/libgconf-2-4
- https://packages.ubuntu.com/jammy-updates/libtinfo5