### PR TITLE
readthedocs: fix retired build image and modernize the docs toolchain

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,13 +5,13 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.12"
   jobs:
     post_install:
-      - wget -nv https://sourceforge.net/projects/doxygen/files/rel-1.10.0/doxygen-1.10.0.linux.bin.tar.gz/download -O doxygen.linux.bin.tar.gz
-      - tar xf doxygen.linux.bin.tar.gz doxygen-1.10.0/bin/doxygen --strip-components 2 --one-top-level=tools/doxygen
+      - wget -nv https://sourceforge.net/projects/doxygen/files/rel-1.17.0/doxygen-1.17.0.linux.bin.tar.gz/download -O doxygen.linux.bin.tar.gz
+      - tar xf doxygen.linux.bin.tar.gz doxygen-1.17.0/bin/doxygen --strip-components 2 --one-top-level=tools/doxygen
       - rm doxygen.linux.bin.tar.gz
 
 python:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -151,10 +151,10 @@ COPY --chown=root:root files/remap-user.sh /usr/local/bin/remap-user.sh
 # Remove the PDF manual and html directory to reduce image size.
 # Use the most recent version of ccache to ensure it supports the compiler
 # versions in the docker image.
-RUN wget -nv https://sourceforge.net/projects/doxygen/files/rel-1.10.0/doxygen-1.10.0.linux.bin.tar.gz/download -O doxygen.linux.bin.tar.gz && \
+RUN wget -nv https://sourceforge.net/projects/doxygen/files/rel-1.17.0/doxygen-1.17.0.linux.bin.tar.gz/download -O doxygen.linux.bin.tar.gz && \
     tar zxf doxygen.linux.bin.tar.gz -C ${HOME}/.local && \
-    rm -rf ${HOME}/.local/doxygen-1.10.0/html ${HOME}/.local/doxygen-1.10.0/*.pdf doxygen.linux.bin.tar.gz && \
-    (cd ${HOME}/.local/bin && ln -s ../doxygen-1.10.0/bin/doxygen .) && \
+    rm -rf ${HOME}/.local/doxygen-1.17.0/html ${HOME}/.local/doxygen-1.17.0/*.pdf doxygen.linux.bin.tar.gz && \
+    (cd ${HOME}/.local/bin && ln -s ../doxygen-1.17.0/bin/doxygen .) && \
     wget -nv https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz && \
     tar xf ccache-4.10.2-linux-x86_64.tar.xz -C ${HOME}/.local/bin --strip-components=1 ccache-4.10.2-linux-x86_64/ccache && \
     rm ccache-*-linux-x86_64.tar.xz

--- a/tools/docker/files/rtd_requirements.txt
+++ b/tools/docker/files/rtd_requirements.txt
@@ -1,7 +1,12 @@
 # Requirements for building Sphinx documentation on readthedocs and inside docker
 # Shared by tools/docker/Dockerfile and .readthedocs.yaml
-sphinx==5.0.2
-sphinx_rtd_theme==1.0.0
-myst_parser==0.18.0
-linkify-it-py==2.0.0
-standard-imghdr ; python_version > '3.12'
+#
+# These versions must stay compatible with the oldest Python that consumes
+# this file: the Docker image (tools/docker/Dockerfile) is based on Ubuntu
+# 22.04, whose system python3 is 3.10. Sphinx >= 9 and myst-parser >= 5
+# require Python >= 3.11, so they cannot be used until the Docker base image
+# is upgraded. sphinx 8.1.x is the latest series supporting Python 3.10.
+sphinx==8.1.3
+sphinx_rtd_theme==3.1.0
+myst_parser==4.0.1
+linkify-it-py==2.1.0

--- a/tools/readthedocs/api-doc.py
+++ b/tools/readthedocs/api-doc.py
@@ -35,7 +35,9 @@ def api_doc_build(app, exception):
 
         api_doc_build_dir = "/".join((app.config.api_doc_doxygen_src_dir,
                                       app.config.api_doc_doxygen_out_dir))
-        api_doc_static_api_dir = "/".join((app.outdir, '_api'))
+        # Sphinx >= 7.2 makes app.outdir a Path object; coerce to str so the
+        # join below works the same way across Sphinx versions.
+        api_doc_static_api_dir = "/".join((str(app.outdir), '_api'))
 
         logger.info('%s moving "%s" to "%s"'
                      % (__name__, api_doc_build_dir, api_doc_static_api_dir))


### PR DESCRIPTION
Recent tests have been failing because the readthedocs configuration relied on ubuntu-20.04, which has now apparently been deprecated.  This PR fixes that and refreshes the docs toolchain, which had drifted years out of date.