### PR TITLE
fix(platform): fix LED_CONF for cooja plaftorm and nrf52840 dongle board

### DIFF
--- a/arch/platform/cooja/contiki-conf.h
+++ b/arch/platform/cooja/contiki-conf.h
@@ -149,8 +149,8 @@ typedef unsigned short uip_stats_t;
 /*---------------------------------------------------------------------------*/
 /* Virtual LED colors */
 #define LEDS_CONF_COUNT                  3
-#define LEDS_CONF_GREEN                  1
-#define LEDS_CONF_RED                    2
-#define LEDS_CONF_YELLOW                 4
+#define LEDS_CONF_GREEN                  0
+#define LEDS_CONF_RED                    1
+#define LEDS_CONF_YELLOW                 2
 /*---------------------------------------------------------------------------*/
 #endif /* CONTIKI_CONF_H_ */

--- a/arch/platform/nrf52840/dongle/nrf52840-board-def.h
+++ b/arch/platform/nrf52840/dongle/nrf52840-board-def.h
@@ -62,9 +62,9 @@
 #define PLATFORM_HAS_LEDS                       1
 #define LEDS_CONF_COUNT                         4
 
-#define LEDS_CONF_RED       2
-#define LEDS_CONF_GREEN     4
-#define LEDS_CONF_BLUE      8
+#define LEDS_CONF_RED       1
+#define LEDS_CONF_GREEN     2
+#define LEDS_CONF_BLUE      3
 /** @} */
 /**
  * \name Button configurations


### PR DESCRIPTION
**Description**
This PR updates the LED pin definitions for the nRF52840 Dongle and Cooja mote to match the actual hardware layout.

**Changes**
- Corrected LED pin mappings in `nrf52840-board-def.h`.
- Corrected LED pin mappings in `arch/platform/cooja/contiki-conf.h`.