### PR TITLE
Harden the IEEE 802.15.4 framer against malformed received frames

### DIFF
--- a/os/net/mac/framer/frame802154.c
+++ b/os/net/mac/framer/frame802154.c
@@ -537,6 +537,19 @@ frame802154_parse_fcf(const uint8_t *data, frame802154_fcf_t *pfcf)
   }
 }
 /*----------------------------------------------------------------------------*/
+/*
+ * Ensure at least n more bytes remain in the input before reading them.
+ * Used throughout frame802154_parse() to bound every field access against
+ * the declared frame length, so a truncated frame whose FCF advertises a
+ * large header (addressing and/or auxiliary security) cannot cause reads
+ * past the end of the input buffer.
+ */
+#define REQUIRE_BYTES(n) do {       \
+    if((p - data) + (n) > len) {    \
+      return 0;                     \
+    }                               \
+  } while(0)
+/*----------------------------------------------------------------------------*/
 /**
  *   \brief Parses an input frame.  Scans the input frame to find each
  *   section, and stores the information of each section in a
@@ -567,6 +580,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
   p += frame802154_parse_fcf(p, &pf->fcf);
 
   if(pf->fcf.sequence_number_suppression == 0) {
+    REQUIRE_BYTES(1);
     pf->seq = p[0];
     p++;
   }
@@ -577,6 +591,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
   if(pf->fcf.dest_addr_mode) {
     if(has_dest_panid) {
       /* Destination PAN */
