### PR TITLE
Update the doxygen version that is installed by Homebrew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,11 +82,7 @@ jobs:
     - name: install macOS software
       if: matrix.os == 'macos-13'
       run: |
-        brew install coreutils make mosquitto mtr rlwrap
-        # Doxygen version needs to be in sync with Doxyfile.
-        wget https://github.com/Homebrew/homebrew-core/raw/f434ee2dce9ae11b27d7450a7cfb7af775a47719/Formula/d/doxygen.rb
-        brew install doxygen.rb
-        rm doxygen.rb
+        brew install coreutils doxygen make mosquitto mtr rlwrap 
         python3 -m pip -q install matplotlib
         python3 -m pip -q install -r tools/docker/files/rtd_requirements.txt
         wget -nv https://github.com/pjonsson/msp430gcc-binary/releases/download/v1.1/mspgcc-4.7.4-macos-x86_64.tar.bz2

--- a/os/net/routing/rpl-classic/rpl-private.h
+++ b/os/net/routing/rpl-classic/rpl-private.h
@@ -302,7 +302,8 @@ void dao_output_target(rpl_parent_t *, uip_ipaddr_t *, uint8_t lifetime);
 void dao_ack_output(rpl_instance_t *, uip_ipaddr_t *, uint8_t, uint8_t);
 void rpl_icmp6_register_handlers(void);
 uip_ds6_nbr_t *rpl_icmp6_update_nbr_table(uip_ipaddr_t *from,
-                                          nbr_table_reason_t r, void *data);
+                                          nbr_table_reason_t reason,
+                                          void *data);
 
 /* RPL logic functions. */
 void rpl_join_dag(uip_ipaddr_t *from, rpl_dio_t *dio);


### PR DESCRIPTION
This fixes the following workflow error by installing a newer version of doxygen:

```
Error: Homebrew requires formulae to be in a tap, rejecting:
  doxygen.rb (/Users/runner/work/contiki-ng/contiki-ng/doxygen.rb)
```

That version of doxygen, however, confuses function prototypes for `rpl_icmp6_update_nbr_table`, which is why this PR also renames a variable.