### PR TITLE
Allow for clock_time() to wrap around zero in timer.c and clock(-arch).c

### DIFF
--- a/arch/cpu/cc2538/clock.c
+++ b/arch/cpu/cc2538/clock.c
@@ -58,6 +58,7 @@
 #include "sys/energest.h"
 #include "sys/etimer.h"
 #include "sys/rtimer.h"
+#include "sys/timer.h"
 
 #include <stdint.h>
 /*---------------------------------------------------------------------------*/
@@ -135,10 +136,9 @@ clock_seconds(void)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start;
-
-  start = clock_time();
-  while(clock_time() - start < (clock_time_t)i);
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer));
 }
 /*---------------------------------------------------------------------------*/
 /*

--- a/arch/cpu/cc26x0-cc13x0/clock.c
+++ b/arch/cpu/cc26x0-cc13x0/clock.c
@@ -44,7 +44,7 @@
  */
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
-
+#include "sys/timer.h"
 #include "ti-lib.h"
 /*---------------------------------------------------------------------------*/
 static volatile uint64_t count;
@@ -148,10 +148,9 @@ clock_seconds(void)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start;
-
-  start = clock_time();
-  while(clock_time() - start < (clock_time_t)i);
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer));
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/cpu/gecko/sys/clock-arch.c
+++ b/arch/cpu/gecko/sys/clock-arch.c
@@ -48,6 +48,7 @@
 #include "contiki.h"
 
 #include "sl_sleeptimer.h"
+#include "sys/timer.h"
 /*---------------------------------------------------------------------------*/
 static volatile uint32_t ticks;
 static sl_sleeptimer_timer_handle_t periodic_timer;
@@ -103,9 +104,9 @@ clock_seconds(void)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start;
-  start = clock_time();
-  while(clock_time() - start < (clock_time_t)i) {
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer)) {
     __WFE();
   }
 }

--- a/arch/cpu/msp430/f1xxx/clock.c
+++ b/arch/cpu/msp430/f1xxx/clock.c
@@ -33,6 +33,7 @@
 #include "sys/clock.h"
 #include "sys/etimer.h"
 #include "sys/energest.h"
+#include "sys/timer.h"
 #include "rtimer-arch.h"
 #include "dev/watchdog.h"
 #include "isr_compat.h"
@@ -198,10 +199,9 @@ clock_delay(unsigned int i)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start;
-
-  start = clock_time();
-  while(clock_time() - start < (clock_time_t)i);
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer));
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/cpu/msp430/f5xxx/clock.c
+++ b/arch/cpu/msp430/f5xxx/clock.c
@@ -33,6 +33,7 @@
 #include "sys/clock.h"
 #include "sys/etimer.h"
 #include "sys/energest.h"
+#include "sys/timer.h"
 #include "rtimer-arch.h"
 #include "dev/watchdog.h"
 #include "isr_compat.h"
@@ -195,10 +196,9 @@ clock_delay(unsigned int i)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start;
-
-  start = clock_time();
-  while(clock_time() - start < (clock_time_t)i);
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer));
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/cpu/nrf/nrf54l15/clock-arch.c
+++ b/arch/cpu/nrf/nrf54l15/clock-arch.c
@@ -25,7 +25,7 @@
  */
 #include "nrfx_grtc.h"
 #include "sys/etimer.h"
-
+#include "sys/timer.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include "nrf.h"
@@ -199,8 +199,9 @@ clock_seconds(void)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start = clock_time();
-  while(clock_time() - start < i) {
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer)) {
     __WFE();
   }
 }

--- a/arch/cpu/nrf/sys/clock-arch.c
+++ b/arch/cpu/nrf/sys/clock-arch.c
@@ -50,6 +50,7 @@
 #include "nrfx_config.h"
 #include "nrfx_rtc.h"
 #include "nrfx_clock.h"
+#include "sys/timer.h"
 
 #if CLOCK_SIZE != 4
 /* 64 bit variables may not be read atomically without extra handling */
@@ -164,8 +165,9 @@ clock_seconds(void)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start = clock_time();
-  while(clock_time() - start < i) {
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer)) {
     __WFE();
   }
 }

--- a/arch/cpu/nrf52840/clock.c
+++ b/arch/cpu/nrf52840/clock.c
@@ -53,7 +53,7 @@
 #include "nrf_drv_clock.h"
 #include "nrf_delay.h"
 #include "app_error.h"
