### PR TITLE
ECC: Correct ecc_generate_key_pair to use PKA_STATUS_POINT_AT_INFINITY

### DIFF
--- a/arch/cpu/cc2538/dev/cc2538-ecc.c
+++ b/arch/cpu/cc2538/dev/cc2538-ecc.c
@@ -1047,7 +1047,7 @@ PT_THREAD(ecc_generate_key_pair(uint8_t *public_key,
                                    curve_g_offset,
                                    public_key_offset,
                                    result));
-    if(*result == PKA_SHIFT_POINT_AT_INFINITY) {
+    if(*result == PKA_STATUS_POINT_AT_INFINITY) {
       LOG_WARN("public key at infinity\n");
       continue;
     }


### PR DESCRIPTION
This PR fixes that `ecc_generate_key_pair` checks the result of `add_or_multiply_point` against a wrong error code.