### PR TITLE
A minor bug fix for cc1200.c

### DIFF
--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -1154,8 +1154,6 @@ off(void)
 
     LOCK_SPI();
 
-    idle();
-
     if(single_read(CC1200_NUM_RXBYTES) > 0) {
       RELEASE_SPI();
       /* In case there is something in the Rx FIFO, read it */
@@ -1165,6 +1163,8 @@ off(void)
       }
       LOCK_SPI();
     }
+
+    idle();
 
     /*
      * As we use GPIO as CHIP_RDYn signal on wake-up / on(),


### PR DESCRIPTION
Think of a TSCH network as Root → Node1 → Node2. In a special case, Node2 and Node1 have some scheduled cells that overlap with the Root’s autonomous cell. When Node2 transmits a unicast packet to Node1 in a slot (which is also the Root’s autonomous RX slot), the Root overhears the packet and then captures the ACK that Node1 sends back.

The radio driver stores this ACK in rx_pkt (in rx_interrupt) during the same slot, but since the read() function has already been called once for the original data frame, the ACK remains stuck in rx_pkt. In the next RX slot of the Root, rx_interrupt drops the new incoming packet because rx_pkt is still occupied by the ACK, and then read() mistakenly delivers the leftover ACK instead of the fresh frame, which results in a frame type error.

The Root should not be receiving the ACK in the first place because its radio is supposed to be off after receiving the original packet. This issue is caused by rx_interrupt() being called after idle() in the off() function in cc1200.c. Because rx_interrupt() calls rx_rx() at the end, the radio switches on again. This also unnecessarily keeps the radio on until the next active slot. After moving idle() to run after rx_interrupt() in off(), all issues were resolved. The Root no longer receives the ACK, and therefore no frame type errors occur.