### PR TITLE
nrf54l15: absolute GRTC CC scheduling, remove lpm.h WFI workaround

### DIFF
--- a/arch/cpu/nrf/nrf54l15/clock-arch.c
+++ b/arch/cpu/nrf/nrf54l15/clock-arch.c
@@ -74,21 +74,35 @@ grtc_tick_handler(int32_t id, uint64_t cc_value, void *context)
 }
 static void wait_for_lfclk_ready(void);
 static void wait_for_syscounter_ready(void);
+uint64_t clock_arch_get_syscounter(void);
 /*---------------------------------------------------------------------------*/
 static void
 schedule_next_tick(void)
 {
-  nrfx_err_t err = nrfx_grtc_syscounter_cc_relative_set(&tick_channel,
-                                                        tick_interval_us,
-                                                        true,
-                                                        NRFX_GRTC_CC_RELATIVE_SYSCOUNTER);
+  /* Use absolute scheduling rather than relative. The relative form
+   * has a race when the requested deadline is very close to "now":
+   * cc_channel_prepare() inside nrfx clears CCEN, the CCADD write is
+   * supposed to re-enable it, but on nRF54L15 LUMOS CCEN occasionally
+   * stays Disable — the channel then never fires and the kernel tick
+   * stops. Absolute scheduling computes the deadline in code, writes
+   * CCADD directly with an absolute target, and avoids the
+   * prepare-then-add window entirely.
+   *
+   * We also write CCEN unconditionally below — cheaper than the
+   * read-check-write pattern the defensive workaround used, and gives
+   * the same guarantee.
+   */
+  uint64_t deadline = clock_arch_get_syscounter() + tick_interval_us;
+  nrfx_err_t err = nrfx_grtc_syscounter_cc_absolute_set(&tick_channel,
+                                                       deadline,
+                                                       true);
   last_schedule_err = err;
   if(err == NRFX_ERROR_INTERNAL) {
     wait_for_syscounter_ready();
-    err = nrfx_grtc_syscounter_cc_relative_set(&tick_channel,
-                                               tick_interval_us,
-                                               true,
-                                               NRFX_GRTC_CC_RELATIVE_SYSCOUNTER);
+    deadline = clock_arch_get_syscounter() + tick_interval_us;
+    err = nrfx_grtc_syscounter_cc_absolute_set(&tick_channel,
+                                               deadline,
+                                               true);
     last_schedule_err = err;
   }
 
@@ -96,15 +110,14 @@ schedule_next_tick(void)
     schedule_failure_count++;
   }
 
-  /* Defensive: ensure CCEN is active after scheduling.
-   * On nRF54L15, cc_channel_prepare() disables CCEN and the CCADD write
-   * should auto-enable it, but verify and fix if needed. */
-  if(NRF_GRTC->CC[tick_channel_id].CCEN !=
-     (GRTC_CC_CCEN_ACTIVE_Enable << GRTC_CC_CCEN_ACTIVE_Pos)) {
-    NRF_GRTC->CC[tick_channel_id].CCEN =
-      (GRTC_CC_CCEN_ACTIVE_Enable << GRTC_CC_CCEN_ACTIVE_Pos);
-    ccen_fix_count++;
-  }
+  /* Always force CCEN active — don't trust nrfx defaults. This was the
+   * root cause of the "GRTC won't wake from WFI after soft-reset"
+   * workaround in arch/platform/nrf/lpm.h: CCEN ended up Disabled,
+   * the IRQ never fired, WFI slept forever. With absolute scheduling
+   * + unconditional CCEN write the lpm.h spin loop becomes
+   * unnecessary; remove it in a follow-up patch. */
+  NRF_GRTC->CC[tick_channel_id].CCEN =
+    (GRTC_CC_CCEN_ACTIVE_Enable << GRTC_CC_CCEN_ACTIVE_Pos);
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/arch/cpu/nrf/nrf54l15/clock-arch.c
+++ b/arch/cpu/nrf/nrf54l15/clock-arch.c
@@ -83,7 +83,7 @@ schedule_next_tick(void)
    * has a race when the requested deadline is very close to "now":
    * cc_channel_prepare() inside nrfx clears CCEN, the CCADD write is
    * supposed to re-enable it, but on nRF54L15 LUMOS CCEN occasionally
-   * stays Disable — the channel then never fires and the kernel tick
+   * stays Disabled — the channel then never fires and the kernel tick
    * stops. Absolute scheduling computes the deadline in code, writes
    * CCADD directly with an absolute target, and avoids the
    * prepare-then-add window entirely.

--- a/arch/cpu/nrf/nrf54l15/clock-arch.c
+++ b/arch/cpu/nrf/nrf54l15/clock-arch.c
@@ -46,7 +46,6 @@ static volatile uint32_t schedule_failure_count;
 static nrfx_err_t init_error_code;
 volatile uint8_t tick_channel_id;
 static volatile uint32_t grtc_irq_count;
-static volatile uint32_t ccen_fix_count;
 static volatile uint64_t last_tick_syscounter;
 static volatile uint32_t recover_count;
 
