### PR TITLE
NAT64: fix TCP/UDP session handling bugs in the stateful gateway

### DIFF
--- a/doc/Home.md
+++ b/doc/Home.md
@@ -23,7 +23,7 @@ Also feel free to download our [cheat sheet](https://contiki-ng.github.io/resour
 * [Vagrant image](/doc/getting-started/Vagrant.md)
 * [Native toolchain installation (Linux)](/doc/getting-started/Toolchain-installation-on-Linux.md)
 * [Native toolchain installation (macOS)](/doc/getting-started/Toolchain-installation-on-macOS.md)
-* [IP64 setup with Jool](/doc/getting-started/NAT64-for-Contiki-NG.md)
+* [NAT64 setup](/doc/getting-started/NAT64-for-Contiki-NG.md)
 * [The Contiki-NG build system](/doc/getting-started/The-Contiki-NG-build-system.md)
 * [The Contiki-NG configuration system](/doc/getting-started/The-Contiki-NG-configuration-system.md)
 * [The Contiki-NG logging system](/doc/getting-started/The-Contiki-NG-logging-system.md)

--- a/doc/getting-started/NAT64-for-Contiki-NG.md
+++ b/doc/getting-started/NAT64-for-Contiki-NG.md
@@ -124,9 +124,9 @@ NAT64-prefixed IPv6 addresses.
 
 | Protocol | Support |
 |----------|---------|
-| UDP | Full — CoAP, DNS, and other UDP-based protocols work transparently. |
-| TCP | Full — the border router runs a TCP splice proxy that handles connection setup, data forwarding, and teardown. |
-| ICMP | Echo Request/Reply (ping) is forwarded via Linux unprivileged ICMP sockets. Destination Unreachable errors are synthesized toward the IoT node when packets cannot be delivered. Other ICMP types are not translated. |
+| UDP | Outbound client-initiated flows. CoAP, DNS, and other UDP payloads are forwarded transparently, except DNS on port 53, which is rewritten by DNS64. UDP payloads are not segmented by NAT64. |
+| TCP | Outbound client-initiated flows. The border router runs a TCP splice proxy that handles connection setup, data forwarding, retransmission toward the IoT node, and teardown. |
+| ICMP | Echo Request/Reply (ping) only, via Linux unprivileged ICMP sockets. Destination Unreachable errors are synthesized toward the IoT node when packets cannot be delivered. Other ICMP types are not translated. |
 
 ### End-to-end security and application protocols
 
@@ -177,7 +177,8 @@ unconditionally:
 ## Example application
 
 The `examples/nat64/` directory contains a demo that performs a DNS
-lookup and sends UDP probes and an HTTP GET request through NAT64:
+lookup, sends UDP probes, and performs one HTTP GET request through
+NAT64:
 
 ```bash
 # In one terminal, start Cooja with the NAT64 simulation:
@@ -228,16 +229,18 @@ headroom to raise `NAT64_TCP_SEGMENT_SIZE` from 76 to ~84 bytes
 (about a 10% TCP throughput improvement) and reduces 6LoWPAN
 fragmentation pressure on UDP responses and DTLS handshakes.
 
-To enable, include the helper header on **both** sides:
+To enable the context on IoT nodes, include the helper header in each
+NAT64-using project:
 
 ```c
 /* In the IoT node's project-conf.h: */
 #include "services/nat64/nat64-6lowpan.h"
 ```
 
-The border router picks up the matching context automatically:
+The native border router picks up the matching context automatically:
 `examples/rpl-border-router/project-conf.h` includes the same
-header when `MAKE_WITH_NAT64=1` is set on the make command line.
+header whenever the border-router build includes the NAT64 module
+(`BUILD_WITH_NAT64` is defined by `os/services/nat64/module-macros.h`).
 
 Both ends MUST agree on the prefix bytes and the context number.
 If only one side is configured, decompression on the other side
@@ -255,6 +258,31 @@ If your deployment uses a non-standard NAT64 prefix configured
 via `ip64_addr_set_prefix()`, override `NAT64_6LOWPAN_PREFIX_BYTES`
 to match before including the header — both ends must use the
 same value.
+
+## Troubleshooting
+
+- **`--nat64` is not accepted by the border router.** Make sure you are
+  running a native border-router build that includes
+  `os/services/nat64/native`. The standard native
+  `examples/rpl-border-router` build does this automatically.
+- **DNS lookups work, but NAT64 packets disappear on the 6LoWPAN side.**
+  Check that the border router and every NAT64-using IoT node agree on
+  the same IPHC context. For the default prefix, include
+  `services/nat64/nat64-6lowpan.h` in the IoT node project; the native
+  border router includes the matching context automatically when NAT64
+  is compiled in.
+- **Ping through NAT64 fails.** ICMP Echo uses Linux unprivileged ICMP
+  sockets. The running user must either have the required capability or
+  be permitted by `net.ipv4.ping_group_range`.
+- **Private, loopback, link-local, or documentation IPv4 addresses do
+  not work.** This is intentional gateway policy. Special-use IPv4
+  ranges are rejected before a host socket is opened. Loopback can be
+  enabled only for tests by building the native border router with
+  `NAT64_ALLOW_LOOPBACK=1`.
+- **Long-lived UDP or TCP sessions stop after being idle.** NAT64
+  reaps idle sessions after `NAT64_SESSION_TIMEOUT` (5 minutes by
+  default). Use application keepalives, or for DTLS use Connection ID
+  or reconnect after idle periods.
 
 ## Standards compliance
 

--- a/examples/nat64/README.md
+++ b/examples/nat64/README.md
@@ -16,8 +16,9 @@ them from IPv6 to IPv4, and forwards them to 8.8.8.8 via a host UDP
 socket. Responses are translated back with DNS64 synthesis: A records
 (IPv4 addresses) become AAAA records with the `64:ff9b::/96` prefix.
 
-After each successful lookup, the node sends a UDP probe to the resolved
-address to demonstrate end-to-end connectivity to the IPv4 internet.
+After successful lookups, the node exercises both transport paths:
+it sends UDP probes for the non-HTTP hosts and performs one HTTP GET
+to `www.contiki-ng.org` to test the TCP splice proxy end to end.
 
 ## Testing with Cooja (no hardware needed)
 
@@ -51,7 +52,10 @@ NAT64 DNS client starting, waiting for network...
 DNS server set to 64:ff9b::808:808 (8.8.8.8 via NAT64)
 Querying DNS for "www.contiki-ng.org"...
 Resolved "www.contiki-ng.org" -> 64:ff9b::b63c:d8a7
-Sent UDP probe to 64:ff9b::b63c:d8a7 (www.contiki-ng.org)
+Starting HTTP GET http://www.contiki-ng.org/
+HTTP complete: received <n> body bytes
+Resolved "www.example.com" -> 64:ff9b::<ipv4>
+Sent UDP probe to 64:ff9b::<ipv4> (www.example.com)
 ```
 
 ## Running on real hardware
@@ -95,9 +99,9 @@ IoT node                    Border router (native)          Internet
    |<-- DNS response (AAAA) -----|   (DNS64 synthesis)        |
    |   64:ff9b::<ipv4>           |                            |
    |                              |                            |
-   |-- UDP probe (IPv6) -------->|                            |
+   |-- UDP probe or HTTP GET ---->|                            |
    |   to 64:ff9b::<ipv4>        |-- UDP probe (IPv4) ------->|
-   |                              |   to <ipv4>               |
+   |                              |   or TCP connect+HTTP ---->|
 ```
 
 ## Files

--- a/examples/nat64/project-conf.h
+++ b/examples/nat64/project-conf.h
@@ -43,8 +43,8 @@
 /* Register the NAT64 prefix as 6LoWPAN compression context 1, saving
  * ~8 bytes of header per NAT64-bound packet.  The border router
  * picks up the matching context automatically because its
- * project-conf.h conditionally includes this header when built with
- * MAKE_WITH_NAT64=1. */
+ * project-conf.h includes this header whenever the NAT64 module is
+ * present in the native border-router build. */
 #include "services/nat64/nat64-6lowpan.h"
 
 #endif /* PROJECT_CONF_H_ */

--- a/examples/rpl-border-router/project-conf.h
+++ b/examples/rpl-border-router/project-conf.h
@@ -50,7 +50,7 @@
 #define UIP_CONF_TCP 1
 #endif
 
-/* When the BR is built with NAT64 (MAKE_WITH_NAT64=1), register the
+/* When the native BR build includes the NAT64 module, register the
  * NAT64 prefix as a 6LoWPAN compression context so its IPHC encoder
  * matches IoT nodes that include the same header in their own
  * project-conf.h. */

--- a/os/services/nat64/README.md
+++ b/os/services/nat64/README.md
@@ -113,9 +113,10 @@ in lossy wireless networks.
 registers the upper 64 bits of the NAT64 prefix as IPHC context 1,
 saving ~8 header bytes per packet.  Both the BR and the IoT nodes
 must include the header at compile time — the BR pulls it in
-automatically when built with `MAKE_WITH_NAT64=1`, and IoT projects
-opt in via `#include "services/nat64/nat64-6lowpan.h"` in their
-`project-conf.h`.  IPHC's SAM modes cap inline-byte counts at
+automatically when the NAT64 module is present in the native
+border-router build, and IoT projects opt in via
+`#include "services/nat64/nat64-6lowpan.h"` in their
+`project-conf.h`. IPHC's SAM modes cap inline-byte counts at
 0/2/8/16, so even a longer (96-bit) context cannot push the
 saving further without a non-standard extension.  Once Contiki-NG
 implements RFC 6775 §4.2 (6CO ND option), the symmetric
@@ -123,7 +124,11 @@ compile-time requirement can be lifted.
 
 ## Usage
 
-Enable NAT64 on the border router with the `--nat64` command-line flag:
+See `doc/getting-started/NAT64-for-Contiki-NG.md` for full build,
+Cooja, hardware, DNS, and troubleshooting instructions.
+
+For the native border router, enable NAT64 at run time with the
+`--nat64` command-line flag:
 
 ```bash
 sudo ./border-router.native --nat64 -s /dev/ttyUSB0

--- a/os/services/nat64/nat64-dns64.c
+++ b/os/services/nat64/nat64-dns64.c
@@ -75,16 +75,16 @@
 #define DNS_QTAIL_QCLASS    2
 #define DNS_QTAIL_SIZE      4
 
-/* Read a big-endian uint16 from a byte buffer. */
-#define RD16(p) (((uint16_t)(p)[0] << 8) | (p)[1])
-/* Write a big-endian uint16 into a byte buffer. */
-#define WR16(p, v) do { (p)[0] = (uint8_t)((v) >> 8); \
-                        (p)[1] = (uint8_t)(v); } while(0)
+/* Read a big-endian uint16 from a DNS packet buffer. */
+#define RD16(bytes) (((uint16_t)(bytes)[0] << 8) | (bytes)[1])
+/* Write a big-endian uint16 into a DNS packet buffer. */
+#define WR16(bytes, value) do { (bytes)[0] = (uint8_t)((value) >> 8); \
+                                (bytes)[1] = (uint8_t)(value); } while(0)
 /*---------------------------------------------------------------------------*/
 /*
- * Skip over a DNS name in a packet (handling label sequences and
- * compressed pointers per RFC 1035 Section 4.1.4).
- * Returns a pointer past the name, or NULL on error.
+ * DNS names can be either inline label chains or two-byte compression
+ * pointers. Callers only need the byte range occupied by the encoded
+ * name; pointer targets are never dereferenced here.
  */
 static const uint8_t *
 skip_dns_name(const uint8_t *p, const uint8_t *end)
@@ -123,7 +123,8 @@ nat64_dns64_6to4(uint8_t *data, uint16_t len)
   LOG_DBG("DNS64 6to4: id=0x%04x, %u questions\n",
           RD16(&data[DNS_HDR_ID]), qdcount);
 
-  /* Walk each question and change AAAA queries to A. */
+  /* Ask the upstream IPv4 resolver for A records on behalf of each
+   * IoT-side AAAA question. */
   for(uint16_t i = 0; i < qdcount; i++) {
     const uint8_t *after_name = skip_dns_name(p, end);
     if(after_name == NULL || after_name + DNS_QTAIL_SIZE > end) {
@@ -164,8 +165,8 @@ nat64_dns64_4to6(const uint8_t *ipv4data, uint16_t ipv4len,
   LOG_DBG("DNS64 4to6: id=0x%04x, %u answers\n",
           RD16(&ipv4data[DNS_HDR_ID]), ancount);
 
-  /* Skip past the question section in both src and dst buffers.
-   * Also patch QTYPE from A back to AAAA in the output. */
+  /* The response should still look like an answer to the IoT node's
+   * original AAAA question, even though the upstream query was A. */
   for(uint16_t i = 0; i < qdcount; i++) {
     const uint8_t *after_name = skip_dns_name(src, src_end);
     if(after_name == NULL || after_name + DNS_QTAIL_SIZE > src_end) {
@@ -181,12 +182,9 @@ nat64_dns64_4to6(const uint8_t *ipv4data, uint16_t ipv4len,
     dst = ipv6data + (src - ipv4data);
   }
 
-  /* Now process each answer RR.  A (4-byte RDATA) records are expanded
-   * to AAAA (16 bytes), shifting all subsequent data by +12 per record.
-   * After the answer section we truncate authority and additional
-   * sections rather than attempting to relocate them — their data would
-   * be at wrong offsets after expansion, and IoT resolvers do not need
-   * them. */
+  /* Expanding A records shifts every later byte in the DNS message.
+   * We rewrite complete answers only, then drop authority/additional
+   * sections whose compressed names may point at offsets that moved. */
   uint16_t emitted_ancount = 0;
   /* Marks the start of the current answer's output bytes.  On a
    * mid-RR truncate, dst is rewound to this point so the message
@@ -195,7 +193,6 @@ nat64_dns64_4to6(const uint8_t *ipv4data, uint16_t ipv4len,
   for(uint16_t i = 0; i < ancount; i++) {
     rr_start = dst;
 
-    /* Copy/skip the name in the answer. */
     const uint8_t *name_end = skip_dns_name(src, src_end);
     if(name_end == NULL) {
       goto truncate;
@@ -209,7 +206,6 @@ nat64_dns64_4to6(const uint8_t *ipv4data, uint16_t ipv4len,
     src += name_len;
     dst += name_len;
 
-    /* We need at least 10 bytes for TYPE(2)+CLASS(2)+TTL(4)+RDLENGTH(2). */
     if(src + 10 > src_end) {
       goto truncate;
     }

--- a/os/services/nat64/nat64-platform.h
+++ b/os/services/nat64/nat64-platform.h
@@ -97,7 +97,8 @@ struct nat64_session {
  * \brief Initialize the platform layer.
  * \return true on success, false on failure.
  *
- * Allocates the session table and calls nat64_activate().
+ * On success, the NAT64 core has been activated and the platform is
+ * ready to create transport sessions for translated packets.
  */
 bool nat64_platform_init(void);
 
@@ -136,8 +137,9 @@ int nat64_platform_udp_send(const uip_ip4addr_t *dst, uint16_t dstport,
  * \param peer_isn The IoT node's initial sequence number.
  * \return The session, or NULL on failure.
  *
- * Uses non-blocking connect().  Calls nat64_tcp_established()
- * asynchronously when the connection completes.
+ * The returned session may still be connecting.  The platform calls
+ * nat64_tcp_established() later, from its event loop, once the IPv4
+ * connection is usable.
  */
 struct nat64_session *nat64_platform_tcp_connect(
   const uip_ip4addr_t *dst, uint16_t dstport,
@@ -150,6 +152,10 @@ struct nat64_session *nat64_platform_tcp_connect(
  * \param data Data to send.
  * \param len  Data length.
  * \return Number of bytes sent, 0 if would block, or -1 on error.
+ *
+ * A zero return means NAT64 did not retain the payload.  The TCP core
+ * must leave its IoT-side acknowledgment point unchanged so the node
+ * retransmits the same bytes.
  */
 int nat64_platform_tcp_send(struct nat64_session *s,
                             const uint8_t *data, uint16_t len);

--- a/os/services/nat64/nat64-tcp.c
+++ b/os/services/nat64/nat64-tcp.c
@@ -413,8 +413,8 @@ nat64_tcp_output(const uint8_t *pkt, uint16_t len)
 
   tcp = (const struct tcphdr *)(pkt + IPV6_HDRLEN);
   data_offset = ((tcp->offset >> 4) & 0x0f) * 4;
-  if(data_offset > payload_len) {
-    LOG_WARN("tcp_output: data offset %u exceeds payload %u\n",
+  if(data_offset < TCP_HDRLEN || data_offset > payload_len) {
+    LOG_WARN("tcp_output: invalid data offset %u for payload %u\n",
              data_offset, payload_len);
     return 0;
   }

--- a/os/services/nat64/nat64-tcp.c
+++ b/os/services/nat64/nat64-tcp.c
@@ -202,6 +202,7 @@ struct tcp_seqstate {
   bool peer_fin_received;
   bool server_fin_pending;
   struct nat64_session *session;
+  uint32_t initial_our_seq;
   uint32_t our_seq;
   uint32_t peer_next;
   /* Paced delivery buffer for server→IoT data. */
@@ -287,6 +288,7 @@ alloc_seqstate(struct nat64_session *s, uint32_t peer_isn)
       tcp_seq[i].server_fin_pending = false;
       tcp_seq[i].session = s;
       tcp_seq[i].our_seq = generate_isn(s);
+      tcp_seq[i].initial_our_seq = tcp_seq[i].our_seq;
       tcp_seq[i].peer_next = peer_isn + 1;
       tcp_seq[i].rxbuf_len = 0;
       tcp_seq[i].rxbuf_offset = 0;
@@ -423,6 +425,19 @@ nat64_tcp_output(const uint8_t *pkt, uint16_t len)
            tcp->flags, data_len, (unsigned long)seq);
 
   if(tcp->flags & TCP_SYN) {
+    struct tcp_seqstate *ts = find_seqstate_by_addrs(
+      &ip6->src, uip_ntohs(tcp->sport),
+      &dst4, uip_ntohs(tcp->dport));
+    if(ts != NULL) {
+      uint32_t saved_seq = ts->our_seq;
+
+      LOG_INFO("TCP duplicate SYN: retransmitting SYN-ACK\n");
+      ts->our_seq = ts->initial_our_seq;
+      inject_tcp(ts->session, ts, TCP_SYN | TCP_ACK, NULL, 0);
+      ts->our_seq = saved_seq;
+      return 1;
+    }
+
     LOG_INFO("TCP SYN: port %u -> %u.%u.%u.%u:%u\n",
              uip_ntohs(tcp->sport),
              dst4.u8[0], dst4.u8[1], dst4.u8[2], dst4.u8[3],

--- a/os/services/nat64/nat64-tcp.c
+++ b/os/services/nat64/nat64-tcp.c
@@ -83,8 +83,10 @@
 #define NAT64_TCP_SEGMENT_SIZE 76
 #endif
 
-/* Per-session buffer for paced server-to-IoT delivery.  Must hold at
- * least one recv() worth of data from the IPv4 socket. */
+/* The native socket backend reads up to 1500 bytes at a time.  The
+ * splice proxy does not have a second staging buffer, so this buffer
+ * must be large enough to retain every byte already consumed from the
+ * IPv4 socket. */
 #ifndef NAT64_TCP_RXBUF_SIZE
 #define NAT64_TCP_RXBUF_SIZE 1500
 #endif
@@ -197,7 +199,17 @@ tcp6_checksum(const struct v6hdr *ip6, const void *tcp, uint16_t tcp_len)
 }
 
 /*---------------------------------------------------------------------------*/
-/* Per-session TCP sequence number state.                                    */
+/* Per-session TCP sequence number state.
+ *
+ * The proxy terminates TCP on both sides, so the numbers here describe
+ * only the synthetic IoT-facing stream.  our_seq is the next sequence
+ * number to send to the IoT node; peer_next is the next sequence number
+ * expected from it.  Buffered server data is stop-and-wait: while
+ * in_flight is non-zero, rxbuf_offset and our_seq still point at the
+ * retransmittable bytes and advance only after the IoT ACK covers them.
+ * initial_our_seq is kept separately so a retransmitted SYN can get the
+ * same SYN-ACK even after our_seq has advanced past the SYN.
+ */
 /*---------------------------------------------------------------------------*/
 
 struct tcp_seqstate {
@@ -209,7 +221,7 @@ struct tcp_seqstate {
   uint32_t initial_our_seq;
   uint32_t our_seq;
   uint32_t peer_next;
-  /* Paced delivery buffer for server→IoT data. */
+  /* Paced delivery buffer for server-to-IoT data. */
   uint8_t rxbuf[NAT64_TCP_RXBUF_SIZE];
   uint16_t rxbuf_len;
   uint16_t rxbuf_offset;
@@ -486,8 +498,8 @@ nat64_tcp_output(const uint8_t *pkt, uint16_t len)
         nat64_tcp_ack_confirmed(ts);
       }
     } else if(ts->rxbuf_len > ts->rxbuf_offset) {
-      /* No segment in flight but data is buffered (e.g., recovery
-       * after retransmit-limit teardown of a sibling state). */
+      /* Make progress if the previous sender stopped after clearing
+       * in_flight but before queuing the next buffered segment. */
       nat64_tcp_send_pending(ts);
     }
   }
@@ -725,8 +737,8 @@ nat64_tcp_data_in(struct nat64_session *s,
   ts->rxbuf_len = len;
   ts->rxbuf_offset = 0;
 
-  /* Send the first chunk immediately; the rest will be paced by
-   * nat64_tcp_send_pending() as ACKs arrive from the IoT node. */
+  /* ACK pacing starts immediately; later chunks are sent only after
+   * the IoT node confirms the previous one. */
   nat64_tcp_send_pending(ts);
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/nat64/nat64-tcp.c
+++ b/os/services/nat64/nat64-tcp.c
@@ -688,8 +688,8 @@ nat64_tcp_established(struct nat64_session *s)
 {
   struct tcp_seqstate *ts = alloc_seqstate(s, s->peer_isn);
   if(ts == NULL) {
-    LOG_ERR("TCP seqstate table full, closing connection\n");
-    nat64_platform_tcp_close(s);
+    LOG_ERR("TCP seqstate table full, aborting connection\n");
+    nat64_platform_tcp_abort(s);
     return;
   }
 

--- a/os/services/nat64/nat64-tcp.c
+++ b/os/services/nat64/nat64-tcp.c
@@ -89,6 +89,10 @@
 #define NAT64_TCP_RXBUF_SIZE 1500
 #endif
 
+#if NAT64_TCP_RXBUF_SIZE < 1500
+#error "NAT64_TCP_RXBUF_SIZE must be at least 1500 bytes"
+#endif
+
 /* Retransmit timeout for an injected paced segment that has not been
  * ACKed by the IoT node.  Sized for typical 6LoWPAN RTTs (100 ms - 1 s)
  * with margin; the IoT-facing TCP layer does not generate dup-ACKs for

--- a/os/services/nat64/nat64.c
+++ b/os/services/nat64/nat64.c
@@ -485,8 +485,6 @@ handle_icmp6_output(const uint8_t *pkt, const struct v6hdr *ip6,
 
   icmp = pkt + IPV6_HDRLEN;
 
-  /* Only Echo Request is forwarded.  Other ICMPv6 types (Neighbor
-   * Discovery, MLD, ...) are link-local and never traverse NAT64. */
   if(icmp[0] != ICMP6_ECHO_REQUEST) {
     LOG_DBG("icmp6_output: ignoring ICMPv6 type %u\n", icmp[0]);
     return 0;
@@ -498,8 +496,6 @@ handle_icmp6_output(const uint8_t *pkt, const struct v6hdr *ip6,
     return 0;
   }
 
-  /* Translate to ICMPv4 Echo Request: rewrite type and recompute the
-   * checksum (which has no IPv4 pseudo-header). */
   memcpy(icmp_buf, icmp, payload_len);
   icmp_buf[0] = ICMP4_ECHO_REQUEST;
   icmp_buf[2] = 0;

--- a/os/services/nat64/native/nat64-sock.c
+++ b/os/services/nat64/native/nat64-sock.c
@@ -292,8 +292,9 @@ generic_set_fd(fd_set *rset, fd_set *wset)
       FD_SET(s->fd, wset);
     } else if(s->proto == NAT64_PROTO_TCP &&
               nat64_tcp_has_pending_data(s)) {
-      /* Don't read more data while the previous chunk is still being
-       * paced to the IoT node — this provides back-pressure. */
+      /* The TCP proxy owns only one server-to-IoT buffer.  Suppressing
+       * reads here keeps unread bytes in the kernel until the IoT node
+       * ACKs the current chunk. */
     } else {
       FD_SET(s->fd, rset);
     }
@@ -536,16 +537,9 @@ nat64_platform_tcp_send(struct nat64_session *s,
   sent = send(s->fd, data, len, 0);
   if(sent < 0) {
     if(errno == EAGAIN || errno == EWOULDBLOCK) {
-      /* Kernel send buffer full.  Returning 0 leaves peer_next un-
-       * advanced in nat64_tcp_output(), so the IoT-side TCP layer
-       * sees no ACK progress and retransmits on its RTO.  We don't
-       * register for write-readiness here because we don't buffer
-       * the IoT-side payload locally — the source of truth for the
-       * unsent bytes is the IoT TCP send queue, not us, so polling
-       * for writability would have nothing to flush.  Sustained
-       * EAGAIN under 6LoWPAN throughput is essentially unreachable
-       * (kernel buffers >>> radio bandwidth); log it and rely on
-       * IoT retransmits for recovery. */
+      /* NAT64 does not own a copy of IoT-to-server bytes.  Returning 0
+       * leaves peer_next unchanged, so the IoT TCP stack remains the
+       * source of truth and retransmits the unsent data on its RTO. */
       LOG_WARN("TCP send would block (fd %d), IoT will retransmit\n",
                s->fd);
       return 0;

--- a/os/services/nat64/native/nat64-sock.c
+++ b/os/services/nat64/native/nat64-sock.c
@@ -358,6 +358,7 @@ generic_handle_fd(fd_set *rset, fd_set *wset)
       ssize_t n = recv(s->fd, buf, sizeof(buf), 0);
       if(n > 0) {
         nat64_udp_input(s, buf, (uint16_t)n);
+        timer_set(&s->expiry, NAT64_SESSION_TIMEOUT);
       } else if(n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
         int e = errno;
 

--- a/os/services/nat64/native/nat64-sock.c
+++ b/os/services/nat64/native/nat64-sock.c
@@ -359,7 +359,13 @@ generic_handle_fd(fd_set *rset, fd_set *wset)
       if(n > 0) {
         nat64_udp_input(s, buf, (uint16_t)n);
       } else if(n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-        LOG_ERR("UDP recvfrom error (fd %d): %s\n", s->fd, strerror(errno));
+        int e = errno;
+
+        LOG_ERR("UDP recvfrom error (fd %d): %s\n", s->fd, strerror(e));
+        nat64_queue_icmp6_unreach_tuple(&s->ip6_peer, s->ip6_peer_port,
+                                        &s->ip4_remote, s->ip4_remote_port,
+                                        IPPROTO_UDP, errno_to_icmp6_code(e));
+        close_session(s);
       }
     } else if(s->proto == NAT64_PROTO_ICMP) {
       uint8_t buf[256];


### PR DESCRIPTION
Several correctness fixes for the NAT64 stateful gateway used by the native  border router, plus comment/documentation cleanup.

**TCP**
- Retransmit the SYN-ACK so connection setup survives a lost handshake packet.
- Abort sessions that have no seqstate rather than acting on inconsistent state.
- Validate TCP data offsets before use to avoid out-of-bounds access.
- Enforce the configured TCP receive buffer size.

**UDP**
- Refresh UDP session timers on input so active flows aren't reaped early.
- Relay UDP socket errors back to the peer.

**Docs/comments**
- Clarify NAT64/DNS64 implementation comments.
- Improve the NAT64 user documentation.