### PR TITLE
SimpleLink: Use the built-in TRNG to seed the CSPRNG

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/platform.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/platform.c
@@ -51,6 +51,7 @@
 #include "dev/leds.h"
 #include "dev/watchdog.h"
 #include "net/mac/framer/frame802154.h"
+#include "lib/csprng.h"
 #include "lib/random.h"
 #include "lib/sensors.h"
 /*---------------------------------------------------------------------------*/
@@ -207,6 +208,16 @@ platform_init_stage_two(void)
 #if BUILD_WITH_SHELL
   uart0_set_callback(serial_line_input_byte);
 #endif
+
+#if CSPRNG_ENABLED
+  /* Use the built-in TRNG to seed the CSPRNG */
+  {
+    struct csprng_seed seed;
+    if(trng_rand(seed.u8, sizeof(seed.u8), TRNG_WAIT_FOREVER)) {
+      csprng_feed(&seed);
+    }
+  }
+#endif /* CSPRNG_ENABLED */
 
   /* Use TRNG to seed PRNG. If TRNG fails, use a hard-coded seed. */
   unsigned short seed = 0;


### PR DESCRIPTION
Currently, the CSPRNG is unusable on SimpleLink platforms because no seed is being generated. To fix this, this PR generates a  CSPRNG seed with the built-in TRNG at start up. On a CC1354p10, the CSPRNG is about 100 times faster than the built-in TRNG, despite there is only a software-based AES-128 driver for SimpleLink platforms (which should also be fixed).