### PR TITLE
SHA-256: Fix test to resume the hash session before finishing it

### DIFF
--- a/tests/08-native-runs/14-sha-256/test-sha-256.c
+++ b/tests/08-native-runs/14-sha-256/test-sha-256.c
@@ -373,14 +373,15 @@ UNIT_TEST(sha_256_hash_with_checkpoint)
     for(size_t j = 0;
         j < sizeof(hashes[i].data) / sizeof(hashes[i].data[0]);
         j++) {
-      SHA_256.restore_checkpoint(&checkpoint);
       if(!hashes[i].data[j]) {
         continue;
       }
+      SHA_256.restore_checkpoint(&checkpoint);
       SHA_256.update((const uint8_t *)hashes[i].data[j],
                      strlen(hashes[i].data[j]));
       SHA_256.create_checkpoint(&checkpoint);
     }
+    SHA_256.restore_checkpoint(&checkpoint);
     uint8_t sha256[SHA_256_DIGEST_LENGTH];
     SHA_256.finalize(sha256);
     UNIT_TEST_ASSERT(!memcmp(sha256, hashes[i].hash, sizeof(sha256)));


### PR DESCRIPTION
One of the SHA-256 tests fails on CC2538 SoCs since they switch off the AES/SHA cryptoprocessor when creating a checkpoint and only re-enable it when restoring the checkpoint. Yet, restoring a checkpoint multiple times is also problematic since this overwrites `was_crypto_enabled`. In effect, the cryptoprocessor stays on and wastes energy.