### PR TITLE
Clean up inclusions of stdlib.h

### DIFF
--- a/os/lib/heapmem.h
+++ b/os/lib/heapmem.h
@@ -78,7 +78,7 @@
 
 #include "contiki.h"
 
-#include <stdlib.h>
+#include <stddef.h>
 /*****************************************************************************/
 #ifndef HEAPMEM_DEBUG
 #define HEAPMEM_DEBUG 0

--- a/os/lib/memb.h
+++ b/os/lib/memb.h
@@ -64,7 +64,7 @@
 #define MEMB_H_
 
 #include <stdbool.h>
-#include <stdlib.h>
+#include <stddef.h>
 #include "sys/cc.h"
 
 /**

--- a/os/net/ipv6/uip-ds6-nbr.c
+++ b/os/net/ipv6/uip-ds6-nbr.c
@@ -44,7 +44,6 @@
  */
 
 #include <string.h>
-#include <stdlib.h>
 #include <stddef.h>
 #include "lib/list.h"
 #include "net/link-stats.h"

--- a/os/net/ipv6/uip-ds6.c
+++ b/os/net/ipv6/uip-ds6.c
@@ -43,7 +43,6 @@
  */
 
 #include <string.h>
-#include <stdlib.h>
 #include <stddef.h>
 #include "lib/random.h"
 #include "net/ipv6/uip-nd6.h"

--- a/os/net/queuebuf.h
+++ b/os/net/queuebuf.h
@@ -54,7 +54,7 @@
 #define QUEUEBUF_H_
 
 #include "net/packetbuf.h"
-#include <stdlib.h>
+#include <stddef.h>
 
 #ifdef QUEUEBUF_CONF_ENABLED
 #define QUEUEBUF_ENABLED QUEUEBUF_CONF_ENABLED


### PR DESCRIPTION
Reduces some inclusions of `stdlib.h` to inclusions of `stddef.h` and deletes some inclusions of `stdlib.h`.