+      REQUIRE_BYTES(2);
       pf->dest_pid = p[0] + (p[1] << 8);
       p += 2;
     } else {
@@ -585,11 +600,13 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
 
     /* Destination address */
     if(pf->fcf.dest_addr_mode == FRAME802154_SHORTADDRMODE) {
+      REQUIRE_BYTES(2);
       linkaddr_copy((linkaddr_t *)&(pf->dest_addr), &linkaddr_null);
       pf->dest_addr[0] = p[1];
       pf->dest_addr[1] = p[0];
       p += 2;
     } else if(pf->fcf.dest_addr_mode == FRAME802154_LONGADDRMODE) {
+      REQUIRE_BYTES(8);
       for(c = 0; c < 8; c++) {
         pf->dest_addr[c] = p[7 - c];
       }
@@ -604,6 +621,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
   if(pf->fcf.src_addr_mode) {
     /* Source PAN */
     if(has_src_panid) {
+      REQUIRE_BYTES(2);
       pf->src_pid = p[0] + (p[1] << 8);
       p += 2;
       if(!has_dest_panid) {
@@ -615,11 +633,13 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
 
     /* Source address */
     if(pf->fcf.src_addr_mode == FRAME802154_SHORTADDRMODE) {
+      REQUIRE_BYTES(2);
       linkaddr_copy((linkaddr_t *)&(pf->src_addr), &linkaddr_null);
       pf->src_addr[0] = p[1];
       pf->src_addr[1] = p[0];
       p += 2;
     } else if(pf->fcf.src_addr_mode == FRAME802154_LONGADDRMODE) {
+      REQUIRE_BYTES(8);
       for(c = 0; c < 8; c++) {
         pf->src_addr[c] = p[7 - c];
       }
@@ -632,6 +652,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
 
 #if LLSEC802154_USES_AUX_HEADER
   if(pf->fcf.security_enabled) {
+    REQUIRE_BYTES(1);
     pf->aux_hdr.security_control.security_level = p[0] & 7;
 #if LLSEC802154_USES_EXPLICIT_KEYS
     pf->aux_hdr.security_control.key_id_mode = (p[0] >> 3) & 3;
@@ -641,9 +662,11 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
     p += 1;
 
     if(pf->aux_hdr.security_control.frame_counter_suppression == 0) {
+      REQUIRE_BYTES(4);
       memcpy(pf->aux_hdr.frame_counter.u8, p, 4);
       p += 4;
       if(pf->aux_hdr.security_control.frame_counter_size == 1) {
+        REQUIRE_BYTES(1);
         p ++;
       }
     }
@@ -652,6 +675,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
     key_id_mode = pf->aux_hdr.security_control.key_id_mode;
     if(key_id_mode) {
       c = (key_id_mode - 1) * 4;
+      REQUIRE_BYTES(c + 1);
       memcpy(pf->aux_hdr.key_source.u8, p, c);
       p += c;
       pf->aux_hdr.key_index = p[0];
@@ -671,4 +695,5 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
   /* return header length if successful */
   return c > len ? 0 : c;
 }
+#undef REQUIRE_BYTES
 /** \}   */

--- a/os/net/mac/framer/frame802154.c
+++ b/os/net/mac/framer/frame802154.c
@@ -262,7 +262,7 @@ frame802154_extract_linkaddr(frame802154_t *frame,
   } else {
     /* Unicast address */
     if(src_addr_len != LINKADDR_SIZE) {
-      /* Destination address has a size we can not handle */
+      /* Source address has a size we can not handle */
       return 0;
     }
     if(source_address != NULL) {
@@ -657,8 +657,8 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
 #if LLSEC802154_USES_EXPLICIT_KEYS
     pf->aux_hdr.security_control.key_id_mode = (p[0] >> 3) & 3;
 #endif /* LLSEC802154_USES_EXPLICIT_KEYS */
-    pf->aux_hdr.security_control.frame_counter_suppression = p[0] >> 5;
-    pf->aux_hdr.security_control.frame_counter_size = p[0] >> 6;
+    pf->aux_hdr.security_control.frame_counter_suppression = (p[0] >> 5) & 1;
+    pf->aux_hdr.security_control.frame_counter_size = (p[0] >> 6) & 1;
     p += 1;
 
     if(pf->aux_hdr.security_control.frame_counter_suppression == 0) {

--- a/os/net/mac/framer/frame802154e-ie.c
+++ b/os/net/mac/framer/frame802154e-ie.c
@@ -676,6 +676,16 @@ frame802154e_parse_information_elements(const uint8_t *buf, uint8_t buf_size,
         }
         break;
     }
+    /*
+     * Backstop for every IE type: never advance past the end of the buffer.
+     * Each case above is expected to bound len against buf_size, but this
+     * check enforces the invariant in one place and protects buf_size
+     * (uint8_t) from underflowing should a future case forget to.
+     */
+    if(len > buf_size) {
+      LOG_ERR("frame802154e: IE len %u exceeds remaining %u\n", len, buf_size);
+      return -1;
+    }
     buf += len;
     buf_size -= len;
   }

--- a/os/net/mac/framer/frame802154e-ie.c
+++ b/os/net/mac/framer/frame802154e-ie.c
@@ -89,7 +89,7 @@ enum ieee802154e_ietf_subie_id {
 
 #define WRITE16(buf, val) \
   do { ((uint8_t *)(buf))[0] = (val) & 0xff; \
-       ((uint8_t *)(buf))[1] = ((val) >> 8) & 0xff; } while(0);
+       ((uint8_t *)(buf))[1] = ((val) >> 8) & 0xff; } while(0)
 
 #define READ16(buf, var) \
   (var) = ((uint8_t *)(buf))[0] | ((uint8_t *)(buf))[1] << 8

--- a/os/net/mac/framer/frame802154e-ie.c
+++ b/os/net/mac/framer/frame802154e-ie.c
@@ -599,6 +599,18 @@ frame802154e_parse_information_elements(const uint8_t *buf, uint8_t buf_size,
             break;
 #if TSCH_WITH_SIXTOP
           case PAYLOAD_IE_IETF:
+            /*
+             * The IETF payload IE carries at least a one-octet Sub-ID field,
+             * and its content must fit within the remaining buffer. Reject
+             * anything shorter or longer to avoid reading past the buffer when
+             * dereferencing the Sub-ID below, underflowing the 6top content
+             * length (len - 1), and underflowing buf_size at the loop tail.
+             */
+            if(len < 1 || len > buf_size) {
+              LOG_ERR("frame802154e: invalid IETF IE len %u (remaining %u)\n",
+                      len, buf_size);
+              return -1;
+            }
             switch(*buf) {
               case IETF_IE_6TOP:
                 /*

--- a/os/net/mac/framer/frame802154e-ie.c
+++ b/os/net/mac/framer/frame802154e-ie.c
@@ -490,18 +490,33 @@ frame802154e_parse_mlme_long_ie(const uint8_t *buf, int len,
 {
   switch(sub_id) {
     case MLME_LONG_IE_TSCH_CHANNEL_HOPPING_SEQUENCE:
-      if(len > 0) {
+      /*
+       * Two valid encodings: a one-octet form carrying only the hopping
+       * sequence ID, or the full form whose 10-octet fixed header is followed
+       * by the sequence list and a two-octet "current hop" field, i.e.
+       * len == 12 + sequence_len. Read the sequence-length field (buf[8..9])
+       * only once the full fixed header is known to be present, and reject any
+       * other length rather than over-reading a short IE or leaving
+       * ie_hopping_sequence_len set from an IE we did not actually copy.
+       */
+      if(len == 1) {
         if(ies != NULL) {
           ies->ie_channel_hopping_sequence_id = buf[0];
-          if(len > 1) {
-            READ16(buf+8, ies->ie_hopping_sequence_len); /* sequence len */
-            if(ies->ie_hopping_sequence_len <= sizeof(ies->ie_hopping_sequence_list)
-                && len == 12 + ies->ie_hopping_sequence_len) {
-              memcpy(ies->ie_hopping_sequence_list, buf+10, ies->ie_hopping_sequence_len); /* sequence list */
-            }
-          }
         }
         return len;
+      }
+      if(len >= 12) {
+        uint16_t seq_len;
+        READ16(buf + 8, seq_len); /* sequence len */
+        if(seq_len <= sizeof(ies->ie_hopping_sequence_list)
+            && len == 12 + seq_len) {
+          if(ies != NULL) {
+            ies->ie_channel_hopping_sequence_id = buf[0];
+            ies->ie_hopping_sequence_len = seq_len;
+            memcpy(ies->ie_hopping_sequence_list, buf + 10, seq_len); /* sequence list */
+          }
+          return len;
+        }
       }
       break;
   }

--- a/tests/13-ieee802154/10-framer-negative.csc
+++ b/tests/13-ieee802154/10-framer-negative.csc
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf version="2022112801">
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>1</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <description>Cooja Mote Type #1</description>
+      <source>[CONFIG_DIR]/code-framer-negative/test-framer-negative.c</source>
+      <commands>$(MAKE) clean TARGET=cooja
+$(MAKE) -j$(CPUS) test-framer-negative.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <mote>
+        <interface_config>
+          org.contikios.cooja.interfaces.Position
+          <pos x="57.636765279141336" y="56.661654369889035" />
+        </interface_config>
+        <interface_config>
+          org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+          <id>1</id>
+        </interface_config>
+      </mote>
+    </motetype>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <scriptfile>[CONFIG_DIR]/js/10-framer-negative.js</scriptfile>
+      <active>true</active>
+    </plugin_config>
+    <bounds x="279" y="2" height="525" width="495" />
+  </plugin>
+</simconf>

--- a/tests/13-ieee802154/README.md
+++ b/tests/13-ieee802154/README.md
@@ -21,3 +21,26 @@ FAILED.
 
 * https://standards.ieee.org/findstds/standard/802.15.4-2015.html
 * https://github.com/contiki-os/contiki/pull/1914
+
+## 10-framer-negative
+
+Negative-path regression tests for the IEEE 802.15.4 framer, covering the
+hardening of `frame802154_parse()` and
+`frame802154e_parse_information_elements()` against malformed input.
+
+### Test Code
+
+[test-framer-negative.c](./code-framer-negative/test-framer-negative.c) feeds
+truncated frames, oversized and zero-length information elements, and a frame
+whose security-control octet sets reserved bits, and asserts that the parsers
+reject the input (returning the documented failure value) and never store
+unvalidated state. Positive controls confirm that well-formed frames and a
+valid TSCH channel hopping sequence IE still parse. The mote prints results
+with the `"=check-me="` prefix, examined by
+[10-framer-negative.js](./js/10-framer-negative.js) as in 01-panid-handling.
+
+Under Cooja the assertions check the parsers' return values and stored state.
+Some guards additionally prevent out-of-bounds *reads* whose return value is
+unchanged; because every test vector is an exact-length array, those reads can
+be caught by compiling the framer together with these vectors under
+AddressSanitizer (its global redzones turn an over-read into a hard failure).

--- a/tests/13-ieee802154/code-framer-negative/Makefile
+++ b/tests/13-ieee802154/code-framer-negative/Makefile
@@ -1,0 +1,9 @@
+CONTIKI_PROJECT = test-framer-negative
+all: $(CONTIKI_PROJECT)
+
+MAKE_MAC = MAKE_MAC_TSCH
+MODULES += os/services/unit-test
+MODULES += $(CONTIKI_NG_MAC_DIR)/tsch/sixtop
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/tests/13-ieee802154/code-framer-negative/project-conf.h
+++ b/tests/13-ieee802154/code-framer-negative/project-conf.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#define UNIT_TEST_PRINT_FUNCTION test_print_report
+
+/* Compile the 6top payload-IE branch so its hardening is exercised. */
+#define TSCH_CONF_WITH_SIXTOP 1
+
+/*
+ * Enable parsing of the auxiliary security header (and its frame counter and
+ * explicit-key subfields) without pulling in a full link-layer security
+ * engine, so the security-control masking test is built and run.
+ */
+#define LLSEC802154_CONF_USES_AUX_HEADER 1
+#define LLSEC802154_CONF_USES_FRAME_COUNTER 1
+#define LLSEC802154_CONF_USES_EXPLICIT_KEYS 1
+
+#endif /* !PROJECT_CONF_H_ */

--- a/tests/13-ieee802154/code-framer-negative/test-framer-negative.c
+++ b/tests/13-ieee802154/code-framer-negative/test-framer-negative.c
@@ -202,7 +202,7 @@ test_print_report(const unit_test_t *utp)
   if(utp->passed == false) {
     printf("FAILED   - %s (exit at %u)\n", utp->descr, utp->exit_line);
   } else {
-    printf("SUCEEDED - %s\n", utp->descr);
+    printf("SUCCEEDED - %s\n", utp->descr);
   }
 }
 

--- a/tests/13-ieee802154/code-framer-negative/test-framer-negative.c
+++ b/tests/13-ieee802154/code-framer-negative/test-framer-negative.c
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Negative-path unit tests for the IEEE 802.15.4 framer.
+ *
+ *         These tests feed deliberately malformed, truncated, and hostile
+ *         input to frame802154_parse() and
+ *         frame802154e_parse_information_elements() and assert that the
+ *         parsers reject it (returning the documented failure value) instead
+ *         of reading past the end of the buffer or storing unvalidated state.
+ *         They lock in the hardening added to the framer so the guards cannot
+ *         be silently regressed.
+ *
+ *         All test vectors are static const arrays. When this test is built
+ *         for the native target with AddressSanitizer
+ *         (make TARGET=native CFLAGS+=-fsanitize=address
+ *          LDFLAGS+=-fsanitize=address), the global redzones turn any read
+ *         past the declared length of a vector into a hard failure; without
+ *         ASan the return-value assertions still catch acceptance of bad
+ *         frames.
+ * \author
+ *         Nicolas Tsiftes <nicolas.tsiftes@ri.se>
+ */
+
+#include "contiki.h"
+#include "unit-test/unit-test.h"
+#include "net/mac/llsec802154.h"
+#include "net/mac/framer/frame802154.h"
+#include "net/mac/framer/frame802154e-ie.h"
+
+#include <stdio.h>
+#include <string.h>
+
+PROCESS(test_process, "framer negative-path test");
+AUTOSTART_PROCESSES(&test_process);
+
+/*
+ * The framer parsers are pure functions over (buffer, length), so each test
+ * vector is just a byte array. The FCF and IE descriptor encodings are
+ * little-endian (low byte first), matching READ16() in the framer.
+ */
+
+/* ---- frame802154_parse(): truncated headers (hardening #1) -------------- */
+
+/*
+ * FCF only: a data frame whose FCF advertises long destination and source
+ * addressing plus a security header (~30 bytes of header), but only the two
+ * FCF bytes are present. The parser must stop at the missing sequence number.
+ */
+static const uint8_t frame_fcf_only[] = {
+  0x09, /* frame type = data, security enabled */
+  0xec, /* dest = long, version = 2015, src = long */
+};
+
+/*
+ * Same FCF, but now long enough for the sequence number and destination PAN
+ * ID, then truncated in the middle of the 8-byte destination address.
+ */
+static const uint8_t frame_trunc_dest_addr[] = {
+  0x09, 0xec,       /* FCF as above */
+  0x11,             /* sequence number */
+  0xcd, 0xab,       /* destination PAN ID */
+};
+
+/* ---- frame802154_parse(): valid baseline (positive control) ------------- */
+
+/*
+ * A well-formed frame: data, short dest + short src addressing, PAN ID
+ * compression on, version 2015. Header length = 2 (FCF) + 1 (seqno) +
+ * 2 (dest PAN) + 2 (dest addr) + 2 (src addr) = 9 bytes.
+ */
+static const uint8_t frame_valid_short[] = {
+  0x41, 0xa8,       /* FCF: data, panid compression, short/short, 2015 */
+  0x05,             /* sequence number */
+  0xcd, 0xab,       /* destination PAN ID */
+  0x02, 0x00,       /* destination short address */
+  0x03, 0x00,       /* source short address */
+};
+#define FRAME_VALID_SHORT_HDR_LEN 9
+
+#if LLSEC802154_USES_AUX_HEADER
+/* ---- frame802154_parse(): security-control subfield masking (#5) -------- */
+
+/*
+ * A secured frame with no addressing. The security-control octet sets the
+ * reserved high bit (0x80) but leaves frame-counter suppression (bit 5) and
+ * size (bit 6) clear, so the frame counter is present. Before masking, the
+ * bare shift made frame_counter_suppression non-zero and the parser wrongly
+ * skipped the 4-byte counter. Header length = 2 + 1 + 1 + 4 = 8.
+ */
+static const uint8_t frame_sec_reserved_bit[] = {
+  0x09, 0x20,             /* FCF: data, security enabled, no addr, 2015 */
+  0x42,                   /* sequence number */
+  0x81,                   /* SCF: level 1, reserved bit 7 set, suppr/size 0 */
+  0xde, 0xad, 0xbe, 0xef, /* 4-byte frame counter */
+};
+#define FRAME_SEC_RESERVED_HDR_LEN 8
+#endif /* LLSEC802154_USES_AUX_HEADER */
+
+/* ---- IE parser: malformed information elements -------------------------- */
+
+/*
+ * Header IE "list termination 1" (moves the parser into payload-IE state)
+ * followed by an IETF payload IE with length 0. The 6top branch must reject
+ * it instead of dereferencing the (absent) Sub-ID and underflowing the
+ * content length to 0xffff (hardening #3).
+ */
+static const uint8_t ie_ietf_zero_len[] = {
+  0x00, 0x3f,       /* header IE: list termination 1 */
+  0x00, 0xa8,       /* payload IE: IETF group, len 0 */
+};
+
+/*
+ * List termination 1, then an MLME payload IE wrapping a TSCH channel hopping
+ * sequence long sub-IE whose length (4) is shorter than the 10-byte fixed
+ * header. The parser must reject it rather than reading the sequence-length
+ * field at offset 8 past the end of the sub-IE (hardening #2).
+ */
+static const uint8_t ie_hopping_short[] = {
+  0x00, 0x3f,             /* header IE: list termination 1 */
+  0x06, 0x88,             /* payload IE: MLME, nested len 6 */
+  0x04, 0xc8,             /* long sub-IE: hopping sequence, len 4 */
+  0xaa, 0xbb, 0xcc, 0xdd, /* 4 bytes of content (too short) */
+};
+
+/*
+ * A header IE that declares a length far larger than the bytes that follow.
+ * The parser must reject it rather than advancing past the buffer (the
+ * per-case bound plus the loop-tail backstop, hardening #4).
+ */
+static const uint8_t ie_len_overruns_buffer[] = {
+  0x64, 0x0f,       /* header IE: ack/nack time correction, len 100 */
+};
+
+/* ---- IE parser: valid hopping sequence (positive control) --------------- */
+
+/*
+ * List termination 1, MLME payload IE, then a complete TSCH channel hopping
+ * sequence sub-IE: 10-byte fixed header (id, page, #channels, phy config,
+ * 2-byte sequence length = 4), a 4-byte sequence list, and a 2-byte current
+ * hop. Total sub-IE content = 12 + 4 = 16 bytes.
+ */
+static const uint8_t ie_hopping_valid[] = {
+  0x00, 0x3f,             /* header IE: list termination 1 */
+  0x12, 0x88,             /* payload IE: MLME, nested len 18 */
+  0x10, 0xc8,             /* long sub-IE: hopping sequence, len 16 */
+  0x01,                   /* [0]    hopping sequence id */
+  0x00,                   /* [1]    channel page */
+  0x00, 0x00,             /* [2-3]  number of channels */
+  0x00, 0x00, 0x00, 0x00, /* [4-7]  phy configuration */
+  0x04, 0x00,             /* [8-9]  sequence length = 4 */
+  0x11, 0x22, 0x33, 0x44, /* [10-13] sequence list */
+  0x00, 0x00,             /* [14-15] current hop */
+};
+
+UNIT_TEST_REGISTER(frame_parse_rejects_truncated,
+                   "frame802154_parse rejects truncated headers");
+UNIT_TEST_REGISTER(frame_parse_accepts_valid,
+                   "frame802154_parse accepts a valid frame");
+#if LLSEC802154_USES_AUX_HEADER
+UNIT_TEST_REGISTER(frame_parse_masks_security_subfields,
+                   "frame802154_parse masks reserved security-control bits");
+#endif /* LLSEC802154_USES_AUX_HEADER */
+UNIT_TEST_REGISTER(ie_parse_rejects_malformed,
+                   "IE parser rejects malformed information elements");
+UNIT_TEST_REGISTER(ie_parse_accepts_valid_hopping,
+                   "IE parser accepts a valid hopping sequence IE");
+
+void
+test_print_report(const unit_test_t *utp)
+{
+  printf("=check-me= ");
+  if(utp->passed == false) {
+    printf("FAILED   - %s (exit at %u)\n", utp->descr, utp->exit_line);
+  } else {
+    printf("SUCEEDED - %s\n", utp->descr);
+  }
+}
+
+UNIT_TEST(frame_parse_rejects_truncated)
+{
+  frame802154_t frame;
+
+  UNIT_TEST_BEGIN();
+
+  /* A frame shorter than the FCF is rejected. */
+  UNIT_TEST_ASSERT(frame802154_parse((uint8_t *)frame_fcf_only, 1, &frame) == 0);
+
+  /* The FCF advertises a large header that the 2 available bytes cannot hold. */
+  UNIT_TEST_ASSERT(frame802154_parse((uint8_t *)frame_fcf_only,
+                                     sizeof(frame_fcf_only), &frame) == 0);
+
+  /* Truncated in the middle of the destination address. */
+  UNIT_TEST_ASSERT(frame802154_parse((uint8_t *)frame_trunc_dest_addr,
+                                     sizeof(frame_trunc_dest_addr),
+                                     &frame) == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(frame_parse_accepts_valid)
+{
+  frame802154_t frame;
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ret = frame802154_parse((uint8_t *)frame_valid_short,
+                          sizeof(frame_valid_short), &frame);
+  UNIT_TEST_ASSERT(ret == FRAME_VALID_SHORT_HDR_LEN);
+  UNIT_TEST_ASSERT(frame.seq == 0x05);
+  UNIT_TEST_ASSERT(frame.fcf.frame_type == FRAME802154_DATAFRAME);
+
+  UNIT_TEST_END();
+}
+
+#if LLSEC802154_USES_AUX_HEADER
+UNIT_TEST(frame_parse_masks_security_subfields)
+{
+  frame802154_t frame;
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  memset(&frame, 0, sizeof(frame));
+  ret = frame802154_parse((uint8_t *)frame_sec_reserved_bit,
+                          sizeof(frame_sec_reserved_bit), &frame);
+
+  /* The reserved high bit must not be interpreted as suppression/size, so the
+     frame counter is parsed and the full header is consumed. */
+  UNIT_TEST_ASSERT(ret == FRAME_SEC_RESERVED_HDR_LEN);
+  UNIT_TEST_ASSERT(frame.aux_hdr.security_control.frame_counter_suppression == 0);
+  UNIT_TEST_ASSERT(frame.aux_hdr.security_control.frame_counter_size == 0);
+  UNIT_TEST_ASSERT(frame.aux_hdr.security_control.security_level == 1);
+  UNIT_TEST_ASSERT(frame.aux_hdr.frame_counter.u8[0] == 0xde);
+  UNIT_TEST_ASSERT(frame.aux_hdr.frame_counter.u8[3] == 0xef);
+
+  UNIT_TEST_END();
+}
+#endif /* LLSEC802154_USES_AUX_HEADER */
+
+UNIT_TEST(ie_parse_rejects_malformed)
+{
+  struct ieee802154_ies ies;
+
+  UNIT_TEST_BEGIN();
+
+  /* IETF 6top IE with zero length: rejected, content length left untouched. */
+  memset(&ies, 0, sizeof(ies));
+  UNIT_TEST_ASSERT(frame802154e_parse_information_elements(ie_ietf_zero_len,
+                       sizeof(ie_ietf_zero_len), &ies) == -1);
+#if TSCH_WITH_SIXTOP
+  UNIT_TEST_ASSERT(ies.sixtop_ie_content_len == 0);
+#endif /* TSCH_WITH_SIXTOP */
+
+  /* Hopping sequence sub-IE shorter than its fixed header: rejected, and the
+     advertised sequence length is not stored from a frame we did not copy. */
+  memset(&ies, 0, sizeof(ies));
+  UNIT_TEST_ASSERT(frame802154e_parse_information_elements(ie_hopping_short,
+                       sizeof(ie_hopping_short), &ies) == -1);
+  UNIT_TEST_ASSERT(ies.ie_hopping_sequence_len == 0);
+
+  /* IE that declares more bytes than the buffer holds: rejected. */
+  memset(&ies, 0, sizeof(ies));
+  UNIT_TEST_ASSERT(frame802154e_parse_information_elements(ie_len_overruns_buffer,
+                       sizeof(ie_len_overruns_buffer), &ies) == -1);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(ie_parse_accepts_valid_hopping)
+{
+  struct ieee802154_ies ies;
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  memset(&ies, 0, sizeof(ies));
+  ret = frame802154e_parse_information_elements(ie_hopping_valid,
+                                                sizeof(ie_hopping_valid), &ies);
+  UNIT_TEST_ASSERT(ret > 0);
+  UNIT_TEST_ASSERT(ies.ie_channel_hopping_sequence_id == 0x01);
+  UNIT_TEST_ASSERT(ies.ie_hopping_sequence_len == 4);
+  UNIT_TEST_ASSERT(ies.ie_hopping_sequence_list[0] == 0x11);
+  UNIT_TEST_ASSERT(ies.ie_hopping_sequence_list[3] == 0x44);
+
+  UNIT_TEST_END();
+}
+
+PROCESS_THREAD(test_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(frame_parse_rejects_truncated);
+  UNIT_TEST_RUN(frame_parse_accepts_valid);
+#if LLSEC802154_USES_AUX_HEADER
+  UNIT_TEST_RUN(frame_parse_masks_security_subfields);
+#endif /* LLSEC802154_USES_AUX_HEADER */
+  UNIT_TEST_RUN(ie_parse_rejects_malformed);
+  UNIT_TEST_RUN(ie_parse_accepts_valid_hopping);
+
+  printf("=check-me= DONE\n");
+
+  PROCESS_END();
+}

--- a/tests/13-ieee802154/js/10-framer-negative.js
+++ b/tests/13-ieee802154/js/10-framer-negative.js
@@ -1,0 +1,21 @@
+TIMEOUT(10000, log.testFailed());
+
+while(true) {
+    YIELD();
+
+    log.log(time + " " + id + " "+ msg + "\n");
+    
+    if(msg.contains("=check-me=") == false) {
+        continue;
+    }
+
+    if(msg.contains("FAILED")) {
+        log.testFailed();
+    }
+
+    if(msg.contains("DONE")) {
+        log.testOK();
+        break;
+    }
+    
+}


### PR DESCRIPTION
The 802.15.4 framer parses received frames on the unauthenticated RX path (TSCH parses EBs and frame headers before the security MIC is verified), so every length field is attacker-controlled. This PR hardens `frame802154.c` and `frame802154e-ie.c` so the parsers validate lengths *before* dereferencing, instead of detecting an overrun only after the reads have happened — and adds a regression test.

## Hardening fixes

- **`frame802154_parse`: bounds-check every field read.** It advanced through the frame using FCF-derived sizes and only compared the consumed length against the input length at the end, allowing reads up to ~36 bytes past the buffer. A `REQUIRE_BYTES()` guard now checks remaining input before each field (seqno, PAN IDs, addresses, aux security header).
- **6top IETF payload IE:** reject `len < 1 || len > buf_size` before dereferencing the Sub-ID and computing `content_len = len - 1`, which could underflow to `0xFFFF` and flow into `sixp_input()` as an OOB read length.
- **TSCH channel hopping sequence IE:** only read the sequence-length field once the 10-byte fixed header is present, and reject inconsistent IEs  instead of returning success with an unvalidated `ie_hopping_sequence_len`.
- **IE parse loop:** add a backstop that rejects any IE whose length exceeds the remaining buffer, preventing `buf_size` (uint8_t) underflow.
- **Security-control subfields:** mask `frame_counter_suppression` and `frame_counter_size` to one bit each (they were extracted with a bare  shift), fixing a latent mis-parse when reserved bits are set.
- Minor: fix a `WRITE16` macro trailing-semicolon and a stale comment.

## Testing

Adds `tests/13-ieee802154/10-framer-negative`, a unit test that feeds  truncated frames, malformed and oversized IEs, and reserved-bit frames to the parsers  and asserts that they reject the input, with positive controls for well-formed frames and a valid hopping sequence IE. Each vector is an exact-length array,  so the out-of-bounds reads that the new guards prevent can also be caught under AddressSanitizer.
  
  No protocol or API changes; the fixes are purely validate-before-read.