### PR TITLE
uip6: fix MPL HBH option advancing offset by twice its length

### DIFF
--- a/os/net/ipv6/uip6.c
+++ b/os/net/ipv6/uip6.c
@@ -872,7 +872,7 @@ ext_hdr_options_process(uint8_t *ext_buf)
       *  we want to process the option and not revert to the default case.
       */
       LOG_DBG("Processing MPL option\n");
-      opt_offset += opt_len + opt_len;
+      opt_offset += opt_len;
       break;
 #endif
     default:


### PR DESCRIPTION
The MPL Hop-by-Hop option is an ordinary TLV option, but ext_hdr_options_process() advanced the parse cursor by opt_len + opt_len, skipping twice the option length. This silently skips or misaligns any option following the MPL option in the same Hop-by-Hop header. Advance by opt_len, matching the RPL/PADN/default cases.