### PR TITLE
lib: Expose ARRAY_LENGTH macro to other modules

### DIFF
--- a/os/dev/button-hal.h
+++ b/os/dev/button-hal.h
@@ -81,6 +81,7 @@
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
 #include "dev/gpio-hal.h"
+#include "sys/array-length.h"
 #include "sys/clock.h"
 #include "sys/ctimer.h"
 
@@ -255,8 +256,7 @@ struct button_hal_button_s {
 /*---------------------------------------------------------------------------*/
 #define BUTTON_HAL_BUTTONS(...) \
   button_hal_button_t *button_hal_buttons[] = {__VA_ARGS__, NULL}; \
-  const uint8_t button_hal_button_count = \
-    (sizeof(button_hal_buttons) / sizeof(button_hal_buttons[0])) - 1;
+  const uint8_t button_hal_button_count = ARRAY_LENGTH(button_hal_buttons) - 1;
 /*---------------------------------------------------------------------------*/
 /**
  * \brief The number of buttons on a device

--- a/os/dev/button-hal.h
+++ b/os/dev/button-hal.h
@@ -81,6 +81,7 @@
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
 #include "dev/gpio-hal.h"
+#include "sys/cc.h"
 #include "sys/clock.h"
 #include "sys/ctimer.h"
 
@@ -256,7 +257,7 @@ struct button_hal_button_s {
 #define BUTTON_HAL_BUTTONS(...) \
   button_hal_button_t *button_hal_buttons[] = {__VA_ARGS__, NULL}; \
   const uint8_t button_hal_button_count = \
-    (sizeof(button_hal_buttons) / sizeof(button_hal_buttons[0])) - 1;
+    CC_ARRAY_LENGTH(button_hal_buttons) - 1;
 /*---------------------------------------------------------------------------*/
 /**
  * \brief The number of buttons on a device

--- a/os/lib/sensors.h
+++ b/os/lib/sensors.h
@@ -34,6 +34,7 @@
 #define SENSORS_H_
 
 #include "contiki.h"
+#include "sys/array-length.h"
 
 /* some constants for the configure API */
 #define SENSORS_HW_INIT 128 /* internal - used only for initialization */
@@ -46,7 +47,7 @@
 #define SENSORS_SENSOR(name, type, value, configure, status)        \
 const struct sensors_sensor name = { type, value, configure, status }
 
-#define SENSORS_NUM (sizeof(sensors) / sizeof(struct sensors_sensor *))
+#define SENSORS_NUM ARRAY_LENGTH(sensors)
 
 #define SENSORS(...) \
 const struct sensors_sensor *sensors[] = {__VA_ARGS__, NULL};       \

--- a/os/lib/sensors.h
+++ b/os/lib/sensors.h
@@ -34,6 +34,7 @@
 #define SENSORS_H_
 
 #include "contiki.h"
+#include "sys/cc.h"
 
 /* some constants for the configure API */
 #define SENSORS_HW_INIT 128 /* internal - used only for initialization */
@@ -46,7 +47,7 @@
 #define SENSORS_SENSOR(name, type, value, configure, status)        \
 const struct sensors_sensor name = { type, value, configure, status }
 
-#define SENSORS_NUM (sizeof(sensors) / sizeof(struct sensors_sensor *))
+#define SENSORS_NUM CC_ARRAY_LENGTH(sensors)
 
 #define SENSORS(...) \
 const struct sensors_sensor *sensors[] = {__VA_ARGS__, NULL};       \

--- a/os/net/mac/csma/csma-security.c
+++ b/os/net/mac/csma/csma-security.c
@@ -96,7 +96,6 @@ csma_security_set_key(uint8_t index, const uint8_t *key)
   return 0;
 }
 
-#define N_KEYS (sizeof(keys) / sizeof(aes_key))
 /*---------------------------------------------------------------------------*/
 static int
 aead(uint8_t hdrlen, int forward)

--- a/os/net/mac/tsch/tsch-security.c
+++ b/os/net/mac/tsch/tsch-security.c
@@ -50,6 +50,7 @@
 #include "net/packetbuf.h"
 #include "lib/ccm-star.h"
 #include "lib/aes-128.h"
+#include "sys/array-length.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -65,7 +66,7 @@ static aes_key keys[] = {
   TSCH_SECURITY_K1,
   TSCH_SECURITY_K2
 };
-#define N_KEYS (sizeof(keys) / sizeof(aes_key))
+#define N_KEYS ARRAY_LENGTH(keys)
 
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/net/mac/tsch/tsch-security.c
+++ b/os/net/mac/tsch/tsch-security.c
@@ -50,6 +50,7 @@
 #include "net/packetbuf.h"
 #include "lib/ccm-star.h"
 #include "lib/aes-128.h"
+#include "sys/cc.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -65,7 +66,7 @@ static aes_key keys[] = {
   TSCH_SECURITY_K1,
   TSCH_SECURITY_K2
 };
-#define N_KEYS (sizeof(keys) / sizeof(aes_key))
+#define N_KEYS CC_ARRAY_LENGTH(keys)
 
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -52,6 +52,7 @@
 #include "net/ipv6/multicast/uip-mcast6.h"
 #include "lib/list.h"
 #include "lib/memb.h"
