### PR TITLE
CSPRNG: Add assertion about the csprng_seed structure

### DIFF
--- a/os/lib/csprng.h
+++ b/os/lib/csprng.h
@@ -80,6 +80,9 @@ struct csprng_seed {
   };
 };
 
+static_assert(sizeof(struct csprng_seed) == CSPRNG_SEED_LEN,
+              "unexpected padding");
+
 /**
  * \brief          Mixes a new seed with the current one.
  * \param new_seed Pointer to the new seed.


### PR DESCRIPTION
This adds an assertion, which ensures that there are no padding bytes between the `key` and `state` fields. Otherwise, this would lead to problems when initializing seeds via the shorthand `seed.u8`.