### PR TITLE
CC2538: Add assertion that the I/Q seeder never fails

### DIFF
--- a/arch/cpu/cc2538/dev/cc2538-rf.c
+++ b/arch/cpu/cc2538/dev/cc2538-rf.c
@@ -49,6 +49,7 @@
 #include "dev/sys-ctrl.h"
 #include "dev/udma.h"
 #include "reg.h"
+#include "lib/assert.h"
 #include "lib/iq-seeder.h"
 
 #include <string.h>
@@ -630,7 +631,10 @@ init(void)
   set_poll_mode(poll_mode);
 
 #if CSPRNG_ENABLED
-  iq_seeder_seed();
+  if(!iq_seeder_seed()) {
+    LOG_ERR("iq_seeder_seed failed\n");
+    assert(0);
+  }
 #endif /* CSPRNG_ENABLED */
 
   process_start(&cc2538_rf_process, NULL);


### PR DESCRIPTION
This PR adds an assertion just to ensure that the I/Q seeder never fails on CC2538 targets.