### PR TITLE
tcp-socket: Retain input buffer contents (updated)

### DIFF
--- a/os/net/ipv6/tcp-socket.c
+++ b/os/net/ipv6/tcp-socket.c
@@ -103,10 +103,11 @@ acked(struct tcp_socket *s)
 static void
 newdata(struct tcp_socket *s)
 {
-  uint16_t len, copylen, bytesleft;
+  uint16_t len, copylen, inputlen, bytesleft;
   uint8_t *dataptr;
   len = uip_datalen();
   dataptr = uip_appdata;
+  bytesleft = s->input_data_len;
 
   /* We have a segment with data coming in. We copy as much data as
      possible into the input buffer and call the input callback
@@ -115,21 +116,29 @@ newdata(struct tcp_socket *s)
      consumed. If there is data to be retained, the highest bytes of
      data are copied down into the input buffer. */
   do {
-    copylen = MIN(len, s->input_data_maxlen);
-    memcpy(s->input_data_ptr, dataptr, copylen);
+    copylen = MIN(len, s->input_data_maxlen - bytesleft);
+    inputlen = copylen + bytesleft;
+    memcpy(s->input_data_ptr + bytesleft, dataptr, copylen);
     if(s->input_callback) {
       bytesleft = s->input_callback(s, s->ptr,
-				    s->input_data_ptr, copylen);
+				    s->input_data_ptr, inputlen);
     } else {
       bytesleft = 0;
     }
     if(bytesleft > 0) {
-      PRINTF("tcp: newdata, bytesleft > 0 (%d) not implemented\n", bytesleft);
+      if(bytesleft > inputlen) {
+        PRINTF("tcp: newdata, tcp_socket_data_callback retains more data (%d)"
+              " than in buffer (%d)\n", bytesleft, inputlen);
+        bytesleft = inputlen;
+      }
+      memmove(s->input_data_ptr, s->input_data_ptr + inputlen - bytesleft, bytesleft);
     }
     dataptr += copylen;
     len -= copylen;
 
   } while(len > 0);
+
+  s->input_data_len = bytesleft;
 }
 /*---------------------------------------------------------------------------*/
 static void
@@ -273,6 +282,7 @@ tcp_socket_register(struct tcp_socket *s, void *ptr,
     return -1;
   }
   s->ptr = ptr;
+  s->input_data_len = 0;
   s->input_data_ptr = input_databuf;
   s->input_data_maxlen = input_databuf_len;
   s->output_data_len = 0;

--- a/os/net/ipv6/tcp-socket.c
+++ b/os/net/ipv6/tcp-socket.c
@@ -117,6 +117,10 @@ newdata(struct tcp_socket *s)
      data are copied down into the input buffer. */
   do {
     copylen = MIN(len, s->input_data_maxlen - bytesleft);
+    if(copylen == 0) {
+      /* Buffer is full with retained data, cannot accept more */
+      break;
+    }
     inputlen = copylen + bytesleft;
     memcpy(s->input_data_ptr + bytesleft, dataptr, copylen);
     if(s->input_callback) {

--- a/tests/07-simulation-base/code-ipv6/tcp-client/tcp-client.c
+++ b/tests/07-simulation-base/code-ipv6/tcp-client/tcp-client.c
@@ -143,8 +143,6 @@ PROCESS_THREAD(test_tcp_client, ev, data)
     PROCESS_EXIT();
   }
 
-  memset(buf, 0xca, sizeof(buf));
-
   LOG_INFO("Sending %u bytes to the server...\n", TEST_STREAM_LENGTH);
 
   for(;;) {
@@ -158,6 +156,10 @@ PROCESS_THREAD(test_tcp_client, ev, data)
     } else if(can_send) {
       size_t bytes_to_send = TEST_STREAM_LENGTH < sizeof(buf) + bytes_sent ?
 	TEST_STREAM_LENGTH - bytes_sent : sizeof(buf);
+      /* Fill buffer with pattern: byte value = (global_index % 256) */
+      for(size_t i = 0; i < bytes_to_send; i++) {
+        buf[i] = (uint8_t)((bytes_sent + i) % 256);
+      }
       int ret = tcp_socket_send(&client_sock, buf, bytes_to_send);
       if(ret < 0) {
         LOG_ERR("Failed to send %zu bytes\n", sizeof(buf));

--- a/tests/07-simulation-base/code-ipv6/tcp-server/tcp-server.c
+++ b/tests/07-simulation-base/code-ipv6/tcp-server/tcp-server.c
@@ -54,14 +54,27 @@ static struct tcp_socket server_sock;
 static uint8_t in_buf[SOCKET_BUF_SIZE];
 static uint8_t out_buf[SOCKET_BUF_SIZE];
 static size_t bytes_received;
+static bool validation_failed;
 /*****************************************************************************/
 static int
 data_callback(struct tcp_socket *sock, void *ptr, const uint8_t *input, int len)
 {
   if(len >= 0) {
+    /* Validate each received byte matches expected pattern: (index % 256) */
+    for(int i = 0; i < len; i++) {
+      uint8_t expected = (uint8_t)((bytes_received + i) % 256);
+      if(input[i] != expected) {
+        LOG_ERR("Validation failed at byte %zu: expected 0x%02x, got 0x%02x\n",
+                bytes_received + i, expected, input[i]);
+        LOG_ERR("Test FAILED\n");
+        validation_failed = true;
+        tcp_socket_close(sock);
+        return 0;
+      }
+    }
     bytes_received += len;
   }
-  LOG_INFO("RECV %d bytes (total %zu)\n", len, bytes_received);
+  LOG_INFO("RECV %d bytes (total %zu) - validation OK\n", len, bytes_received);
 
   return 0;
 }
@@ -76,6 +89,11 @@ event_callback(struct tcp_socket *sock, void *ptr, tcp_socket_event_t event)
     break;
   case TCP_SOCKET_CLOSED:
     LOG_INFO_("CLOSED\n");
+    if(validation_failed) {
+      LOG_ERR("Test FAILED - byte validation error\n");
+    } else {
+      LOG_INFO("All %zu bytes validated successfully\n", bytes_received);
+    }
     break;
   case TCP_SOCKET_TIMEDOUT:
     LOG_INFO_("TIMED OUT\n");
@@ -96,6 +114,8 @@ event_callback(struct tcp_socket *sock, void *ptr, tcp_socket_event_t event)
 PROCESS_THREAD(test_tcp_server, ev, data)
 {
   PROCESS_BEGIN();
+
+  validation_failed = false;
 
   LOG_INFO("Listening for TCP connections on port %d\n", TCP_TEST_PORT);
 


### PR DESCRIPTION
This PR contains the change in #1634 that has been rebased, and an additional commit with a check to prevent an infinite loop.