### PR TITLE
Bitrev on cc13xx for standard compliant 802.15.4g

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-conf.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-conf.h
@@ -311,15 +311,6 @@
  */
 
 /**
- * \brief  Configuration to set bitreverse of payload in Prop-mode.
- *         0 => keep bitorder
- *         1 => reverse bitorder - for 802.15.4g compliance.
- */
-#ifndef PROP_MODE_CONF_BITREV_PAYLOAD
-#define PROP_MODE_CONF_BITREV_PAYLOAD        0
-#endif
-
-/**
  * \brief  Configuration to set whitener in Prop-mode.
  *         0 => No whitener
  *         1 => Whitener.

--- a/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-conf.h
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/cc13xx-cc26xx-conf.h
@@ -311,6 +311,15 @@
  */
 
 /**
+ * \brief  Configuration to set bitreverse of payload in Prop-mode.
+ *         0 => keep bitorder
+ *         1 => reverse bitorder - for 802.15.4g compliance.
+ */
+#ifndef PROP_MODE_CONF_BITREV_PAYLOAD
+#define PROP_MODE_CONF_BITREV_PAYLOAD        0
+#endif
+
+/**
  * \brief  Configuration to set whitener in Prop-mode.
  *         0 => No whitener
  *         1 => Whitener.

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
@@ -79,16 +79,19 @@
 #include <stdbool.h>
 #include <assert.h>
 /*---------------------------------------------------------------------------*/
+#if RADIO_PAYLOAD_BIT_REVERSE
+#include "lib/bitrev.h"
+#endif
+/*---------------------------------------------------------------------------*/
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "Radio"
-#define LOG_LEVEL LOG_LEVEL_DBG
+#define LOG_LEVEL LOG_LEVEL_NONE
 /*---------------------------------------------------------------------------*/
 #undef CLAMP
 #define CLAMP(v, vmin, vmax)  (MAX(MIN(v, vmax), vmin))
 /*---------------------------------------------------------------------------*/
 /* Configuration parameters */
-#define PROP_MODE_BITREV_PAYLOAD      PROP_MODE_CONF_BITREV_PAYLOAD
 #define PROP_MODE_DYN_WHITENER        PROP_MODE_CONF_DW
 #define PROP_MODE_USE_CRC16           PROP_MODE_CONF_USE_CRC16
 #define PROP_MODE_CENTER_FREQ         PROP_MODE_CONF_CENTER_FREQ
@@ -101,24 +104,6 @@ typedef enum {
   CCA_STATE_BUSY = 1,
   CCA_STATE_INVALID = 2
 } cca_state_t;
-/*---------------------------------------------------------------------------*/
-#if PROP_MODE_BITREV_PAYLOAD
-static const unsigned char bitreverse_table256[256] = {
-    #define R2(n)   n    ,   n + 2*64  ,     n + 1*64,    n + 3*64
-    #define R4(n)   R2(n), R2(n + 2*16), R2(n + 1*16), R2(n + 3*16)
-    #define R6(n)   R4(n), R4(n + 2*4) , R4(n + 1*4) , R4(n + 3*4)
-    R6(0), R6(2), R6(1), R6(3)
-};
-
-static void 
-bit_reverse_array(uint8_t *arr, int len)
-{
-    int i;
-    for (i = 0; i < len; i++) {
-        arr[i] = bitreverse_table256[arr[i]];
-    }
-}
-#endif /* PROP_MODE_BITREV_PAYLOAD */
 /*---------------------------------------------------------------------------*/
 #if MAC_CONF_WITH_TSCH
 static volatile uint8_t is_receiving_packet;
@@ -429,10 +414,9 @@ prepare(const void *payload, unsigned short payload_len)
 
   memcpy(prop_radio.tx_buf + TX_BUF_HDR_LEN, payload, payload_len);
 
-
-  /* Test for bit-rev payload only */
-#if PROP_MODE_BITREV_PAYLOAD
-    bit_reverse_array(prop_radio.tx_buf + TX_BUF_HDR_LEN, payload_len);
+  /* Bit reverse payload for 802.15.4g compliance */
+#if RADIO_PAYLOAD_BIT_REVERSE
+  bitrev_array(prop_radio.tx_buf + TX_BUF_HDR_LEN, payload_len);
 #endif
   return 0;
 }
