### PR TITLE
lwm2m: harden TLV/JSON parsing against malformed input

### DIFF
--- a/os/services/lwm2m/lwm2m-engine.c
+++ b/os/services/lwm2m/lwm2m-engine.c
@@ -1143,8 +1143,12 @@ perform_multi_resource_write_op(lwm2m_object_t *object,
       LOG_DBG("Last TLV ID:%d final:%d\n", last_tlv_id,
               lwm2m_object_is_final_incoming(ctx));
       if(offset > 0) {
+        /* The BLOCK1 size is derived from the option's SZX field and is
+           independent of the actual payload length. Clamp it to the bytes
+           actually present so the resource callback cannot read past the
+           payload buffer. */
         status = process_tlv_write(ctx, object, last_tlv_id,
-                                   inbuf, size);
+                                   inbuf, MIN(size, insize));
         return status;
       }
     }

--- a/os/services/lwm2m/lwm2m-engine.c
+++ b/os/services/lwm2m/lwm2m-engine.c
@@ -1076,7 +1076,7 @@ perform_multi_resource_write_op(lwm2m_object_t *object,
       }
       LOG_DBG_("'\n");
 
-      if(json.name[0] == 'n') {
+      if(json.name != NULL && json.name_len > 0 && json.name[0] == 'n') {
         i = parse_path((const char *) json.value, json.value_len, &oid, &iid, &rid);
         if(i > 0) {
           if(ctx->level == 1) {

--- a/os/services/lwm2m/lwm2m-json.c
+++ b/os/services/lwm2m/lwm2m-json.c
@@ -73,10 +73,12 @@ lwm2m_json_next_token(lwm2m_context_t *ctx, struct json_data *json)
 {
   int pos = ctx->inbuf->pos;
   uint8_t type = T_NONE;
-  uint8_t vpos_start = 0;
-  uint8_t vpos_end = 0;
+  /* Positions index into the input buffer, which can be larger than 255
+     bytes, so these must be as wide as pos rather than uint8_t. */
+  unsigned int vpos_start = 0;
+  unsigned int vpos_end = 0;
   uint8_t cont;
-  uint8_t wscount = 0;
+  unsigned int wscount = 0;
 
   json->name = NULL;
   json->value = NULL;
@@ -93,7 +95,10 @@ lwm2m_json_next_token(lwm2m_context_t *ctx, struct json_data *json)
     case ',':
       if(type == T_VAL || type == T_STRING) {
         json->value = &ctx->inbuf->buffer[vpos_start];
-        json->value_len = vpos_end - vpos_start - wscount;
+        /* Guard against the trailing-whitespace count exceeding the token
+           span, which would otherwise underflow value_len. */
+        json->value_len = (vpos_end > vpos_start + wscount) ?
+          (vpos_end - vpos_start - wscount) : 0;
         type = T_NONE;
         cont = 0;
       }
@@ -119,7 +124,7 @@ lwm2m_json_next_token(lwm2m_context_t *ctx, struct json_data *json)
     case ':':
       if(type == T_STRING) {
         json->name = &ctx->inbuf->buffer[vpos_start];
-        json->name_len = vpos_end - vpos_start;
+        json->name_len = (vpos_end > vpos_start) ? (vpos_end - vpos_start) : 0;
         vpos_start = vpos_end = pos;
         type = T_VAL;
       } else {

--- a/os/services/lwm2m/lwm2m-json.c
+++ b/os/services/lwm2m/lwm2m-json.c
@@ -78,6 +78,8 @@ lwm2m_json_next_token(lwm2m_context_t *ctx, struct json_data *json)
   uint8_t cont;
   uint8_t wscount = 0;
 
+  json->name = NULL;
+  json->value = NULL;
   json->name_len = 0;
   json->value_len = 0;
 

--- a/os/services/lwm2m/lwm2m-json.h
+++ b/os/services/lwm2m/lwm2m-json.h
@@ -49,8 +49,8 @@ struct json_data {
   uint8_t type; /* S,B,V */
   uint8_t *name;
   uint8_t *value;
-  uint8_t name_len;
-  uint8_t value_len;
+  uint16_t name_len;
+  uint16_t value_len;
 };
 
 extern const lwm2m_writer_t lwm2m_json_writer;

--- a/os/services/lwm2m/lwm2m-tlv-reader.c
+++ b/os/services/lwm2m/lwm2m-tlv-reader.c
@@ -89,7 +89,10 @@ read_float32fix(lwm2m_context_t *ctx, const uint8_t *inbuf, size_t len,
   size_t size;
   size = lwm2m_tlv_read(&tlv, inbuf, len);
   if(size > 0) {
-    lwm2m_tlv_float32_to_fix(&tlv, value, bits);
+    if(lwm2m_tlv_float32_to_fix(&tlv, value, bits) == 0) {
+      /* Malformed float value (wrong length) - reject. */
+      return 0;
+    }
     ctx->last_value_len = tlv.length;
   }
   return size;

--- a/os/services/lwm2m/lwm2m-tlv.c
+++ b/os/services/lwm2m/lwm2m-tlv.c
@@ -183,6 +183,12 @@ lwm2m_tlv_get_int32(const lwm2m_tlv_t *tlv)
   int i;
   int32_t value = 0;
 
+  /* A zero-length integer represents the value 0. Returning here also
+     avoids reading tlv->value[0] below when there is no value at all. */
+  if(tlv->length == 0) {
+    return 0;
+  }
+
   for(i = 0; i < tlv->length; i++) {
     value = (value << 8) | tlv->value[i];
   }
@@ -289,7 +295,16 @@ lwm2m_tlv_float32_to_fix(const lwm2m_tlv_t *tlv, int32_t *value, int bits)
   /* TLV needs to be 4 bytes */
   int e, i;
   int32_t val;
-  int sign = (tlv->value[0] & 0x80) != 0;
+  int sign;
+
+  /* The IEEE 754 single-precision representation requires exactly 4 bytes.
+     Reject anything shorter to avoid reading past the value. */
+  if(tlv->length < 4) {
+    *value = 0;
+    return 0;
+  }
+
+  sign = (tlv->value[0] & 0x80) != 0;
   e = ((tlv->value[0] << 1) & 0xff) | (tlv->value[1] >> 7);
   val = (((long)tlv->value[1] & 0x7f) << 16) | (tlv->value[2] << 8) | tlv->value[3];
 


### PR DESCRIPTION
Fixes several out-of-bounds reads in the LWM2M server input paths, all reachable from untrusted CoAP request payloads.

- **TLV integer/float readers** (`lwm2m-tlv.c`, `lwm2m-tlv-reader.c`): `lwm2m_tlv_get_int32()` read `value[0]` for the sign bit on a zero-length TLV, and `lwm2m_tlv_float32_to_fix()` read `value[0..3]` without checking the length. Now a zero-length integer returns 0 and a float shorter than 4 bytes is rejected.

- **Uninitialized JSON token name** (`lwm2m-json.c`, `lwm2m-engine.c`): the tokenizer left `json->name` uninitialized for a name-less token, and the engine dereferenced `json.name[0]` unconditionally, which is a wild pointer read. `name`/`value` are now initialized and the access is guarded.

- **JSON position/length truncation** (`lwm2m-json.c`, `lwm2m-json.h`): `uint8_t` offset/length fields truncated for payloads > 255 bytes and could underflow `value_len`. Widened the fields and guarded the subtractions.

- **BLOCK1 write size** (`lwm2m-engine.c`): the SZX-derived block size (up to 2048, independent of the real payload length) was used as the buffer length on continuation writes. Now clamped with `MIN(size, insize)`.