### PR TITLE
nat64: standalone NAT64 translator for the native platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         fail-fast: false
         matrix:
             os: [ ubuntu-latest, macos-15-intel ]
-            test: [ documentation, compile-base, compile-arm-ports, rpl-lite, rpl-classic, renode-simulation, simulation-base, ipv6, ieee802154, tun-rpl-br, script-base, native-runs, ipv6-nbr, coap-lwm2m, packet-parsing ]
+            test: [ documentation, compile-base, compile-arm-ports, rpl-lite, rpl-classic, renode-simulation, simulation-base, ipv6, ieee802154, tun-rpl-br, script-base, native-runs, ipv6-nbr, coap-lwm2m, packet-parsing, nat64-standalone ]
             exclude:
               # Renode tests done by Linux (more CI runners available).
               - os: macos-15-intel
@@ -54,6 +54,10 @@ jobs:
               # tests/utils.sh: kill_bg contains ps --ppid (not portable).
               - os: macos-15-intel
                 test: native-runs
+              # Native execution test; matches the native-runs treatment above
+              # to avoid x86 macOS surprises with the background echo server.
+              - os: macos-15-intel
+                test: nat64-standalone
               - os: macos-15-intel
                 test: coap-lwm2m
               # Failed simulations for no obvious reason, Cooja issue?

--- a/arch/platform/native/platform.c
+++ b/arch/platform/native/platform.c
@@ -215,6 +215,14 @@ set_lladdr(void)
 }
 /*---------------------------------------------------------------------------*/
 #if NETSTACK_CONF_WITH_IPV6
+/* The native node assumes a border router at PREFIX::1 and adds a default route
+ * to it. A node that reaches off-link networks some other way (for example the
+ * standalone NAT64 translator in os/services/nat64/native/standalone) sets this
+ * to 0 via its module-macros.h, suppressing a route that would be unreachable
+ * and would shadow the alternative path. */
+#ifndef NATIVE_WITH_IPV6_DEFAULT_ROUTE
+#define NATIVE_WITH_IPV6_DEFAULT_ROUTE 1
+#endif
 static void
 set_global_address(void)
 {
@@ -233,10 +241,12 @@ set_global_address(void)
   LOG_INFO_6ADDR(&ipaddr);
   LOG_INFO_("\n");
 
+#if NATIVE_WITH_IPV6_DEFAULT_ROUTE
   /* set the PREFIX::1 address to the IF */
   uip_ip6addr_copy(&ipaddr, default_prefix);
   ipaddr.u8[15] = 1;
   uip_ds6_defrt_add(&ipaddr, 0);
+#endif
 }
 #endif
 /*---------------------------------------------------------------------------*/

--- a/os/services/nat64/native/nat64-sock.c
+++ b/os/services/nat64/native/nat64-sock.c
@@ -81,7 +81,13 @@
 #endif
 
 static struct nat64_session sessions[NAT64_MAX_SESSIONS];