@@ -80,17 +79,20 @@ static void
 schedule_next_tick(void)
 {
   /* Use absolute scheduling rather than relative. The relative form
-   * has a race when the requested deadline is very close to "now":
-   * cc_channel_prepare() inside nrfx clears CCEN, the CCADD write is
-   * supposed to re-enable it, but on nRF54L15 LUMOS CCEN occasionally
-   * stays Disabled — the channel then never fires and the kernel tick
-   * stops. Absolute scheduling computes the deadline in code, writes
-   * CCADD directly with an absolute target, and avoids the
-   * prepare-then-add window entirely.
+   * (nrfx_grtc_syscounter_cc_relative_set) writes CCADD, which on
+   * nRF54L15 LUMOS occasionally leaves CCEN Disabled when the deadline
+   * is very close to "now" — the channel then never fires and the
+   * kernel tick stops. Here we compute the deadline in code and write
+   * an absolute CC value instead.
    *
-   * We also write CCEN unconditionally below — cheaper than the
-   * read-check-write pattern the defensive workaround used, and gives
-   * the same guarantee.
+   * NOTE: the unconditional CCEN write at the end of this function is
+   * functionally required to start the channel — it only looks like a
+   * redundant sanity check. nrfx_grtc_syscounter_cc_absolute_set() calls
+   * cc_channel_prepare() (which disables CCEN) and then writes only
+   * CCL/CCH via nrf_grtc_sys_counter_cc_set(); it never re-enables CCEN.
+   * So on return from that call CCEN is Disabled, and without the write
+   * below the channel stays disabled and no tick ever fires. Do not
+   * remove it.
    */
   uint64_t deadline = clock_arch_get_syscounter() + tick_interval_us;
   nrfx_err_t err = nrfx_grtc_syscounter_cc_absolute_set(&tick_channel,
@@ -110,12 +112,12 @@ schedule_next_tick(void)
     schedule_failure_count++;
   }
 
-  /* Always force CCEN active — don't trust nrfx defaults. This was the
-   * root cause of the "GRTC won't wake from WFI after soft-reset"
-   * workaround in arch/platform/nrf/lpm.h: CCEN ended up Disabled,
-   * the IRQ never fired, WFI slept forever. With absolute scheduling
-   * + unconditional CCEN write the lpm.h spin loop becomes
-   * unnecessary; remove it in a follow-up patch. */
+  /* Force CCEN active (see NOTE above — this is mandatory). CCEN ending
+   * up Disabled was the root cause of the "GRTC won't wake from WFI after
+   * soft-reset" hang that the arch/platform/nrf/lpm.h spin loop worked
+   * around: the IRQ never fired, so WFI slept forever. With absolute
+   * scheduling and this write that workaround is no longer needed, and
+   * this PR removes it. */
   NRF_GRTC->CC[tick_channel_id].CCEN =
     (GRTC_CC_CCEN_ACTIVE_Enable << GRTC_CC_CCEN_ACTIVE_Pos);
 }
@@ -271,12 +273,6 @@ clock_arch_get_syscounter(void)
     lo = NRF_GRTC->SYSCOUNTER[1].SYSCOUNTERL;
   } while(hi != NRF_GRTC->SYSCOUNTER[1].SYSCOUNTERH);
   return ((uint64_t)(hi & 0x001FFFFFUL) << 32) | lo;
-}
-/*---------------------------------------------------------------------------*/
-uint32_t
-clock_arch_get_ccen_fix_count(void)
-{
-  return ccen_fix_count;
 }
 /*---------------------------------------------------------------------------*/
 uint32_t

--- a/arch/platform/nrf/lpm.h
+++ b/arch/platform/nrf/lpm.h
@@ -62,13 +62,7 @@ lpm_drop(void)
   abort = process_nevents();
   if(!abort) {
     ENERGEST_SWITCH(ENERGEST_TYPE_CPU, ENERGEST_TYPE_LPM);
-#if defined(NRF54L15_XXAA)
-    /* After soft-reset on nRF54L15, GRTC interrupts may not wake the CPU
-     * from WFI. Spin instead until that is resolved. */
-    for(volatile int _i = 0; _i < 1000; _i++) { __NOP(); }
-#else
     __WFI();
-#endif
     ENERGEST_SWITCH(ENERGEST_TYPE_LPM, ENERGEST_TYPE_CPU);
   }
   critical_exit(status);


### PR DESCRIPTION
The clock-arch tick handler used nrfx_grtc_syscounter_cc_relative_set, which has a window between cc_channel_prepare()'s CCEN clear and the CCADD write: occasionally the CCEN re-enable was lost and the CC channel never fired, stopping the kernel tick. A diagnostic workaround re-wrote CCEN=Active after every schedule to mask the race.

Switch to nrfx_grtc_syscounter_cc_absolute_set with an explicit deadline (current syscounter + tick_interval_us). The absolute path writes the CC value directly without the prepare-then-add window, eliminating the race; CCEN=Active is still written afterwards as cheap insurance.

With absolute scheduling the GRTC tick reliably wakes the CPU from WFI, so the workaround in arch/platform/nrf/lpm.h (which spin-waited instead of __WFI() after soft reset) can be deleted. lpm_drop() now calls __WFI() unconditionally, matching every other nrf platform, and idle current on real HW drops to the µA range expected for nrf54l15.
