### PR TITLE
nfr52: always flash with `--recover`

### DIFF
--- a/arch/cpu/nrf52840/Makefile.nrf52840
+++ b/arch/cpu/nrf52840/Makefile.nrf52840
@@ -137,7 +137,7 @@ endif
 ifeq (, $(shell which $(NRFJPROG)))
 	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
 else
-	$(NRFJPROG) -f nrf52 $(NRFJPROG_FLAGS) --sectorerase --verify --program $<
+	$(NRFJPROG) -f nrf52 $(NRFJPROG_FLAGS) --recover --verify --program $<
 	$(NRFJPROG) -f nrf52 $(NRFJPROG_FLAGS) --reset
 endif
 


### PR DESCRIPTION
Flashing my nRF52840 devkit with `make node.upload` always used to fail until I manually ran `nrfutil device recover`.
This had to be repeated at least after every power cycle.

With this PR, this is no longer necessary. It works for me, but I'm not sure if this change has any unintended side-effects.
I'm leaving it here for the maintainers to decide.