### PR TITLE
Fix CC1200 RSSI double offset bug

### DIFF
--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -929,7 +929,8 @@ read(void *buf, unsigned short buf_len)
 
   if(rx_pkt_len > 0) {
 
-    rssi = (int8_t)rx_pkt[rx_pkt_len - 2] + (int)CC1200_RF_CFG.rssi_offset;
+    /* RSSI offset already applied by hardware via AGC_GAIN_ADJUST register */
+    rssi = (int8_t)rx_pkt[rx_pkt_len - 2];
     /* CRC is already checked */
     uint8_t crc_lqi = rx_pkt[rx_pkt_len - 1];
 
@@ -1216,7 +1217,8 @@ get_rssi(void)
                 & CC1200_CARRIER_SENSE_VALID),
                 RTIMER_SECOND / 100);
   RF_ASSERT(rssi0 & CC1200_CARRIER_SENSE_VALID);
-  rssi1 = (int8_t)single_read(CC1200_RSSI1) + (int)CC1200_RF_CFG.rssi_offset;
+  /* RSSI offset already applied by hardware via AGC_GAIN_ADJUST register */
+  rssi1 = (int8_t)single_read(CC1200_RSSI1);
 
   /* If we were off, turn back off */
   if(was_off) {


### PR DESCRIPTION
Bugfix: The RSSI offset is configured in hardware via the AGC_GAIN_ADJUST register during init(). The driver was incorrectly adding the offset again in software in both get_rssi() and read(), resulting in RSSI values being ~80 dB too low.

For example, a packet received at 1 meter distance showed -117 dBm instead of the expected -35 dBm.

Noise floor before fix -180 or even -190 - with the fix around -115.

