### PR TITLE
nrf: add USB DFU trigger support to the unified nrf platform

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -102,6 +102,7 @@ ifeq ($(NRF_NATIVE_USB),1)
   TINYUSB_C_SRCS += $(TINYUSB_ROOT)/src/device/usbd.c
   TINYUSB_C_SRCS += $(TINYUSB_ROOT)/src/device/usbd_control.c
   TINYUSB_C_SRCS += $(TINYUSB_ROOT)/src/class/cdc/cdc_device.c
+  TINYUSB_C_SRCS += $(TINYUSB_ROOT)/src/class/dfu/dfu_rt_device.c
 
   #assembly files
   TINYUSB_ASM_SRCS += 
@@ -114,6 +115,7 @@ ifeq ($(NRF_NATIVE_USB),1)
   TINYUSB_INC_PATHS += src/common/
   TINYUSB_INC_PATHS += src/device/
   TINYUSB_INC_PATHS += src/class/cdc/
+  TINYUSB_INC_PATHS += src/class/dfu/
 
   EXTERNALDIRS += $(addprefix $(TINYUSB_ROOT)/, $(TINYUSB_INC_PATHS))
 

--- a/arch/cpu/nrf/dev/usb-arch.c
+++ b/arch/cpu/nrf/dev/usb-arch.c
@@ -55,6 +55,15 @@
 #include "nrfx.h"
 #include "nrfx_power.h"
 #include "nrf_ficr.h"
+#include "nrf_power.h"
+#include "nrf_gpio.h"
+
+#include "tusb_config.h"
+#include "tusb.h"
+
+#include "sys/process.h"
+
+PROCESS_NAME(usb_arch_process);
 /*---------------------------------------------------------------------------*/
 extern void tusb_hal_nrf_power_event(uint32_t event);
 /*---------------------------------------------------------------------------*/
