### PR TITLE
lwm2m-tlv: bounds-check lwm2m_tlv_read against available buffer length

### DIFF
--- a/os/services/lwm2m/lwm2m-engine.c
+++ b/os/services/lwm2m/lwm2m-engine.c
@@ -1151,6 +1151,12 @@ perform_multi_resource_write_op(lwm2m_object_t *object,
 
     while(tlvpos < insize) {
       len = lwm2m_tlv_read(&tlv, &inbuf[tlvpos], insize - tlvpos);
+      if(len == 0) {
+        /* Malformed or truncated TLV - stop parsing to avoid a stuck loop. */
+        LOG_WARN("Failed to read TLV at offset %d/%d\n",
+                 (int)tlvpos, (int)insize);
+        return LWM2M_STATUS_BAD_REQUEST;
+      }
       LOG_DBG("Got TLV format First is: type:%d id:%d len:%d (p:%d len:%d/%d)\n",
              tlv.type, tlv.id, (int) tlv.length,
              (int) tlvpos, (int) len, (int) insize);

--- a/os/services/lwm2m/lwm2m-tlv.c
+++ b/os/services/lwm2m/lwm2m-tlv.c
@@ -74,9 +74,24 @@ lwm2m_tlv_read(lwm2m_tlv_t *tlv, const uint8_t *buffer, size_t len)
   uint8_t len_pos = 1;
   size_t tlv_len;
 
+  /* A TLV needs at least the type byte and a single ID byte. */
+  if(len < 2) {
+    LOG_WARN("Truncated TLV header (%u bytes available).\n", (unsigned)len);
+    return 0;
+  }
+
   tlv->type = (buffer[0] >> 6) & 3;
   len_type = (buffer[0] >> 3) & 3;
   len_pos = 1 + (((buffer[0] & (1 << 5)) != 0) ? 2 : 1);
+
+  /* len_pos is the offset of the length field (== header size when there
+     is no separate length field). Ensure the ID bytes and any length
+     bytes are within the buffer before reading them. */
+  if(len < (size_t)len_pos + len_type) {
+    LOG_WARN("Truncated TLV header (need %u bytes, have %u).\n",
+             (unsigned)(len_pos + len_type), (unsigned)len);
+    return 0;
+  }
 
   tlv->id = buffer[1];
   /* if len_pos is larger than two it means that there is more ID to read */
@@ -94,6 +109,15 @@ lwm2m_tlv_read(lwm2m_tlv_t *tlv, const uint8_t *buffer, size_t len)
       len_type--;
     }
   }
+
+  /* Ensure the value fits within the remaining buffer. len_pos now points
+     to the first value byte and is guaranteed to be <= len. */
+  if(tlv_len > len - len_pos) {
+    LOG_WARN("Truncated TLV value (need %u bytes, have %u).\n",
+             (unsigned)tlv_len, (unsigned)(len - len_pos));
+    return 0;
+  }
+
   /* and read out the data??? */
   tlv->length = tlv_len;
   tlv->value = &buffer[len_pos];


### PR DESCRIPTION
lwm2m_tlv_read() accepted a len argument but never used it, so it would read the TLV type/ID/length header and report a value pointer and length without verifying they fit within the supplied buffer. A truncated or malformed TLV (e.g. the last TLV in a payload with too few bytes left) caused out-of-bounds reads of the header and let tlv->value/tlv->length reference memory past the end of the input.

Validate that the header bytes and the declared value length all fit within len, returning 0 otherwise. The TLV reader callbacks and the inner write loop already treat a 0 return as a stop/failure; add the same guard to the outer loop in perform_multi_resource_write_op(), which advanced by the return value and would otherwise spin on a 0-length read.