### PR TITLE
nRF54L15: fix XIAO LED polarity

### DIFF
--- a/arch/platform/nrf/nrf54l15/xiao/board-leds.c
+++ b/arch/platform/nrf/nrf54l15/xiao/board-leds.c
@@ -39,12 +39,12 @@
 
 #include "dev/leds.h"
 /*---------------------------------------------------------------------------*/
-/* XIAO nRF54L15 has one user LED on P2.0, active high */
+/* XIAO nRF54L15 has one user LED on P2.0, active low */
 const leds_t leds_arch_leds[] = {
   {
     .port = NRF_LED1_PORT,
     .pin = NRF_LED1_PIN,
-    .negative_logic = false
+    .negative_logic = true
   },
 };
 /*---------------------------------------------------------------------------*/

--- a/os/dev/leds.h
+++ b/os/dev/leds.h
@@ -211,7 +211,8 @@ void leds_arch_set(leds_mask_t leds);
  * \e port corresponds to the GPIO port that the pin is connected to. This
  * only makes sense if GPIO_HAL_CONF_PORT_PIN_NUMBERING is non-zero.
  *
- * \e negative_logic should be set to false if the LED is active low.
+ * \e negative_logic should be set to true if the LED is active low (that is,
+ * the LED turns on when the GPIO pin is driven low).
  *
  * \note Do not access the \e port member of this struct direct, use the
  * LED_PORT() macro instead.


### PR DESCRIPTION
The LED switch appeared inverted during tests with the XIAO board, so this PR fixes it. Additionally, it fixes a comment regarding the negative logic in os/dev/leds.h.