### PR TITLE
zoul: Fix bug in CC1200 driver - was bump CSMA_CONF_ACK_WAIT_TIME for CC1200 sub-GHz

### DIFF
--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -1960,18 +1960,25 @@ idle_tx_rx(const uint8_t *payload, uint16_t payload_len)
   single_write(CC1200_IOCFG0, CC1200_IOCFG_MARC_2PIN_STATUS_0);
 
 #if CC1200_WITH_TX_BUF
-  /* Prepare and write header */
+  /* Prepare and write header (issues the SFTX flush) */
   copy_header_to_tx_fifo(payload_len);
+#endif /* CC1200_WITH_TX_BUF */
 
 #if USE_SFSTXON
   /*
    * Pre-arm the synthesizer now, before streaming the payload into
-   * the FIFO, so it settles concurrently with the burst_write below
-   * rather than stalling the subsequent STX. Under CC1200_AUTOCAL
-   * this strobe triggers calibration; otherwise it just locks the
-   * (already-calibrated) synth. The STX then transitions FSTXON->TX
-   * in ~25 us instead of the ~150-700 us cal+settle from IDLE. Must
-   * come after the SFTX issued in copy_header_to_tx_fifo() - SFSTXON
+   * the FIFO (when CC1200_WITH_TX_BUF is set), so it settles
+   * concurrently with the burst_write below rather than stalling the
+   * subsequent STX. Under CC1200_AUTOCAL this strobe triggers
+   * calibration; otherwise it just locks the (already-calibrated)
+   * synth. The STX then transitions FSTXON->TX in ~25 us instead of
+   * the ~150-700 us cal+settle from IDLE.
+   *
+   * This is gated on USE_SFSTXON only (not CC1200_WITH_TX_BUF) so the
+   * strobe is never dropped if the two options are configured
+   * independently. The SFTX it must follow has already been issued by
+   * this point in both configurations: copy_header_to_tx_fifo() above
+   * for CC1200_WITH_TX_BUF, or earlier in prepare() otherwise. SFSTXON
    * before SFTX leaves the synth in an undefined state.
    *
    * The strobe was inadvertently dropped in b5e12154c (2018) while
@@ -1982,6 +1989,7 @@ idle_tx_rx(const uint8_t *payload, uint16_t payload_len)
   strobe(CC1200_SFSTXON);
 #endif
 
+#if CC1200_WITH_TX_BUF
   /*
    * Fill FIFO with data. If SPI is slow it might make sense
    * to divide this process into several chunks.

--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -1981,6 +1981,21 @@ idle_tx_rx(const uint8_t *payload, uint16_t payload_len)
 #endif /* CC1200_WITH_TX_BUF */
 
 #if USE_SFSTXON
+  /*
+   * Pre-arm the synthesizer before STX. Under CC1200_AUTOCAL this
+   * strobe triggers calibration; otherwise it just locks the
+   * (already-calibrated) synth. The subsequent STX then transitions
+   * FSTXON->TX in ~25 us instead of the ~150-700 us cal+settle from
+   * IDLE. Must come after the last SFTX (issued in
+   * copy_header_to_tx_fifo) - SFSTXON before SFTX leaves the synth
+   * in an undefined state.
+   *
+   * The strobe was inadvertently dropped in b5e12154c (2018) while
+   * the wait below was left in place, turning the wait into a
+   * RTIMER_SECOND/100 (~10 ms) dead timeout on every TX in non-TSCH
+   * builds. TSCH builds set USE_SFSTXON=0 and skip this block.
+   */
+  strobe(CC1200_SFSTXON);
   /* Wait for synthesizer to be ready */
   RTIMER_BUSYWAIT_UNTIL_STATE(STATE_FSTXON, RTIMER_SECOND / 100);
 #endif

--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -1963,6 +1963,25 @@ idle_tx_rx(const uint8_t *payload, uint16_t payload_len)
   /* Prepare and write header */
   copy_header_to_tx_fifo(payload_len);
 
+#if USE_SFSTXON
+  /*
+   * Pre-arm the synthesizer now, before streaming the payload into
+   * the FIFO, so it settles concurrently with the burst_write below
+   * rather than stalling the subsequent STX. Under CC1200_AUTOCAL
+   * this strobe triggers calibration; otherwise it just locks the
+   * (already-calibrated) synth. The STX then transitions FSTXON->TX
+   * in ~25 us instead of the ~150-700 us cal+settle from IDLE. Must
+   * come after the SFTX issued in copy_header_to_tx_fifo() - SFSTXON
+   * before SFTX leaves the synth in an undefined state.
+   *
+   * The strobe was inadvertently dropped in b5e12154c (2018) while
+   * the wait below was left in place, turning the wait into a
+   * RTIMER_SECOND/100 (~10 ms) dead timeout on every TX in non-TSCH
+   * builds. TSCH builds set USE_SFSTXON=0 and skip this block.
+   */
+  strobe(CC1200_SFSTXON);
+#endif
+
   /*
    * Fill FIFO with data. If SPI is slow it might make sense
    * to divide this process into several chunks.
@@ -1981,22 +2000,7 @@ idle_tx_rx(const uint8_t *payload, uint16_t payload_len)
 #endif /* CC1200_WITH_TX_BUF */
 
 #if USE_SFSTXON
-  /*
-   * Pre-arm the synthesizer before STX. Under CC1200_AUTOCAL this
-   * strobe triggers calibration; otherwise it just locks the
-   * (already-calibrated) synth. The subsequent STX then transitions
-   * FSTXON->TX in ~25 us instead of the ~150-700 us cal+settle from
-   * IDLE. Must come after the last SFTX (issued in
-   * copy_header_to_tx_fifo) - SFSTXON before SFTX leaves the synth
-   * in an undefined state.
-   *
-   * The strobe was inadvertently dropped in b5e12154c (2018) while
-   * the wait below was left in place, turning the wait into a
-   * RTIMER_SECOND/100 (~10 ms) dead timeout on every TX in non-TSCH
-   * builds. TSCH builds set USE_SFSTXON=0 and skip this block.
-   */
-  strobe(CC1200_SFSTXON);
-  /* Wait for synthesizer to be ready */
+  /* Wait for the synthesizer (pre-armed above) to reach FSTXON */
   RTIMER_BUSYWAIT_UNTIL_STATE(STATE_FSTXON, RTIMER_SECOND / 100);
 #endif
 


### PR DESCRIPTION
The previous default of RTIMER_SECOND/200 (5 ms) is too short for the ACK round-trip the cc1200 driver actually delivers at SUN FSK 50 kbps. Per IEEE 802.15.4-2015 §6.4.5.4 the spec macAckWaitDuration on this PHY is ~3.6 ms, but in practice the driver does the receiver-side SPI read of the data frame, software auto-ACK construction, PLL calibration, and ACK air time serially — measured round-trip is ~12.5 ms for a 25-byte data frame on Zolertia Firefly hardware (and larger frames take longer because of the SPI read).

With the 5 ms wait, every unicast retransmits to the MAC retry cap on real hardware: the ACK is on air but arrives outside the wait window. Bumping to RTIMER_SECOND/40 (25 ms) gives comfortable margin for ~1000 B frames; users sending close to the 802.15.4g 2047 B max may want to override to RTIMER_SECOND/20 (50 ms) — the new #ifndef guards make that override possible from project-conf.h.

NOTE: The main reason was that we had a wait loop that added 10ms in the driver. Adding back the "lost" Strobe made this 10 ms very much shorter.
