### PR TITLE
trustzone: bug fixes and security improvement

### DIFF
--- a/arch/cpu/arm/cortex-m/trustzone/module-macros.h
+++ b/arch/cpu/arm/cortex-m/trustzone/module-macros.h
@@ -1,2 +1,2 @@
 #define PLATFORM_CONF_PROVIDES_MAIN_LOOP 1
-#define PROCESS_CONF_POLL_REQUESTED tz_api_request_poll_from_ns
+#define PROCESS_CONF_POLL_REQUESTED tz_api_request_ns_poll

--- a/arch/cpu/arm/cortex-m/trustzone/normal/tz-normal.c
+++ b/arch/cpu/arm/cortex-m/trustzone/normal/tz-normal.c
@@ -102,8 +102,18 @@ PROCESS_THREAD(tz_normal_process, ev, data)
 void
 platform_main_loop(void)
 {
-  init_tz_api();
+  /*
+   * Start tz_normal_process before init_tz_api so the EGU doorbell
+   * armed by tz_arch_init_ns_signal() can validly poll a process in
+   * PROCESS_STATE_RUNNING if the IRQ fires immediately on enable.
+   * Then issue one explicit poll to drain trustzone_init_event and
+   * any other secure-side events queued during init -- process_post
+   * does not fire PROCESS_POLL_REQUESTED, so without this kick the
+   * init events would sit unread until something else woke NS.
+   */
   process_start(&tz_normal_process, NULL);
+  init_tz_api();
+  tz_normal_request_poll();
 
   while(1) {
     process_num_events_t r;

--- a/arch/cpu/arm/cortex-m/trustzone/normal/tz-normal.h
+++ b/arch/cpu/arm/cortex-m/trustzone/normal/tz-normal.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *   Normal-world TrustZone API hooks.
+ */
+
+#ifndef TZ_NORMAL_H
+#define TZ_NORMAL_H
+
+#include <stdbool.h>
+
+/**
+ * \brief Request a poll of the normal-world TrustZone process.
+ *
+ *        Safe to call from any context, including NS interrupt
+ *        handlers. The platform NS-side wake handler invokes this
+ *        when the secure side has signalled that it has work for
+ *        the normal world to drain.
+ */
+bool tz_normal_request_poll(void);
+
+/**
+ * \brief Initialize the platform-specific mechanism that delivers
+ *        secure-side wake-up requests to the normal world.
+ *
+ *        Called once during normal-world TrustZone initialization.
+ *        Weakly defined as a no-op so platforms without a wake
+ *        mechanism still link; in that case secure-only events do
+ *        not autonomously wake the normal world.
+ */
+void tz_arch_init_ns_signal(void);
+
+#endif /* TZ_NORMAL_H */

--- a/arch/cpu/arm/cortex-m/trustzone/tz-api.c
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-api.c
@@ -145,7 +145,7 @@ tz_api_println(const char *text, size_t len)
 }
 /*---------------------------------------------------------------------------*/
 bool
-tz_api_request_poll_from_ns(void)
+tz_api_request_ns_poll(void)
 {
   if(!initialized) {
     return false;

--- a/arch/cpu/arm/cortex-m/trustzone/tz-api.c
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-api.c
@@ -46,7 +46,7 @@
 
 static struct tz_api tz_api;
 static bool initialized;
-static volatile unsigned poll_wait_counter;
+static volatile bool ns_poll_pending;
 
 /*---------------------------------------------------------------------------*/
 #include "sys/log.h"
@@ -62,26 +62,24 @@ tz_api_init(struct tz_api *apip)
     return false;
   }
 
-  trustzone_init_event = process_alloc_event();
-
   apip = cmse_check_address_range(apip, sizeof(*apip), CMSE_NONSECURE);
   if(apip == NULL || apip->request_poll == NULL) {
     return false;
   }
 
-  if(cmse_check_address_range(apip->request_poll, sizeof(apip->request_poll),
-                              CMSE_NONSECURE) == NULL) {
+  ns_poll_t poll_fn = cmse_nsfptr_create(apip->request_poll);
+  if(!cmse_is_nsfptr(poll_fn)) {
     return false;
   }
 
-  memcpy(&tz_api, apip, sizeof(tz_api));
+  trustzone_init_event = process_alloc_event();
+  tz_api.request_poll = poll_fn;
 
   initialized = true;
 
   for(size_t i = 0; autostart_processes[i] != NULL; i++) {
     process_post(autostart_processes[i], trustzone_init_event, NULL);
   }
-  tz_api_poll();
 
   return true;
 }
@@ -89,7 +87,7 @@ tz_api_init(struct tz_api *apip)
 CC_TRUSTZONE_SECURE_CALL bool
 tz_api_poll(void)
 {
-  static bool is_poll_running;
+  static volatile bool is_poll_running;
 
   if(!initialized || is_poll_running) {
     return false;
@@ -109,15 +107,29 @@ tz_api_poll(void)
   }
 
   is_poll_running = false;
-  poll_wait_counter = 0;
+
+  if(ns_poll_pending) {
+    ns_poll_pending = false;
+    tz_api.request_poll();
+  }
 
   return process_nevents() > 0;
 }
 /*---------------------------------------------------------------------------*/
+#define TZ_API_PRINTLN_MAX_LEN 256
+
 CC_TRUSTZONE_SECURE_CALL void
-tz_api_println(const char *text)
+tz_api_println(const char *text, size_t len)
 {
-  printf("n> %s\n", text);
+  if(len > TZ_API_PRINTLN_MAX_LEN) {
+    len = TZ_API_PRINTLN_MAX_LEN;
+  }
+  if(text == NULL || len == 0 ||
+     cmse_check_address_range((void *)text, len,
+                              CMSE_NONSECURE) == NULL) {
+    return;
+  }
+  printf("n> %.*s\n", (int)len, text);
 }
 /*---------------------------------------------------------------------------*/
 bool
@@ -126,12 +138,7 @@ tz_api_request_poll_from_ns(void)
   if(!initialized) {
     return false;
   }
-  if(poll_wait_counter > 0) {
-    poll_wait_counter--;
-    return false;
-  }
-  /* Wait some time for the poll before timeout and request again */
-  poll_wait_counter = 128;
-  return tz_api.request_poll();
+  ns_poll_pending = true;
+  return true;
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/arm/cortex-m/trustzone/tz-api.c
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-api.c
@@ -38,6 +38,7 @@
 
 #include "contiki.h"
 #include "sys/autostart.h"
+#include "sys/int-master.h"
 #include "tz-api.h"
 
 #include <arm_cmse.h>
@@ -87,8 +88,19 @@ tz_api_init(struct tz_api *apip)
 CC_TRUSTZONE_SECURE_CALL bool
 tz_api_poll(void)
 {
-  static volatile bool is_poll_running;
+  static bool is_poll_running;
 
+  /*
+   * tz_api_poll() runs process_run() and is not reentrant. Per the
+   * contract in tz-api.h it must be called only from NS thread mode.
+   * Reject handler-mode callers (NS interrupt or, defensively, a
+   * secure ISR) up front so the API fails closed instead of
+   * corrupting the event loop. IPSR is preserved across the SG
+   * transition, so it reflects the NS caller's mode.
+   */
+  if(__get_IPSR() != 0) {
+    return false;
+  }
   if(!initialized || is_poll_running) {
     return false;
   }

--- a/arch/cpu/arm/cortex-m/trustzone/tz-api.c
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-api.c
@@ -38,7 +38,6 @@
 
 #include "contiki.h"
 #include "sys/autostart.h"
-#include "sys/int-master.h"
 #include "tz-api.h"
 
 #include <arm_cmse.h>
@@ -106,11 +105,19 @@ tz_api_poll(void)
   }
   is_poll_running = true;
 
+  /*
+   * Clear ns_poll_pending before draining the queue so that any
+   * secure ISR that fires during or after the loop is captured by
+   * the final read below. The NS caller reschedules itself when we
+   * return true, so no cross-boundary callback is needed here.
+   */
+  ns_poll_pending = false;
+
   process_num_events_t event_count = process_nevents();
 
   if(event_count > 0) {
-    LOG_DBG("Processing %u event%s at %lu\n", event_count,
-	    event_count == 1 ? "" : "s", (unsigned long)clock_time());
+    LOG_DBG("Processing %u event%s at %" CLOCK_PRI "\n", event_count,
+            event_count == 1 ? "" : "s", clock_time());
   }
 
   while(event_count-- > 0) {
@@ -120,12 +127,7 @@ tz_api_poll(void)
 
   is_poll_running = false;
 
-  if(ns_poll_pending) {
-    ns_poll_pending = false;
-    tz_api.request_poll();
-  }
-
-  return process_nevents() > 0;
+  return ns_poll_pending || process_nevents() > 0;
 }
 /*---------------------------------------------------------------------------*/
 #define TZ_API_PRINTLN_MAX_LEN 256
@@ -144,6 +146,11 @@ tz_api_println(const char *text, size_t len)
   printf("n> %.*s\n", (int)len, text);
 }
 /*---------------------------------------------------------------------------*/
+__attribute__((weak)) void
+tz_arch_signal_ns(void)
+{
+}
+/*---------------------------------------------------------------------------*/
 bool
 tz_api_request_ns_poll(void)
 {
@@ -151,6 +158,7 @@ tz_api_request_ns_poll(void)
     return false;
   }
   ns_poll_pending = true;
+  tz_arch_signal_ns();
   return true;
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/arm/cortex-m/trustzone/tz-api.h
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-api.h
@@ -117,6 +117,16 @@ extern uint32_t __sg_end;
 
 /* Secure Gateway region size, aligned to the next 32 byte boundary. */
 extern uint32_t __nsc_size;
+
+/**
+ * \brief Pend an NS-targeted IRQ to wake the normal world.
+ *
+ *        Called from secure context (including secure ISRs) by
+ *        tz_api_request_ns_poll after setting ns_poll_pending.
+ *        Implemented by the platform; weakly defined as a no-op in
+ *        tz-api.c so platforms without a wake mechanism still link.
+ */
+void tz_arch_signal_ns(void);
 /******************************************************************************/
 
 #else /* TRUSTZONE_SECURE */
@@ -148,9 +158,12 @@ bool tz_api_init(struct tz_api *apip);
 
 /**
  * \brief        Poll the secure world and process all events in the queue.
- * \retval true  If the secure world has more events to process.
- * \retval false If the secure world has no more events to process, or
- *               the call was rejected (see note).
+ * \retval true  If the secure world has more work to do — either residual
+ *               events in the queue, or a deferred poll request raised by
+ *               the secure side during the call. The NS caller should
+ *               reschedule itself.
+ * \retval false If the secure world has nothing more to do, or the call
+ *               was rejected (see note).
  *
  * \note         Must be called only from NS thread mode. The function
  *               runs process_run() and is not reentrant; calls from a

--- a/arch/cpu/arm/cortex-m/trustzone/tz-api.h
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-api.h
@@ -121,6 +121,7 @@ extern uint32_t __nsc_size;
 
 #else /* TRUSTZONE_SECURE */
 
+#define CC_TRUSTZONE_SECURE_CALL
 #define CC_TRUSTZONE_NONSECURE_CALL
 
 #endif /* TRUSTZONE_SECURE */
@@ -150,9 +151,10 @@ bool tz_api_poll(void);
 
 /**
  * \brief        Print the specified message via the secure world.
- *
+ * \param text   A pointer to the message text in non-secure memory.
+ * \param len    The length of the message in bytes.
  */
-void tz_api_println(const char *text);
+void tz_api_println(const char *text, size_t len);
 
 /**
  * \brief        Request poll from normal world.

--- a/arch/cpu/arm/cortex-m/trustzone/tz-api.h
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-api.h
@@ -138,6 +138,11 @@ struct tz_api {
  * \retval false Error (apip pointed to invalid memory,
  *               or the API has been initialized already.)
  * \retval true  Success.
+ *
+ * \note         Must be called from the normal world before any
+ *               normal-world scheduling begins, since the secure side
+ *               posts trustzone_init_event to autostart processes
+ *               from inside this call.
  */
 bool tz_api_init(struct tz_api *apip);
 
@@ -163,11 +168,20 @@ bool tz_api_poll(void);
 void tz_api_println(const char *text, size_t len);
 
 /**
- * \brief        Request poll from normal world.
+ * \brief        Mark the normal world as needing another poll cycle.
  *
- *               Only called from secure world.
+ *               Called from the secure world (e.g. via the Contiki-NG
+ *               process module's PROCESS_CONF_POLL_REQUESTED hook)
+ *               when secure-side state changes that the normal world
+ *               needs to react to. The flag is observed by the next
+ *               tz_api_poll(), which then returns true so the NS
+ *               caller reschedules itself.
+ *
+ *               This is a secure-internal helper, not a secure
+ *               gateway entry, and must not be called from the
+ *               normal world.
  */
-bool tz_api_request_poll_from_ns(void);
+bool tz_api_request_ns_poll(void);
 
 #endif /* !TZ_API_H */
 /** @} */

--- a/arch/cpu/arm/cortex-m/trustzone/tz-api.h
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-api.h
@@ -144,8 +144,14 @@ bool tz_api_init(struct tz_api *apip);
 /**
  * \brief        Poll the secure world and process all events in the queue.
  * \retval true  If the secure world has more events to process.
- * \retval false If the secure world has no more events to process.
+ * \retval false If the secure world has no more events to process, or
+ *               the call was rejected (see note).
  *
+ * \note         Must be called only from NS thread mode. The function
+ *               runs process_run() and is not reentrant; calls from a
+ *               handler context (NS interrupt or, defensively, a
+ *               secure ISR) are rejected and return false without
+ *               running events.
  */
 bool tz_api_poll(void);
 

--- a/arch/cpu/arm/cortex-m/trustzone/tz-secure.c
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-secure.c
@@ -87,9 +87,20 @@ setup(void)
     return NULL;
   }
 
