### PR TITLE
Adding missing nrf52840 cc310 crypto hw acc support

### DIFF
--- a/arch/cpu/nrf52840/Makefile.cc310-crypto
+++ b/arch/cpu/nrf52840/Makefile.cc310-crypto
@@ -1,0 +1,149 @@
+# =============================================================================
+# nRF52840 CryptoCell-310 (CC310) hardware-crypto backend for lib/ecc.h.
+# Included from Makefile.nrf52840 when ECC_HW_BACKEND=cc310.
+#
+# Routes ecc_sign / ecc_verify / ecc_generate_shared_secret /
+# ecc_generate_key_pair onto CC310 via Nordic's nrf_crypto frontend + cc310
+# backend (both vendored in Contiki's nrf52-sdk subset) plus the closed-source
+# CC310 runtime blob and CRYS/SaSi headers taken from the FULL nRF5 SDK 17.1.0
+# (those two are not part of the vendored subset).
+# See arch/cpu/nrf52840/dev/nrf52840-cc310-ecc.c for the full rationale.
+# =============================================================================
+
+# Full nRF5 SDK 17.1.0 root — provides the CC310 blob + CRYS/SaSi headers.
+# Override on the make command line if the SDK lives elsewhere.
+NRF_CC310_SDK ?= $(CONTIKI)/../nRF5_SDK_17.1.0_ddde560
+
+CC310_BLOB := $(NRF_CC310_SDK)/external/nrf_cc310/lib/cortex-m4/hard-float/libnrf_cc310_0.9.13.a
+ifeq (,$(wildcard $(CC310_BLOB)))
+  $(error CC310 blob not found at $(CC310_BLOB) -- set NRF_CC310_SDK to your nRF5 SDK 17.1.0 root)
+endif
+
+# --- the lib/ecc.h hardware backend itself ---
+CONTIKI_CPU_SOURCEFILES += nrf52840-cc310-ecc.c
+
+# --- vendored nrf_crypto frontend (Contiki's nrf52-sdk subset) ---
+CONTIKI_CPU_DIRS        += lib/nrf52-sdk/components/libraries/crypto
+CONTIKI_CPU_SOURCEFILES += nrf_crypto_ecc.c nrf_crypto_ecdsa.c nrf_crypto_ecdh.c \
+                           nrf_crypto_rng.c nrf_crypto_shared.c nrf_crypto_init.c
+
+# --- vendored CC310 backend ---
+CONTIKI_CPU_DIRS        += lib/nrf52-sdk/components/libraries/crypto/backend/cc310
+CONTIKI_CPU_SOURCEFILES += cc310_backend_ecc.c cc310_backend_ecdsa.c \
+                           cc310_backend_ecdh.c cc310_backend_init.c \
+                           cc310_backend_mutex.c cc310_backend_shared.c \
+                           cc310_backend_rng.c
+
+# --- mem manager (nrf_crypto allocates key/operation contexts through it) ---
+CONTIKI_CPU_DIRS        += lib/nrf52-sdk/components/libraries/mem_manager
+CONTIKI_CPU_SOURCEFILES += mem_manager.c
+
+# --- atomics (cc310 mutex uses nrf_atomic_u32_fetch_store) ---
+CONTIKI_CPU_DIRS        += lib/nrf52-sdk/components/libraries/atomic
+CONTIKI_CPU_SOURCEFILES += nrf_atomic.c
+
+# --- include paths (vendored headers) ---
+# The nrf_crypto frontend (nrf_crypto_*_backend.h) #includes EVERY backend's
+# header unconditionally; each compiles to nothing unless its
+# NRF_CRYPTO_BACKEND_<X>_ENABLED flag is set, but all must be on the include
+# path.  So add every backend dir, not just cc310.
+NRF_CC310_INC_PATHS += components/libraries/crypto
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/cc310
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/cc310_bl
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/cifra
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/mbedtls
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/micro_ecc
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/nrf_hw
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/nrf_sw
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/oberon
+NRF_CC310_INC_PATHS += components/libraries/crypto/backend/optiga
+NRF_CC310_INC_PATHS += components/libraries/mem_manager
+NRF_CC310_INC_PATHS += components/libraries/stack_info
+NRF_CC310_INC_PATHS += components/libraries/mutex
+NRF_CC310_INC_PATHS += components/libraries/atomic
+EXTERNALDIRS += $(addprefix $(NRF5_SDK_ROOT)/, $(NRF_CC310_INC_PATHS))
+
+# CRYS / SaSi headers from the full SDK (sns_silib.h, crys_ecpki_*.h, ...).
+CFLAGS += -I$(NRF_CC310_SDK)/external/nrf_cc310/include
+
+# --- enable the CC310 crypto backend in nrf_crypto + select secp256r1 ---
+# The nrf_crypto headers gate every feature on NRF_MODULE_ENABLED(<flag>)
+# (i.e. <flag>_ENABLED).  Set ONLY the backend-selection flags: each CC310
+# backend header then defines the corresponding generic feature flag itself
+# (e.g. cc310_backend_ecc.h sets NRF_CRYPTO_ECC_SECP256R1_ENABLED from
+# NRF_CRYPTO_BACKEND_CC310_ECC_SECP256R1_ENABLED) and #errors if we had
+# already defined it (its "more than one backend" guard).  Enable only what
+# scenarios C/D need: the CC310 backend, secp256r1 ECC, and the RNG (CC310
+# ECDSA draws its per-signature nonce from the on-chip TRNG).  All other
+# curves stay undefined and compile to nothing.
+CFLAGS += -DNRF_CRYPTO_ENABLED=1
+CFLAGS += -DNRF_CRYPTO_BACKEND_CC310_ENABLED=1
+CFLAGS += -DNRF_CRYPTO_BACKEND_CC310_ECC_SECP256R1_ENABLED=1
+CFLAGS += -DNRF_CRYPTO_BACKEND_CC310_RNG_ENABLED=1
+# Auto-init of the CC310 TRNG inside nrf_crypto_init() is DISABLED on
+# purpose: (1) it passes a NULL context, which fails under the ALLOC_ON_STACK
+# allocator (the RNG context must be persistent, see nrf52840-cc310-ecc.c's
+# static rng_context); and (2) the TRNG entropy collection must run inside a
+# BASEPRI critical section that masks the 128 Hz RTC tick and other ISRs
+# (otherwise CRYS_RndInit fails its startup test -- root cause confirmed
+# 2026-06-19, PLAN section 9.11.4). The real, isolated instantiation is done
+# in ecc_session_begin() instead.
+CFLAGS += -DNRF_CRYPTO_RNG_AUTO_INIT_ENABLED=0
+# REQUIRED, not optional: the blob's own TRNG wait mechanism
+# (SaSi_HalWaitInterrupt / LLF_RND_StartTrngHW) genuinely depends on the
+# CRYPTOCELL NVIC interrupt to ever complete -- `nm` on the blob shows it
+# provides its own real CRYPTOCELL_IRQHandler (a distinct symbol from
+# Default_Handler), so no handler needs to be written; this flag only
+# needs to enable delivery via NVIC_EnableIRQ. The original "busy-wait,
+# no IRQ needed" assumption here was wrong: with this =0, CRYS_RndInit()
+# fails fast (~750us) because its bounded wait/retry loop times out
+# without ever receiving the completion signal; with ALL interrupts
+# globally disabled on top of that (a diagnostic test, not a real
+# config), it hangs forever instead, proving the dependency. Real-hardware
+# confirmed 2026-06-18 (see PLAN-c509-lice-followup.md Sec. 9.10).
+CFLAGS += -DNRF_CRYPTO_BACKEND_CC310_INTERRUPTS_ENABLED=1
+
+# --- optional: also enable Curve25519 (X25519 ECDH) + Ed25519 (EdDSA) ---
+# Off by default so the validated secp256r1 production builds stay byte-for-byte
+# unchanged.  Set CC310_ECC_25519=1 (the ec25519-bench does) to additionally
+# wire the CC310 Curve25519 + Ed25519 backends and their frontend/backend
+# sources.  These curves are independent of secp256r1, so the "more than one
+# backend" guards in cc310_backend_ecc.h are not triggered.
+ifeq ($(CC310_ECC_25519),1)
+  CONTIKI_CPU_SOURCEFILES += nrf_crypto_eddsa.c cc310_backend_eddsa.c
+  CFLAGS += -DNRF_CRYPTO_BACKEND_CC310_ECC_CURVE25519_ENABLED=1
+  CFLAGS += -DNRF_CRYPTO_BACKEND_CC310_ECC_ED25519_ENABLED=1
+  # Curve25519 parameter endianness.  RFC 7748 X25519 uses little-endian
+  # encoding for scalars and u-coordinates, so select little-endian (=0).
+  CFLAGS += -DNRF_CRYPTO_CURVE25519_BIG_ENDIAN_ENABLED=0
+endif
+
+# Nordic's own CC310 examples (examples/crypto/nrf_cc310/*/pca10056/blank/
+# armgcc/Makefile) all build with -D__STACK_SIZE=16384, double our default
+# 8192 (gcc_startup_nrf52840.S). The closed blob's own internal call frames
+# during CRYS_RndInit() (AES-CTR-DRBG instantiate, etc.) are invisible to
+# us -- testing whether 8 KB is simply too tight once Contiki's own call
+# depth at the point of the call is added on top.
+CFLAGS += -D__STACK_SIZE=16384
+
+# GCC 13 mis-reads nrf_crypto_init.c's linker-section walk (NRF_SECTION_ITEM_GET)
+# as an out-of-bounds access on a zero-length array — a false positive in
+# vendored Nordic SDK code that we keep pristine.  Suppress array-bounds for the
+# CC310 build only; -Warray-bounds (and -Werror) stay fully active in the
+# default / software-crypto builds, which compile the same shared code.
+CFLAGS += -Wno-array-bounds
+
+# --- vendored linker script ---
+# nrf_crypto registers its backends into a "crypto_data" linker section
+# (CRYPTO_BACKEND_REGISTER); nrf_crypto_init() walks it via
+# __start_crypto_data / __stop_crypto_data.  The stock mdk nrf_common.ld has no
+# such section, so we ship a patched copy in this platform's ld/ directory and
+# put it ahead of the SDK's on the linker search path, leaving the nrf52-sdk
+# submodule untouched.  (nrf52840.ld does INCLUDE "nrf_common.ld"; ld resolves
+# it from the first -L match.)  This -L is added here, before the SDK's mdk -L
+# in Makefile.nrf52840, so the patched copy wins — for CC310 builds only.
+LDFLAGS += -L $(CONTIKI_CPU)/ld
+
+# --- the closed-source CC310 runtime (hard-float, matches the platform ABI:
+#     -mfloat-abi=hard -mfpu=fpv4-sp-d16) ---
+TARGET_LIBFILES += $(CC310_BLOB)

