### PR TITLE
adding linkaddr u8 8 byte support macro function to construct linkaddr_t

### DIFF
--- a/os/net/linkaddr.h
+++ b/os/net/linkaddr.h
@@ -71,6 +71,31 @@ typedef union {
 } linkaddr_t;
 
 /**
+ * \brief      Construct a MAC eight-bytes address.
+ * \param addr  The linkaddr_t variable to set (must be of type linkaddr_t)
+ *
+ *             This macro constructs a MAC address of 8 bytes.
+ * Example:
+ \code
+ linkaddr_t addr;
+ linkaddr_u8(addr, 0x01, 0x02, 0x23, 0x24, 0x25, 0x06, 0x07, 0x08);
+ \endcode
+ *
+ * \hideinitializer
+ */
+#define linkaddr_u8(addr, addr0, addr1, addr2, addr3, addr4, addr5, addr6, addr7) \
+  do { \
+    (addr).u8[0] = (addr0); \
+    (addr).u8[1] = (addr1); \
+    (addr).u8[2] = (addr2); \
+    (addr).u8[3] = (addr3); \
+    (addr).u8[4] = (addr4); \
+    (addr).u8[5] = (addr5); \
+    (addr).u8[6] = (addr6); \
+    (addr).u8[7] = (addr7); \
+  } while(0)
+
+/**
  * \brief      Copy a link-layer address
  * \param dest The destination
  * \param from The source


### PR DESCRIPTION
Added linkadr_u8 so we can now construct linkaddr_t, that makes code cleaner and more understandable.


It's my first contribution, I hope this is good enough to be added and I really appreciate any comments, feedbacks or suggestions to improve. 