+  if(system_reset_cfg() != TFM_PLAT_ERR_SUCCESS) {
+    LOG_ERR("Failed to configure system reset\n");
+    return NULL;
+  }
+
   enum tfm_plat_err_t tfm_err = nvic_interrupt_target_state_cfg();
   if(tfm_err != TFM_PLAT_ERR_SUCCESS) {
-    LOG_DBG("Interrupt state: 0x%x\n", tfm_err);
+    LOG_ERR("Failed to configure NVIC interrupt target state: 0x%x\n", tfm_err);
+    return NULL;
+  }
+
+  if(nvic_interrupt_enable() != TFM_PLAT_ERR_SUCCESS) {
+    LOG_ERR("Failed to enable secure interrupts\n");
+    return NULL;
   }
 
   uintptr_t *vtor_ns = (uintptr_t *)NS_CODE_START;

--- a/arch/cpu/arm/cortex-m/trustzone/tz-secure.c
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-secure.c
@@ -137,6 +137,7 @@ void
 platform_main_loop(void)
 {
   tz_fault_init();
+  spu_report_violation();
 
   /* Process all events before switching to non-secure */
   process_num_events_t r;

--- a/arch/cpu/arm/cortex-m/trustzone/tz-secure.c
+++ b/arch/cpu/arm/cortex-m/trustzone/tz-secure.c
@@ -59,14 +59,8 @@ setup(void)
 {
   LOG_INFO("Initializing TrustZone\n");
 
-  /* SPM example */
-  LOG_INFO("Enabling fault handlers: ");
-  if(enable_fault_handlers() == TFM_PLAT_ERR_SUCCESS) {
-    LOG_INFO_("success\n");
-  } else {
-    LOG_INFO_("failure\n");
-    return NULL;
-  }
+  LOG_INFO("Enabling fault handlers\n");
+  enable_fault_handlers();
 
   /*
    * Set flash and RAM secure.
@@ -87,21 +81,9 @@ setup(void)
     return NULL;
   }
 
-  if(system_reset_cfg() != TFM_PLAT_ERR_SUCCESS) {
-    LOG_ERR("Failed to configure system reset\n");
-    return NULL;
-  }
-
-  enum tfm_plat_err_t tfm_err = nvic_interrupt_target_state_cfg();
-  if(tfm_err != TFM_PLAT_ERR_SUCCESS) {
-    LOG_ERR("Failed to configure NVIC interrupt target state: 0x%x\n", tfm_err);
-    return NULL;
-  }
-
-  if(nvic_interrupt_enable() != TFM_PLAT_ERR_SUCCESS) {
-    LOG_ERR("Failed to enable secure interrupts\n");
-    return NULL;
-  }
+  system_reset_cfg();
+  nvic_interrupt_target_state_cfg();
+  nvic_interrupt_enable();
 
   uintptr_t *vtor_ns = (uintptr_t *)NS_CODE_START;
   LOG_DBG("NS image at %p\n", vtor_ns);

--- a/arch/cpu/nrf/Makefile.nrf5340_application
+++ b/arch/cpu/nrf/Makefile.nrf5340_application
@@ -27,6 +27,9 @@ ifeq ($(TRUSTZONE_SECURE_BUILD),1)
 else ifeq ($(TRUSTZONE_SECURE_BUILD),0)
   # Use a custom linker script for the normal world when TrustZone is enabled.
   SOURCE_LDSCRIPT ?= $(CONTIKI_CPU)/nrf5340/tz-mdk/nrf5340_xxaa_application_SPM_ns.lds
+
+  CONTIKI_CPU_DIRS += nrf5340
+  CONTIKI_CPU_SOURCEFILES += tz-ns-cfg.c
 else
   # Use the regular linker script when TrustZone is disabled.
   SOURCE_LDSCRIPT ?= $(NRFX_ROOT)/mdk/nrf5340_xxaa_application.ld

--- a/arch/cpu/nrf/dev/spu.c
+++ b/arch/cpu/nrf/dev/spu.c
@@ -35,7 +35,7 @@
 #define DEVICE_SRAM_BASE_ADDRESS SRAM_BASE_ADDRESS
 
 static int arr_flash[NUM_FLASH_SECURE_ATTRIBUTION_REGIONS];
-static int arr_ram[NUM_FLASH_SECURE_ATTRIBUTION_REGIONS];
+static int arr_ram[NUM_SRAM_SECURE_ATTRIBUTION_REGIONS];
 
 /* Convenience macros for SPU Non-Secure Callable (NCS) attribution */
 

--- a/arch/cpu/nrf/nrf5340/tz-mdk/nrf_common.lds
+++ b/arch/cpu/nrf/nrf5340/tz-mdk/nrf_common.lds
@@ -148,7 +148,12 @@ SECTIONS
         . = ALIGN(4);
         __bss_end__ = .;
     } > RAM
-    
+
+    .noinit (NOLOAD) :
+    {
+        *(.noinit*)
+    } > RAM
+
     .heap (COPY):
     {
         __HeapBase = .;

--- a/arch/cpu/nrf/nrf5340/tz-ns-cfg.c
+++ b/arch/cpu/nrf/nrf5340/tz-ns-cfg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, RISE Research Institutes of Sweden
+ * Copyright (c) 2026, RISE Research Institutes of Sweden
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,88 +31,31 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
+/**
  * \file
- *   TrustZone API setup for normal world.
- * \author
- *   Niclas Finne <niclas.finne@ri.se>
- *   Nicolas Tsiftes <nicolas.tsiftes@ri.se>
+ *   Normal-world nRF5340 hooks for the TrustZone API.
+ *
+ *   Provides the NS-side wake mechanism that the secure side pends
+ *   via tz_arch_signal_ns. EGU0_IRQn is borrowed as a software-only
+ *   doorbell: the EGU peripheral itself is unused, only its NVIC slot.
  */
 
 #include "contiki.h"
-#include "sys/platform.h"
-#include "trustzone/tz-api.h"
 #include "trustzone/normal/tz-normal.h"
 
-/*---------------------------------------------------------------------------*/
-#include "sys/log.h"
-#define LOG_MODULE "TZNormalWorld"
-#define LOG_LEVEL LOG_LEVEL_INFO
-/*---------------------------------------------------------------------------*/
-static volatile bool is_poll_requested;
+#include <nrfx.h>
 
-PROCESS(tz_normal_process, "TZ normal process");
 /*---------------------------------------------------------------------------*/
-bool
-tz_normal_request_poll(void)
-{
-  is_poll_requested = true;
-  process_poll(&tz_normal_process);
-  return true;
-}
-/*---------------------------------------------------------------------------*/
-__attribute__((weak)) void
+void
 tz_arch_init_ns_signal(void)
 {
-}
-/*---------------------------------------------------------------------------*/
-static void
-init_tz_api(void)
-{
-  struct tz_api tz_api = {0};
-
-  tz_api.request_poll = tz_normal_request_poll;
-  bool result = tz_api_init(&tz_api);
-  LOG_INFO("Initialize TrustZone API: %s\n",
-           result ? "SUCCESS" : "FAILURE");
-
-  tz_arch_init_ns_signal();
-}
-/*---------------------------------------------------------------------------*/
-PROCESS_THREAD(tz_normal_process, ev, data)
-{
-  PROCESS_BEGIN();
-
-  while(true) {
-    PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_POLL);
-    if(is_poll_requested) {
-      is_poll_requested = false;
-      LOG_DBG("> Poll secure world\n");
-      if(tz_api_poll()) {
-        tz_normal_request_poll();
-      }
-      LOG_DBG("< Poll secure world %s!\n",
-              is_poll_requested ? "waiting" : "done");
-    }
-  }
-
-  PROCESS_END();
+  NVIC_ClearPendingIRQ(EGU0_IRQn);
+  NVIC_EnableIRQ(EGU0_IRQn);
 }
 /*---------------------------------------------------------------------------*/
 void
-platform_main_loop(void)
+EGU0_IRQHandler(void)
 {
-  init_tz_api();
-  process_start(&tz_normal_process, NULL);
-
-  while(1) {
-    process_num_events_t r;
-    do {
-      r = process_run();
-      watchdog_periodic();
-    } while(r > 0);
-
-    platform_idle();
-  }
+  tz_normal_request_poll();
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/nrf/nrf5340/tz-ns-cfg.c
+++ b/arch/cpu/nrf/nrf5340/tz-ns-cfg.c
@@ -49,7 +49,11 @@
 void
 tz_arch_init_ns_signal(void)
 {
-  NVIC_ClearPendingIRQ(EGU0_IRQn);
+  /*
+   * Do not clear pending before enabling: the only source of an EGU0
+   * pending bit is a deliberate tz_arch_signal_ns() from secure code,
+   * so clearing here would silently discard a legitimate wake request.
+   */
   NVIC_EnableIRQ(EGU0_IRQn);
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.c
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.c
@@ -21,6 +21,7 @@
 
 #include "tz-target-cfg.h"
 #include "region_defs.h"
+#include "trustzone/tz-api.h"
 
 #include <spu.h>
 #include <nrfx.h>
@@ -108,6 +109,19 @@ nvic_interrupt_enable(void)
 
   NVIC_ClearPendingIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPU));
   NVIC_EnableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPU));
