### PR TITLE
link-stats: Use wraparound-safe comparison of clock_time_t values

### DIFF
--- a/os/net/link-stats.c
+++ b/os/net/link-stats.c
@@ -105,8 +105,9 @@ int
 link_stats_is_fresh(const struct link_stats *stats)
 {
   return (stats != NULL)
-      && clock_time() - stats->last_tx_time < FRESHNESS_EXPIRATION_TIME
-      && stats->freshness >= FRESHNESS_TARGET;
+         && CLOCK_LT(clock_time(),
+                     stats->last_tx_time + FRESHNESS_EXPIRATION_TIME)
+         && stats->freshness >= FRESHNESS_TARGET;
 }
 /*---------------------------------------------------------------------------*/
 #if LINK_STATS_INIT_ETX_FROM_RSSI


### PR DESCRIPTION
This PR replaces a comparison between `clock_time_t` values with the wraparound-safe `CLOCK_LT` macro. I also ran uncrustify over this snippet.