@@ -559,9 +543,9 @@ read(void *buf, unsigned short buf_len)
 
   memcpy(buf, payload_ptr, payload_len);
 
-  /* Bitreverse payload for compliance with 802.15.4g. */
-#if PROP_MODE_BITREV_PAYLOAD
-  bit_reverse_array(buf, payload_len);
+  /* Bit reverse payload for 802.15.4g compliance */
+#if RADIO_PAYLOAD_BIT_REVERSE
+  bitrev_array(buf, payload_len);
 #endif
 
   /* RSSI stored after payload */

--- a/os/contiki-default-conf.h
+++ b/os/contiki-default-conf.h
@@ -58,6 +58,14 @@
 #ifndef QUEUEBUF_CONF_NUM
 #define QUEUEBUF_CONF_NUM 8
 #endif /* QUEUEBUF_CONF_NUM */
+
+/* Enable 802.15.4g payload bit-reversal (LSB⇄MSB) on TX/RX */
+#ifdef RADIO_CONF_PAYLOAD_BIT_REVERSE
+#define RADIO_PAYLOAD_BIT_REVERSE RADIO_CONF_PAYLOAD_BIT_REVERSE
+#else
+#define RADIO_PAYLOAD_BIT_REVERSE 0
+#endif
+
 /*---------------------------------------------------------------------------*/
 /* uIPv6 configuration options.
  *

--- a/os/lib/bitrev.c
+++ b/os/lib/bitrev.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \addtogroup bitrev
+ * @{
+ */
+
+/**
+ * \file
+ *         Bit reversal library implementation
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+
+#include "bitrev.h"
+/*---------------------------------------------------------------------------*/
+/*
+ * Lookup table for bit reversal
+ *
+ * This precomputed lookup table allows O(1) bit reversal for each byte.
+ * The table is generated using the bit manipulation technique where:
+ * - R2(n) generates 4 entries: n, n+128, n+64, n+192  
+ * - R4(n) generates 16 entries by applying R2 to 4 different bases
+ * - R6(n) generates 64 entries by applying R4 to 4 different bases
+ * - Final call generates all 256 entries
+ */
+static const uint8_t bitrev_lookup_table[256] = {
+  #define R2(n)   n,     n + 2*64,   n + 1*64,   n + 3*64
+  #define R4(n)   R2(n), R2(n + 2*16), R2(n + 1*16), R2(n + 3*16)
+  #define R6(n)   R4(n), R4(n + 2*4),  R4(n + 1*4),  R4(n + 3*4)
+  R6(0), R6(2), R6(1), R6(3)
+  #undef R2
+  #undef R4
+  #undef R6
+};
+/*---------------------------------------------------------------------------*/
+uint8_t
+bitrev_byte(uint8_t byte)
+{
+  return bitrev_lookup_table[byte];
+}
+/*---------------------------------------------------------------------------*/
+void
+bitrev_array(uint8_t *data, size_t len)
+{
+  size_t i;
+  for(i = 0; i < len; i++) {
+    data[i] = bitrev_lookup_table[data[i]];
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+bitrev_array_copy(const uint8_t *input, uint8_t *output, size_t len)
+{
+  size_t i;
+  for(i = 0; i < len; i++) {
+    output[i] = bitrev_lookup_table[input[i]];
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/os/lib/bitrev.h
+++ b/os/lib/bitrev.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \addtogroup lib
+ * @{
+ *
+ * \defgroup bitrev Bit Reversal Library
+ *
+ * This library provides functions for reversing bits in bytes and byte arrays.
+ * It's commonly used by radio drivers for protocol compliance (e.g., 802.15.4g).
+ *
+ * @{
+ */
+
+/**
+ * \file
+ *         Bit reversal library header
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+
+#ifndef BITREV_H_
+#define BITREV_H_
+
+#include "contiki.h"
+
+/**
+ * \brief Reverse the bits in a single byte
+ * \param byte The input byte
+ * \return The byte with bits reversed
+ *
+ * Example: bitrev_byte(0xF0) returns 0x0F
+ */
+uint8_t bitrev_byte(uint8_t byte);
+
+/**
+ * \brief Reverse bits in all bytes of an array (in-place)
+ * \param data Pointer to the data array
+ * \param len Length of the array in bytes
+ *
+ * This function modifies the input array in-place, reversing the bit
+ * order within each byte. Commonly used for protocol compliance.
+ */
+void bitrev_array(uint8_t *data, size_t len);
+
+/**
+ * \brief Reverse bits in all bytes of an array (copy to output)
+ * \param input Pointer to the input data array
+ * \param output Pointer to the output data array
+ * \param len Length of the arrays in bytes
+ *
+ * This function copies data from input to output while reversing
+ * the bit order within each byte. Input and output arrays must not overlap.
+ */
+void bitrev_array_copy(const uint8_t *input, uint8_t *output, size_t len);
+
+#endif /* BITREV_H_ */
+
+/** @} */
+/** @} */

--- a/tests/08-native-runs/19-bitrev-test.sh
+++ b/tests/08-native-runs/19-bitrev-test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+source ../utils.sh
+
+# Contiki directory
+CONTIKI=$1
+
+# Example code directory
+CODE_DIR=$CONTIKI/tests/08-native-runs/19-bitrev/
+CODE=test-bitrev
+
+# Starting Contiki-NG native node
+echo "Starting native node for bit reversal test"
+make -C $CODE_DIR TARGET=native > make.log 2> make.err
+$CODE_DIR/build/native/$CODE.native > $CODE.log 2> $CODE.err &
+CPID=$!
+sleep 2
+
+echo "Closing native node"
+sleep 2
+kill_bg $CPID
+
+if grep -q "=check-me= FAILED" $CODE.log ; then
+  echo "==== make.log ====" ; cat make.log;
+  echo "==== make.err ====" ; cat make.err;
+  echo "==== $CODE.log ====" ; cat $CODE.log;
+  echo "==== $CODE.err ====" ; cat $CODE.err;
+
+  printf "%-32s TEST FAIL\n" "$CODE" | tee $CODE.testlog;
+  rm -f make.log make.err $CODE.log $CODE.err
+  exit 1
+else
+  cp $CODE.log $CODE.testlog
+  printf "%-32s TEST OK\n" "$CODE" | tee $CODE.testlog;
+fi
+
+rm -f make.log make.err $CODE.log $CODE.err
+
+# We do not want Make to stop -> Return 0
+# The Makefile will check if a log contains FAIL at the end
+exit 0

--- a/tests/08-native-runs/19-bitrev/Makefile
+++ b/tests/08-native-runs/19-bitrev/Makefile
@@ -1,0 +1,12 @@
+CONTIKI_PROJECT = test-bitrev
+all: $(CONTIKI_PROJECT)
+
+# Enable bit reversal library for testing
+CFLAGS += -DRADIO_CONF_PAYLOAD_BIT_REVERSE=1
+
+TARGET = native
+
+MODULES += os/services/unit-test
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/19-bitrev/test-bitrev.c
+++ b/tests/08-native-runs/19-bitrev/test-bitrev.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2023, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Unit tests for bit reversal library
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+
+#include "contiki.h"
+#include "unit-test.h"
+#include "lib/bitrev.h"
+
+#include <stdio.h>
+#include <string.h>
+
+PROCESS(run_tests, "Bit reversal unit tests");
+AUTOSTART_PROCESSES(&run_tests);
+
+/* Test individual byte reversal */
+UNIT_TEST_REGISTER(test_bitrev_byte, "Bit reversal for single byte");
+UNIT_TEST(test_bitrev_byte)
+{
+  UNIT_TEST_BEGIN();
+
+  /* Test common patterns */
+  UNIT_TEST_ASSERT(bitrev_byte(0x00) == 0x00);
+  UNIT_TEST_ASSERT(bitrev_byte(0xFF) == 0xFF);
+  UNIT_TEST_ASSERT(bitrev_byte(0xF0) == 0x0F);
+  UNIT_TEST_ASSERT(bitrev_byte(0x0F) == 0xF0);
+  UNIT_TEST_ASSERT(bitrev_byte(0xAA) == 0x55);
+  UNIT_TEST_ASSERT(bitrev_byte(0x55) == 0xAA);
+  UNIT_TEST_ASSERT(bitrev_byte(0x01) == 0x80);
+  UNIT_TEST_ASSERT(bitrev_byte(0x80) == 0x01);
+  UNIT_TEST_ASSERT(bitrev_byte(0x02) == 0x40);
+  UNIT_TEST_ASSERT(bitrev_byte(0x40) == 0x02);
+
+  UNIT_TEST_END();
+}
+
+/* Test array reversal in-place */
+UNIT_TEST_REGISTER(test_bitrev_array, "Bit reversal for byte arrays");
+UNIT_TEST(test_bitrev_array)
+{
+  uint8_t test_array[] = {0xF0, 0x0F, 0xAA, 0x55, 0x01, 0x80};
+  uint8_t expected[] = {0x0F, 0xF0, 0x55, 0xAA, 0x80, 0x01};
+
+  UNIT_TEST_BEGIN();
+
+  bitrev_array(test_array, 6);
+
+  for(int i = 0; i < 6; i++) {
+    UNIT_TEST_ASSERT(test_array[i] == expected[i]);
+  }
+
+  UNIT_TEST_END();
+}
+
+/* Test array copy with bit reversal */
+UNIT_TEST_REGISTER(test_bitrev_array_copy, "Bit reversal with array copy");
+UNIT_TEST(test_bitrev_array_copy)
+{
+  uint8_t input[] = {0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80};
+  uint8_t output[8];
+  uint8_t expected[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
+
+  UNIT_TEST_BEGIN();
+
+  /* Ensure output starts clean */
+  memset(output, 0x00, 8);
+
+  bitrev_array_copy(input, output, 8);
+
+  /* Input should remain unchanged */
+  uint8_t original_input[] = {0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80};
+  for(int i = 0; i < 8; i++) {
+    UNIT_TEST_ASSERT(input[i] == original_input[i]);
+  }
+
+  /* Output should contain bit-reversed values */
+  for(int i = 0; i < 8; i++) {
+    UNIT_TEST_ASSERT(output[i] == expected[i]);
+  }
+
+  UNIT_TEST_END();
+}
+
+/* Test edge cases */
+UNIT_TEST_REGISTER(test_bitrev_edge_cases, "Edge cases for bit reversal");
+UNIT_TEST(test_bitrev_edge_cases)
+{
+  UNIT_TEST_BEGIN();
+
+  /* Test zero-length array (should not crash) */
+  uint8_t dummy;
+  bitrev_array(&dummy, 0);
+  bitrev_array_copy(&dummy, &dummy, 0);
+
+  /* Test single byte array */
+  uint8_t single[] = {0xF0};
+  bitrev_array(single, 1);
+  UNIT_TEST_ASSERT(single[0] == 0x0F);
+
+  UNIT_TEST_END();
+}
+
+PROCESS_THREAD(run_tests, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("\nRunning bit reversal library unit tests\n");
+
+  UNIT_TEST_RUN(test_bitrev_byte);
+  UNIT_TEST_RUN(test_bitrev_array);
+  UNIT_TEST_RUN(test_bitrev_array_copy);
+  UNIT_TEST_RUN(test_bitrev_edge_cases);
+
+  if(!UNIT_TEST_PASSED(test_bitrev_byte) ||
+     !UNIT_TEST_PASSED(test_bitrev_array) ||
+     !UNIT_TEST_PASSED(test_bitrev_array_copy) ||
+     !UNIT_TEST_PASSED(test_bitrev_edge_cases)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
+  printf("=check-me= DONE\n");
+  printf("---\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -22,6 +22,7 @@ tests/08-native-runs/14-sha-256/native:./14-sha-256.sh \
 tests/08-native-runs/15-ieee802154-security/native:./15-ieee802154-security.sh \
 tests/08-native-runs/16-cbor/native:./16-cbor.sh \
 tests/08-native-runs/17-process-mutex/native:./17-process-mutex.sh \
-tests/08-native-runs/18-ecc/native:./18-ecc.sh
+tests/08-native-runs/18-ecc/native:./18-ecc.sh \
+tests/08-native-runs/19-bitrev/native:./19-bitrev-test.sh
 
 include ../Makefile.compile-test


### PR DESCRIPTION
Due to 802.15.4g having one bit-order in the header and another in the payload, we have had a non-compliant radio driver. This PR will allow configuration of bit order for the payload by setting RADIO_PAYLOAD_BIT_REVERSE for the radio. 

NOTE: It is a bit of a reverse library included, so it should be easy to add to other radios.