+}
+/******************************************************************************/
+/*----------------- TrustZone API platform hooks -----------------------------*/
+/*
+ * Borrow EGU0_IRQn as a software-pended doorbell to wake the normal
+ * world from a secure ISR. The EGU peripheral itself is left unused;
+ * we only need an NS-targeted NVIC slot. EGU0 is configured non-secure
+ * and the ITNS bit is set by nvic_interrupt_target_state_cfg above.
+ */
+void
+tz_arch_signal_ns(void)
+{
+  TZ_NVIC_SetPendingIRQ_NS(EGU0_IRQn);
 }
 /******************************************************************************/
 /*----------------- SPU violation diagnostics --------------------------------*/

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.c
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.c
@@ -112,6 +112,15 @@ nvic_interrupt_enable(void)
   return TFM_PLAT_ERR_SUCCESS;
 }
 /******************************************************************************/
+/*----------------- SPU interrupt handler ------------------------------------*/
+void
+SPU_IRQHandler(void)
+{
+  LOG_ERR("SPU security violation detected!\n");
+  spu_clear_events();
+  NVIC_SystemReset();
+}
+/******************************************************************************/
 /*------------------- SAU/IDAU configuration functions -----------------------*/
 void
 sau_and_idau_cfg(void)
@@ -164,10 +173,7 @@ spu_periph_init_cfg(void)
   NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_TIMER0));
   spu_peripheral_config_non_secure((uint32_t)NRF_TIMER0, false);
 