-static bool nat64_enabled;
+
+/* Whether NAT64 is active. Off by default and enabled with --nat64, unless a
+ * build turns it on at compile time (the standalone translator module does). */
+#ifndef NAT64_DEFAULT_ENABLED
+#define NAT64_DEFAULT_ENABLED 0
+#endif
+static bool nat64_enabled = NAT64_DEFAULT_ENABLED;
 
 /*---------------------------------------------------------------------------*/
 /**

--- a/os/services/nat64/native/standalone/Makefile.standalone
+++ b/os/services/nat64/native/standalone/Makefile.standalone
@@ -1,0 +1,11 @@
+# Standalone native NAT64 translator: lets a lone node translate its own NAT64
+# traffic over host sockets, with no border router or tun device. Pulls in the
+# NAT64 service and its native backend; module-macros.h wires
+# UIP_FALLBACK_INTERFACE to the standalone interface, so building the module is
+# all an example needs.
+MODULES += os/services/nat64 os/services/nat64/native
+
+# One host socket (hence one select callback slot) per NAT64 session, plus a
+# margin for the platform's own slots (stdin, etc.). NAT64_MAX_SESSIONS is 128.
+SELECT_CONF_MAX ?= 256
+CFLAGS += -DSELECT_CONF_MAX=$(SELECT_CONF_MAX)

--- a/os/services/nat64/native/standalone/README.md
+++ b/os/services/nat64/native/standalone/README.md
@@ -1,0 +1,51 @@
+# Standalone native NAT64 translator
+
+Lets a single native node reach IPv4 hosts through NAT64 with no border router
+and no `tun` device (hence no `sudo`). It is the same mechanism the RPL border
+router uses for NAT64 — a uIP fallback interface (`nat64_standalone_interface`)
+that hands the node's own `64:ff9b::/96` (RFC 6052) traffic to the NAT64
+service, which translates it over ordinary host IPv4 sockets — but without the
+border router, the mesh, or the `tun`.
+
+## Use
+
+Build the module into a native application; that is the whole opt-in:
+
+```makefile
+ifeq ($(TARGET),native)
+MODULES += os/services/nat64/native/standalone
+endif
+```
+
+The module's `module-macros.h` is force-included into every translation unit
+(`-imacros`), so the application needs no configuration and no code. It wires
+`UIP_FALLBACK_INTERFACE` to the standalone interface, suppresses the platform's
+default route, and enables NAT64. The application then just sends to a
+`64:ff9b::<IPv4>` address. Native target only.
+
+## Design notes
+
+- **NAT64 becomes the node's only off-link path.** uIP's fallback interface
+  fires only for packets with no route *and* no default route, and there is no
+  way to point a per-prefix route at it without an on-link next hop. So the
+  module must suppress the platform's default route to `PREFIX::1`
+  (`NATIVE_WITH_IPV6_DEFAULT_ROUTE=0`), and the fallback's `output()` drops any
+  off-link destination that is not a NAT64 address. This is exactly the
+  intended scenario — a lone node with no border router — but it does mean such
+  a node cannot also reach other IPv6 networks through some upstream.
+
+- **Mutually exclusive with the RPL border router module.** Both define
+  `UIP_FALLBACK_INTERFACE`; a binary uses one or the other, not both.
+
+- **NAT64 is enabled at compile time** (`NAT64_DEFAULT_ENABLED=1`), to stay
+  consistent with the compile-time route suppression: a build that suppressed
+  the default route but left NAT64 off (the `--nat64` default) could reach
+  nothing off-link. There is therefore no run-time switch to turn NAT64 off in
+  a standalone build. A plain `os/services/nat64/native` build (e.g. the border
+  router) is unaffected and still defaults to off until `--nat64`.
+
+## DNS
+
+The module gives raw IPv4 reachability only; there is no name resolution, so
+applications address servers by IPv4 literal embedded in the NAT64 prefix. For
+name resolution see the DNS64 support in `os/services/nat64`.

--- a/os/services/nat64/native/standalone/module-macros.h
+++ b/os/services/nat64/native/standalone/module-macros.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+ * Built into every translation unit via -imacros, so a node becomes a
+ * standalone NAT64 translator just by building the module:
+ *
+ *  - Route the node's routeless (off-link) traffic through the standalone
+ *    fallback interface, so NAT64-prefix destinations reach the translator.
+ *  - Drop the platform's default route to PREFIX::1 (platform.c). With no
+ *    border router it is unreachable, and as a default route it would shadow
+ *    the fallback interface.
+ *  - Enable NAT64 without the --nat64 flag (nat64-sock.c). Building the module
+ *    already says "this node is a NAT64 translator", and it keeps enablement a
+ *    compile-time choice that matches the route suppression above. Otherwise a
+ *    build without the flag would have neither a default route nor NAT64, and
+ *    could reach nothing off-link.
+ */
+#define UIP_FALLBACK_INTERFACE nat64_standalone_interface
+#define NATIVE_WITH_IPV6_DEFAULT_ROUTE 0
+#define NAT64_DEFAULT_ENABLED 1