@@ -77,8 +86,29 @@ power_event_handler(nrfx_power_usb_evt_t event)
 void
 usb_arch_init(void)
 {
-  const uint16_t serial_num_high_bytes = nrf_ficr_deviceid_get(NRF_FICR, 1) | 0xC000;
-  const uint32_t serial_num_low_bytes  = nrf_ficr_deviceid_get(NRF_FICR, 0);
+  /* On nRF52 series, FICR exposes DEVICEADDR -- the 48-bit BLE-style
+   * address. Use it so the USB iSerialNumber matches the value Nordic's
+   * open-bootloader and the old arch/platform/nrf52840 USB stack
+   * (app_usbd_serial_num_generate) report; the OR with 0xC000 mirrors
+   * how the SDK turns it into a static-random BLE address.
+   *
+   * On nRF5340/nRF54 series, FICR has no DEVICEADDR -- only an INFO
+   * struct with a DEVICEID. Fall back to that on those CPUs. The
+   * serial number won't match the nRF52 bootloader-vs-app trick (there
+   * is no comparable bootloader on those parts anyway), but it stays
+   * unique per device, which is all the descriptor needs. */
+#if defined(NRF52_SERIES) || defined(NRF52840_XXAA) \
+  || defined(NRF52833_XXAA) || defined(NRF52832_XXAA) \
+  || defined(NRF52820_XXAA) || defined(NRF52811_XXAA) \
+  || defined(NRF52810_XXAA) || defined(NRF52805_XXAA)
+  const uint16_t serial_num_high_bytes =
+    (uint16_t)NRF_FICR->DEVICEADDR[1] | 0xC000;
+  const uint32_t serial_num_low_bytes = NRF_FICR->DEVICEADDR[0];
+#else
+  const uint16_t serial_num_high_bytes =
+    (uint16_t)NRF_FICR->INFO.DEVICEID[1] | 0xC000;
+  const uint32_t serial_num_low_bytes = NRF_FICR->INFO.DEVICEID[0];
+#endif
   const nrfx_power_config_t power_config = { 0 };
   const nrfx_power_usbevt_config_t power_usbevt_config = {
     .handler = power_event_handler
@@ -104,6 +134,262 @@ usb_arch_init(void)
     tusb_hal_nrf_power_event(NRFX_POWER_USB_EVT_DETECTED);
   } else if(usb_reg == NRFX_POWER_USB_STATE_READY) {
     tusb_hal_nrf_power_event(NRFX_POWER_USB_EVT_READY);
+  }
+}
+/*---------------------------------------------------------------------------*/
+#if CFG_TUD_DFU_RUNTIME
+/*
+ * Standard USB DFU runtime detach handler. Set the Nordic open-bootloader
+ * retention pattern in GPREGRET so the bootloader stays in DFU mode after
+ * the system reset, and reboot. Mirrors the behavior of the old nrf52840
+ * platform's app_usbd_nrf_dfu_trigger-based handler in
+ * arch/cpu/nrf52840/usb/usb-dfu-trigger.c.
+ */
+#define BOOTLOADER_DFU_GPREGRET_MAGIC   0xB0u
+#define BOOTLOADER_DFU_START_BIT        0x01u
+#define BOOTLOADER_DFU_START            (BOOTLOADER_DFU_GPREGRET_MAGIC | BOOTLOADER_DFU_START_BIT)
+
+#ifndef BOARD_DFU_SELF_RESET_PIN
+/* nRF52840 Dongle (PCA10059) has P0.19 solder-bridged to the chip's
+ * RESET pin. Driving it low triggers a pin reset, which the dongle's
+ * open-bootloader treats as a request to enter DFU mode. Boards without
+ * this hardware can override BOARD_DFU_SELF_RESET_PIN to -1 to skip the
+ * pin-reset path. */
+#define BOARD_DFU_SELF_RESET_PIN  NRF_GPIO_PIN_MAP(0, 19)
+#endif
+
+void
+tud_dfu_runtime_reboot_to_dfu_cb(void)
+{
+  /* Drive the self-reset GPIO low. On PCA10059 the GP pin is solder-
+   * bridged to the chip's nRESET line, so this causes a hardware pin
+   * reset within microseconds and the bootloader (which sees
+   * RESETREAS.RESETPIN set) enters DFU mode. Mirrors what the OLD
+   * arch/cpu/nrf52840/usb/usb-dfu-trigger.c did and what RIOT-OS's
+   * boards/nrf52840dongle/reset.c does. The control transfer's USB
+   * ACK won't reach the host (the device disappears mid-transfer),
+   * but that's the expected behavior for bitWillDetach. */
+#if BOARD_DFU_SELF_RESET_PIN >= 0
+  nrf_gpio_cfg_output(BOARD_DFU_SELF_RESET_PIN);
+  nrf_gpio_pin_clear(BOARD_DFU_SELF_RESET_PIN);
+#endif
+
+  /* Belt-and-braces for boards without the GP-pin-to-RESET wiring:
+   * also set Nordic's GPREGRET DFU magic and trigger a soft reset.
+   * Won't run on PCA10059 because the pin-reset above is faster. */
+  nrf_power_gpregret_set(NRF_POWER, 0, BOOTLOADER_DFU_START);
+  NVIC_SystemReset();
+}
+#endif /* CFG_TUD_DFU_RUNTIME */
+/*---------------------------------------------------------------------------*/
+/*
+ * Nordic-vendor-specific DFU trigger interface, mirroring what the OLD
+ * arch/cpu/nrf52840/usb/usb-dfu-trigger.c exposed via Nordic SDK's
+ * app_usbd_nrf_dfu_trigger. Lets `nrfutil dfu usb-serial` and other
+ * Nordic-aware host tools reboot the dongle into Open DFU Bootloader
+ * without touching the physical RESET button.
+ *
+ * Wire format (from app_usbd_nrf_dfu_trigger_types.h):
+ *   Interface  class/subclass/protocol = 0xFF / 0x01 / 0x01
+ *   Functional descriptor type         = 0x21 (CS_FUNCTIONAL), 9 bytes
+ *   Control requests on this interface:
+ *     bRequest 0x00  DETACH        (host->dev, no data, triggers reboot)
+ *     bRequest 0x07  NORDIC_INFO   (dev->host, 24 bytes of dfu_nordic_info)
+ *     bRequest 0x08  SEM_VER       (dev->host, ASCII version string)
+ */
+#include "device/usbd_pvt.h"
+
+#define NORDIC_DFU_TRIGGER_CLASS        0xFFu
+#define NORDIC_DFU_TRIGGER_SUBCLASS     0x01u
+#define NORDIC_DFU_TRIGGER_PROTOCOL     0x01u
+#define NORDIC_DFU_TRIGGER_CS_FUNCTIONAL 0x21u
+#define NORDIC_DFU_TRIGGER_REQ_DETACH      0x00u
+#define NORDIC_DFU_TRIGGER_REQ_NORDIC_INFO 0x07u
+#define NORDIC_DFU_TRIGGER_REQ_SEM_VER     0x08u
+
+struct nordic_dfu_info {
+  uint32_t wAddress;
+  uint32_t wFirmwareSize;
+  uint16_t wVersionMajor;
+  uint16_t wVersionMinor;
+  uint32_t wFirmwareID;
+  uint32_t wFlashSize;
+  uint32_t wFlashPageSize;
+} __attribute__((packed));
+
+static const struct nordic_dfu_info nordic_info = {
+  .wAddress = 0x1000u,            /* App start (after Nordic MBR) */
+  .wFirmwareSize = 0u,            /* Unknown at runtime; left zero */
+  .wVersionMajor = 1u,
+  .wVersionMinor = 0u,
+  .wFirmwareID = 0u,
+  .wFlashSize = 1024u * 1024u,    /* nRF52840 has 1 MiB flash */
+  .wFlashPageSize = 4096u,
+};
+
+static const char nordic_sem_ver[] = "Contiki-NG DFU";
+
+static void
+nordic_dfu_trigger_init(void)
+{
+}
+/*---------------------------------------------------------------------------*/
+static void
+nordic_dfu_trigger_reset(uint8_t rhport)
+{
+  (void)rhport;
+}
+/*---------------------------------------------------------------------------*/
+static uint16_t
+nordic_dfu_trigger_open(uint8_t rhport,
+                       tusb_desc_interface_t const *itf_desc,
+                       uint16_t max_len)
+{
+  (void)rhport;
+  (void)max_len;
+
+  if(itf_desc->bInterfaceClass != NORDIC_DFU_TRIGGER_CLASS
+     || itf_desc->bInterfaceSubClass != NORDIC_DFU_TRIGGER_SUBCLASS
+     || itf_desc->bInterfaceProtocol != NORDIC_DFU_TRIGGER_PROTOCOL) {
+    return 0;
+  }
+
+  uint16_t drv_len = sizeof(tusb_desc_interface_t);
+  uint8_t const *p = tu_desc_next(itf_desc);
+
+  /* Optional Nordic functional descriptor (type 0x21, 9 bytes). */
+  if(tu_desc_type(p) == NORDIC_DFU_TRIGGER_CS_FUNCTIONAL) {
+    drv_len += tu_desc_len(p);
+  }
+
+  return drv_len;
+}
+/*---------------------------------------------------------------------------*/
+static bool
+nordic_dfu_trigger_control_xfer_cb(uint8_t rhport, uint8_t stage,
+                                  tusb_control_request_t const *request)
+{
+  if(stage != CONTROL_STAGE_SETUP) {
+    return true;
+  }
+
+  /* Standard SET_INTERFACE during enumeration. */
+  if(request->bmRequestType_bit.type == TUSB_REQ_TYPE_STANDARD
+     && request->bRequest == TUSB_REQ_SET_INTERFACE
+     && request->bmRequestType_bit.recipient == TUSB_REQ_RCPT_INTERFACE) {
+    tud_control_status(rhport, request);
+    return true;
+  }
+
+  /*
+   * Nordic's nrfutil and the Nordic SDK's own app_usbd_nrf_dfu_trigger
+   * dispatch class-type requests purely by direction+type, ignoring the
+   * recipient field. Tools in the wild (incl. the libusb-based scripts
+   * documented at https://hackjumpzero.ca/posts/2024/04/trigger-dfu-via-usb-on-nrf52840-dongle/)
+   * send DETACH with bmRequestType = OUT|CLASS|DEVICE (0x20), not the
+   * INTERFACE recipient (0x21) that a strict USB spec reader would
+   * expect. Accept any recipient here for compatibility.
+   */
+  if(request->bmRequestType_bit.type != TUSB_REQ_TYPE_VENDOR
+     && request->bmRequestType_bit.type != TUSB_REQ_TYPE_CLASS) {
+    return false;
+  }
+
+  switch(request->bRequest) {
+  case NORDIC_DFU_TRIGGER_REQ_DETACH:
+    /* Drive the dongle's self-reset GPIO (P0.19, solder-bridged to
+     * nRESET via SB2 on PCA10059) immediately, exactly like the OLD
+     * arch/cpu/nrf52840/usb/usb-dfu-trigger.c handler. Once the pin
+     * is driven low, the hardware reset fires within microseconds and
+     * the bootloader sees RESETREAS.RESETPIN set, which it treats as
+     * a request to enter DFU mode. No need to ACK the control transfer
+     * or do any further work -- the chip is gone. */
+    nrf_gpio_cfg_output(BOARD_DFU_SELF_RESET_PIN);
+    nrf_gpio_pin_clear(BOARD_DFU_SELF_RESET_PIN);
+    return true;
+  case NORDIC_DFU_TRIGGER_REQ_NORDIC_INFO:
+    return tud_control_xfer(rhport, request,
+                            (void *)&nordic_info, sizeof(nordic_info));
+  case NORDIC_DFU_TRIGGER_REQ_SEM_VER:
+    return tud_control_xfer(rhport, request,
+                            (void *)nordic_sem_ver,
+                            sizeof(nordic_sem_ver) - 1);
+  default:
+    return false;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static usbd_class_driver_t const nordic_dfu_trigger_driver = {
+#if CFG_TUSB_DEBUG >= 2
+  .name = "NORDIC-DFU",
+#endif
+  .init = nordic_dfu_trigger_init,
+  .reset = nordic_dfu_trigger_reset,
+  .open = nordic_dfu_trigger_open,
+  .control_xfer_cb = nordic_dfu_trigger_control_xfer_cb,
+  .xfer_cb = NULL,
+  .sof = NULL,
+};
+/*---------------------------------------------------------------------------*/
+/*
+ * Register the Nordic DFU trigger driver with TinyUSB. TinyUSB picks
+ * this up automatically via its weakly-defined application driver hook.
+ */
+usbd_class_driver_t const *
+usbd_app_driver_get_cb(uint8_t *driver_count)
+{
+  *driver_count = 1;
+  return &nordic_dfu_trigger_driver;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Nordic's nrfutil (and the open-source Python triggers that mimic it)
+ * send the DFU DETACH control request with bmRequestType recipient
+ * field set to DEVICE rather than INTERFACE. The Nordic SDK's
+ * app_usbd_nrf_dfu_trigger never checks the recipient field, so it
+ * accepts the request regardless. TinyUSB, on the other hand, routes
+ * INTERFACE-recipient class requests to per-interface class drivers
+ * (which is what nordic_dfu_trigger_control_xfer_cb above handles) but
+ * routes DEVICE-recipient class requests through this global hook.
+ *
+ * Mirror Nordic's behavior by catching the DETACH request here too, so
+ * either recipient form works.
+ */
+bool
+tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage,
+                          tusb_control_request_t const *request)
+{
+  if(stage != CONTROL_STAGE_SETUP) {
+    return true;
+  }
+
+  /* Only catch Nordic's vendor-class control requests at device level.
+   * Standard requests at device level (descriptors, configuration, etc.)
+   * are TinyUSB's responsibility. */
+  if(request->bmRequestType_bit.type != TUSB_REQ_TYPE_CLASS
+     && request->bmRequestType_bit.type != TUSB_REQ_TYPE_VENDOR) {
+    return false;
+  }
+
+  switch(request->bRequest) {
+  case NORDIC_DFU_TRIGGER_REQ_DETACH:
+    /* Same inline pin-reset as the standard runtime callback above. */
+#if BOARD_DFU_SELF_RESET_PIN >= 0
+    nrf_gpio_cfg_output(BOARD_DFU_SELF_RESET_PIN);
+    nrf_gpio_pin_clear(BOARD_DFU_SELF_RESET_PIN);
+#endif
+    nrf_power_gpregret_set(NRF_POWER, 0, BOOTLOADER_DFU_START);
+    NVIC_SystemReset();
+    return true;
+  case NORDIC_DFU_TRIGGER_REQ_NORDIC_INFO:
+    return tud_control_xfer(rhport, request,
+                            (void *)&nordic_info, sizeof(nordic_info));
+  case NORDIC_DFU_TRIGGER_REQ_SEM_VER:
+    return tud_control_xfer(rhport, request,
+                            (void *)nordic_sem_ver,
+                            sizeof(nordic_sem_ver) - 1);
+  default:
+    return false;
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/nrf/usb/tusb_config.h
+++ b/arch/cpu/nrf/usb/tusb_config.h
@@ -101,6 +101,7 @@
 #define CFG_TUD_HID              0
 #define CFG_TUD_MIDI             0
 #define CFG_TUD_VENDOR           0
+#define CFG_TUD_DFU_RUNTIME      1
 
 // CDC FIFO size of TX and RX
 #define CFG_TUD_CDC_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)

--- a/arch/cpu/nrf/usb/usb.c
+++ b/arch/cpu/nrf/usb/usb.c
@@ -54,8 +54,12 @@
 /*---------------------------------------------------------------------------*/
 static int (*input_handler)(unsigned char c) = NULL;
 static unsigned char usb_buffer[BULK_PACKET_SIZE];
-static char manufacturer[] = "Contiki-NG";
-static char product[] = "Contiki-NG USB";
+/* Match the strings the OLD arch/platform/nrf52840 USB stack used so
+ * the dongle keeps the same iManufacturer / iProduct across firmware
+ * versions. The iManufacturer string should also match the owner of
+ * the iVendor VID (0x1915 = Nordic Semiconductor) per the USB IF. */
+static char manufacturer[] = "Nordic Semiconductor";
+static char product[] = "nRF52 USB CDC on Contiki-NG";
 static char cdc_interface[] = "Contiki-NG CDC";
 /*---------------------------------------------------------------------------*/
 PROCESS(usb_arch_process, "USB Arch");

--- a/arch/cpu/nrf/usb/usb_descriptors.c
+++ b/arch/cpu/nrf/usb/usb_descriptors.c
@@ -32,8 +32,16 @@
  *   [MSB]         HID | MSC | CDC          [LSB]
  */
 #define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
-#define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
-                           _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+
+/* Use Nordic's blessed VID:PID for the nRF52840 dongle CDC + DFU-trigger
+ * image (0x1915:0x520F). nrfutil v7+ keys its `nordicDfu` trait
+ * detection off this exact pair, so a vendor-specific DFU trigger
+ * interface only gets exercised by the host when the device announces
+ * itself with this PID. This matches what the OLD arch/platform/nrf52840
+ * port did via APP_USBD_PID in sdk_config.h. */
+#ifndef USB_PID
+#define USB_PID  0x520Fu
+#endif
 
 //--------------------------------------------------------------------+
 // Device Descriptors
@@ -78,10 +86,35 @@ enum
 {
   ITF_NUM_CDC = 0,
   ITF_NUM_CDC_DATA,
+#if CFG_TUD_DFU_RUNTIME
+  ITF_NUM_DFU_RT,
+#endif
+  ITF_NUM_NORDIC_DFU,
   ITF_NUM_TOTAL
 };
 
-#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN)
+/* Length of the Nordic-vendor DFU trigger interface descriptor block:
+ * one 9-byte interface descriptor + one 9-byte Nordic functional descriptor. */
+#define NORDIC_DFU_TRIGGER_DESC_LEN (9 + 9)
+
+#if CFG_TUD_DFU_RUNTIME
+#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN \
+                             + TUD_DFU_RT_DESC_LEN + NORDIC_DFU_TRIGGER_DESC_LEN)
+#else
+#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN \
+                             + NORDIC_DFU_TRIGGER_DESC_LEN)
+#endif
+
+/* Raw bytes for the Nordic DFU trigger interface + functional descriptor.
+ * Mirrors what arch/cpu/nrf52840/lib/nrf52-sdk/.../app_usbd_nrf_dfu_trigger
+ * emits so nrfutil can recognise the interface. */
+#define NORDIC_DFU_TRIGGER_DESCRIPTOR(_itfnum, _stridx) \
+  /* Interface */ \
+  9, TUSB_DESC_INTERFACE, _itfnum, 0, 0, 0xFF, 0x01, 0x01, _stridx, \
+  /* Functional (bmAttributes = bitCanDnload | bitWillDetach,
+   *              wDetachTimeout = 1000, wTransferSize = 4096,
+   *              bcdDFUVersion = 0x0101) */ \
+  9, 0x21, 0x09, 0xE8, 0x03, 0x00, 0x10, 0x01, 0x01
 
 #if CFG_TUSB_MCU == OPT_MCU_LPC175X_6X || CFG_TUSB_MCU == OPT_MCU_LPC177X_8X || CFG_TUSB_MCU == OPT_MCU_LPC40XX
   // LPC 17xx and 40xx endpoint type (bulk/interrupt/iso) are fixed by its number
@@ -113,6 +146,15 @@ enum
 
 #endif
 
+/* DFU runtime descriptor parameters: bitWillDetach so the device reboots
+ * to bootloader on its own when the host sends a DETACH request. The
+ * detach timeout and transfer size are conventional values; the actual
+ * download happens after the device has re-enumerated as the bootloader,
+ * so the runtime transfer size is not load-bearing. */
+#define DFU_RT_ATTR     (DFU_ATTR_CAN_DOWNLOAD | DFU_ATTR_WILL_DETACH)
+#define DFU_RT_TIMEOUT  1000
+#define DFU_RT_XFER     4096
+
 uint8_t const desc_fs_configuration[] =
 {
   // Config number, interface count, string index, total length, attribute, power in mA
@@ -120,6 +162,10 @@ uint8_t const desc_fs_configuration[] =
 
   // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
+#if CFG_TUD_DFU_RUNTIME
+  TUD_DFU_RT_DESCRIPTOR(ITF_NUM_DFU_RT, 5, DFU_RT_ATTR, DFU_RT_TIMEOUT, DFU_RT_XFER),
+#endif
+  NORDIC_DFU_TRIGGER_DESCRIPTOR(ITF_NUM_NORDIC_DFU, 6),
 };
 
 #if TUD_OPT_HIGH_SPEED
@@ -130,6 +176,10 @@ uint8_t const desc_hs_configuration[] =
 
   // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 512),
+#if CFG_TUD_DFU_RUNTIME
+  TUD_DFU_RT_DESCRIPTOR(ITF_NUM_DFU_RT, 5, DFU_RT_ATTR, DFU_RT_TIMEOUT, DFU_RT_XFER),
+#endif
+  NORDIC_DFU_TRIGGER_DESCRIPTOR(ITF_NUM_NORDIC_DFU, 6),
 };
 #endif
 
@@ -161,6 +211,12 @@ char const* string_desc_arr [] =
   NULL,                           // 2: Product
   NULL,                           // 3: Serials, should use chip ID
   NULL,                           // 4: CDC Interface
+#if CFG_TUD_DFU_RUNTIME
+  "Contiki-NG DFU",               // 5: DFU runtime Interface
+#else
+  NULL,                           // 5: (placeholder, keep index alignment)
+#endif
+  "Contiki-NG Nordic DFU",        // 6: Nordic DFU trigger Interface
 };
 
 void usb_descriptor_set_manufacturer(char * manufacturer)