-#if 0
-  NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_TIMER1));
-  spu_peripheral_config_non_secure((uint32_t)NRF_TIMER1, false);
-#endif
+  /* TIMER1 is kept secure: used by the secure world for rtimer. */
 
   NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_TIMER2));
   spu_peripheral_config_non_secure((uint32_t)NRF_TIMER2, false);
@@ -175,10 +181,7 @@ spu_periph_init_cfg(void)
   NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_RTC0));
   spu_peripheral_config_non_secure((uint32_t)NRF_RTC0, false);
 
-#if 0
-  NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_RTC1));
-  spu_peripheral_config_non_secure((uint32_t)NRF_RTC1, false);
-#endif
+  /* RTC1 is kept secure: used by the secure world for the clock. */
 
   NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_DPPIC));
   spu_peripheral_config_non_secure((uint32_t)NRF_DPPIC, false);
@@ -275,7 +278,6 @@ spu_periph_init_cfg(void)
   spu_peripheral_config_non_secure((uint32_t)NRF_UARTE1, false);
 #endif /* SECURE_UART1 */
 
-  /* Skip this one because it is secure explicitly. */
   NVIC_DisableIRQ(NRFX_IRQ_NUMBER_GET(NRF_UARTE2));
   spu_peripheral_config_non_secure((uint32_t)NRF_UARTE2, false);
 

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.c
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.c
@@ -73,13 +73,12 @@ system_reset_cfg(void)
 enum tfm_plat_err_t
 nvic_interrupt_target_state_cfg(void)
 {
-  /* Target most interrupt to NS; unimplemented interrupts will be
-     Write-Ignored */
-
-  NVIC_SetTargetState(NRFX_IRQ_NUMBER_GET(NRF_TIMER0));
-  NVIC_SetTargetState(NRFX_IRQ_NUMBER_GET(NRF_RTC0));
-
-  for(uint8_t i = 1; i < sizeof(NVIC->ITNS) / sizeof(NVIC->ITNS[0]); i++) {
+  /*
+   * Target all interrupts to NS by default; unimplemented interrupts
+   * will be Write-Ignored. Peripherals that must remain secure are
+   * cleared explicitly below.
+   */
+  for(uint8_t i = 0; i < sizeof(NVIC->ITNS) / sizeof(NVIC->ITNS[0]); i++) {
     NVIC->ITNS[i] = 0xffffffff;
   }
 
@@ -95,6 +94,12 @@ nvic_interrupt_target_state_cfg(void)
   /* UARTE1 is a secure peripheral, so its IRQ has to target S state */
   NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE1));
 #endif
