### PR TITLE
rtimer: add format specifier for printing rtimer_clock_t

### DIFF
--- a/arch/cpu/native/rtimer-arch.c
+++ b/arch/cpu/native/rtimer-arch.c
@@ -72,12 +72,13 @@ rtimer_arch_schedule(rtimer_clock_t t)
   struct itimerval val;
   rtimer_clock_t c;
 
-  c = t - clock_time();
-  
-  val.it_value.tv_sec = c / CLOCK_SECOND;
-  val.it_value.tv_usec = (c % CLOCK_SECOND) * CLOCK_SECOND;
+  c = t - rtimer_arch_now();
 
-  PRINTF("rtimer_arch_schedule time %"PRIu32 " %"PRIu32 " in %ld.%ld seconds\n",
+  val.it_value.tv_sec = c / RTIMER_SECOND;
+  val.it_value.tv_usec = (c % RTIMER_SECOND) * RTIMER_SECOND;
+
+  PRINTF("rtimer_arch_schedule time %" RTIMER_PRI " %" RTIMER_PRI
+         " in %ld.%ld seconds\n",
          t, c, (long)val.it_value.tv_sec, (long)val.it_value.tv_usec);
 
   val.it_interval.tv_sec = val.it_interval.tv_usec = 0;

--- a/arch/cpu/native/rtimer-arch.h
+++ b/arch/cpu/native/rtimer-arch.h
@@ -44,6 +44,6 @@
 
 #define RTIMER_ARCH_SECOND CLOCK_CONF_SECOND
 
-#define rtimer_arch_now() clock_time()
+#define rtimer_arch_now() (rtimer_clock_t)clock_time()
 
 #endif /* RTIMER_ARCH_H_ */

--- a/os/sys/rtimer.h
+++ b/os/sys/rtimer.h
@@ -55,6 +55,7 @@
 
 #include "contiki.h"
 #include "dev/watchdog.h"
+#include <inttypes.h>
 #include <stdbool.h>
 
 /*---------------------------------------------------------------------------*/
@@ -71,16 +72,19 @@
 /* 16-bit rtimer */
 typedef uint16_t rtimer_clock_t;
 #define RTIMER_CLOCK_DIFF(a,b)     ((int16_t)((a)-(b)))
+#define RTIMER_PRI PRIu16
 
 #elif RTIMER_CLOCK_SIZE == 4
 /* 32-bit rtimer */
 typedef uint32_t rtimer_clock_t;
 #define RTIMER_CLOCK_DIFF(a, b)    ((int32_t)((a) - (b)))
+#define RTIMER_PRI PRIu32
 
 #elif RTIMER_CLOCK_SIZE == 8
 /* 64-bit rtimer */
 typedef uint64_t rtimer_clock_t;
 #define RTIMER_CLOCK_DIFF(a,b)     ((int64_t)((a)-(b)))
+#define RTIMER_PRI PRIu64
 
 #else
 #error Unsupported rtimer size (check RTIMER_CLOCK_SIZE)


### PR DESCRIPTION
Add a preprocessor macro for printing values of type `rtimer_clock_t` in a platform-independent manner. Inspired by how #3032 added this for `clock_time_t`.