### PR TITLE
Coffee: Avoid invalid header causing endless loops

### DIFF
--- a/os/storage/cfs/cfs-coffee.c
+++ b/os/storage/cfs/cfs-coffee.c
@@ -410,6 +410,18 @@ next_file(coffee_page_t page, struct file_header *hdr)
   } else if(HDR_ISOLATED(*hdr)) {
     return page + 1;
   }
+
+  // Negative max_pages may lead to endless loops as it causes scans
+  // through the flash to jump backwards. The same applies if max_pages is too
+  // large and cause page + hdr->max_pages to wrap around.  In these cases we
+  // rather return one page forward. This may cause strange behavior(?), but
+  // more importantly it avoids endless loops.
+  if(hdr->max_pages < 0 || hdr->max_pages >= COFFEE_PAGE_COUNT) {
+    PRINTF("Coffee: %s has invalid max_pages %d\n",
+        hdr->name, (int)hdr->max_pages);
+    return page + 1;
+  }
+
   return page + hdr->max_pages;
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
We had experiences where a corrupt file header could cause endless loops in coffee. In our cases it was caused by the header `max_pages` field that was either negative or extremely large. This in turn caused scans through the flash to jump backwards when meeting this header, thus scanning indefinitely.

Without being too familiar with the internal workings of coffee I added some handling I that I believe is benign, but would love to get some feedback one it.