+
+  /* TIMER1 is kept secure for the secure-world rtimer. */
+  NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_TIMER1));
+
+  /* RTC1 is kept secure for the secure-world clock. */
+  NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_RTC1));
 
   return TFM_PLAT_ERR_SUCCESS;
 }

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.c
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.c
@@ -42,7 +42,7 @@
  */
 #define SCB_AIRCR_WRITE_MASK ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos))
 /******************************************************************************/
-enum tfm_plat_err_t
+void
 enable_fault_handlers(void)
 {
   /* Explicitly set secure fault priority to the highest */
@@ -50,10 +50,9 @@ enable_fault_handlers(void)
 
   /* Enables BUS, MEM, USG and Secure faults */
   SCB->SHCSR |= SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk | SCB_SHCSR_MEMFAULTENA_Msk | SCB_SHCSR_SECUREFAULTENA_Msk;
-  return TFM_PLAT_ERR_SUCCESS;
 }
 /******************************************************************************/
-enum tfm_plat_err_t
+void
 system_reset_cfg(void)
 {
   uint32_t reg_value = SCB->AIRCR;
@@ -65,12 +64,10 @@ system_reset_cfg(void)
   reg_value |= (uint32_t)(SCB_AIRCR_WRITE_MASK | SCB_AIRCR_SYSRESETREQS_Msk);
 
   SCB->AIRCR = reg_value;
-
-  return TFM_PLAT_ERR_SUCCESS;
 }
 /******************************************************************************/
 /*----------------- NVIC interrupt target state to NS configuration ----------*/
