### PR TITLE
linkaddr: guard linkaddr_u8 with _Static_assert on LINKADDR_SIZE

### DIFF
--- a/os/net/linkaddr.h
+++ b/os/net/linkaddr.h
@@ -85,6 +85,8 @@ typedef union {
  */
 #define linkaddr_u8(addr, addr0, addr1, addr2, addr3, addr4, addr5, addr6, addr7) \
   do { \
+    _Static_assert(LINKADDR_SIZE == 8, \
+                   "linkaddr_u8 requires LINKADDR_SIZE == 8"); \
     (addr).u8[0] = (addr0); \
     (addr).u8[1] = (addr1); \
     (addr).u8[2] = (addr2); \


### PR DESCRIPTION
The macro unconditionally writes eight bytes into linkaddr_t.u8, but that array is sized LINKADDR_SIZE. When LINKADDR_SIZE == 2 the stores to u8[2]..u8[7] are out of bounds. Add a _Static_assert so any call under a non-8-byte configuration fails at the call site rather than silently corrupting adjacent memory.