--- a/arch/cpu/nrf52840/Makefile.nrf52840
+++ b/arch/cpu/nrf52840/Makefile.nrf52840
@@ -51,6 +51,11 @@ CONTIKI_CPU_SOURCEFILES += clock.c rtimer-arch.c uart0.c dbg.c watchdog.c
 CONTIKI_CPU_SOURCEFILES += int-master.c slip-arch.c gpio-hal-arch.c
 CONTIKI_CPU_SOURCEFILES += nrf52840-ieee.c
 
+# CryptoCell-310 hardware ECC backend (opt-in via ECC_HW_BACKEND=cc310).
+ifeq ($(ECC_HW_BACKEND),cc310)
+  include $(CONTIKI_CPU)/Makefile.cc310-crypto
+endif
+
 CONTIKI_SOURCEFILES += $(CONTIKI_CPU_SOURCEFILES)
 
 CFLAGS += -DNRF52840_XXAA

--- a/arch/cpu/nrf52840/dev/nrf52840-cc310-ecc.c
+++ b/arch/cpu/nrf52840/dev/nrf52840-cc310-ecc.c
@@ -1,0 +1,527 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *   nRF52840 CryptoCell-310 (CC310) hardware backend for the Contiki-NG
+ *   ECC service (\c lib/ecc.h).
+ *
+ *   This is the nRF52840 analogue of arch/cpu/cc2538/dev/cc2538-ecc.c
+ *   (which backs the same lib/ecc.h API onto the CC2538 PKA engine).
+ *   It routes ECDSA / ECDH / key-gen onto the ARM CryptoCell-310 via
+ *   Nordic's nrf_crypto abstraction (NRF_CRYPTO_BACKEND_CC310_ENABLED).
+ *
+ *   Once selected (see the build wiring at the bottom of this file), the
+ *   EDHOC / COSE / C509 stack accelerates transparently: cose.c calls
+ *   ecc_sign_hash() -> edhoc/ecdh.c -> ecc_sign() (this file) -> CC310.
+ *   No changes to cose.c / ecdh.c / edhoc are required.
+ *
+ *   DESIGN NOTE — blocking vs. protothread.
+ *   The lib/ecc.h API is protothread-based (callers spin
+ *   `while(PT_SCHEDULE(ecc_sign(...))) watchdog_periodic();`).
+ *   nrf_crypto operations are *blocking* (they call synchronously into
+ *   the closed-source CC310 runtime).  We therefore implement each
+ *   PT_THREAD as a single-shot protothread: it performs the whole
+ *   operation between PT_BEGIN/PT_END and returns PT_ENDED on the first
+ *   schedule.  This blocks the calling protothread for the (short, ~ms)
+ *   duration of the hardware op, which is acceptable for benchmarking and
+ *   matches the semantics of a synchronous accelerator call.  A fully
+ *   asynchronous variant would start the op, return PT_YIELDED, and resume
+ *   from the CC310 completion IRQ — left as future work (requires
+ *   nrf_crypto async mode + the CRYPTOCELL IRQ).
+ *
+ *   CURVE SUPPORT.  CC310 covers secp256r1 (and others), but this skeleton
+ *   wires only secp256r1 — the curve used by scenarios C/D.  Ed25519 does
+ *   NOT flow through lib/ecc.h (it uses os/services/c509/ed25519_verify.c),
+ *   so it is intentionally out of scope here.  brainpoolP256r1 is not
+ *   offered by CC310; ecc_enable() returns an error for unsupported curves
+ *   so the caller can fall back to the software backend.
+ * \author
+ *   Joel Höglund <joel.hoglund@ri.se>
+ */
+
+#include "lib/ecc.h"
+#include "lib/ecc-curve.h"
+#include "lib/csprng.h"
+#include "dev/watchdog.h"
+#include "sys/int-master.h"
+#include "sys/process-mutex.h"
+#include "sys/pt.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Nordic nRF5 SDK crypto abstraction (CC310 backend). */
+#include "nrf_crypto.h"
+#include "nrf_crypto_ecc.h"
+#include "nrf_crypto_ecdsa.h"
+#include "nrf_crypto_ecdh.h"
+#include "nrf_crypto_error.h"
+#include "nrf_crypto_rng.h"
+#include "cc310_backend_shared.h"
+#include "sns_silib.h"
+#include "crys_rnd.h"
+
+/*
+ * uECC is kept linked solely for software point decompression (see
+ * ecc_decompress_public_key below) — CC310/nrf_crypto exposes no public
+ * decompression entry point.  The build wiring excludes only
+ * os/services/ecc/ecc.c (the lib/ecc.h software backend, which would clash
+ * with the ecc_* symbols defined here); micro-ecc's uECC_* symbols do not
+ * clash and stay available.
+ */
+#include "uECC.h"
+
+/* Log configuration */
+#include "sys/log.h"
+#define LOG_MODULE "ECC-CC310"
+#define LOG_LEVEL LOG_LEVEL_NONE
+
+/*
+ * Raw key/element sizes for secp256r1.  nrf_crypto's "raw" encodings are
+ * big-endian and prefix-less, matching the lib/ecc.h convention exactly:
+ *   - private key / shared secret / hash : |CURVE|      = 32 bytes
+ *   - public key (X||Y, no 0x04)         : 2|CURVE|     = 64 bytes
+ *   - ECDSA signature (R||S)             : 2|CURVE|     = 64 bytes
+ */
+#define P256_ELEMENT_BYTES   32
+#define P256_POINT_BYTES     64
+#define P256_SIGNATURE_BYTES 64
+
+static struct pt main_protothread;
+static const ecc_curve_t *curve;
+static process_mutex_t mutex;
+
+/*
+ * nrf_crypto's default allocator on this toolchain is the ALLOCA one
+ * (NRF_CRYPTO_ALLOC_ON_STACK == 1, see nrf_crypto_mem.h) -- and
+ * nrf_crypto_rng_init() explicitly refuses a NULL context in that case
+ * (returns NRF_ERROR_CRYPTO_ALLOC_FAILED) rather than handing back a
+ * stack-allocated pointer that would dangle the instant the function
+ * returns, since the RNG context must stay valid across every later
+ * nrf_crypto_rng_vector_generate() call. A persistent (static) context is
+ * required; passing NULL (as both the boot-time NRF_CRYPTO_RNG_AUTO_INIT
+ * call and an earlier version of ecc_session_begin() did) always fails.
+ *
+ * The temp work buffer has the same stack-lifetime problem in spirit, plus
+ * a size problem: it is 6112 bytes (CRYS_RND_WORK_BUFFER_SIZE_WORDS=1528,
+ * crys_rnd.h) and the default nRF52840 stack is only 8192 bytes
+ * (gcc_startup_nrf52840.S) -- alloca'ing it (passing NULL, the only other
+ * option) at this call depth risks overflowing the stack outright. Static
+ * for both, for the same reason.
+ */
+static nrf_crypto_rng_context_t rng_context;
+static nrf_crypto_rng_temp_buffer_t rng_temp_buffer;
+
+/* Map a lib/ecc.h curve to the nrf_crypto curve_info.  NULL => unsupported. */
+static const nrf_crypto_ecc_curve_info_t *
+map_curve(const ecc_curve_t *c)
+{
+  if(c == &ecc_curve_p_256) {
+    return &g_nrf_crypto_ecc_secp256r1_curve_info;
+  }
+  /* brainpoolP256r1 / P-192 are not provided by CC310 in this skeleton. */
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+void
+ecc_init(void)
+{
+  /*
+   * nrf_crypto_init() is idempotent in the SDK (guarded by an internal
+   * "initialized" flag), so it is safe to call here even if the mbedTLS
+   * DTLS path (mbedtls-support.c) also initialises it.  It powers up the
+   * CRYPTOCELL wrapper (NRF_CRYPTOCELL->ENABLE) and the CC310 runtime.
+   */
+  ret_code_t ret = nrf_crypto_init();
+  if(ret != NRF_SUCCESS) {
+    LOG_ERR("nrf_crypto_init() failed (0x%lx)\n", (unsigned long)ret);
+  }
+}
+/*---------------------------------------------------------------------------*/
+process_mutex_t *
+ecc_get_mutex(void)
+{
+  return &mutex;
+}
+/*---------------------------------------------------------------------------*/
+int
+ecc_enable(const ecc_curve_t *c)
+{
+  if(map_curve(c) == NULL) {
+    LOG_WARN("curve '%s' not supported by CC310 backend\n",
+             c ? c->name : "(null)");
+    process_mutex_unlock(&mutex);
+    return -1;     /* caller falls back to software backend */
+  }
+  curve = c;
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+struct pt *
+ecc_get_protothread(void)
+{
+  return &main_protothread;
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(ecc_validate_public_key(const uint8_t *public_key, int *result))
+{
+  PT_BEGIN(&main_protothread);
+
+  watchdog_periodic();
+
+  /*
+   * nrf_crypto validates the point when importing it from raw, so a
+   * successful public_key_from_raw() is an on-curve / range check.
+   */
+  nrf_crypto_ecc_public_key_t pub;
+  ret_code_t ret = nrf_crypto_ecc_public_key_from_raw(map_curve(curve),
+                                                      &pub, public_key,
+                                                      P256_POINT_BYTES);
+  *result = (ret == NRF_SUCCESS) ? 0 : (int)ret;
+  if(ret == NRF_SUCCESS) {
+    nrf_crypto_ecc_public_key_free(&pub);
+  }
+
+  PT_END(&main_protothread);
+}
+/*---------------------------------------------------------------------------*/
+void
+ecc_compress_public_key(const uint8_t *uncompressed_public_key,
+                        uint8_t *compressed_public_key)
+{
+  /* SECG SEC 1 point compression: 0x02|0x03 prefix + X. */
+  compressed_public_key[0] =
+    0x02 | (uncompressed_public_key[2 * P256_ELEMENT_BYTES - 1] & 1);
+  memcpy(compressed_public_key + 1, uncompressed_public_key,
+         P256_ELEMENT_BYTES);
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(ecc_decompress_public_key(const uint8_t *compressed_public_key,
+                                    uint8_t *uncompressed_public_key,
+                                    int *result))
+{
+  PT_BEGIN(&main_protothread);
+
+  watchdog_periodic();
+
+  /*
+   * nrf_crypto has no public point-decompression entry point, so we reuse
+   * uECC's software decompressor (the same routine the lib/ecc.h software
+   * backend uses).  This runs at most once per handshake, when a peer C509
+   * credential carries a compressed EC point (c5t / c5c); all heavy
+   * operations (sign / verify / ECDH / key-gen) still execute on CC310.
+   * Input  : SEC1 compressed form (0x02|0x03 prefix || X), 1 + |CURVE| bytes.
+   * Output : prefix-less X||Y, 2|CURVE| bytes — the raw form lib/ecc.h and
+   *          nrf_crypto both expect.
+   */
+  if(curve == &ecc_curve_p_256) {
+    uECC_decompress(compressed_public_key, uncompressed_public_key,
+                    uECC_secp256r1());
+    *result = 0;
+  } else {
+    *result = -1;     /* only secp256r1 is wired in this backend */
+  }
+
+  PT_END(&main_protothread);
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(ecc_sign(const uint8_t *message_hash,
+                   const uint8_t *private_key,
+                   uint8_t *signature,
+                   int *result))
+{
+  PT_BEGIN(&main_protothread);
+
+  watchdog_periodic();
+
+  nrf_crypto_ecc_private_key_t priv;
+  ret_code_t ret = nrf_crypto_ecc_private_key_from_raw(map_curve(curve),
+                                                       &priv, private_key,
+                                                       P256_ELEMENT_BYTES);
+  if(ret != NRF_SUCCESS) {
+    *result = (int)ret;
+    PT_EXIT(&main_protothread);
+  }
+
+  size_t sig_size = P256_SIGNATURE_BYTES;
+  ret = nrf_crypto_ecdsa_sign(NULL, &priv,
+                              message_hash, P256_ELEMENT_BYTES,
+                              signature, &sig_size);
+  nrf_crypto_ecc_private_key_free(&priv);
+
+  *result = (ret == NRF_SUCCESS) ? 0 : (int)ret;
+
+  PT_END(&main_protothread);
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(ecc_verify(const uint8_t *signature,
+                     const uint8_t *message_hash,
+                     const uint8_t *public_key,
+                     int *result))
+{
+  PT_BEGIN(&main_protothread);
+
+  watchdog_periodic();
+
+  nrf_crypto_ecc_public_key_t pub;
+  ret_code_t ret = nrf_crypto_ecc_public_key_from_raw(map_curve(curve),
+                                                      &pub, public_key,
+                                                      P256_POINT_BYTES);
+  if(ret != NRF_SUCCESS) {
+    *result = (int)ret;
+    PT_EXIT(&main_protothread);
+  }
+
+  ret = nrf_crypto_ecdsa_verify(NULL, &pub,
+                                message_hash, P256_ELEMENT_BYTES,
+                                signature, P256_SIGNATURE_BYTES);
+  nrf_crypto_ecc_public_key_free(&pub);
+
+  /* nrf_crypto returns NRF_ERROR_CRYPTO_ECDSA_INVALID_SIGNATURE on mismatch. */
+  *result = (ret == NRF_SUCCESS) ? 0 : (int)ret;
+
+  PT_END(&main_protothread);
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(ecc_generate_key_pair(uint8_t *public_key,
+                                uint8_t *private_key,
+                                int *result))
+{
+  PT_BEGIN(&main_protothread);
+
+  watchdog_periodic();
+
+  nrf_crypto_ecc_private_key_t priv;
+  nrf_crypto_ecc_public_key_t pub;
+  ret_code_t ret = nrf_crypto_ecc_key_pair_generate(NULL, map_curve(curve),
+                                                    &priv, &pub);
+  if(ret != NRF_SUCCESS) {
+    *result = (int)ret;
+    PT_EXIT(&main_protothread);
+  }
+
+  size_t priv_size = P256_ELEMENT_BYTES;
+  size_t pub_size = P256_POINT_BYTES;
+  ret = nrf_crypto_ecc_private_key_to_raw(&priv, private_key, &priv_size);
+  if(ret == NRF_SUCCESS) {
+    ret = nrf_crypto_ecc_public_key_to_raw(&pub, public_key, &pub_size);
+  }
+  nrf_crypto_ecc_private_key_free(&priv);
+  nrf_crypto_ecc_public_key_free(&pub);
+
+  *result = (ret == NRF_SUCCESS) ? 0 : (int)ret;
+
+  PT_END(&main_protothread);
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(ecc_generate_shared_secret(const uint8_t *public_key,
+                                     const uint8_t *private_key,
+                                     uint8_t *shared_secret,
+                                     int *result))
+{
+  PT_BEGIN(&main_protothread);
+
+  watchdog_periodic();
+
+  nrf_crypto_ecc_private_key_t priv;
+  nrf_crypto_ecc_public_key_t pub;
+  ret_code_t ret = nrf_crypto_ecc_private_key_from_raw(map_curve(curve),
+                                                       &priv, private_key,
+                                                       P256_ELEMENT_BYTES);
+  if(ret != NRF_SUCCESS) {
+    *result = (int)ret;
+    PT_EXIT(&main_protothread);
+  }
+  ret = nrf_crypto_ecc_public_key_from_raw(map_curve(curve), &pub,
+                                           public_key, P256_POINT_BYTES);
+  if(ret != NRF_SUCCESS) {
+    nrf_crypto_ecc_private_key_free(&priv);
+    *result = (int)ret;
+    PT_EXIT(&main_protothread);
+  }
+
+  /*
+   * nrf_crypto_ecdh_compute yields the X coordinate of the shared point
+   * (|CURVE| bytes) — the same raw ECDH output lib/ecc.h specifies.
+   */
+  size_t secret_size = P256_ELEMENT_BYTES;
+  ret = nrf_crypto_ecdh_compute(NULL, &priv, &pub,
+                                shared_secret, &secret_size);
+  nrf_crypto_ecc_private_key_free(&priv);
+  nrf_crypto_ecc_public_key_free(&pub);
+
+  *result = (ret == NRF_SUCCESS) ? 0 : (int)ret;
+
+  PT_END(&main_protothread);
+}
+/*---------------------------------------------------------------------------*/
+void
+ecc_disable(void)
+{
+  curve = NULL;
+  process_mutex_unlock(&mutex);
+}
+/*---------------------------------------------------------------------------*/
+void
+ecc_session_begin(void)
+{
+  /*
+   * Begin a CC310 crypto session: power the block on, ensure the CC310
+   * runtime library is initialised for this power-up, and instantiate the
+   * TRNG-seeded CTR-DRBG once for the whole session.
+   *
+   * ROOT CAUSE of the long CC310 bring-up failure (confirmed 2026-06-19,
+   * PLAN section 9.11.4): the CC310 TRNG seeds the DRBG by sampling
+   * ring-oscillator jitter over a bounded CPU-cycle window. Any unrelated
+   * interrupt firing during that window -- notably Contiki's 128 Hz RTC0
+   * system tick (clock.c) -- injects latency that blows the window and
+   * fails the TRNG startup test (CRYS_RND_STARTUP_FAILED /
+   * CRYS_RND_INSTANTIATION_ERROR). The bare-metal SDK reference has no such
+   * interrupts and works. The instantiation must therefore run with all
+   * interrupts masked EXCEPT CC310's own completion interrupt -- masking
+   * that one too (e.g. via PRIMASK / __disable_irq) deadlocks, because the
+   * entropy-wait needs it to make progress. BASEPRI gives exactly that:
+   * raise CRYPTOCELL_IRQn to the top priority (0) and block every priority
+   * >= 1. This only matters for the TRNG seeding; once the DRBG is
+   * instantiated, per-op output (keygen / ECDSA nonce) is deterministic
+   * AES-CTR and needs no isolation.
+   *
+   * SaSi_LibInit() is called here (not just at boot) because it sets up
+   * CC310 HW state on the current power-up and clears NRF_CRYPTOCELL->ENABLE
+   * on exit -- so ENABLE is explicitly re-asserted before instantiation.
+   */
+  cc310_backend_enable();                 /* NRF_CRYPTOCELL->ENABLE = 1 */
+
+  NVIC_SetPriority(CRYPTOCELL_IRQn, 0);   /* highest priority: never BASEPRI-masked */
+  NVIC_EnableIRQ(CRYPTOCELL_IRQn);
+  uint32_t old_basepri = __get_BASEPRI();
+  __set_BASEPRI(1u << (8u - __NVIC_PRIO_BITS)); /* mask all IRQs of priority >= 1 */
+
+  SaSi_LibInit();
+  *(volatile uint32_t *)0x5002A500UL = 1; /* SaSi_LibInit clears ENABLE; re-assert */
+  ret_code_t ret = nrf_crypto_rng_init(&rng_context, &rng_temp_buffer);
+
+  __set_BASEPRI(old_basepri);
+
+  if(ret != NRF_SUCCESS) {
+    LOG_ERR("ecc_session_begin: nrf_crypto_rng_init failed (0x%lx)\n",
+            (unsigned long)ret);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+ecc_session_end(void)
+{
+  cc310_backend_disable();
+}
+/*---------------------------------------------------------------------------*/
+
+/*
+ * ============================ BUILD WIRING ============================
+ *
+ * 1. Add the blob + nrf_crypto sources.  Use the FULL library, NOT the
+ *    bootloader subset:
+ *      - WRONG: external/nrf_cc310_bl/.../libnrf_cc310_bl_0.9.13.a
+ *               (verify + SHA-256 + AES only; no ECDSA sign, no ECDH,
+ *                no keygen, and a different low-level nrf_cc310_bl_ / CRYS
+ *                API — it cannot drive an EDHOC handshake).
+ *      - RIGHT (verified, nRF5_SDK_17.1.0_ddde560, hard-float to match
+ *               Contiki's -mfloat-abi=hard -mfpu=fpv4-sp-d16):
+ *          external/nrf_cc310/lib/cortex-m4/hard-float/libnrf_cc310_0.9.13.a
+ *        Exports CRYS_ECDSA_Sign / CRYS_ECDSA_Verify / CRYS_ECDH_SVDP_DH /
+ *        CRYS_ECPKI_GenKeyPair — everything this backend needs.
+ *
+ *    High-level frontend + CC310 backend C sources: USE THE ALREADY-
+ *    VENDORED Contiki copies under
+ *      arch/cpu/nrf52840/lib/nrf52-sdk/components/libraries/crypto/
+ *    They were diffed against SDK 17.1.0 and are identical except for
+ *    (a) copyright year and (b) a deliberate Contiki power-gating patch
+ *    that toggles NRF_CRYPTOCELL->ENABLE around each ECDSA/ECDH op (stock
+ *    17.1.0 leaves CC310 enabled after init).  The blob-facing structs
+ *    (nrf_crypto_ecc.h, cc310_backend_ecc.h) are byte-identical to 17.1.0,
+ *    and the vendored backend calls the SAME CRYS_* symbols — so it is
+ *    ABI-compatible with the 17.1.0 blob AND keeps the low-power gating.
+ *    Only the CRYS/SaSi headers and the blob are NOT vendored; take those
+ *    two from SDK 17.1.0:
+ *      external/nrf_cc310/include/                       (CRYS/SaSi headers)
+ *      external/nrf_cc310/lib/cortex-m4/hard-float/libnrf_cc310_0.9.13.a
+ *
+ *    In arch/cpu/nrf52840/Makefile.nrf52840 (or a dedicated
+ *    Makefile.cc310-crypto it includes):
+ *
+ *      # CryptoCell-310 hardware crypto (full lib)
+ *      CONTIKI_CPU_DIRS        += dev
+ *      CONTIKI_CPU_SOURCEFILES += nrf52840-cc310-ecc.c
+ *      # vendored nrf_crypto frontend + cc310 backend (already in-tree):
+ *      VCRYPTO := lib/nrf52-sdk/components/libraries/crypto
+ *      CONTIKI_CPU_DIRS        += $(VCRYPTO) $(VCRYPTO)/backend/cc310
+ *      CONTIKI_CPU_SOURCEFILES += \
+ *          nrf_crypto_ecc.c nrf_crypto_ecdsa.c nrf_crypto_ecdh.c \
+ *          nrf_crypto_init.c \
+ *          cc310_backend_ecc.c cc310_backend_ecdsa.c cc310_backend_ecdh.c \
+ *          cc310_backend_init.c cc310_backend_mutex.c cc310_backend_shared.c
+ *      # headers + blob from SDK 17.1.0 (NOT vendored):
+ *      SDK := $(CONTIKI)/../nRF5_SDK_17.1.0_ddde560      # adjust to taste
+ *      CFLAGS += -I$(SDK)/external/nrf_cc310/include
+ *      CFLAGS += -DNRF_CRYPTO_BACKEND_CC310_ENABLED=1 \
+ *                -DNRF_CRYPTO_ECC_SECP256R1_ENABLED=1
+ *      TARGET_LIBFILES += \
+ *          $(SDK)/external/nrf_cc310/lib/cortex-m4/hard-float/libnrf_cc310_0.9.13.a
+ *
+ *    (If the 2019-vintage vendored backend ever fails to compile against
+ *    the 17.1.0 CRYS headers, fall back to copying 17.1.0's own frontend +
+ *    backend .c over the vendored ones — they are a matched pair — at the
+ *    cost of losing the power-gating patch.)
+ *
+ * 2. Suppress the software backend so symbols don't clash.  Only
+ *    os/services/ecc/ecc.c defines the lib/ecc.h ecc_* entry points that
+ *    this file also defines, so that ONE file must be excluded.  micro-ecc
+ *    (uECC_*) does NOT clash and is kept linked for ecc_decompress_public_key
+ *    above.  Gate Makefile.ecc on a flag, e.g.
+ *      ifeq ($(ECC_HW_BACKEND),cc310)
+ *        MODULES += os/net/security/micro-ecc      # for uECC_decompress only
+ *        CONTIKI_SOURCES_EXCLUDES += ecc.c         # hw backend supplies ecc_*
+ *      else
+ *        MODULES += os/net/security/micro-ecc
+ *      endif
+ *    and set ECC_HW_BACKEND=cc310 in the nRF52840 app project Makefile.
+ *
+ * 3. SHA-256 (optional, separate swap).  os/lib/sha-256.c exposes a
+ *    sha_256_driver struct; a CC310 SHA driver (cc310_backend_hash.c) can
+ *    replace it the same way for additional acceleration of the COSE
+ *    Sig_structure hashing.  Not required for the ECDSA/ECDH speedup.
+ *
+ * 4. Verify: build edhoc-oscore-c5t-* for TARGET=nrf52840, flash a DK, run
+ *    the handshake, and compare wall-clock vs. the uECC software baseline
+ *    (paper Table bp256-arm-timing, secp256r1 = 1172 ms) and Fedrecheski
+ *    2024's ~135 ms CC310 EDHOC figure.
+ * =====================================================================
+ */

--- a/arch/cpu/nrf52840/ld/nrf_common.ld
+++ b/arch/cpu/nrf52840/ld/nrf_common.ld
@@ -1,0 +1,195 @@
+/* Linker script for Nordic Semiconductor nRF devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+
+/*
+ * RISE/Contiki-NG NOTE: this is a verbatim copy of the nrf52-sdk submodule's
+ * modules/nrfx/mdk/nrf_common.ld, with ONE addition — the ".crypto_data"
+ * output section (see below) required by Nordic's nrf_crypto backend registry.
+ * It is kept here (outside the submodule, which stays pristine) and selected
+ * ahead of the submodule copy via "-L $(CONTIKI_CPU)/ld" in
+ * Makefile.cc310-crypto, which is only added for CC310 (ECC_HW_BACKEND=cc310)
+ * builds.  If the submodule's nrf_common.ld is ever updated, re-sync this copy.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    /*
+     * Nordic nrf_crypto registers each crypto backend into the "crypto_data"
+     * linker section via CRYPTO_BACKEND_REGISTER (NRF_SECTION_ITEM_REGISTER);
+     * nrf_crypto_init() walks it between __start_crypto_data and
+     * __stop_crypto_data.  Placed here (read-only FLASH, before __etext) so
+     * that .data's load address (AT (__etext)) accounts for it.  Harmless when
+     * nrf_crypto is unused: the section is empty and the symbols unreferenced.
+     */
+    . = ALIGN(4);
+    .crypto_data :
+    {
+        PROVIDE(__start_crypto_data = .);
+        KEEP(*(SORT(.crypto_data*)))
+        PROVIDE(__stop_crypto_data = .);
+    } > FLASH
+
+    . = ALIGN(4);
+    __etext = .;
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+    
+    .heap (COPY):
+    {
+        __HeapBase = .;
+        __end__ = .;
+        PROVIDE(end = .);
+        KEEP(*(.heap*))
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        KEEP(*(.stack*))
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+    
+    /* Check if text sections + data exceeds FLASH limit */
+    DataInitFlashUsed = __bss_start__ - __data_start__;
+    CodeFlashUsed = __etext - ORIGIN(FLASH);
+    TotalFlashUsed = CodeFlashUsed + DataInitFlashUsed;
+    ASSERT(TotalFlashUsed <= LENGTH(FLASH), "region FLASH overflowed with .data and user data")
+    
+}

--- a/examples/libs/ecc/Makefile
+++ b/examples/libs/ecc/Makefile
@@ -4,9 +4,26 @@ all: $(CONTIKI_PROJECT)
 CONTIKI = ../../..
 include $(CONTIKI)/Makefile.identify-target
 
-ifeq ($(TARGET),native)
-# Include software implementation of ECC
+# The lib/ecc.h ECC service. Uses the portable software (uECC) backend by
+# default on every target.
 MODULES += os/services/ecc
+
+# Hardware acceleration is opt-in and selected at build time (the backend is
+# chosen at link time, so it is not a runtime switch). On a platform that ships
+# a hardware lib/ecc.h backend, set ECC_HW_BACKEND to route these examples onto
+# it -- e.g. the nRF52840 CryptoCell-310:
+#
+#   make TARGET=nrf52840 BOARD=dk ECC_HW_BACKEND=cc310 \
+#        NRF_CC310_SDK=/path/to/nRF5_SDK_17.1.0_ddde560
+#
+# Leave ECC_HW_BACKEND unset for the software backend (the default, all targets).
+# The examples call ecc_session_begin()/ecc_session_end() (no-ops in software),
+# so the identical source runs with or without hardware acceleration; the chosen
+# backend is printed at startup ("ECC backend: ...").
+ifeq ($(ECC_HW_BACKEND),cc310)
+  CFLAGS += -DECC_BACKEND_LABEL='"CC310 hardware"'
+else
+  CFLAGS += -DECC_BACKEND_LABEL='"software (uECC)"'
 endif
 
 include $(CONTIKI)/Makefile.include

--- a/examples/libs/ecc/compress.c
+++ b/examples/libs/ecc/compress.c
@@ -46,6 +46,14 @@
 #define ECC_CURVE (&ecc_curve_p_256)
 #define ECC_CURVE_SIZE (ECC_CURVE_P_256_SIZE)
 
+/*
+ * Set by the Makefile from ECC_HW_BACKEND so the log says which backend ran.
+ * Defaults to the portable software (uECC) backend.
+ */
+#ifndef ECC_BACKEND_LABEL
+#define ECC_BACKEND_LABEL "software (uECC)"
+#endif
+
 PROCESS(compress_process, "compress_process");
 AUTOSTART_PROCESSES(&compress_process);
 static rtimer_clock_t t1, t2;
@@ -68,10 +76,21 @@ PROCESS_THREAD(compress_process, ev, data)
 
   PROCESS_BEGIN();
 
+  LOG_INFO("ECC backend: %s\n", ECC_BACKEND_LABEL);
+
+  /*
+   * Begin an ECC session. A hardware backend (e.g. nRF52840 CC310) holds
+   * accelerator power and performs a one-time RNG instantiation here; the
+   * software backend treats it as a no-op. Always paired with ecc_session_end()
+   * so the same source works with or without hardware acceleration.
+   */
+  ecc_session_begin();
+
   /* enable ECC driver */
   PROCESS_WAIT_UNTIL(process_mutex_try_lock(ecc_get_mutex()));
   if(ecc_enable(ECC_CURVE)) {
     LOG_ERR("enable failed\n");
+    ecc_session_end();
     PROCESS_EXIT();
   }
 
@@ -106,6 +125,7 @@ PROCESS_THREAD(compress_process, ev, data)
 
 exit:
   ecc_disable();
+  ecc_session_end();
   PROCESS_END();
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/libs/ecc/ecdh.c
+++ b/examples/libs/ecc/ecdh.c
@@ -46,6 +46,14 @@
 #define ECC_CURVE (&ecc_curve_p_256)
 #define ECC_CURVE_SIZE (ECC_CURVE_P_256_SIZE)
 
+/*
+ * Set by the Makefile from ECC_HW_BACKEND so the log says which backend ran.
+ * Defaults to the portable software (uECC) backend.
+ */
+#ifndef ECC_BACKEND_LABEL
+#define ECC_BACKEND_LABEL "software (uECC)"
+#endif
+
 PROCESS(ecdh_process, "ecdh_process");
 AUTOSTART_PROCESSES(&ecdh_process);
 static rtimer_clock_t t1, t2;
@@ -70,10 +78,21 @@ PROCESS_THREAD(ecdh_process, ev, data)
 
   PROCESS_BEGIN();
 
+  LOG_INFO("ECC backend: %s\n", ECC_BACKEND_LABEL);
+
+  /*
+   * Begin an ECC session. A hardware backend (e.g. nRF52840 CC310) holds
+   * accelerator power and performs a one-time RNG instantiation here; the
+   * software backend treats it as a no-op. Always paired with ecc_session_end()
+   * so the same source works with or without hardware acceleration.
+   */
+  ecc_session_begin();
+
   /* enable ECC driver */
   PROCESS_WAIT_UNTIL(process_mutex_try_lock(ecc_get_mutex()));
   if(ecc_enable(ECC_CURVE)) {
     LOG_ERR("enable failed\n");
+    ecc_session_end();
     PROCESS_EXIT();
   }
 
@@ -143,6 +162,7 @@ PROCESS_THREAD(ecdh_process, ev, data)
 
 exit:
   ecc_disable();
+  ecc_session_end();
   PROCESS_END();
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/libs/ecc/ecdsa.c
+++ b/examples/libs/ecc/ecdsa.c
@@ -46,6 +46,14 @@
 #define ECC_CURVE (&ecc_curve_p_256)
 #define ECC_CURVE_SIZE (ECC_CURVE_P_256_SIZE)
 
+/*
+ * Set by the Makefile from ECC_HW_BACKEND so the log says which backend ran.
+ * Defaults to the portable software (uECC) backend.
+ */
+#ifndef ECC_BACKEND_LABEL
+#define ECC_BACKEND_LABEL "software (uECC)"
+#endif
+
 PROCESS(ecdsa_process, "ecdsa_process");
 AUTOSTART_PROCESSES(&ecdsa_process);
 static rtimer_clock_t t1, t2;
@@ -68,10 +76,21 @@ PROCESS_THREAD(ecdsa_process, ev, data)
 
   PROCESS_BEGIN();
 
+  LOG_INFO("ECC backend: %s\n", ECC_BACKEND_LABEL);
+
+  /*
+   * Begin an ECC session. A hardware backend (e.g. nRF52840 CC310) holds
+   * accelerator power and performs a one-time RNG instantiation here; the
+   * software backend treats it as a no-op. Always paired with ecc_session_end()
+   * so the same source works with or without hardware acceleration.
+   */
+  ecc_session_begin();
+
   /* enable ECC driver */
   PROCESS_WAIT_UNTIL(process_mutex_try_lock(ecc_get_mutex()));
   if(ecc_enable(ECC_CURVE)) {
     LOG_ERR("enable failed\n");
+    ecc_session_end();
     PROCESS_EXIT();
   }
 
@@ -114,6 +133,7 @@ PROCESS_THREAD(ecdsa_process, ev, data)
 
 exit:
   ecc_disable();
+  ecc_session_end();
   PROCESS_END();
 }
 /*---------------------------------------------------------------------------*/

--- a/os/lib/ecc.h
+++ b/os/lib/ecc.h
@@ -166,6 +166,23 @@ PT_THREAD(ecc_generate_shared_secret(const uint8_t *public_key,
  */
 void ecc_disable(void);
 
+/**
+ * \brief Begins a session covering multiple ecc_enable()/ecc_disable() pairs
+ *        (e.g. a whole handshake's worth of keygen/sign/verify/ECDH calls).
+ *
+ * Hardware backends with accelerator power-gating and/or RNG/DRBG state that
+ * does not survive a power-down (e.g. nRF52840 CC310) use this to hold power
+ * (and re-seed any RNG once) across the whole session, instead of repeating
+ * that work for every individual operation. No-op on backends without such
+ * state (e.g. the software uECC backend) -- always safe to call.
+ */
+void ecc_session_begin(void);
+
+/**
+ * \brief Ends a session started with ecc_session_begin().
+ */
+void ecc_session_end(void);
+
 #endif /* ECC_H_ */
 
 /** @} */

--- a/os/services/ecc/Makefile.ecc
+++ b/os/services/ecc/Makefile.ecc
@@ -1,5 +1,15 @@
-# Include uECC
+# Include uECC.
+# Kept linked even with a hardware backend: the CC310 backend reuses
+# uECC_decompress for EC point decompression (nrf_crypto has none).
 MODULES += os/net/security/micro-ecc
+
+# ECC_HW_BACKEND=cc310 routes lib/ecc.h onto the nRF52840 CryptoCell-310
+# (arch/cpu/nrf52840/dev/nrf52840-cc310-ecc.c, wired via
+# arch/cpu/nrf52840/Makefile.cc310-crypto).  Exclude the software lib/ecc.h
+# backend so its ecc_* symbols don't clash with the hardware backend's.
+ifeq ($(ECC_HW_BACKEND),cc310)
+  CONTIKI_SOURCES_EXCLUDES += ecc.c
+endif
 
 # Disable hardware-accelerated ECC
 CONTIKI_SOURCES_EXCLUDES += cc2538-ecc.c

--- a/os/services/ecc/ecc.c
+++ b/os/services/ecc/ecc.c
@@ -186,5 +186,22 @@ ecc_disable(void)
   process_mutex_unlock(&mutex);
 }
 /*---------------------------------------------------------------------------*/
+/*
+ * No-op session hooks for the software (uECC) backend. They exist so callers
+ * can wrap ECC operations in ecc_session_begin()/ecc_session_end() uniformly
+ * across backends (see lib/ecc.h). The CC310 hardware backend uses them to
+ * enable CryptoCell and perform the BASEPRI-isolated RNG instantiation; the
+ * software backend needs neither, so these are intentionally empty.
+ */
+void
+ecc_session_begin(void)
+{
+}
+/*---------------------------------------------------------------------------*/
+void
+ecc_session_end(void)
+{
+}
+/*---------------------------------------------------------------------------*/
 
 /** @} */


### PR DESCRIPTION
### Contribution

An opt-in nRF52840 CryptoCell-310 backend for the `lib/ecc.h` ECC service, mirroring the existing `cc2538-ecc.c` precedent. Enabled with `ECC_HW_BACKEND=cc310`; default builds are unchanged. secp256r1 by default, Curve25519/Ed25519 behind `CC310_ECC_25519=1`.

The Nordic `nrf_crypto` frontend + cc310 backend sources come from the in-tree `nrf52-sdk` submodule. The closed CryptoCell runtime blob and CRYS headers are referenced from nRF5 SDK 17.1.0 (via `NRF_CC310_SDK`), not vendored - the build emits a clear error if the SDK isn't found. A patched `nrf_common.ld` (shipped in `arch/cpu/nrf52840/ld/`, used only for CC310 builds) supplies the `crypto_data` linker section `nrf_crypto_init()` walks, leaving the submodule untouched.

Adds a small `ecc_session_begin()/ecc_session_end()` ECC-service API so a caller can hold accelerator power and perform the one-time CC310 TRNG instantiation across a handshake; both are no-ops on the software backend.

### Testing

Builds cleanly for `nrf52840/dk` in both the CC310 and default software configurations. Validated on nRF52840-DK hardware: secp256r1 keygen/sign/verify/ECDH run correctly on CC310, ~19 ms per operation.

### Note for reviewers

The binary blob is licensed under Nordic's 5-clause SLA and cannot be redistributed in-tree - hence the reference-by-path. The `INTERRUPTS_ENABLED=1` / BASEPRI-isolated TRNG instantiation is required: the blob's TRNG wait depends on the CRYPTOCELL NVIC interrupt, and entropy collection must be isolated from the RTC tick (tested on the nrf hardware).
