### PR TITLE
uip6: fix two out-of-bounds writes in IPv6 fragment reassembly

### DIFF
--- a/os/net/ipv6/uip6.c
+++ b/os/net/ipv6/uip6.c
@@ -634,7 +634,12 @@ uip_listen(uint16_t port)
 
 static uint8_t uip_reassbuf[UIP_REASS_BUFSIZE];
 
-static uint8_t uip_reassbitmap[UIP_REASS_BUFSIZE / (8 * 8)];
+/* One bit per 8 bytes, i.e. one byte per 64 bytes of the reassembly
+   buffer. Round the element count up so the bitmap covers the whole
+   buffer even when UIP_REASS_BUFSIZE is not a multiple of 64; otherwise
+   integer division would truncate the last partial block and let
+   (offset + len) >> 6 index one element past the end. */
+static uint8_t uip_reassbitmap[(UIP_REASS_BUFSIZE + (8 * 8) - 1) / (8 * 8)];
 /*the first byte of an IP fragment is aligned on an 8-byte boundary */
 
 static const uint8_t bitmap_bits[8] = {0xff, 0x7f, 0x3f, 0x1f,
@@ -718,9 +723,14 @@ uip_reass(uint8_t *prev_proto_ptr)
     }
 
     /* If the offset or the offset + fragment length overflows the
-       reassembly buffer, we discard the entire packet. */
+       reassembly buffer, we discard the entire packet. The fragment is
+       copied to FBUF + UIP_IPH_LEN + uip_ext_len + offset, so the
+       unfragmentable part (UIP_IPH_LEN + uip_ext_len) must be included in
+       the bound; otherwise a fragment with offset + len close to
+       UIP_REASS_BUFSIZE would write up to UIP_IPH_LEN + uip_ext_len bytes
+       past the end of uip_reassbuf[]. */
     if(offset > UIP_REASS_BUFSIZE ||
-       offset + len > UIP_REASS_BUFSIZE) {
+       UIP_IPH_LEN + uip_ext_len + offset + len > UIP_REASS_BUFSIZE) {
       uip_reass_on = 0;
       etimer_stop(&uip_reass_timer);
       return 0;


### PR DESCRIPTION
The overflow guard in uip_reass() bounded only offset + len against UIP_REASS_BUFSIZE, which left two out-of-bounds writes reachable from the attacker-controlled fragment offset and length fields:

1. Bitmap off-by-one. uip_reassbitmap[] has UIP_REASS_BUFSIZE / 64 elements and is indexed by (offset + len) >> 6. The strict ">" comparison let offset + len == UIP_REASS_BUFSIZE through, indexing uip_reassbitmap[UIP_REASS_BUFSIZE / 64], one element past the end of the array.

2. Buffer overflow. Each fragment is copied to FBUF + UIP_IPH_LEN + uip_ext_len + offset, but the unfragmentable part (UIP_IPH_LEN + uip_ext_len) was not included in the bound, so a fragment with offset + len close to UIP_REASS_BUFSIZE wrote up to that many bytes past the end of uip_reassbuf[].

Both share one root cause: the guard did not bound the actual write region. Include UIP_IPH_LEN + uip_ext_len in the comparison so the fragment copy stays within uip_reassbuf[]; this also keeps (offset + len) >> 6 within uip_reassbitmap[]. A fragment that fills the buffer exactly is still accepted.

This path is only built when UIP_CONF_IPV6_REASSEMBLY is enabled.