### PR TITLE
Fix bug in link-stats RSSI->ETX estimate where better RSSI yields worse ETX

### DIFF
--- a/os/net/link-stats.c
+++ b/os/net/link-stats.c
@@ -114,7 +114,7 @@ link_stats_is_fresh(const struct link_stats *stats)
  * Returns initial ETX value from an RSSI value.
  *    RSSI >= RSSI_HIGH           -> use default ETX
  *    RSSI_LOW < RSSI < RSSI_HIGH -> ETX is a linear function of RSSI
- *    RSSI <= RSSI_LOW            -> use minimal initial ETX
+ *    RSSI <= RSSI_LOW            -> use maximal initial ETX
  **/
 static uint16_t
 guess_etx_from_rssi(const struct link_stats *stats)
@@ -123,7 +123,7 @@ guess_etx_from_rssi(const struct link_stats *stats)
     if(stats->rssi == LINK_STATS_RSSI_UNKNOWN) {
       return ETX_DEFAULT * ETX_DIVISOR;
     } else {
-      const int16_t rssi_delta = stats->rssi - LINK_STATS_RSSI_LOW;
+      const int16_t rssi_delta = LINK_STATS_RSSI_HIGH - stats->rssi;
       const int16_t bounded_rssi_delta = BOUND(rssi_delta, 0, RSSI_DIFF);
       /* Penalty is in the range from 0 to ETX_DIVISOR */
       const uint16_t penalty = ETX_DIVISOR * bounded_rssi_delta / RSSI_DIFF;


### PR DESCRIPTION
Introduced in #2367, the RSSI to ETX estimate was supposed to be be positive correlated, however, the function does the opposite: An RSSI of -60 yields an ETX of 3 and -90 yields an ETX of 2. This PR fixes it, and the output now matches the example outputs provided in the original PR #2367. 


See [online example](https://www.programiz.com/online-compiler/6bPQwHhqJxyn5) output:
```
 RSSI | ETX old (buggy)    | ETX new (fixed)       
------+--------------------+-------------------
  -55 |   384 ( 3.000)     |   256 ( 2.000)
  -60 |   384 ( 3.000)     |   256 ( 2.000)
  -65 |   362 ( 2.828)     |   277 ( 2.164)
  -70 |   341 ( 2.664)     |   298 ( 2.328)
  -75 |   320 ( 2.500)     |   320 ( 2.500)
  -80 |   298 ( 2.328)     |   341 ( 2.664)
  -85 |   277 ( 2.164)     |   362 ( 2.828)
  -90 |   256 ( 2.000)     |   384 ( 3.000)
  -95 |   256 ( 2.000)     |   384 ( 3.000)
```

Closes #3070 and #2953 