+#include "sys/array-length.h"
 #include "sys/ctimer.h"
 #include "sys/log.h"
 
@@ -1108,9 +1109,7 @@ rpl_get_instance(uint8_t instance_id)
 rpl_of_t *
 rpl_find_of(rpl_ocp_t ocp)
 {
-  for(unsigned i = 0;
-      i < sizeof(objective_functions) / sizeof(objective_functions[0]);
-      i++) {
+  for(unsigned i = 0; i < ARRAY_LENGTH(objective_functions); i++) {
     if(objective_functions[i]->ocp == ocp) {
       return objective_functions[i];
     }

--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -52,6 +52,7 @@
 #include "net/ipv6/multicast/uip-mcast6.h"
 #include "lib/list.h"
 #include "lib/memb.h"
+#include "sys/cc.h"
 #include "sys/ctimer.h"
 #include "sys/log.h"
 
@@ -1108,9 +1109,7 @@ rpl_get_instance(uint8_t instance_id)
 rpl_of_t *
 rpl_find_of(rpl_ocp_t ocp)
 {
-  for(unsigned i = 0;
-      i < sizeof(objective_functions) / sizeof(objective_functions[0]);
-      i++) {
+  for(unsigned i = 0; i < CC_ARRAY_LENGTH(objective_functions); i++) {
     if(objective_functions[i]->ocp == ocp) {
       return objective_functions[i];
     }

--- a/os/net/routing/rpl-lite/rpl-dag.c
+++ b/os/net/routing/rpl-lite/rpl-dag.c
@@ -46,6 +46,7 @@
 #include "net/ipv6/uip-sr.h"
 #include "net/nbr-table.h"
 #include "net/link-stats.h"
+#include "sys/array-length.h"
 
 /* Log configuration */
 #include "sys/log.h"
@@ -177,7 +178,7 @@ static rpl_of_t *
 find_objective_function(rpl_ocp_t ocp)
 {
   unsigned int i;
-  for(i = 0; i < sizeof(objective_functions) / sizeof(objective_functions[0]); i++) {
+  for(i = 0; i < ARRAY_LENGTH(objective_functions); i++) {
     if(objective_functions[i]->ocp == ocp) {
       return objective_functions[i];
     }

--- a/os/net/routing/rpl-lite/rpl-dag.c
+++ b/os/net/routing/rpl-lite/rpl-dag.c
@@ -46,6 +46,7 @@
 #include "net/ipv6/uip-sr.h"
 #include "net/nbr-table.h"
 #include "net/link-stats.h"
+#include "sys/cc.h"
 
 /* Log configuration */
 #include "sys/log.h"
@@ -177,7 +178,7 @@ static rpl_of_t *
 find_objective_function(rpl_ocp_t ocp)
 {
   unsigned int i;
-  for(i = 0; i < sizeof(objective_functions) / sizeof(objective_functions[0]); i++) {
+  for(i = 0; i < CC_ARRAY_LENGTH(objective_functions); i++) {
     if(objective_functions[i]->ocp == ocp) {
       return objective_functions[i];
     }

--- a/os/services/orchestra/orchestra.c
+++ b/os/services/orchestra/orchestra.c
@@ -47,6 +47,7 @@
 #include "net/routing/rpl-classic/rpl.h"
 #include "net/routing/rpl-classic/rpl-private.h"
 #endif
+#include "sys/array-length.h"
 
 #include "sys/log.h"
 #define LOG_MODULE "Orchestra"
@@ -64,7 +65,7 @@ int orchestra_parent_knows_us = 0;
 
 /* The set of Orchestra rules in use */
 const struct orchestra_rule *all_rules[] = ORCHESTRA_RULES;
-#define NUM_RULES (sizeof(all_rules) / sizeof(struct orchestra_rule *))
+#define NUM_RULES ARRAY_LENGTH(all_rules)
 
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/services/orchestra/orchestra.c
+++ b/os/services/orchestra/orchestra.c
@@ -47,6 +47,7 @@
 #include "net/routing/rpl-classic/rpl.h"
 #include "net/routing/rpl-classic/rpl-private.h"
 #endif
+#include "sys/cc.h"
 
 #include "sys/log.h"
 #define LOG_MODULE "Orchestra"
@@ -64,7 +65,7 @@ int orchestra_parent_knows_us = 0;
 
 /* The set of Orchestra rules in use */
 const struct orchestra_rule *all_rules[] = ORCHESTRA_RULES;
-#define NUM_RULES (sizeof(all_rules) / sizeof(struct orchestra_rule *))
+#define NUM_RULES CC_ARRAY_LENGTH(all_rules)
 
 /*---------------------------------------------------------------------------*/
 static void

--- a/os/storage/antelope/aql-lexer.c
+++ b/os/storage/antelope/aql-lexer.c
@@ -35,7 +35,7 @@
  */
 
 #include "aql.h"
-
+#include "sys/array-length.h"
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
@@ -140,7 +140,7 @@ get_token_id(const char *string, const size_t length)
 
   start = skip_hint[length - 1];
   if(sizeof(skip_hint) == length) {
-    end = sizeof(keywords) / sizeof(keywords[0]);
+    end = ARRAY_LENGTH(keywords);
   } else {
     end = skip_hint[length];
   }

--- a/os/storage/antelope/aql-lexer.c
+++ b/os/storage/antelope/aql-lexer.c
@@ -35,7 +35,7 @@
  */
 
 #include "aql.h"
-
+#include "sys/cc.h"
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
@@ -140,7 +140,7 @@ get_token_id(const char *string, const size_t length)
 
   start = skip_hint[length - 1];
   if(sizeof(skip_hint) == length) {
-    end = sizeof(keywords) / sizeof(keywords[0]);
+    end = CC_ARRAY_LENGTH(keywords);
   } else {
     end = skip_hint[length];
   }

--- a/os/storage/antelope/index.c
+++ b/os/storage/antelope/index.c
@@ -47,6 +47,7 @@
 #include "db-options.h"
 #include "index.h"
 #include "storage.h"
+#include "sys/array-length.h"
 
 static index_api_t *index_components[] = {&index_inline,
 	&index_maxheap};
@@ -62,7 +63,7 @@ find_index_api(index_type_t index_type)
 {
   int i;
 
-  for(i = 0; i < sizeof(index_components) / sizeof(index_components[0]); i++) {
+  for(i = 0; i < ARRAY_LENGTH(index_components); i++) {
       if(index_components[i]->type == index_type) {
 	return index_components[i];
       }

--- a/os/storage/antelope/index.c
+++ b/os/storage/antelope/index.c
@@ -47,6 +47,7 @@
 #include "db-options.h"
 #include "index.h"
 #include "storage.h"
+#include "sys/cc.h"
 
 static index_api_t *index_components[] = {&index_inline,
 	&index_maxheap};
@@ -62,7 +63,7 @@ find_index_api(index_type_t index_type)
 {
   int i;
 
-  for(i = 0; i < sizeof(index_components) / sizeof(index_components[0]); i++) {
+  for(i = 0; i < CC_ARRAY_LENGTH(index_components); i++) {
       if(index_components[i]->type == index_type) {
 	return index_components[i];
       }

--- a/os/storage/antelope/lvm.c
+++ b/os/storage/antelope/lvm.c
@@ -41,6 +41,7 @@
 
 #include "aql.h"
 #include "lvm.h"
+#include "sys/array-length.h"
 
 #define DEBUG DEBUG_NONE
 #include "debug.h"
@@ -782,7 +783,7 @@ print_operator(lvm_instance_t *p, lvm_ip_t index)
 
   memcpy(&operator, p->code + index, sizeof(operator));
 
-  for(i = 0; i < sizeof(operator_map) / sizeof(operator_map[0]); i++) {
+  for(i = 0; i < ARRAY_LENGTH(operator_map); i++) {
     if(operator_map[i].op == operator) {
       PRINTF("%s ", operator_map[i].representation);
       break;

--- a/os/storage/antelope/lvm.c
+++ b/os/storage/antelope/lvm.c
@@ -41,6 +41,7 @@
 
 #include "aql.h"
 #include "lvm.h"
+#include "sys/cc.h"
 
 #define DEBUG DEBUG_NONE
 #include "debug.h"
@@ -782,7 +783,7 @@ print_operator(lvm_instance_t *p, lvm_ip_t index)
 
   memcpy(&operator, p->code + index, sizeof(operator));
 
-  for(i = 0; i < sizeof(operator_map) / sizeof(operator_map[0]); i++) {
+  for(i = 0; i < CC_ARRAY_LENGTH(operator_map); i++) {
     if(operator_map[i].op == operator) {
       PRINTF("%s ", operator_map[i].representation);
       break;

--- a/os/sys/array-length.h
+++ b/os/sys/array-length.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, Konrad-Felix Krentz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Provides a macro for computing the length of an array.
+ * \author
+ *         Konrad Krentz <konrad.krentz@gmail.com>
+ */
+
+#ifndef ARRAY_LENGTH_H_
+#define ARRAY_LENGTH_H_
+
+#include "sys/cc.h"
+
+/**
+ * \brief       Counts the number of elements of an array.
+ * \param array The array.
+ * \return      The number of elements of the array.
+ */
+#define ARRAY_LENGTH(array) ((sizeof(array) / sizeof((array)[0])) \
+                             + CC_MUST_BE_ARRAY(array))
+
+#endif /* ARRAY_LENGTH_H_ */

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -73,6 +73,12 @@
 
 #define CC_CONF_NORETURN __attribute__((__noreturn__))
 
+#define CC_CONF_MUST_BE_ARRAY(array) \
+  (sizeof(struct {_Static_assert( \
+                      (!__builtin_types_compatible_p(__typeof(array), \
+                                                     __typeof(&(array)[0]))), \
+                      "not an array");}))
+
 #endif /* __GNUC__ */
 
 /**
@@ -98,6 +104,15 @@
 #else
 #define CC_NORETURN
 #endif /* CC_CONF_NORETURN */
+
+/**
+ * Returns 0 if the provided variable is an array and raises an error if not.
+ */
+#ifdef CC_CONF_MUST_BE_ARRAY
+#define CC_MUST_BE_ARRAY(array) CC_CONF_MUST_BE_ARRAY(array)
+#else /* CC_CONF_MUST_BE_ARRAY */
+#define CC_MUST_BE_ARRAY(array) 0
+#endif /* CC_CONF_MUST_BE_ARRAY */
 
 /**
  * Configure if the C compiler supports marking functions as constructors

--- a/os/sys/cc.h
+++ b/os/sys/cc.h
@@ -73,6 +73,12 @@
 
 #define CC_CONF_NORETURN __attribute__((__noreturn__))
 
+#define CC_CONF_MUST_BE_ARRAY(array) \
+  (sizeof(struct {_Static_assert( \
+                      (!__builtin_types_compatible_p(__typeof(array), \
+                                                     __typeof(&(array)[0]))), \
+                      "not an array");}))
+
 #endif /* __GNUC__ */
 
 /**
@@ -98,6 +104,23 @@
 #else
 #define CC_NORETURN
 #endif /* CC_CONF_NORETURN */
+
+/**
+ * Returns 0 if the provided variable is an array and raises an error if not.
+ */
+#ifdef CC_CONF_MUST_BE_ARRAY
+#define CC_MUST_BE_ARRAY(array) CC_CONF_MUST_BE_ARRAY(array)
+#else /* CC_CONF_MUST_BE_ARRAY */
+#define CC_MUST_BE_ARRAY(array) 0
+#endif /* CC_CONF_MUST_BE_ARRAY */
+
+/**
+ * \brief       Counts the number of elements of an array.
+ * \param array The array.
+ * \return      The number of elements of the array.
+ */
+#define CC_ARRAY_LENGTH(array) ((sizeof(array) / sizeof((array)[0])) \
+                                + CC_MUST_BE_ARRAY(array))
 
 /**
  * Configure if the C compiler supports marking functions as constructors

--- a/tests/08-native-runs/11-aes-ccm/test-aesccm.c
+++ b/tests/08-native-runs/11-aes-ccm/test-aesccm.c
@@ -33,6 +33,7 @@
 #include "unit-test.h"
 #include "lib/ccm-star.h"
 #include "lib/hexconv.h"
+#include "sys/array-length.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
@@ -49,7 +50,6 @@ static const char *testcases[][3] = {
 #include "test-vectors.c"
 };
 
-#define NUM_TESTSCASES (sizeof(testcases) / sizeof(testcases[0]))
 #define MAXLEN 65536
 
 /*---------------------------------------------------------------------------*/
@@ -66,7 +66,7 @@ UNIT_TEST(aesccm_encrypt)
   hexconv_unhexlify(key, strlen(key), key_bytes, sizeof(key_bytes));
   hexconv_unhexlify(nonce, strlen(nonce), nonce_bytes, sizeof(nonce_bytes));
 
-  for(i = 0; i < NUM_TESTSCASES; i++) {
+  for(i = 0; i < ARRAY_LENGTH(testcases); i++) {
     bool success;
     const char *hdr_string = testcases[i][0];
     const char *cleartext_string = testcases[i][1];
@@ -119,7 +119,7 @@ UNIT_TEST(aesccm_decrypt)
   hexconv_unhexlify(key, strlen(key), key_bytes, sizeof(key_bytes));
   hexconv_unhexlify(nonce, strlen(nonce), nonce_bytes, sizeof(nonce_bytes));
 
-  for(i = 0; i < NUM_TESTSCASES; i++) {
+  for(i = 0; i < ARRAY_LENGTH(testcases); i++) {
     bool success;
     bool auth_check;
     const char *hdr_string = testcases[i][0];

--- a/tests/08-native-runs/11-aes-ccm/test-aesccm.c
+++ b/tests/08-native-runs/11-aes-ccm/test-aesccm.c
@@ -33,6 +33,7 @@
 #include "unit-test.h"
 #include "lib/ccm-star.h"
 #include "lib/hexconv.h"
+#include "sys/cc.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
@@ -49,7 +50,6 @@ static const char *testcases[][3] = {
 #include "test-vectors.c"
 };
 
-#define NUM_TESTSCASES (sizeof(testcases) / sizeof(testcases[0]))
 #define MAXLEN 65536
 
 /*---------------------------------------------------------------------------*/
@@ -66,7 +66,7 @@ UNIT_TEST(aesccm_encrypt)
   hexconv_unhexlify(key, strlen(key), key_bytes, sizeof(key_bytes));
   hexconv_unhexlify(nonce, strlen(nonce), nonce_bytes, sizeof(nonce_bytes));
 
-  for(i = 0; i < NUM_TESTSCASES; i++) {
+  for(i = 0; i < CC_ARRAY_LENGTH(testcases); i++) {
     bool success;
     const char *hdr_string = testcases[i][0];
     const char *cleartext_string = testcases[i][1];
@@ -119,7 +119,7 @@ UNIT_TEST(aesccm_decrypt)
   hexconv_unhexlify(key, strlen(key), key_bytes, sizeof(key_bytes));
   hexconv_unhexlify(nonce, strlen(nonce), nonce_bytes, sizeof(nonce_bytes));
 
-  for(i = 0; i < NUM_TESTSCASES; i++) {
+  for(i = 0; i < CC_ARRAY_LENGTH(testcases); i++) {
     bool success;
     bool auth_check;
     const char *hdr_string = testcases[i][0];

--- a/tests/08-native-runs/14-sha-256/test-sha-256.c
+++ b/tests/08-native-runs/14-sha-256/test-sha-256.c
@@ -32,6 +32,7 @@
 #include "unit-test.h"
 #include "lib/sha-256.h"
 #include "lib/hexconv.h"
+#include "sys/array-length.h"
 #include <stddef.h>
 #include <string.h>
 #include <stdio.h>
@@ -342,11 +343,9 @@ UNIT_TEST(sha_256_hash_stepwise)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(hashes) / sizeof(hashes[0]); i++) {
+  for(size_t i = 0; i < ARRAY_LENGTH(hashes); i++) {
     SHA_256.init();
-    for(size_t j = 0;
-        j < sizeof(hashes[i].data) / sizeof(hashes[i].data[0]);
-        j++) {
+    for(size_t j = 0; j < ARRAY_LENGTH(hashes[i].data); j++) {
       if(!hashes[i].data[j]) {
         continue;
       }
@@ -366,13 +365,11 @@ UNIT_TEST(sha_256_hash_with_checkpoint)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(hashes) / sizeof(hashes[0]); i++) {
+  for(size_t i = 0; i < ARRAY_LENGTH(hashes); i++) {
     SHA_256.init();
     sha_256_checkpoint_t checkpoint;
     SHA_256.create_checkpoint(&checkpoint);
-    for(size_t j = 0;
-        j < sizeof(hashes[i].data) / sizeof(hashes[i].data[0]);
-        j++) {
+    for(size_t j = 0; j < ARRAY_LENGTH(hashes[i].data); j++) {
       if(!hashes[i].data[j]) {
         continue;
       }
@@ -395,12 +392,10 @@ UNIT_TEST(sha_256_hash_shorthand)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(hashes) / sizeof(hashes[0]); i++) {
+  for(size_t i = 0; i < ARRAY_LENGTH(hashes); i++) {
     uint8_t buf[256];
     size_t buf_len = 0;
-    for(size_t j = 0;
-        j < sizeof(hashes[i].data) / sizeof(hashes[i].data[0]);
-        j++) {
+    for(size_t j = 0; j < ARRAY_LENGTH(hashes[i].data); j++) {
       if(!hashes[i].data[j]) {
         continue;
       }
@@ -420,7 +415,7 @@ UNIT_TEST(sha_256_hmac)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(hmacs) / sizeof(hmacs[0]); i++) {
+  for(size_t i = 0; i < ARRAY_LENGTH(hmacs); i++) {
     uint8_t hmac[SHA_256_DIGEST_LENGTH];
     sha_256_hmac((uint8_t *)hmacs[i].key, hmacs[i].keylen,
                  hmacs[i].data, hmacs[i].datalen,
@@ -436,7 +431,7 @@ UNIT_TEST(sha_256_hkdf)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); i++) {
+  for(size_t i = 0; i < ARRAY_LENGTH(keys); i++) {
     uint8_t prk[SHA_256_DIGEST_LENGTH];
     sha_256_hkdf_extract(keys[i].salt, keys[i].salt_len,
                          keys[i].ikm, keys[i].ikm_len,

--- a/tests/08-native-runs/14-sha-256/test-sha-256.c
+++ b/tests/08-native-runs/14-sha-256/test-sha-256.c
@@ -32,6 +32,7 @@
 #include "unit-test.h"
 #include "lib/sha-256.h"
 #include "lib/hexconv.h"
+#include "sys/cc.h"
 #include <stddef.h>
 #include <string.h>
 #include <stdio.h>
@@ -342,11 +343,9 @@ UNIT_TEST(sha_256_hash_stepwise)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(hashes) / sizeof(hashes[0]); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(hashes); i++) {
     SHA_256.init();
-    for(size_t j = 0;
-        j < sizeof(hashes[i].data) / sizeof(hashes[i].data[0]);
-        j++) {
+    for(size_t j = 0; j < CC_ARRAY_LENGTH(hashes[i].data); j++) {
       if(!hashes[i].data[j]) {
         continue;
       }
@@ -366,13 +365,11 @@ UNIT_TEST(sha_256_hash_with_checkpoint)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(hashes) / sizeof(hashes[0]); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(hashes); i++) {
     SHA_256.init();
     sha_256_checkpoint_t checkpoint;
     SHA_256.create_checkpoint(&checkpoint);
-    for(size_t j = 0;
-        j < sizeof(hashes[i].data) / sizeof(hashes[i].data[0]);
-        j++) {
+    for(size_t j = 0; j < CC_ARRAY_LENGTH(hashes[i].data); j++) {
       if(!hashes[i].data[j]) {
         continue;
       }
@@ -395,12 +392,10 @@ UNIT_TEST(sha_256_hash_shorthand)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(hashes) / sizeof(hashes[0]); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(hashes); i++) {
     uint8_t buf[256];
     size_t buf_len = 0;
-    for(size_t j = 0;
-        j < sizeof(hashes[i].data) / sizeof(hashes[i].data[0]);
-        j++) {
+    for(size_t j = 0; j < CC_ARRAY_LENGTH(hashes[i].data); j++) {
       if(!hashes[i].data[j]) {
         continue;
       }
@@ -420,7 +415,7 @@ UNIT_TEST(sha_256_hmac)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(hmacs) / sizeof(hmacs[0]); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(hmacs); i++) {
     uint8_t hmac[SHA_256_DIGEST_LENGTH];
     sha_256_hmac((uint8_t *)hmacs[i].key, hmacs[i].keylen,
                  hmacs[i].data, hmacs[i].datalen,
@@ -436,7 +431,7 @@ UNIT_TEST(sha_256_hkdf)
 {
   UNIT_TEST_BEGIN();
 
-  for(size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(keys); i++) {
     uint8_t prk[SHA_256_DIGEST_LENGTH];
     sha_256_hkdf_extract(keys[i].salt, keys[i].salt_len,
                          keys[i].ikm, keys[i].ikm_len,

--- a/tests/08-native-runs/16-cbor/test-cbor.c
+++ b/tests/08-native-runs/16-cbor/test-cbor.c
@@ -37,6 +37,7 @@
 #include "contiki.h"
 #include "lib/cbor.h"
 #include "unit-test.h"
+#include "sys/array-length.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -80,12 +81,12 @@ UNIT_TEST(test_write_read)
     cbor_write_data(&writer, foo, sizeof(foo));
     array_size++;
     /* unsigned values */
-    for(int i = 0; i < sizeof(unsigned_values) / sizeof(int64_t); i++) {
+    for(int i = 0; i < ARRAY_LENGTH(unsigned_values); i++) {
       cbor_write_unsigned(&writer, unsigned_values[i]);
       array_size++;
     }
     /* signed values */
-    for(int i = 0; i < sizeof(signed_values) / sizeof(int64_t); i++) {
+    for(int i = 0; i < ARRAY_LENGTH(signed_values); i++) {
       cbor_write_signed(&writer, signed_values[i]);
       array_size++;
     }
@@ -146,12 +147,12 @@ UNIT_TEST(test_write_read)
     UNIT_TEST_ASSERT(data_size == sizeof(foo));
     UNIT_TEST_ASSERT(!memcmp(foo, data, data_size));
     uint64_t value;
-    for(int i = 0; i < sizeof(unsigned_values) / sizeof(uint64_t); i++) {
+    for(int i = 0; i < ARRAY_LENGTH(unsigned_values); i++) {
       UNIT_TEST_ASSERT(CBOR_SIZE_NONE != cbor_read_unsigned(&reader, &value));
       UNIT_TEST_ASSERT(unsigned_values[i] == value);
     }
     int64_t signed_value;
-    for(int i = 0; i < sizeof(signed_values) / sizeof(uint64_t); i++) {
+    for(int i = 0; i < ARRAY_LENGTH(signed_values); i++) {
       UNIT_TEST_ASSERT(CBOR_SIZE_NONE != cbor_read_signed(&reader, &signed_value));
       UNIT_TEST_ASSERT(signed_values[i] == signed_value);
     }

--- a/tests/08-native-runs/16-cbor/test-cbor.c
+++ b/tests/08-native-runs/16-cbor/test-cbor.c
@@ -37,6 +37,7 @@
 #include "contiki.h"
 #include "lib/cbor.h"
 #include "unit-test.h"
+#include "sys/cc.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -80,12 +81,12 @@ UNIT_TEST(test_write_read)
     cbor_write_data(&writer, foo, sizeof(foo));
     array_size++;
     /* unsigned values */
-    for(int i = 0; i < sizeof(unsigned_values) / sizeof(int64_t); i++) {
+    for(int i = 0; i < CC_ARRAY_LENGTH(unsigned_values); i++) {
       cbor_write_unsigned(&writer, unsigned_values[i]);
       array_size++;
     }
     /* signed values */
-    for(int i = 0; i < sizeof(signed_values) / sizeof(int64_t); i++) {
+    for(int i = 0; i < CC_ARRAY_LENGTH(signed_values); i++) {
       cbor_write_signed(&writer, signed_values[i]);
       array_size++;
     }
@@ -146,12 +147,12 @@ UNIT_TEST(test_write_read)
     UNIT_TEST_ASSERT(data_size == sizeof(foo));
     UNIT_TEST_ASSERT(!memcmp(foo, data, data_size));
     uint64_t value;
-    for(int i = 0; i < sizeof(unsigned_values) / sizeof(uint64_t); i++) {
+    for(int i = 0; i < CC_ARRAY_LENGTH(unsigned_values); i++) {
       UNIT_TEST_ASSERT(CBOR_SIZE_NONE != cbor_read_unsigned(&reader, &value));
       UNIT_TEST_ASSERT(unsigned_values[i] == value);
     }
     int64_t signed_value;
-    for(int i = 0; i < sizeof(signed_values) / sizeof(uint64_t); i++) {
+    for(int i = 0; i < CC_ARRAY_LENGTH(signed_values); i++) {
       UNIT_TEST_ASSERT(CBOR_SIZE_NONE != cbor_read_signed(&reader, &signed_value));
       UNIT_TEST_ASSERT(signed_values[i] == signed_value);
     }

--- a/tests/08-native-runs/20-random/test-random.c
+++ b/tests/08-native-runs/20-random/test-random.c
@@ -29,16 +29,10 @@
 
 #include "contiki.h"
 #include "lib/random.h"
+#include "sys/array-length.h"
 #include "unit-test/unit-test.h"
 #include <stdio.h>
 #include <string.h>
-
-/**
- * \brief       Counts the number of elements of an array.
- * \param array The array.
- * \return      The number of elements of the array.
- */
-#define ARRAY_LENGTH(array) (sizeof(array) / sizeof((array)[0]))
 
 PROCESS(test_random_process, "test");
 AUTOSTART_PROCESSES(&test_random_process);

--- a/tests/08-native-runs/20-random/test-random.c
+++ b/tests/08-native-runs/20-random/test-random.c
@@ -29,16 +29,10 @@
 
 #include "contiki.h"
 #include "lib/random.h"
+#include "sys/cc.h"
 #include "unit-test/unit-test.h"
 #include <stdio.h>
 #include <string.h>
-
-/**
- * \brief       Counts the number of elements of an array.
- * \param array The array.
- * \return      The number of elements of the array.
- */
-#define ARRAY_LENGTH(array) (sizeof(array) / sizeof((array)[0]))
 
 PROCESS(test_random_process, "test");
 AUTOSTART_PROCESSES(&test_random_process);
@@ -60,7 +54,7 @@ UNIT_TEST(sfc32_conformance_1)
   UNIT_TEST_BEGIN();
 
   sfc32_prng.seed(0ULL);
-  for(size_t i = 0; i < ARRAY_LENGTH(oracle_outputs); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(oracle_outputs); i++) {
     UNIT_TEST_ASSERT(oracle_outputs[i] == sfc32_prng.rand());
   }
 
@@ -82,7 +76,7 @@ UNIT_TEST(sfc32_conformance_2)
   UNIT_TEST_BEGIN();
 
   sfc32_prng.seed(0x0102030405060708ULL);
-  for(size_t i = 0; i < ARRAY_LENGTH(oracle_outputs); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(oracle_outputs); i++) {
     UNIT_TEST_ASSERT(oracle_outputs[i] == sfc32_prng.rand());
   }
 
@@ -104,7 +98,7 @@ UNIT_TEST(sfc16_conformance_1)
   UNIT_TEST_BEGIN();
 
   sfc16_prng.seed(0ULL);
-  for(size_t i = 0; i < ARRAY_LENGTH(oracle_outputs); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(oracle_outputs); i++) {
     UNIT_TEST_ASSERT(oracle_outputs[i] == sfc16_prng.rand());
   }
 
@@ -126,7 +120,7 @@ UNIT_TEST(sfc16_conformance_2)
   UNIT_TEST_BEGIN();
 
   sfc16_prng.seed(0x0102030405060708ULL);
-  for(size_t i = 0; i < ARRAY_LENGTH(oracle_outputs); i++) {
+  for(size_t i = 0; i < CC_ARRAY_LENGTH(oracle_outputs); i++) {
     UNIT_TEST_ASSERT(oracle_outputs[i] == sfc16_prng.rand());
   }
 

--- a/tests/13-ieee802154/code-panid-handling/test-panid-handling.c
+++ b/tests/13-ieee802154/code-panid-handling/test-panid-handling.c
@@ -32,7 +32,7 @@
 #include "contiki.h"
 #include "unit-test/unit-test.h"
 #include "net/mac/framer/frame802154.h"
-
+#include "sys/array-length.h"
 #include <stdio.h>
 
 #define VERBOSE 0
@@ -258,14 +258,13 @@ panid_run_test(const panid_test_def table[], size_t table_size,
 UNIT_TEST(panid_frame_ver_0b00)
 {
   int index;
-  int num_of_tests = sizeof(panid_table_0b00_0b01) / sizeof(panid_test_def);
 
   UNIT_TEST_BEGIN();
 
   UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b00_0b01,
                                            sizeof(panid_table_0b00_0b01),
                                            setup_frame802154_2003_fcf)) ==
-                   num_of_tests);
+                   ARRAY_LENGTH(panid_table_0b00_0b01));
 
   UNIT_TEST_END();
   unit_test_ptr->exit_line = index;
@@ -274,14 +273,13 @@ UNIT_TEST(panid_frame_ver_0b00)
 UNIT_TEST(panid_frame_ver_0b01)
 {
   int index;
-  int num_of_tests = sizeof(panid_table_0b00_0b01) / sizeof(panid_test_def);
 
   UNIT_TEST_BEGIN();
 
   UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b00_0b01,
                                            sizeof(panid_table_0b00_0b01),
                                            setup_frame802154_2006_fcf)) ==
-                   num_of_tests);
+                   ARRAY_LENGTH(panid_table_0b00_0b01));
 
   UNIT_TEST_END();
   unit_test_ptr->exit_line = index;
@@ -290,14 +288,13 @@ UNIT_TEST(panid_frame_ver_0b01)
 UNIT_TEST(panid_frame_ver_0b10)
 {
   int index;
-  int num_of_tests = sizeof(panid_table_0b10) / sizeof(panid_test_def);
 
   UNIT_TEST_BEGIN();
 
   UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b10,
                                            sizeof(panid_table_0b10),
                                            setup_frame802154_2015_fcf)) ==
-                   num_of_tests);
+                   ARRAY_LENGTH(panid_table_0b10));
 
   UNIT_TEST_END();
   unit_test_ptr->exit_line = index;

--- a/tests/13-ieee802154/code-panid-handling/test-panid-handling.c
+++ b/tests/13-ieee802154/code-panid-handling/test-panid-handling.c
@@ -32,7 +32,7 @@
 #include "contiki.h"
 #include "unit-test/unit-test.h"
 #include "net/mac/framer/frame802154.h"
-
+#include "sys/cc.h"
 #include <stdio.h>
 
 #define VERBOSE 0
@@ -258,14 +258,13 @@ panid_run_test(const panid_test_def table[], size_t table_size,
 UNIT_TEST(panid_frame_ver_0b00)
 {
   int index;
-  int num_of_tests = sizeof(panid_table_0b00_0b01) / sizeof(panid_test_def);
 
   UNIT_TEST_BEGIN();
 
   UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b00_0b01,
                                            sizeof(panid_table_0b00_0b01),
                                            setup_frame802154_2003_fcf)) ==
-                   num_of_tests);
+                   CC_ARRAY_LENGTH(panid_table_0b00_0b01));
 
   UNIT_TEST_END();
   unit_test_ptr->exit_line = index;
@@ -274,14 +273,13 @@ UNIT_TEST(panid_frame_ver_0b00)
 UNIT_TEST(panid_frame_ver_0b01)
 {
   int index;
-  int num_of_tests = sizeof(panid_table_0b00_0b01) / sizeof(panid_test_def);
 
   UNIT_TEST_BEGIN();
 
   UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b00_0b01,
                                            sizeof(panid_table_0b00_0b01),
                                            setup_frame802154_2006_fcf)) ==
-                   num_of_tests);
+                   CC_ARRAY_LENGTH(panid_table_0b00_0b01));
 
   UNIT_TEST_END();
   unit_test_ptr->exit_line = index;
@@ -290,14 +288,13 @@ UNIT_TEST(panid_frame_ver_0b01)
 UNIT_TEST(panid_frame_ver_0b10)
 {
   int index;
-  int num_of_tests = sizeof(panid_table_0b10) / sizeof(panid_test_def);
 
   UNIT_TEST_BEGIN();
 
   UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b10,
                                            sizeof(panid_table_0b10),
                                            setup_frame802154_2015_fcf)) ==
-                   num_of_tests);
+                   CC_ARRAY_LENGTH(panid_table_0b10));
 
   UNIT_TEST_END();
   unit_test_ptr->exit_line = index;

--- a/tests/20-packet-parsing/packet-injector/packet-injector.c
+++ b/tests/20-packet-parsing/packet-injector/packet-injector.c
@@ -56,6 +56,7 @@
 #include <net/ipv6/sicslowpan.h>
 #include <net/app-layer/coap/coap.h>
 #include <net/app-layer/coap/coap-engine.h>
+#include "sys/array-length.h"
 
 /* Log configuration. */
 #include "sys/log.h"
@@ -192,7 +193,7 @@ select_protocol(const char *protocol_name)
     return NULL;
   }
 
-  for(i = 0; i < sizeof(map) / sizeof(map[0]); i++) {
+  for(i = 0; i < ARRAY_LENGTH(map); i++) {
     if(strcasecmp(protocol_name, map[i].protocol_name) == 0) {
       return map[i].function;
     }

--- a/tests/20-packet-parsing/packet-injector/packet-injector.c
+++ b/tests/20-packet-parsing/packet-injector/packet-injector.c
@@ -56,6 +56,7 @@
 #include <net/ipv6/sicslowpan.h>
 #include <net/app-layer/coap/coap.h>
 #include <net/app-layer/coap/coap-engine.h>
+#include "sys/cc.h"
 
 /* Log configuration. */
 #include "sys/log.h"
@@ -192,7 +193,7 @@ select_protocol(const char *protocol_name)
     return NULL;
   }
 
-  for(i = 0; i < sizeof(map) / sizeof(map[0]); i++) {
+  for(i = 0; i < CC_ARRAY_LENGTH(map); i++) {
     if(strcasecmp(protocol_name, map[i].protocol_name) == 0) {
       return map[i].function;
     }


### PR DESCRIPTION
This PR exposes the `ARRAY_LENGTH` macro to avoid duplicating it. Like in the Linux kernel, I added a compile time check, which ensures that the provided parameter is an array.