-
+#include "sys/timer.h"
 /*---------------------------------------------------------------------------*/
 const nrf_drv_rtc_t rtc = NRF_DRV_RTC_INSTANCE(PLATFORM_RTC_INSTANCE_ID); /**< RTC instance used for platform clock */
 /*---------------------------------------------------------------------------*/
@@ -138,9 +138,9 @@ clock_seconds(void)
 void
 clock_wait(clock_time_t i)
 {
-  clock_time_t start;
-  start = clock_time();
-  while(clock_time() - start < (clock_time_t)i) {
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer)) {
     __WFE();
   }
 }

--- a/arch/cpu/simplelink-cc13xx-cc26xx/dev/clock-arch.c
+++ b/arch/cpu/simplelink-cc13xx-cc26xx/dev/clock-arch.c
@@ -45,6 +45,7 @@
 #include "sys/cc.h"
 #include "sys/clock.h"
 #include "sys/etimer.h"
+#include "sys/timer.h"
 /*---------------------------------------------------------------------------*/
 #include <ti/devices/DeviceFamily.h>
 #include DeviceFamily_constructPath(driverlib/aon_rtc.h)
@@ -240,10 +241,9 @@ clock_seconds(void)
 void
 clock_wait(clock_time_t i)
 {
-  uint32_t usec;
-
-  usec = (uint32_t)((1000 * 1000 * i) / CLOCK_SECOND);
-  clock_delay_usec(usec);
+  struct timer timer;
+  timer_set(&timer, i);
+  while(!timer_expired(&timer));
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/os/sys/clock.h
+++ b/os/sys/clock.h
@@ -82,16 +82,17 @@
  * and other header files have clock_time_t defined. */
 #if CLOCK_SIZE == 4
 typedef uint32_t clock_time_t;
-#define CLOCK_LT(a, b)  ((int32_t)((a) - (b)) < 0)
+typedef int32_t clock_diff_t;
 #define CLOCK_PRI PRIu32
 #elif CLOCK_SIZE == 8
 typedef uint64_t clock_time_t;
-#define CLOCK_LT(a, b)  ((int64_t)((a) - (b)) < 0)
+typedef int64_t clock_diff_t;
 #define CLOCK_PRI PRIu64
 #else
 #error Unsupported clock_time_t size (check CLOCK_CONF_SIZE)
 #endif
 
+#define CLOCK_LT(a, b) (clock_cmp((a),(b)) < 0)
 #include "contiki.h"
 
 /**
@@ -122,6 +123,19 @@ void clock_init(void);
  * \return The current clock time, measured in system ticks.
  */
 clock_time_t clock_time(void);
+
+/**
+ * Compares two instants and returns the time span between them.
+ *
+ * \param a First instant.
+ * \param b Second instant.
+ * \return  0 if a == b, < 0 if a is before b, and > 0 otherwise.
+ *          The absolute value is the time span between a and b.
+ */
+static inline clock_diff_t clock_cmp(clock_time_t a, clock_time_t b)
+{
+  return a - b;
+}
 
 /**
  * Get the current value of the platform seconds.

--- a/os/sys/timer.c
+++ b/os/sys/timer.c
@@ -45,6 +45,7 @@
  */
 
 #include "contiki.h"
+#include "sys/cc.h"
 #include "sys/clock.h"
 #include "sys/timer.h"
 
@@ -122,11 +123,7 @@ timer_restart(struct timer *t)
 bool
 timer_expired(struct timer *t)
 {
-  /* Note: Can not return diff >= t->interval so we add 1 to diff and return
-     t->interval < diff - required to avoid an internal error in mspgcc. */
-  clock_time_t diff = (clock_time() - t->start) + 1;
-  return t->interval < diff;
-
+  return clock_cmp(t->start + t->interval, clock_time()) <= 0;
 }
 /*---------------------------------------------------------------------------*/
 /**
@@ -142,7 +139,8 @@ timer_expired(struct timer *t)
 clock_time_t
 timer_remaining(struct timer *t)
 {
-  return t->start + t->interval - clock_time();
+  clock_diff_t diff = clock_cmp(t->start + t->interval, clock_time());
+  return MAX(diff, 0);
 }
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
This PR replaces comparisons of clock_time_t values with wraparound-safe equivalents in `timer_expired()`, `timer_remaining`, and `clock_wait()`.