### PR TITLE
CC2538: Fix timer issues

### DIFF
--- a/arch/cpu/cc2538/clock.c
+++ b/arch/cpu/cc2538/clock.c
@@ -54,7 +54,7 @@
 #include "cpu.h"
 #include "dev/gptimer.h"
 #include "dev/sys-ctrl.h"
-
+#include "sys/atomic.h"
 #include "sys/energest.h"
 #include "sys/etimer.h"
 #include "sys/rtimer.h"
@@ -76,7 +76,13 @@
 #endif
 #define SYSTICK_PERIOD          (SYS_CTRL_SYS_CLOCK / CLOCK_SECOND)
 
-static volatile uint64_t rt_ticks_startup = 0, rt_ticks_epoch = 0;
+static void update_ticks(void);
+void clock_isr(void);
+
+PROCESS(clock_process, "clock_process");
+static uint64_t rt_ticks_startup = 0, rt_ticks_epoch = 0;
+static uint8_t pending_update;
+
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Arch-specific implementation of clock_init for the cc2538
@@ -92,6 +98,8 @@ static volatile uint64_t rt_ticks_startup = 0, rt_ticks_epoch = 0;
 void
 clock_init(void)
 {
+  process_start(&clock_process, NULL);
+
   SysTick_Config(SYSTICK_PERIOD);
 
   /*
@@ -117,6 +125,7 @@ clock_init(void)
 clock_time_t
 clock_time(void)
 {
+  update_ticks();
   return rt_ticks_startup / RTIMER_CLOCK_TICK_RATIO;
 }
 /*---------------------------------------------------------------------------*/
@@ -129,6 +138,7 @@ clock_set_seconds(unsigned long sec)
 unsigned long
 clock_seconds(void)
 {
+  update_ticks();
   return rt_ticks_epoch / RTIMER_SECOND;
 }
 /*---------------------------------------------------------------------------*/
@@ -186,6 +196,9 @@ clock_delay(unsigned int i)
 static void
 update_ticks(void)
 {
+  if(!atomic_cas_uint8(&pending_update, 1, 0)) {
+    return;
+  }
   rtimer_clock_t now;
   uint64_t prev_rt_ticks_startup, cur_rt_ticks_startup;
   uint32_t cur_rt_ticks_startup_hi;
@@ -223,25 +236,37 @@ update_ticks(void)
 void
 clock_adjust(void)
 {
-  /* Halt the SysTick while adjusting */
-  SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
-
-  update_ticks();
-
-  /* Re-Start the SysTick */
-  SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+  clock_isr();
 }
 /*---------------------------------------------------------------------------*/
 /**
  * \brief The clock Interrupt Service Routine
- *
- * It polls the etimer process if an etimer has expired. It also updates the
- * software clock tick and seconds counter.
  */
 void
 clock_isr(void)
 {
-  update_ticks();
+  if(atomic_cas_uint8(&pending_update, 0, 1)) {
+    process_poll(&clock_process);
+  }
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Updates ticks upon request, which then triggers the etimer process.
+ *
+ * While we could poll the etimer process directly, we might miss "wraparounds"
+ * if no process called clock_time() or clock_seconds() for a while.
+ */
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(clock_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  while(1) {
+    PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
+    update_ticks();
+  }
+
+  PROCESS_END();
 }
 /*---------------------------------------------------------------------------*/
 

--- a/arch/cpu/cc2538/rtimer-arch.c
+++ b/arch/cpu/cc2538/rtimer-arch.c
@@ -37,6 +37,7 @@
  *
  */
 #include "contiki.h"
+#include "sys/atomic.h"
 #include "sys/rtimer.h"
 #include "dev/nvic.h"
 #include "dev/smwdthrosc.h"
@@ -46,6 +47,7 @@
 #include <stdint.h>
 /*---------------------------------------------------------------------------*/
 static volatile rtimer_clock_t next_trigger;
+static uint8_t busy;
 /*---------------------------------------------------------------------------*/
 /**
  * \brief We don't need to explicitly initialise anything but this
@@ -81,11 +83,15 @@ rtimer_arch_schedule(rtimer_clock_t t)
     t = now + RTIMER_GUARD_TIME;
   }
 
+  atomic_cas_uint8(&busy, 0, 1);
+
   /* ST0 latches ST[1:3] and must be written last */
   REG(SMWDTHROSC_ST3) = (t >> 24) & 0x000000FF;
   REG(SMWDTHROSC_ST2) = (t >> 16) & 0x000000FF;
   REG(SMWDTHROSC_ST1) = (t >> 8) & 0x000000FF;
   REG(SMWDTHROSC_ST0) = t & 0x000000FF;
+
+  atomic_cas_uint8(&busy, 1, 0);
 
   INTERRUPTS_ENABLE();
 
@@ -110,11 +116,20 @@ rtimer_arch_now()
 {
   rtimer_clock_t rv;
 
-  /* SMWDTHROSC_ST0 latches ST[1:3] and must be read first */
-  rv = REG(SMWDTHROSC_ST0);
-  rv |= (REG(SMWDTHROSC_ST1) << 8);
-  rv |= (REG(SMWDTHROSC_ST2) << 16);
-  rv |= (REG(SMWDTHROSC_ST3) << 24);
+  do {
+    atomic_cas_uint8(&busy, 0, 1);
+
+    /* waiting for STLOAD helps avoid some timer issues */
+    while((REG(SMWDTHROSC_STLOAD) & SMWDTHROSC_STLOAD_STLOAD) != 1);
+
+    /* SMWDTHROSC_ST0 latches ST[1:3] and must be read first */
+    rv = REG(SMWDTHROSC_ST0);
+    rv |= (REG(SMWDTHROSC_ST1) << 8);
+    rv |= (REG(SMWDTHROSC_ST2) << 16);
+    rv |= (REG(SMWDTHROSC_ST3) << 24);
+
+    /* repeat if we were interrupted */
+  } while(!atomic_cas_uint8(&busy, 1, 0));
 
   return rv;
 }

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -197,9 +197,9 @@ main(void)
 #endif /* PLATFORM_MAIN_ACCEPTS_ARGS */
   platform_init_stage_one();
 
+  process_init();
   clock_init();
   rtimer_init();
-  process_init();
   process_start(&etimer_process, NULL);
   ctimer_init();
   watchdog_init();


### PR DESCRIPTION
I encountered situations, where `clock_time()` jumped and `etimer_expired()` returned true right after having called `etimer_reset()`, similar to what was reported in #2991 and #186. There seem to be two problem areas:
* **clock.c:** Disabling the SysTick interrupt via `SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;` might happen only after that interrupt occurs. Besides, `clock.c` concurrently reads and writes `rt_ticks_startup`.
* **rtimer-arch.c**: When an ISR interrupts a process that is inside of `rtimer_arch_now()` and also calls this function, I suspect there is a chance for reading a garbage timer value.