### PR TITLE
Clean up inclusions of frame802154.h

### DIFF
--- a/arch/cpu/gecko/dev/efr32-radio.c
+++ b/arch/cpu/gecko/dev/efr32-radio.c
@@ -31,6 +31,7 @@
 
 #include "contiki.h"
 #include "dev/radio.h"
+#include "net/mac/framer/frame802154.h"
 #include "net/packetbuf.h"
 #include "net/netstack.h"
 #include "em_core.h"

--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -37,6 +37,7 @@
 #include "dev/radio/cc1200/cc1200-arch.h"
 #include "dev/radio/cc1200/cc1200-rf-cfg.h"
 
+#include "net/mac/framer/frame802154.h"
 #include "net/netstack.h"
 #include "net/packetbuf.h"
 #include "dev/watchdog.h"

--- a/examples/slip-radio/slip-radio.c
+++ b/examples/slip-radio/slip-radio.c
@@ -37,6 +37,7 @@
 #include "contiki.h"
 #include "net/ipv6/uip.h"
 #include "net/ipv6/uip-ds6.h"
+#include "net/mac/framer/frame802154.h"
 #include "dev/slip.h"
 #include <string.h>
 #include "net/netstack.h"

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -52,6 +52,7 @@
 #include "net/queuebuf.h"
 #include "net/app-layer/coap/coap-engine.h"
 #include "net/app-layer/snmp/snmp.h"
+#include "net/mac/framer/frame802154.h"
 #include "services/rpl-border-router/rpl-border-router.h"
 #include "services/orchestra/orchestra.h"
 #include "services/shell/serial-shell.h"

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -70,6 +70,7 @@
 #include "net/ipv6/uip-ds6.h"
 #include "net/ipv6/uipbuf.h"
 #include "net/ipv6/sicslowpan.h"
+#include "net/mac/framer/frame802154.h"
 #include "net/netstack.h"
 #include "net/packetbuf.h"
 #include "net/queuebuf.h"

--- a/os/net/mac/anti-replay.c
+++ b/os/net/mac/anti-replay.c
@@ -43,6 +43,7 @@
 
 #include "net/mac/anti-replay.h"
 #include "net/packetbuf.h"
+#include "net/mac/framer/frame802154.h"
 #include "net/mac/llsec802154.h"
 
 #if LLSEC802154_USES_FRAME_COUNTER

--- a/os/net/mac/csma/csma-output.c
+++ b/os/net/mac/csma/csma-output.c
@@ -41,6 +41,7 @@
 
 #include "net/mac/csma/csma.h"
 #include "net/mac/csma/csma-security.h"
+#include "net/mac/framer/frame802154.h"
 #include "net/mac/mac-sequence.h"
 #include "net/packetbuf.h"
 #include "net/queuebuf.h"

--- a/os/net/mac/csma/csma.c
+++ b/os/net/mac/csma/csma.c
@@ -40,6 +40,7 @@
 
 #include "net/mac/csma/csma.h"
 #include "net/mac/csma/csma-output.h"
+#include "net/mac/framer/frame802154.h"
 #include "net/mac/mac-sequence.h"
 #include "net/packetbuf.h"
 #include "net/netstack.h"

--- a/os/net/mac/framer/framer-802154.h
+++ b/os/net/mac/framer/framer-802154.h
@@ -41,6 +41,7 @@
 
 #include "net/packetbuf.h"
 #include "net/mac/framer/framer.h"
+#include "net/mac/framer/frame802154.h"
 
 /* Setup frame802154_t with use of a specified get_attr */
 void framer_802154_setup_params(packetbuf_attr_t (*get_attr)(uint8_t type),

--- a/os/net/mac/framer/nullframer.c
+++ b/os/net/mac/framer/nullframer.c
@@ -36,6 +36,7 @@
  *         Joakim Eriksson <joakime@sics.se>
  */
 #include "net/mac/framer/framer.h"
+#include "net/mac/framer/frame802154.h"
 #include "net/packetbuf.h"
 
 #ifdef NULLFRAMER_CONF_PARSE_802154

--- a/os/net/mac/llsec802154.h
+++ b/os/net/mac/llsec802154.h
@@ -51,7 +51,6 @@
 #ifndef LLSEC802154_H_
 #define LLSEC802154_H_
 
-#include "net/mac/framer/frame802154.h"
 #include "net/ipv6/uip.h"
 
 #ifdef LLSEC802154_CONF_ENABLED

--- a/os/services/rpl-border-router/native/border-router-mac.c
+++ b/os/services/rpl-border-router/native/border-router-mac.c
@@ -40,6 +40,7 @@
 #include "net/packetbuf.h"
 #include "net/queuebuf.h"
 #include "net/netstack.h"
+#include "net/mac/framer/frame802154.h"
 #include "net/mac/mac-sequence.h"
 #include "packetutils.h"
 #include "border-router.h"


### PR DESCRIPTION
This PR cleans up inclusions of `frame802154.h`. A couple of modules rely on `llsec802154.h` to include `frame802154.h` and `llsec802154.h` does not use `frame802154.h` anymore.