--- a/arch/platform/nrf/nrf52840/dongle/Makefile.dongle
+++ b/arch/platform/nrf/nrf52840/dongle/Makefile.dongle
@@ -14,3 +14,44 @@ include $(PLATFORM_ROOT_DIR)/nrf52840/Makefile.nrf52840
 CONTIKI_TARGET_DIRS += nrf52840/dongle
 
 MODULES += $(CONTIKI_NG_DRIVERS_ETC_DIR)/rgb-led
+
+#
+# Dongle upload via Nordic open-bootloader (no J-Link). Overrides the
+# nrfjprog-based %.upload rule from arch/cpu/nrf/Makefile.nrf. Triggers
+# DFU mode on a running Contiki-NG firmware if needed, generates the
+# Nordic DFU zip, then flashes via the Rust-based nrfutil.
+#
+# Requirements:
+#   - Rust nrfutil v7+ (https://www.nordicsemi.com/Software-and-tools/
+#     Development-Tools/nrfutil) + `nrfutil install nrf5sdk-tools`
+#   - pyusb for the optional in-firmware DFU trigger
+#     (pip install pyusb). Skipped automatically if not installed.
+#
+# Override the Python interpreter with PYTHON3, the nrfutil binary
+# with NRFUTIL, or pick a specific dongle with NRF_UPLOAD_SN=<serial>.
+#
+NRFUTIL ?= nrfutil
+PYTHON3 ?= python3
+DONGLE_DFU_TRIGGER := $(CONTIKI)/tools/nrf/dongle-dfu-trigger.py
+DONGLE_DFU_ZIP := $(BUILD_DIR_BOARD)/dongle-dfu-image.zip
+
+ifdef NRF_UPLOAD_SN
+  DONGLE_PROGRAM_OPTS := --serial-number $(NRF_UPLOAD_SN)
+else
+  DONGLE_PROGRAM_OPTS := --traits nordicDfu
+endif
+
+%.upload: $(BUILD_DIR_BOARD)/%.$(TARGET)
+ifeq (,$(shell command -v $(NRFUTIL)))
+	$(error Could not find nrfutil "$(NRFUTIL)", install it from https://www.nordicsemi.com/Software-and-tools/Development-Tools/nrfutil)
+else
+	@echo "==> Converting ELF to Intel HEX"
+	$(OBJCOPY) -O ihex $< $(BUILD_DIR_BOARD)/$*.hex
+	@echo "==> Triggering DFU mode on running firmware (if any)"
+	-@$(PYTHON3) $(DONGLE_DFU_TRIGGER) $(DONGLE_TRIGGER_OPTS) || echo "    (no running firmware to trigger; assuming bootloader)"
+	@sleep 2
+	@echo "==> Generating Nordic DFU package"
+	$(NRFUTIL) nrf5sdk-tools pkg generate --hw-version 52 --sd-req 0x00 --debug-mode --application $(BUILD_DIR_BOARD)/$*.hex $(DONGLE_DFU_ZIP)
+	@echo "==> Flashing"
+	$(NRFUTIL) device program --firmware $(DONGLE_DFU_ZIP) $(DONGLE_PROGRAM_OPTS)
+endif

--- a/tools/nrf/dongle-dfu-trigger.py
+++ b/tools/nrf/dongle-dfu-trigger.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 RISE Research Institutes of Sweden AB
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+"""
+Trigger Nordic open-bootloader DFU mode on a PCA10059 dongle running
+Contiki-NG firmware with USB DFU trigger support.
+
+Sends the Nordic-vendor-specific DETACH control transfer that the
+firmware's USB DFU trigger interface listens for, the same way the OLD
+arch/cpu/nrf52840/usb/usb-dfu-trigger.c handler expected.
+
+  bmRequestType = OUT | CLASS | DEVICE   (= 0x20)
+  bRequest      = 0x00                   (DETACH)
+  wValue        = 0
+  wIndex        = 3                      (Contiki-NG's Nordic-DFU
+                                          interface number; matches
+                                          our usb_descriptors.c layout)
+  wLength       = 0
+
+The firmware receives this in nordic_dfu_trigger_control_xfer_cb() in
+arch/cpu/nrf/dev/usb-arch.c, which then drives the dongle's self-reset
+GPIO (P0.19) low to pin-reset the chip into the bootloader.
+
+Usage:
+  dongle-dfu-trigger.py                  # any dongle running the firmware
+  dongle-dfu-trigger.py --serial-number <SN>
+                                         # restrict to a specific dongle
+
+Exits 0 on success or "device already in bootloader" (idempotent),
+1 on hard errors.
+"""
+import argparse
+import sys
+
+try:
+    import usb.core
+    import usb.util
+except ImportError:
+    print("error: pyusb not installed (run: pip install pyusb)", file=sys.stderr)
+    sys.exit(1)
+
+VID = 0x1915
+APP_PID = 0x520F   # Contiki-NG dongle app w/ DFU trigger
+BL_PID = 0x521F    # Nordic open-bootloader in DFU mode
+
+
+def _match_serial(serial):
+    """Return a pyusb matcher that selects only devices whose USB
+    iSerialNumber descriptor equals ``serial``. ``None`` selects any."""
+    if serial is None:
+        return lambda d: True
+
+    def _check(d):
+        try:
+            return usb.util.get_string(d, d.iSerialNumber) == serial
+        except (usb.core.USBError, ValueError):
+            return False
+    return _check
+
+
+parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+parser.add_argument(
+    "--serial-number",
+    help="Restrict the trigger to the dongle with this USB serial number.",
+)
+args = parser.parse_args()
+
+match = _match_serial(args.serial_number)
+
+# If the bootloader is already enumerated for our target, there's nothing to do.
+if usb.core.find(idVendor=VID, idProduct=BL_PID, custom_match=match) is not None:
+    print("Dongle already in DFU bootloader mode.")
+    sys.exit(0)
+
+dev = usb.core.find(idVendor=VID, idProduct=APP_PID, custom_match=match)
+if dev is None:
+    msg = f"no dongle with VID:PID {VID:04X}:{APP_PID:04X}"
+    if args.serial_number:
+        msg += f" and serial number {args.serial_number}"
+    print(f"error: {msg} found", file=sys.stderr)
+    sys.exit(1)
+
+bmRequestType = usb.util.build_request_type(
+    usb.util.CTRL_OUT,
+    usb.util.CTRL_TYPE_CLASS,
+    usb.util.CTRL_RECIPIENT_DEVICE,
+)
+
+try:
+    dev.ctrl_transfer(bmRequestType, 0x00, 0, 3, None, timeout=1000)
+except usb.core.USBError:
+    # Expected: the chip pin-resets in the middle of the control transfer.
+    pass
+
+print("DFU detach triggered.")
+sys.exit(0)


### PR DESCRIPTION
## Summary

  Bring USB DFU trigger support back to the unified `arch/platform/nrf`
  USB stack so the nRF52840 dongle (PCA10059) workflow doesn't regress
  to "press the reset button on every re-flash."

  The old `arch/platform/nrf52840` platform exposed a Nordic-vendor
  DFU trigger interface via Nordic SDK's `app_usbd`. The new TinyUSB-based
  stack only had CDC. This PR adds:

  - Standard USB DFU runtime interface (`dfu-util -e` compatible)
  - Nordic-vendor DFU trigger interface (`nrfutil` / libusb compatible)
  - VID:PID `0x1915:0x520F` matching Nordic's `APP_USBD_PID`
  - All DETACH paths drive P0.19 low inline (same mechanism as the old
    port and RIOT-OS) to pin-reset into the bootloader via the PCA10059's
    SB2 solder bridge
  - `make hello-world.upload` rule for the dongle that auto-triggers DFU
    and flashes via `nrfutil device program`

  ## Test plan
  
  - [x] `dfu-util -l` shows the standard DFU runtime interface
  - [x] `tools/nrf/dongle-dfu-trigger.py` resets a running firmware into bootloader
  - [x] `make TARGET=nrf BOARD=nrf52840/dongle hello-world.upload` end-to-end works on a PCA10059
  - [x] Reviewer to verify on another dongle / OS