-enum tfm_plat_err_t
+void
 nvic_interrupt_target_state_cfg(void)
 {
   /*
@@ -100,12 +97,10 @@ nvic_interrupt_target_state_cfg(void)
 
   /* RTC1 is kept secure for the secure-world clock. */
   NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_RTC1));
-
-  return TFM_PLAT_ERR_SUCCESS;
 }
 /******************************************************************************/
 /*----------------- NVIC interrupt enabling for S peripherals ----------------*/
-enum tfm_plat_err_t
+void
 nvic_interrupt_enable(void)
 {
   /* SPU interrupt enabling */
@@ -113,8 +108,6 @@ nvic_interrupt_enable(void)
 
   NVIC_ClearPendingIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPU));
   NVIC_EnableIRQ(NRFX_IRQ_NUMBER_GET(NRF_SPU));
-
-  return TFM_PLAT_ERR_SUCCESS;
 }
 /******************************************************************************/
 /*----------------- SPU violation diagnostics --------------------------------*/
@@ -172,7 +165,7 @@ sau_and_idau_cfg(void)
   SAU->CTRL |= SAU_CTRL_ALLNS_Msk;
 }
 /******************************************************************************/
-enum tfm_plat_err_t
+void
 spu_periph_init_cfg(void)
 {
   /* Peripheral configuration */
@@ -366,8 +359,6 @@ spu_periph_init_cfg(void)
    * code; that's why it is placed here).
    */
   NRF_CACHE->ENABLE = CACHE_ENABLE_ENABLE_Enabled;
-
-  return TFM_PLAT_ERR_SUCCESS;
 }
 /******************************************************************************/
 void

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.c
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.c
@@ -117,11 +117,46 @@ nvic_interrupt_enable(void)
   return TFM_PLAT_ERR_SUCCESS;
 }
 /******************************************************************************/
