### PR TITLE
CI: replace deprecated macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,33 +35,33 @@ jobs:
         # Always run all jobs in the matrix, even if one fails
         fail-fast: false
         matrix:
-            os: [ ubuntu-latest, macos-13 ]
+            os: [ ubuntu-latest, macos-15-intel ]
             test: [ documentation, compile-base, compile-arm-ports, rpl-lite, rpl-classic, renode-simulation, simulation-base, ipv6, ieee802154, tun-rpl-br, script-base, native-runs, ipv6-nbr, coap-lwm2m, packet-parsing ]
             exclude:
               # Renode tests done by Linux (more CI runners available).
-              - os: macos-13
+              - os: macos-15-intel
                 test: renode-simulation
               # Runs on x86, already have intermittent failures there.
-              - os: macos-13
+              - os: macos-15-intel
                 test: simulation-base
               # No arm-none-eabi-gcc installed.
-              - os: macos-13
+              - os: macos-15-intel
                 test: compile-arm-ports
               # Uses zoul as dummy target, fails on missing arm-none-eabi-gcc.
               # Tests/build system should be fixed.
-              - os: macos-13
+              - os: macos-15-intel
                 test: tun-rpl-br
               # tests/utils.sh: kill_bg contains ps --ppid (not portable).
-              - os: macos-13
+              - os: macos-15-intel
                 test: native-runs
-              - os: macos-13
+              - os: macos-15-intel
                 test: coap-lwm2m
               # Failed simulations for no obvious reason, Cooja issue?
-              - os: macos-13
+              - os: macos-15-intel
                 test: ieee802154
 
     # Default job name is too long to be visible in the "Checks" tab.
-    name: ${{ matrix.test }}/${{ matrix.os == 'macos-13' && 'macos-x64' || matrix.os }}
+    name: ${{ matrix.test }}/${{ matrix.os == 'macos-15-intel' && 'macos-x64' || matrix.os }}
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     # Checks-out the contiki-ng $GITHUB_WORKSPACE, so your job can access it
@@ -80,11 +80,11 @@ jobs:
 
     # Install sha256 command on macOS so print-dockerhash.sh can work.
     - name: install macOS software
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-15-intel'
       run: |
-        brew install coreutils doxygen make mosquitto mtr rlwrap 
-        python3 -m pip -q install matplotlib
-        python3 -m pip -q install -r tools/docker/files/rtd_requirements.txt
+        brew install coreutils doxygen make mosquitto mtr rlwrap
+        python3 -m pip -q install --break-system-packages matplotlib
+        python3 -m pip -q install --break-system-packages -r tools/docker/files/rtd_requirements.txt
         wget -nv https://github.com/pjonsson/msp430gcc-binary/releases/download/v1.1/mspgcc-4.7.4-macos-x86_64.tar.bz2
         sudo tar xf mspgcc*.tar.bz2 -C /usr/local --strip-components=1 --no-same-owner
         # Homebrew prefix is different for x86-64 and aarch64.
@@ -96,7 +96,7 @@ jobs:
 
     # Valgrind takes a long time to build, so only install when required.
     - name: install macOS valgrind
-      if: matrix.os == 'macos-13' && matrix.test == 'native-runs'
+      if: matrix.os == 'macos-15-intel' && matrix.test == 'native-runs'
       run: |
         # 3 cores on CI runners, so use make -j6 for homebrew.
         export HOMEBREW_MAKE_JOBS=6
@@ -207,14 +207,14 @@ jobs:
 
     # Pre-install a Java 21 on macOS to avoid 503 responses in Gradle.
     - name: Setup Java 21
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-15-intel'
       uses: actions/setup-java@v5
       with:
         java-version: 21
         distribution: 'zulu'
 
     - name: Execute tests
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-15-intel'
       run: |
         # Silence Doxygen warnings (not compilied with -Duse_libclang=ON).
         perl -pi -e 's/^CLANG_ASSISTED_PARSING/# CLANG_ASSISTED_PARSING/g;' \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-13') || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-15-intel') || 'ubuntu-22.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read


### PR DESCRIPTION
Switch to the macos-15-intel while
it exists.

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/