### PR TITLE
simplelink-cc13xx-cc26xx: fix wrong pointer passed to rf_get_tx_power in get_value()

### DIFF
--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/ieee-mode.c
@@ -741,12 +741,15 @@ get_value(radio_param_t param, radio_value_t *value)
     return RADIO_RESULT_OK;
 
   /* TX power */
-  case RADIO_PARAM_TXPOWER:
-    res = rf_get_tx_power(ieee_radio.rf_handle, rf_tx_power_table, (int8_t *)&value);
+  case RADIO_PARAM_TXPOWER: {
+    int8_t dbm;
+    res = rf_get_tx_power(ieee_radio.rf_handle, rf_tx_power_table, &dbm);
+    *value = (radio_value_t)dbm;
     return ((res == RF_RESULT_OK) &&
-            (*value != RF_TxPowerTable_INVALID_DBM))
+            (dbm != RF_TxPowerTable_INVALID_DBM))
            ? RADIO_RESULT_OK
            : RADIO_RESULT_ERROR;
+  }
 
   /* CCA threshold */
   case RADIO_PARAM_CCA_THRESHOLD:

--- a/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/rf/prop-mode.c
@@ -760,12 +760,15 @@ get_value(radio_param_t param, radio_value_t *value)
     *value = 0;
     return RADIO_RESULT_OK;
 
-  case RADIO_PARAM_TXPOWER:
-    res = rf_get_tx_power(prop_radio.rf_handle, rf_tx_power_table, (int8_t *)&value);
+  case RADIO_PARAM_TXPOWER: {
+    int8_t dbm;
+    res = rf_get_tx_power(prop_radio.rf_handle, rf_tx_power_table, &dbm);
+    *value = (radio_value_t)dbm;
     return ((res == RF_RESULT_OK) &&
-            (*value != RF_TxPowerTable_INVALID_DBM))
+            (dbm != RF_TxPowerTable_INVALID_DBM))
            ? RADIO_RESULT_OK
            : RADIO_RESULT_ERROR;
+  }
 
   case RADIO_PARAM_CCA_THRESHOLD:
     *value = prop_radio.rssi_threshold;


### PR DESCRIPTION
## Summary

Fixes #3124.

For `RADIO_PARAM_TXPOWER`, `get_value()` passed `(int8_t *)&value` to `rf_get_tx_power()`. Since `value` is a `radio_value_t *` parameter, `&value` is the address of the *pointer variable* on the stack, not the caller's `radio_value_t`. As a result:

- the TX power byte was written into the pointer's own stack memory;
- `*value` was never set, so the caller read uninitialized/stale data;
- the `RF_TxPowerTable_INVALID_DBM` check (`*value != ...`) also read uninitialized data;
- consecutive `NETSTACK_RADIO.get_value(RADIO_PARAM_TXPOWER, ...)` calls could return different values depending on stack state.

The `(int8_t *)` cast also suppressed the compiler warning that would normally have caught the pointer-type mismatch.

## Fix

Read into a local `int8_t dbm` and widen it into `*value`, mirroring the existing correct idiom in `ble-beacond.c`. Dropping the cast restores compiler type checking.

## Scope

The issue reports `prop-mode.c`, but `ieee-mode.c` contains an identical copy of the bug. Both are fixed here. A sweep of all in-tree radio drivers (`cc2538-rf.c`, `efr32-radio.c`, `at86rf215.c`, `cc1200.c`, `cc2420.c`, `nullradio.c`) found no other instances of this pattern.