+/*----------------- SPU violation diagnostics --------------------------------*/
+#define SPU_VIOLATION_MAGIC 0x5BADACCEUL
+struct spu_violation_info {
+  uint32_t magic;
+  uint32_t flashaccerr;
+  uint32_t ramaccerr;
+  uint32_t periphaccerr;
+};
+__attribute__((section(".noinit"))) static volatile struct spu_violation_info
+  spu_violation_info;
+
+void
+spu_report_violation(void)
+{
+  if(spu_violation_info.magic != SPU_VIOLATION_MAGIC) {
+    return;
+  }
+  spu_violation_info.magic = 0;
+
+  LOG_WARN("Reboot caused by SPU violation:%s%s%s\n",
+           spu_violation_info.flashaccerr ? " FLASHACCERR" : "",
+           spu_violation_info.ramaccerr ? " RAMACCERR" : "",
+           spu_violation_info.periphaccerr ? " PERIPHACCERR" : "");
+}
+/******************************************************************************/
 /*----------------- SPU interrupt handler ------------------------------------*/
 void
 SPU_IRQHandler(void)
 {
-  LOG_ERR("SPU security violation detected!\n");
+  /*
+   * Stash the violation type in .noinit for spu_report_violation() to
+   * print on the next boot. No log call here: the UARTE TX path would
+   * block waiting for an ENDTX ISR that cannot run while this handler
+   * is active.
+   */
+  spu_violation_info.flashaccerr = NRF_SPU->EVENTS_FLASHACCERR;
+  spu_violation_info.ramaccerr = NRF_SPU->EVENTS_RAMACCERR;
+  spu_violation_info.periphaccerr = NRF_SPU->EVENTS_PERIPHACCERR;
+  spu_violation_info.magic = SPU_VIOLATION_MAGIC;
+
   spu_clear_events();
   NVIC_SystemReset();
 }

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.h
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.h
@@ -165,4 +165,11 @@ enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void);
  */
 enum tfm_plat_err_t nvic_interrupt_enable(void);
 
+/**
+ * \brief Report and clear any SPU violation captured by the previous
+ *        boot's SPU_IRQHandler. Should be called early in secure
+ *        initialization to surface the cause of an unexpected reset.
+ */
+void spu_report_violation(void);
+
 #endif /* __TZ_TARGET_CFG_H__ */

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.h
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.h
@@ -92,13 +92,6 @@ struct platform_data_t {
 };
 
 /**
- * \brief Configures memory permissions via the System Protection Unit.
- *
- * \return Returns values as specified by the \ref tfm_plat_err_t
- */
-enum tfm_plat_err_t spu_init_cfg(void);
-
-/**
  * \brief Configures peripheral permissions via the System Protection Unit.
  *
  * The function does the following:
@@ -131,11 +124,6 @@ void spu_periph_configure_to_non_secure(uint32_t periph_num);
 void spu_periph_config_uarte(void);
 
 /**
- * \brief Clears SPU interrupt.
- */
-void spu_clear_irq(void);
-
-/**
  * \brief Configures SAU and IDAU.
  */
 void sau_and_idau_cfg(void);
@@ -144,21 +132,6 @@ void sau_and_idau_cfg(void);
  * \brief Configure rom, ram and peripherials non-secure
  */
 void non_secure_configuration(void);
-
-/**
- * \brief Get non-secure vector table.
- */
-uint32_t tfm_spm_hal_get_ns_VTOR(void);
-
-/**
- * \brief Get non-secure MSP location.
- */
-uint32_t tfm_spm_hal_get_ns_MSP(void);
-
-/**
- * \brief Get entry point location.
- */
-uint32_t tfm_spm_hal_get_ns_entry_point(void);
 
 /**
  * \brief Enables the fault handlers and sets priorities.
@@ -173,13 +146,6 @@ enum tfm_plat_err_t enable_fault_handlers(void);
  * \return Returns values as specified by the \ref tfm_plat_err_t
  */
 enum tfm_plat_err_t system_reset_cfg(void);
-
-/**
- * \brief Configures the system debug properties.
- *
- * \return Returns values as specified by the \ref tfm_plat_err_t
- */
-enum tfm_plat_err_t init_debug(void);
 
 /**
  * \brief Configures all external interrupts to target the
@@ -199,4 +165,4 @@ enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void);
  */
 enum tfm_plat_err_t nvic_interrupt_enable(void);
 
