### PR TITLE
doxygen: remove obsolete DOT_MULTI_TARGETS tag

### DIFF
--- a/tools/doxygen/Doxyfile
+++ b/tools/doxygen/Doxyfile
@@ -2827,15 +2827,6 @@ DOT_GRAPH_MAX_NODES    = 50
 
 MAX_DOT_GRAPH_DEPTH    = 0
 
-# Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
-# files in one run (i.e. multiple -o and -T options on the command line). This
-# makes dot run faster, but since only newer versions of dot (>1.8.10) support
-# this, this feature is disabled by default.
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_MULTI_TARGETS      = NO
-
 # If the GENERATE_LEGEND tag is set to YES doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated
 # graphs.


### PR DESCRIPTION
Newer Doxygen versions treat DOT_MULTI_TARGETS as obsolete and emit a warning, which the 00-documentation test counts as a failure. The tag just defaulted to NO, so dropping it is a no-op for output while clearing the CI warning.