### PR TITLE
6lowpan: harden input path against malformed packets

### DIFF
--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -1340,12 +1340,12 @@ uncompress_hdr_iphc(uint8_t *buf, uint16_t buf_size, uint16_t ip_len)
 
     /* uncompress the extension header */
     exthdr = (struct uip_ext_hdr *)ip_payload;
-    exthdr->len = (UIP_EXT_HDR_LEN + len) / 8;
-    if(exthdr->len == 0) {
-      LOG_WARN("Extension header length is below 8\n");
+    if((UIP_EXT_HDR_LEN + len) < 8 || (UIP_EXT_HDR_LEN + len) % 8 != 0) {
+      LOG_WARN("Extension header length %u is not a valid multiple of 8\n",
+               (unsigned)(UIP_EXT_HDR_LEN + len));
       return false;
     }
-    exthdr->len--;
+    exthdr->len = (UIP_EXT_HDR_LEN + len) / 8 - 1;
     exthdr->next = next;
     last_nextheader = &exthdr->next;
 

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -319,6 +319,16 @@ store_fragment(uint8_t index, uint8_t offset)
     return -1;
   }
 
+  /* Reject duplicates: a fragment at this offset is already stored for
+     this reassembly context. Counting duplicates toward reassembled_len
+     would let the completion check fire with zero-filled gaps. */
+  for(i = 0; i < SICSLOWPAN_FRAGMENT_BUFFERS; i++) {
+    if(frag_buf[i].len > 0 && frag_buf[i].index == index &&
+       frag_buf[i].offset == offset) {
+      return 0;
+    }
+  }
+
   for(i = 0; i < SICSLOWPAN_FRAGMENT_BUFFERS; i++) {
     if(frag_buf[i].len == 0) {
       /* copy over the data from packetbuf into the fragment buffer,
@@ -408,6 +418,9 @@ add_fragment(uint16_t tag, uint16_t frag_size, uint8_t offset)
   }
   if(len > 0) {
     frag_info[i].reassembled_len += len;
+    return i;
+  } else if(len == 0) {
+    /* Duplicate fragment: already stored and accounted for. */
     return i;
   } else {
     /* should we also clear all fragments since we failed to store

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -384,8 +384,13 @@ add_fragment(uint16_t tag, uint16_t frag_size, uint8_t offset)
       return -1;
     }
 
-    /* Found a free fragment info to store data in */
+    /* Found a free fragment info to store data in. Reset the running
+       reassembly state so that stale values from a previous session on
+       a reused context cannot survive if this FRAG1 later fails to
+       decompress and is never overwritten. */
     frag_info[found].len = frag_size;
+    frag_info[found].reassembled_len = 0;
+    frag_info[found].first_frag_len = 0;
     frag_info[found].tag = tag;
     linkaddr_copy(&frag_info[found].sender,
                   packetbuf_addr(PACKETBUF_ADDR_SENDER));

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -1101,6 +1101,9 @@ uncompress_hdr_iphc(uint8_t *buf, uint16_t buf_size, uint16_t ip_len)
 
   /* another if the CID flag is set */
   if(iphc1 & SICSLOWPAN_IPHC_CID) {
+    if(cmpr_len < packetbuf_hdr_len + 3) {
+      return false;
+    }
     LOG_DBG("uncompression: CID flag set - increase header with one\n");
     iphc_ptr++;
   }

--- a/os/net/ipv6/sicslowpan.c
+++ b/os/net/ipv6/sicslowpan.c
@@ -351,6 +351,16 @@ add_fragment(uint16_t tag, uint16_t frag_size, uint8_t offset)
         clear_fragments(i);
       }
 
+      /* Reuse any existing context for this (sender, tag) so duplicate
+         FRAG1 packets cannot exhaust the reassembly table. */
+      if(frag_info[i].len > 0 && frag_info[i].tag == tag &&
+         linkaddr_cmp(&frag_info[i].sender,
+                      packetbuf_addr(PACKETBUF_ADDR_SENDER))) {
+        clear_fragments(i);
+        found = i;
+        continue;
+      }
+
       /* We use len as indication on used or not used */
       if(found < 0 && frag_info[i].len == 0) {
         /* We remember the first free fragment info but must continue


### PR DESCRIPTION
This PR contains four hardening fixes in the 6LoWPAN receive path:

* Validate packetbuf length before reading the IPHC CID byte. The base check only guarantees two bytes; when the CID flag is set, the third byte (SCI/DCI) was later read without a bounds check, allowing a one-byte over-read on truncated frames.
* Reuse the existing reassembly context for a duplicate FRAG1 instead of allocating a new one. With only two contexts by default, a handful of duplicate FRAG1 packets could block legitimate multi-fragment reassembly until contexts timed out.
* Reject duplicate-offset fragments during reassembly. Storing them consumed extra frag_buf slots and inflated reassembled_len so the completion check fired before all offsets were covered, yielding a packet whose gaps were filled with attacker-chosen zero bytes.
* Require NHC-encoded IPv6 extension headers to be 8-octet aligned per RFC 8200. Otherwise the floor-divided length field disagreed with the memcpy size, leaving up to seven bytes of payload past the advance point to be overwritten by the next header or leaked into the IP payload.