-#endif /* __TARGET_CFG_H__ */
+#endif /* __TZ_TARGET_CFG_H__ */

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.h
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.h
@@ -34,22 +34,6 @@
  */
 
 /**
- * \brief TFM error codes.
- */
-enum tfm_plat_err_t {
-  TFM_PLAT_ERR_SUCCESS = 0,
-  TFM_PLAT_ERR_SYSTEM_ERR = 0x3A5C,
-  TFM_PLAT_ERR_MAX_VALUE = 0x55A3,
-  TFM_PLAT_ERR_INVALID_INPUT = 0xA3C5,
-  TFM_PLAT_ERR_UNSUPPORTED = 0xC35A,
-  /* Following entry is only to ensure the error code of int size */
-  /* TFM_PLAT_ERR_FORCE_INT_SIZE = INT_MAX */
-};
-
-#define TFM_DRIVER_STDIO    Driver_USART1
-#define NS_DRIVER_STDIO     Driver_USART0
-
-/**
  * \brief A convenient struct to include all required Non-Secure state configuration.
  */
 typedef struct tz_nonsecure_setup_conf {
@@ -98,10 +82,8 @@ struct platform_data_t {
  * - grants Non-Secure access to nRF peripherals that are not Secure-only
  * - grants Non-Secure access to DDPI channels
  * - grants Non-Secure access to GPIO pins
- *
- * \return Returns values as specified by the \ref tfm_plat_err_t
  */
-enum tfm_plat_err_t spu_periph_init_cfg(void);
+void spu_periph_init_cfg(void);
 
 /**
  * \brief Setup nonsecure state
@@ -135,35 +117,27 @@ void non_secure_configuration(void);
 
 /**
  * \brief Enables the fault handlers and sets priorities.
- *
- * \return Returns values as specified by the \ref tfm_plat_err_t
  */
-enum tfm_plat_err_t enable_fault_handlers(void);
+void enable_fault_handlers(void);
 
 /**
  * \brief Configures the system reset request properties
- *
- * \return Returns values as specified by the \ref tfm_plat_err_t
  */
-enum tfm_plat_err_t system_reset_cfg(void);
+void system_reset_cfg(void);
 
 /**
  * \brief Configures all external interrupts to target the
  *        NS state, apart for the ones associated to secure
  *        peripherals (plus SPU)
- *
- * \return Returns values as specified by the \ref tfm_plat_err_t
  */
-enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void);
+void nvic_interrupt_target_state_cfg(void);
 
 /**
  * \brief This function enable the interrupts associated
  *        to the secure peripherals (plus the isolation boundary violation
  *        interrupts)
- *
- * \return Returns values as specified by the \ref tfm_plat_err_t
  */
-enum tfm_plat_err_t nvic_interrupt_enable(void);
+void nvic_interrupt_enable(void);
 
 /**
  * \brief Report and clear any SPU violation captured by the previous

--- a/arch/cpu/nrf/os/dbg-arch.c
+++ b/arch/cpu/nrf/os/dbg-arch.c
@@ -68,13 +68,13 @@ static uint16_t dbg_pos;
 int
 dbg_putchar(int c)
 {
-  if(dbg_pos < DBG_BUF_SIZE) {
+  if(dbg_pos < DBG_BUF_SIZE - 1) {
     dbg_buf[dbg_pos++] = c;
   }
 
   if(c == '\n' || dbg_pos >= DBG_BUF_SIZE - 1) {
-    dbg_buf[MIN(dbg_pos - 1, DBG_BUF_SIZE - 1)] = '\0';
-    tz_api_println(dbg_buf);
+    dbg_buf[dbg_pos] = '\0';
+    tz_api_println(dbg_buf, dbg_pos);
     dbg_pos = 0;
   }
 

--- a/arch/cpu/nrf/os/dbg-arch.c
+++ b/arch/cpu/nrf/os/dbg-arch.c
@@ -73,8 +73,11 @@ dbg_putchar(int c)
   }
 
   if(c == '\n' || dbg_pos >= DBG_BUF_SIZE - 1) {
-    dbg_buf[dbg_pos] = '\0';
-    tz_api_println(dbg_buf, dbg_pos);
+    /* Strip the trailing newline; tz_api_println adds one. */
+    uint16_t len = (dbg_pos > 0 && dbg_buf[dbg_pos - 1] == '\n')
+                   ? dbg_pos - 1 : dbg_pos;
+    dbg_buf[len] = '\0';
+    tz_api_println(dbg_buf, len);
     dbg_pos = 0;
   }
 

--- a/examples/platform-specific/nrf/trustzone/normal-world/normal-world-example.c
+++ b/examples/platform-specific/nrf/trustzone/normal-world/normal-world-example.c
@@ -60,6 +60,23 @@ PROCESS_THREAD(normal_world_process, ev, data)
   printf("sec ret = %d\n", *sec_retp);
 #endif
 
+#if TEST_SPU_RAMACCERR
+  /*
+   * Trigger an SPU RAMACCERR by pointing a non-secure EasyDMA master
+   * (UARTE2) at a source buffer in secure RAM. The CPU does not
+   * attempt the load, so no SecureFault fires; the SPU catches the
+   * bus-master access, raises its IRQ, captures the violation type,
+   * and resets. On the next boot, spu_report_violation() prints
+   * "Reboot caused by SPU violation: RAMACCERR".
+   */
+  NRF_UARTE2_NS->PSEL.TXD = 0xFFFFFFFFUL;
+  NRF_UARTE2_NS->BAUDRATE = UARTE_BAUDRATE_BAUDRATE_Baud115200;
+  NRF_UARTE2_NS->ENABLE = UARTE_ENABLE_ENABLE_Enabled;
+  NRF_UARTE2_NS->TXD.PTR = 0x20001000UL;
+  NRF_UARTE2_NS->TXD.MAXCNT = 1;
+  NRF_UARTE2_NS->TASKS_STARTTX = 1;
+#endif
+
   etimer_set(&et, CLOCK_SECOND * 10);
   while(true) {
     PROCESS_WAIT_EVENT();


### PR DESCRIPTION
nrf5340: fix TrustZone init ordering, atomicity, and SPU diagnostics
                                                                                  
Bug fixes and hardening for the nRF5340 TrustZone infrastructure:
                                                                                  
* Fix TZ API validation, init ordering, and poll signaling.                     
* Make tz_api_poll reentrancy guard and ns_poll_pending test-and-clear atomic.                                                                       
* Fix arr_ram array sizing bug in the SPU driver.                    
* Run system_reset_cfg and nvic_interrupt_enable during TZ setup, target all NVIC interrupts to NS by default, and add an SPU security-violation handler that captures diagnostics across reset.            
* Add a .noinit linker section so violation state survives reset.