--- a/os/services/nat64/native/standalone/nat64-standalone.c
+++ b/os/services/nat64/native/standalone/nat64-standalone.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * \file
+ *         Standalone native NAT64 translator: lets a single node reach IPv4
+ *         hosts through NAT64 without a border router or tun device.
+ *
+ *         NAT64 normally lives in a border router, which provides the uIP
+ *         fallback interface and initializes the translator. This module is a
+ *         native-platform stand-in: a fallback interface that hands the node's
+ *         own 64:ff9b::/96 datagrams to the NAT64 service, which translates
+ *         them over host IPv4 sockets. Its module-macros.h wires
+ *         UIP_FALLBACK_INTERFACE to this interface, so building the module is
+ *         all an application has to do.
+ *
+ * \author Nicolas Tsiftes <nicolas.tsiftes@ri.se>
+ */
+#include "contiki.h"
+#include "net/ipv6/uip.h"
+#include "nat64.h"
+#include "nat64-platform.h"
+#include "nat64-standalone.h"
+
+#include "sys/log.h"
+#define LOG_MODULE "NAT64-SA"
+#define LOG_LEVEL LOG_LEVEL_INFO
+
+/*---------------------------------------------------------------------------*/
+/*
+ * Called once at startup via UIP_FALLBACK_INTERFACE.init(). Bring up the
+ * socket translator when NAT64 is enabled. There is no default route to undo
+ * here: module-macros.h sets NATIVE_WITH_IPV6_DEFAULT_ROUTE=0, so the platform
+ * never adds one.
+ */
+static void
+init(void)
+{
+  if(nat64_is_enabled()) {
+    nat64_platform_init();
+    LOG_INFO("standalone NAT64 translator active (no border router, no tun)\n");
+  }
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * uIP hands packets with no matching route here. Translate NAT64-prefix
+ * destinations through the NAT64 service; a lone node can reach nothing else,
+ * so drop the rest.
+ */
+static int
+output(void)
+{
+  if(uip_len == 0) {
+    return 0;
+  }
+  if(nat64_is_ip64_addr(&UIP_IP_BUF->destipaddr)) {
+    return nat64_output(uip_buf, uip_len);
+  }
+  LOG_DBG("dropping off-link packet to non-NAT64 destination ");
+  LOG_DBG_6ADDR(&UIP_IP_BUF->destipaddr);
+  LOG_DBG_("\n");
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+const struct uip_fallback_interface nat64_standalone_interface = { init, output };
+/*---------------------------------------------------------------------------*/

--- a/os/services/nat64/native/standalone/nat64-standalone.h
+++ b/os/services/nat64/native/standalone/nat64-standalone.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * \file
+ *         Standalone native NAT64 translator -- see nat64-standalone.c.
+ *
+ * \author Nicolas Tsiftes <nicolas.tsiftes@ri.se>
+ */
+#ifndef NAT64_STANDALONE_H_
+#define NAT64_STANDALONE_H_
+
+#include "net/ipv6/uip.h"
+
+/**
+ * \brief uIP fallback interface that translates the node's own NAT64-prefix
+ *        traffic over host IPv4 sockets. The module's module-macros.h points
+ *        UIP_FALLBACK_INTERFACE at it automatically when the module is built.
+ */
+extern const struct uip_fallback_interface nat64_standalone_interface;
+
+#endif /* NAT64_STANDALONE_H_ */

--- a/tests/25-nat64-standalone/Makefile
+++ b/tests/25-nat64-standalone/Makefile
@@ -1,0 +1,36 @@
+# Standalone native NAT64 test.
+#
+# One check, reported via the summary/"TEST FAIL" convention that
+# tests/check-test.sh expects: build a native uIP UDP probe with the standalone
+# NAT64 module (os/services/nat64/native/standalone), send to a 64:ff9b::
+# address mapping 127.0.0.1, and check it is echoed back through the
+# translator's host sockets. Needs no Cooja, border router, tun, sudo, or
+# internet.
+#
+# Author: Nicolas Tsiftes <nicolas.tsiftes@ri.se>
+
+SHELL := /bin/bash
+
+CONTIKI ?= ../..
+
+NAT64_TEST := $(CURDIR)/test-nat64-standalone.sh
+
+.PHONY: all summary nat64-standalone clean
+
+all: summary
+
+# A successful check leaves no summary line; the final rule then creates an
+# empty summary so check-test.sh (which greps for "TEST FAIL") sees a pass.
+summary: clean
+	@$(MAKE) nat64-standalone
+	@echo "========== Summary =========="
+	@([ ! -f summary ] && echo "All tests OK" && touch summary) || \
+          (echo "Failures:" && cat summary && false)
+
+nat64-standalone:
+	@echo ">> standalone NAT64 native round-trip"
+	@$(NAT64_TEST) || echo "TEST FAIL: nat64-standalone-native" >> summary
+
+clean:
+	@rm -f *.*log *.pid report summary
+	@$(MAKE) -C code-nat64-standalone TARGET=native clean >/dev/null 2>&1 || true

--- a/tests/25-nat64-standalone/code-nat64-standalone/Makefile
+++ b/tests/25-nat64-standalone/code-nat64-standalone/Makefile
@@ -1,0 +1,13 @@
+CONTIKI_PROJECT = nat64-standalone-test
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../..
+
+# The standalone NAT64 module makes the node translate its own NAT64 traffic
+# over host sockets, enables NAT64 at compile time, and suppresses the default
+# route, so the probe needs no run-time flags. Native target only.
+ifeq ($(TARGET),native)
+MODULES += os/services/nat64/native/standalone
+endif
+
+include $(CONTIKI)/Makefile.include

--- a/tests/25-nat64-standalone/code-nat64-standalone/nat64-standalone-test.c
+++ b/tests/25-nat64-standalone/code-nat64-standalone/nat64-standalone-test.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Probe for the standalone native NAT64 translator
+ *         (os/services/nat64/native/standalone).
+ *
+ *         A plain native uIP application (no RVM, no RPL, no border router),
+ *         built with the standalone module so the node translates its own
+ *         NAT64 traffic over host sockets. It sends a UDP datagram to an IPv4
+ *         address written in the well-known NAT64 prefix (64:ff9b::/96); the
+ *         translator forwards it to a host IPv4 socket where a loopback echo
+ *         server reflects it. When the reply returns (translated back to
+ *         IPv6), the probe logs NAT64_ECHO_OK.
+ *
+ *         The destination is 127.0.0.1, which NAT64 rejects by default, so the
+ *         test build sets NAT64_CONF_ALLOW_LOOPBACK=1 (project-conf.h) to keep
+ *         the exchange on the loopback interface.
+ */
+
+#include "contiki.h"
+#include "net/ipv6/simple-udp.h"
+#include "net/ipv6/ip64-addr.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "sys/log.h"
+#define LOG_MODULE "NAT64Test"
+#define LOG_LEVEL LOG_LEVEL_INFO
+
+/* Loopback echo server port; matches test-nat64-standalone.sh. */
+#ifndef NAT64_TEST_PORT
+#define NAT64_TEST_PORT 5557
+#endif
+
+#define PROBE_INTERVAL (CLOCK_SECOND)
+#define PROBE_MAX 15
+
+static const char payload[] = "PING-NAT64";
+#define PAYLOAD_LEN (sizeof(payload) - 1)
+
+static struct simple_udp_connection udp_conn;
+static bool echo_received;
+/*---------------------------------------------------------------------------*/
+PROCESS(nat64_standalone_test_process, "standalone NAT64 probe");
+AUTOSTART_PROCESSES(&nat64_standalone_test_process);
+/*---------------------------------------------------------------------------*/
+static void
+udp_rx_callback(struct simple_udp_connection *c,
+                const uip_ipaddr_t *sender_addr, uint16_t sender_port,
+                const uip_ipaddr_t *receiver_addr, uint16_t receiver_port,
+                const uint8_t *data, uint16_t datalen)
+{
+  if(datalen == PAYLOAD_LEN && memcmp(data, payload, PAYLOAD_LEN) == 0) {
+    if(!echo_received) {
+      echo_received = true;
+      LOG_INFO("NAT64_ECHO_OK\n");
+    }
+  } else {
+    LOG_INFO("NAT64_RX_UNEXPECTED bytes=%u\n", datalen);
+  }
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(nat64_standalone_test_process, ev, data)
+{
+  static struct etimer probe_timer;
+  static uip_ipaddr_t target;
+  static unsigned probes;
+
+  PROCESS_BEGIN();
+
+  simple_udp_register(&udp_conn, NAT64_TEST_PORT, NULL, NAT64_TEST_PORT,
+                      udp_rx_callback);
+
+  /* 64:ff9b::7f00:1 maps 127.0.0.1 via the well-known NAT64 prefix. */
+  uip_nat64addr(&target, 127, 0, 0, 1);
+
+  /* Let the interface settle before the first probe. */
+  etimer_set(&probe_timer, PROBE_INTERVAL);
+  PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&probe_timer));
+
+  for(probes = 0; probes < PROBE_MAX && !echo_received; probes++) {
+    LOG_INFO("NAT64_PROBE_SEND probe=%u\n", probes);
+    simple_udp_sendto(&udp_conn, payload, PAYLOAD_LEN, &target);
+    etimer_set(&probe_timer, PROBE_INTERVAL);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&probe_timer));
+  }
+
+  if(echo_received) {
+    LOG_INFO("NAT64_TEST_DONE result=ok\n");
+  } else {
+    LOG_INFO("NAT64_TEST_DONE result=timeout\n");
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/25-nat64-standalone/code-nat64-standalone/project-conf.h
+++ b/tests/25-nat64-standalone/code-nat64-standalone/project-conf.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+/*
+ * Test-only: let the NAT64 translator forward to 127.0.0.0/8 so the round-trip
+ * stays on the host loopback (the echo server binds 127.0.0.1). NAT64 rejects
+ * loopback destinations by default; do not enable this outside a test.
+ */
+#define NAT64_CONF_ALLOW_LOOPBACK 1
+
+#endif /* PROJECT_CONF_H_ */

--- a/tests/25-nat64-standalone/test-nat64-standalone.sh
+++ b/tests/25-nat64-standalone/test-nat64-standalone.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# Round-trip test for the standalone native NAT64 translator
+# (os/services/nat64/native/standalone). Needs no Cooja, border router, tun,
+# sudo, or internet:
+#   1. Build a plain native uIP UDP probe with the standalone module. The
+#      module makes the node translate its own NAT64 traffic over host sockets,
+#      enables NAT64 at compile time, and suppresses the default route.
+#   2. Start a Python IPv4 echo server on 127.0.0.1 (reused from
+#      tests/17-tun-rpl-br).
+#   3. Run the probe. It sends "PING-NAT64" to 64:ff9b::7f00:1 (= 127.0.0.1 via
+#      the well-known NAT64 prefix); the translator turns it into an IPv4
+#      loopback datagram, the server reflects it, and the translator turns the
+#      reply back into IPv6.
+#   4. Assert the server saw the IPv4 datagram (IPv6->IPv4 leg) and the probe
+#      logged NAT64_ECHO_OK (IPv4->IPv6 return leg).
+#
+# The probe build sets NAT64_CONF_ALLOW_LOOPBACK=1 (project-conf.h) so the
+# whole exchange stays on the loopback interface.
+#
+# Author: Nicolas Tsiftes <nicolas.tsiftes@ri.se>
+
+set -u
+
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTIKI="$THIS_DIR/../.."
+PROBE_DIR="$THIS_DIR/code-nat64-standalone"
+ECHO_SERVER="$CONTIKI/tests/17-tun-rpl-br/nat64-echo-server.py"
+
+UDP_PORT=5557
+TCP_PORT=5558
+RUN_TIME=20
+
+PROBE_BIN="$PROBE_DIR/build/native/nat64-standalone-test.native"
+BUILD_LOG="$THIS_DIR/nat64-standalone.buildlog"
+PROBE_LOG="$THIS_DIR/nat64-standalone.probelog"
+ECHO_LOG="$THIS_DIR/nat64-standalone.echo.log"
+ECHO_PIDFILE="$THIS_DIR/nat64-standalone.echo.pid"
+
+cleanup() {
+  if [ -f "$ECHO_PIDFILE" ]; then
+    PID=$(cat "$ECHO_PIDFILE" 2>/dev/null || true)
+    [ -n "$PID" ] && kill "$PID" 2>/dev/null || true
+    rm -f "$ECHO_PIDFILE"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+rm -f "$BUILD_LOG" "$PROBE_LOG" "$ECHO_LOG" "$ECHO_PIDFILE"
+
+echo "Building standalone NAT64 probe"
+if ! make -C "$PROBE_DIR" -B TARGET=native nat64-standalone-test \
+     >"$BUILD_LOG" 2>&1; then
+  echo "FAIL: probe build failed"
+  tail -n 40 "$BUILD_LOG"
+  exit 1
+fi
+
+echo "Starting IPv4 echo server (UDP $UDP_PORT) on 127.0.0.1"
+python3 "$ECHO_SERVER" \
+  --host 127.0.0.1 \
+  --udp-port "$UDP_PORT" \
+  --tcp-port "$TCP_PORT" \
+  --log "$ECHO_LOG" \
+  --pidfile "$ECHO_PIDFILE" &
+
+# Wait for the server to bind before launching the probe.
+for _ in 1 2 3 4 5; do
+  grep -q "UDP_LISTEN" "$ECHO_LOG" 2>/dev/null && break
+  sleep 1
+done
+if ! grep -q "UDP_LISTEN" "$ECHO_LOG" 2>/dev/null; then
+  echo "FAIL: echo server did not start"
+  cat "$ECHO_LOG" 2>/dev/null || true
+  exit 1
+fi
+
+echo "Running probe (up to ${RUN_TIME}s)"
+# The probe exits on its own once it gets the echo back (NAT64_TEST_DONE); the
+# timeout is only a backstop.
+timeout "$RUN_TIME" "$PROBE_BIN" >"$PROBE_LOG" 2>&1
+
+STATUS=0
+
+if grep -q "UDP_ECHO .*payload=b'PING-NAT64'" "$ECHO_LOG" 2>/dev/null; then
+  echo "PASS: echo server received the translated IPv4 datagram"
+else
+  echo "FAIL: echo server saw no PING-NAT64 datagram (IPv6->IPv4 leg)"
+  STATUS=1
+fi
+
+if grep -q "NAT64_ECHO_OK" "$PROBE_LOG" 2>/dev/null; then
+  echo "PASS: probe received the reflected datagram back over IPv6"
+else
+  echo "FAIL: probe did not log NAT64_ECHO_OK (IPv4->IPv6 return leg)"
+  STATUS=1
+fi
+
+if [ $STATUS -ne 0 ]; then
+  echo "==== probe log ===="
+  cat "$PROBE_LOG" 2>/dev/null || true
+  echo "==== echo server log ===="
+  cat "$ECHO_LOG" 2>/dev/null || true
+fi
+
+exit $STATUS


### PR DESCRIPTION
This PR lets a single native node reach IPv4 hosts through NAT64 with no border router and no `tun` device (hence no `sudo`). It reuses the same mechanism the RPL border router uses for NAT64: a uIP fallback interface that hands the node's own `64:ff9b::/96` traffic to the NAT64 service for translation over ordinary host IPv4 sockets, but without the border router or the tun.