### PR TITLE
nrf: use nrfutil to program Nordic Semiconductor devices

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -138,60 +138,113 @@ CONTIKI_CPU_DIRS += usb/
 
 CONTIKI_SOURCEFILES += $(CONTIKI_CPU_SOURCEFILES)
 
-# Upload via J-Link using nrfjprog 
+# Upload via J-Link using nrfutil
 
 .PHONY: nrf-upload-sequence
 
-NRFJPROG ?= nrfjprog
 NRFUTIL ?= nrfutil
 
-ifdef NRF_UPLOAD_SN
-  NRFJPROG_OPTIONS += --snr $(NRF_UPLOAD_SN)
+# Default serial port for the login/serialdump targets.
+PORT ?= /dev/ttyACM0
+
+# Fail at recipe run time (not makefile parse time) if nrfutil is missing.
+NRFUTIL_CHECK = @command -v $(NRFUTIL) >/dev/null 2>&1 || { echo 'ERROR: Could not find nrfutil "$(NRFUTIL)", please install it' >&2; exit 1; }
+
+# The device family, set by the SoC makefiles (nrf52, nrf53, ...). Used both
+# as a safety check when programming and to only consider attached devices
+# of the right family.
+NRFUTIL_FAMILY = $(if $(NRF_DEVICE_FAMILY),--family $(NRF_DEVICE_FAMILY))
+
+# Number of boards to program in parallel
+NUMPAR = 4
+
+# Boards that override the upload targets with a non-J-Link method
+# (e.g. the nRF52840 dongle) set this to 0 to skip the J-Link-based
+# upload rules and device enumeration below.
+NRF_JLINK_UPLOAD ?= 1
+
+ifeq ($(NRF_JLINK_UPLOAD),1)
+
+# When uploading without an explicit serial number, look up the device to
+# program: from a PORT given on the command line (as used by the login
+# target; the file-level default above must not select the device), or by
+# enumerating the attached devices of the right family. Skipped when
+# nrfutil is not installed - the upload recipe reports the missing tool
+# instead - and when the SoC makefile declares no device family
+# (e.g. nrf54l15, which overrides the upload rules with its own).
+ifneq ($(filter %.upload,$(MAKECMDGOALS)),)
+  ifeq ($(NRF_UPLOAD_SN),)
+    ifneq ($(NRF_DEVICE_FAMILY),)
+      ifeq ($(origin PORT),command line)
+        NRF_PORT_SN := $(shell command -v $(NRFUTIL) >/dev/null 2>&1 && NRFUTIL=$(NRFUTIL) $(CONTIKI)/tools/nrf/nrf-serials --port $(PORT) $(NRF_DEVICE_FAMILY))
+      else
+        NRF_ATTACHED_SNRS := $(shell command -v $(NRFUTIL) >/dev/null 2>&1 && NRFUTIL=$(NRFUTIL) $(CONTIKI)/tools/nrf/nrf-serials $(NRF_DEVICE_FAMILY))
+      endif
+    endif
+  endif
 endif
 
-%.upload: $(OUT_HEX)
-ifeq (, $(shell which $(NRFJPROG)))
-	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
-else
-	$(NRFJPROG) $(NRFJPROG_OPTIONS) $(NRFJPROG_FLAGS) --sectorerase --verify --program $<
-	$(NRFJPROG) $(NRFJPROG_OPTIONS) $(NRFJPROG_FLAGS) --reset
+# .upload-all programs every attached devkit of the target's device
+# family. Refuse when the SoC makefile declares no device family:
+# without the family filter, firmware could be programmed onto attached
+# devices of other families.
+ifneq ($(filter %.upload-all,$(MAKECMDGOALS)),)
+  ifeq ($(NRF_DEVICE_FAMILY),)
+    $(error .upload-all is not supported for this SoC (no NRF_DEVICE_FAMILY set) - use .upload with NRF_UPLOAD_SN to program a specific device)
+  endif
 endif
+
+# The device to program: NRF_UPLOAD_SN if given, otherwise the device with
+# serial port PORT, otherwise the only attached device of the right family.
+# Empty if no or several devices are attached.
+NRF_SELECTED_SN = $(or $(NRF_UPLOAD_SN),$(NRF_PORT_SN),$(if $(filter 1,$(words $(NRF_ATTACHED_SNRS))),$(strip $(NRF_ATTACHED_SNRS))))
+
+NRFUTIL_SELECT = --serial-number $(NRF_SELECTED_SN)
+
+# Fail the single-device upload target unless exactly one device is selected.
+NRF_SELECT_ERROR = $(if $(filter command line,$(origin PORT)),Could not find an attached device with serial port $(PORT),Cannot select the device to program (attached: $(if $(NRF_ATTACHED_SNRS),$(NRF_ATTACHED_SNRS),none)))
+NRFUTIL_DEVICE_CHECK = $(if $(NRF_SELECTED_SN),,@{ echo 'ERROR: $(NRF_SELECT_ERROR).'; echo 'Specify the device with NRF_UPLOAD_SN=<serial number> or program all attached devices with the .upload-all target.'; echo 'Diagnose the device enumeration with: $(CONTIKI)/tools/nrf/nrf-serials $(NRF_DEVICE_FAMILY)'; } >&2; exit 1)
+
+# Same semantics as the old nrfjprog invocation:
+# --sectorerase --verify --program followed by a system reset.
+NRFUTIL_PROGRAM_OPTIONS = --options chip_erase_mode=ERASE_RANGES_TOUCHED_BY_FIRMWARE,verify=VERIFY_READ,reset=RESET_SYSTEM
+
+# Opt-in device recovery. NRF_RECOVER=1 runs "nrfutil device recover"
+# (FULL CHIP ERASE of the selected core, unlocks a protected device)
+# immediately before programming.
+nrfutil-recover = $(if $(filter 1,$(NRF_RECOVER)),$(NRFUTIL) device recover $(NRFUTIL_FAMILY) $(NRFUTIL_CORE) $(1))
+
+%.upload: $(OUT_HEX)
+	$(NRFUTIL_CHECK)
+	$(NRFUTIL_DEVICE_CHECK)
+	$(call nrfutil-recover,$(NRFUTIL_SELECT))
+	$(NRFUTIL) device program $(NRFUTIL_PROGRAM_OPTIONS) $(NRFUTIL_FAMILY) $(NRFUTIL_CORE) $(NRFUTIL_SELECT) --firmware $<
 
 # Upload to all attached boards
 # This approach is similar to the sky platform
 
-# Number of boards to program in parallel
-NUMPAR=4
-
-# Only get serial numbers if nrfjprog is installed
+# Only enumerate serial numbers when actually running the upload sequence.
+# Only devices of the right family are programmed. Fail when the
+# enumeration returns nothing (the shell function discards its exit
+# status): a silently empty list would make the upload sequence a
+# falsely successful no-op. The nrf-serials stderr diagnostic explains
+# the reason and is passed through to the terminal.
 ifneq ($(filter nrf-upload-sequence,$(MAKECMDGOALS)),)
-  ifneq (, $(shell which $(NRFJPROG)))
-    NRF_SNRS := $(shell $(NRFJPROG) -i)
+  NRF_SNRS := $(shell NRFUTIL=$(NRFUTIL) $(CONTIKI)/tools/nrf/nrf-serials $(NRF_DEVICE_FAMILY))
+  ifeq ($(NRF_SNRS),)
+    $(error No devices to program)
   endif
 endif
 
 nrf-upload-snr.%:
-	$(NRFJPROG) $(NRFJPROG_OPTIONS) --snr $* --sectorerase --verify --program $(HEX_FILE)
-	$(NRFJPROG) $(NRFJPROG_OPTIONS) --snr $* --reset
+	$(call nrfutil-recover,--serial-number $*)
+	$(NRFUTIL) device program $(NRFUTIL_PROGRAM_OPTIONS) $(NRFUTIL_FAMILY) $(NRFUTIL_CORE) --serial-number $* --firmware $(HEX_FILE)
 
 nrf-upload-sequence: $(foreach SNR, $(NRF_SNRS), nrf-upload-snr.$(SNR))
 	@echo Done
 
 %.upload-all: $(OUT_HEX)
-ifeq (, $(shell which $(NRFJPROG)))
-	$(error Could not find nrfjprog "$(NRFJPROG)", please install it)
-else
+	$(NRFUTIL_CHECK)
 	$(MAKE) HEX_FILE=$< -j $(NUMPAR) nrf-upload-sequence
-endif
 
-# DFU Upload for dongles
-PORT ?= /dev/ttyACM0
-DFU_FLAGS = -p $(PORT)
-
-%.dfu-upload: $(OUT_HEX)
-ifeq (, $(shell which $(NRFUTIL)))
-	$(error Could not find nrfutil "$(NRFUTIL)", please install it first)
-else
-	$(NRFUTIL) pkg generate --hw-version 52 --sd-req 0x00 --debug-mode --application $< $(BUILD_DIR_BOARD)/nrf52840_dfu_image.zip
-	$(NRFUTIL) dfu usb-serial $(DFU_FLAGS) -pkg $(BUILD_DIR_BOARD)/nrf52840_dfu_image.zip
-endif
+endif  # NRF_JLINK_UPLOAD

--- a/arch/cpu/nrf/Makefile.nrf52840
+++ b/arch/cpu/nrf/Makefile.nrf52840
@@ -15,6 +15,8 @@ NRFX_C_SRCS += $(NRFX_ROOT)/mdk/system_nrf52840.c
 
 EXTERNALDIRS += $(NRFX_ROOT)/mdk/
 
+NRF_DEVICE_FAMILY = nrf52
+
 CFLAGS += -DCPU_CONF_PATH=\"nrf52840-conf.h\"
 CFLAGS += -DCPU_DEF_PATH=\"nrf52840-def.h\"
 

--- a/arch/cpu/nrf/Makefile.nrf5340_application
+++ b/arch/cpu/nrf/Makefile.nrf5340_application
@@ -16,7 +16,8 @@ NRFX_C_SRCS += $(CONTIKI_CPU)/nrf5340/legacy-mdk/system_nrf5340_application.c
 EXTERNALDIRS += $(CONTIKI_CPU)/nrf5340/legacy-mdk
 EXTERNALDIRS += $(NRFX_ROOT)/mdk/
 
-NRFJPROG_OPTIONS=-f NRF53 --coprocessor CP_APPLICATION 
+NRF_DEVICE_FAMILY = nrf53
+NRFUTIL_CORE = --core application
 
 CFLAGS += -DCPU_CONF_PATH=\"nrf5340-application-conf.h\"
 CFLAGS += -DCPU_DEF_PATH=\"nrf5340-application-def.h\"

--- a/arch/cpu/nrf/Makefile.nrf5340_network
+++ b/arch/cpu/nrf/Makefile.nrf5340_network
@@ -9,7 +9,8 @@ NRFX_C_SRCS += $(NRFX_ROOT)/mdk/system_nrf5340_network.c
 
 EXTERNALDIRS += $(NRFX_ROOT)/mdk/
 
-NRFJPROG_OPTIONS=-f NRF53 --coprocessor CP_NETWORK 
+NRF_DEVICE_FAMILY = nrf53
+NRFUTIL_CORE = --core network
 
 CFLAGS += -DCPU_CONF_PATH=\"nrf5340-network-conf.h\"
 CFLAGS += -DCPU_DEF_PATH=\"nrf5340-network-def.h\"

--- a/arch/platform/nrf/nrf52840/dongle/Makefile.dongle
+++ b/arch/platform/nrf/nrf52840/dongle/Makefile.dongle
@@ -8,6 +8,11 @@ CFLAGS += -DBOARD_DEF_PATH=\"nrf52840-dongle-def.h\"
 # Dongle only has USB and not UART
 NRF_NATIVE_USB=1
 
+# The dongle is programmed via DFU (see the upload rules below), so
+# disable the J-Link-based upload rules and device enumeration in
+# Makefile.nrf.
+NRF_JLINK_UPLOAD = 0
+
 ### Include the common nrf52840 makefile
 include $(PLATFORM_ROOT_DIR)/nrf52840/Makefile.nrf52840
 
@@ -16,8 +21,9 @@ CONTIKI_TARGET_DIRS += nrf52840/dongle
 MODULES += $(CONTIKI_NG_DRIVERS_ETC_DIR)/rgb-led
 
 #
-# Dongle upload via Nordic open-bootloader (no J-Link). Overrides the
-# nrfjprog-based %.upload rule from arch/cpu/nrf/Makefile.nrf. Triggers
+# Dongle upload via Nordic open-bootloader (no J-Link). Replaces the
+# J-Link-based upload rules from arch/cpu/nrf/Makefile.nrf, which are
+# disabled with NRF_JLINK_UPLOAD=0 above. Triggers
 # DFU mode on a running Contiki-NG firmware if needed, generates the
 # Nordic DFU zip, then flashes via the Rust-based nrfutil.
 #
@@ -28,30 +34,88 @@ MODULES += $(CONTIKI_NG_DRIVERS_ETC_DIR)/rgb-led
 #     (pip install pyusb). Skipped automatically if not installed.
 #
 # Override the Python interpreter with PYTHON3, the nrfutil binary
-# with NRFUTIL, or pick a specific dongle with NRF_UPLOAD_SN=<serial>.
+# with NRFUTIL, or pick a specific dongle with NRF_UPLOAD_SN=<serial>
+# or PORT=<serial port>.
 #
 NRFUTIL ?= nrfutil
 PYTHON3 ?= python3
 DONGLE_DFU_TRIGGER := $(CONTIKI)/tools/nrf/dongle-dfu-trigger.py
 DONGLE_DFU_ZIP := $(BUILD_DIR_BOARD)/dongle-dfu-image.zip
 
+# A PORT given on the make command line (as used by the login target)
+# can also select the dongle to program (unless NRF_UPLOAD_SN is used).
+# Only DFU-capable devices are considered, in firmware mode (nordicUsb)
+# or bootloader mode (nordicDfu) - not J-Link devkits. A PORT from the
+# environment or a file-level default must not select the device.
+ifneq ($(filter %.upload,$(MAKECMDGOALS)),)
+  ifndef NRF_UPLOAD_SN
+    ifeq ($(origin PORT),command line)
+      # Skip the lookup when nrfutil is missing: the upload recipe's
+      # $(NRFUTIL_CHECK) reports the missing tool with install guidance.
+      ifneq ($(shell command -v $(NRFUTIL) 2>/dev/null),)
+        NRF_UPLOAD_SN := $(shell NRFUTIL=$(NRFUTIL) $(CONTIKI)/tools/nrf/nrf-serials --traits nordicDfu,nordicUsb --port $(PORT))
+        ifeq ($(NRF_UPLOAD_SN),)
+          $(error Could not find an attached DFU device with serial port $(PORT))
+        endif
+      endif
+    endif
+  endif
+endif
+
 ifdef NRF_UPLOAD_SN
+  # The dongle keeps its serial number across the firmware/bootloader
+  # mode switch, so the same serial selects the device in both steps.
+  DONGLE_TRIGGER_OPTS := --serial-number $(NRF_UPLOAD_SN)
   DONGLE_PROGRAM_OPTS := --serial-number $(NRF_UPLOAD_SN)
 else
   DONGLE_PROGRAM_OPTS := --traits nordicDfu
 endif
 
 %.upload: $(BUILD_DIR_BOARD)/%.$(TARGET)
-ifeq (,$(shell command -v $(NRFUTIL)))
-	$(error Could not find nrfutil "$(NRFUTIL)", install it from https://www.nordicsemi.com/Software-and-tools/Development-Tools/nrfutil)
-else
+	$(NRFUTIL_CHECK)
 	@echo "==> Converting ELF to Intel HEX"
-	$(OBJCOPY) -O ihex $< $(BUILD_DIR_BOARD)/$*.hex
+	$(Q)$(OBJCOPY) -O ihex $< $(BUILD_DIR_BOARD)/$*.hex
 	@echo "==> Triggering DFU mode on running firmware (if any)"
-	-@$(PYTHON3) $(DONGLE_DFU_TRIGGER) $(DONGLE_TRIGGER_OPTS) || echo "    (no running firmware to trigger; assuming bootloader)"
-	@sleep 2
+	$(Q)$(PYTHON3) $(DONGLE_DFU_TRIGGER) $(DONGLE_TRIGGER_OPTS) && sleep 2 || { \
+	  [ $$? -eq 3 ] || exit 1; \
+	  echo "    (cannot check dongle state without pyusb; assuming bootloader)"; }
 	@echo "==> Generating Nordic DFU package"
-	$(NRFUTIL) nrf5sdk-tools pkg generate --hw-version 52 --sd-req 0x00 --debug-mode --application $(BUILD_DIR_BOARD)/$*.hex $(DONGLE_DFU_ZIP)
+	$(Q)$(NRFUTIL) nrf5sdk-tools pkg generate --hw-version 52 --sd-req 0x00 --debug-mode --application $(BUILD_DIR_BOARD)/$*.hex $(DONGLE_DFU_ZIP)
 	@echo "==> Flashing"
-	$(NRFUTIL) device program --firmware $(DONGLE_DFU_ZIP) $(DONGLE_PROGRAM_OPTS)
+	$(Q)$(NRFUTIL) device program --firmware $(DONGLE_DFU_ZIP) $(DONGLE_PROGRAM_OPTS)
+
+# Upload to all attached dongles (in firmware or bootloader mode),
+# analogous to the J-Link %.upload-all rule in Makefile.nrf.
+
+# Only enumerate dongle serial numbers when actually running the
+# upload sequence. Fail when the enumeration returns nothing (the shell
+# function discards its exit status): a silently empty list would make
+# the upload sequence a falsely successful no-op. The --list stderr
+# diagnostic (no dongle, unreadable or duplicate serial numbers,
+# missing pyusb) explains the reason and is passed through to the
+# terminal.
+ifneq ($(filter nrf-dongle-upload-sequence,$(MAKECMDGOALS)),)
+  NRF_DONGLE_SNRS := $(shell $(PYTHON3) $(DONGLE_DFU_TRIGGER) --list)
+  ifeq ($(NRF_DONGLE_SNRS),)
+    $(error No dongles to program)
+  endif
 endif
+
+nrf-dongle-upload-snr.%:
+	@$(PYTHON3) $(DONGLE_DFU_TRIGGER) --serial-number $* && sleep 2 || { \
+	  [ $$? -eq 3 ] || exit 1; \
+	  echo "    (cannot check dongle state without pyusb; assuming bootloader)"; }
+	@echo "==> Flashing dongle $*"
+	$(Q)$(NRFUTIL) device program --firmware $(DONGLE_DFU_ZIP) --serial-number $*
+
+.PHONY: nrf-dongle-upload-sequence
+nrf-dongle-upload-sequence: $(foreach SNR, $(NRF_DONGLE_SNRS), nrf-dongle-upload-snr.$(SNR))
+	@echo Done
+
+%.upload-all: $(BUILD_DIR_BOARD)/%.$(TARGET)
+	$(NRFUTIL_CHECK)
+	@echo "==> Converting ELF to Intel HEX"
+	$(Q)$(OBJCOPY) -O ihex $< $(BUILD_DIR_BOARD)/$*.hex
+	@echo "==> Generating Nordic DFU package"
+	$(Q)$(NRFUTIL) nrf5sdk-tools pkg generate --hw-version 52 --sd-req 0x00 --debug-mode --application $(BUILD_DIR_BOARD)/$*.hex $(DONGLE_DFU_ZIP)
+	$(Q)$(MAKE) -j $(NUMPAR) nrf-dongle-upload-sequence

--- a/doc/platforms/nrf.md
+++ b/doc/platforms/nrf.md
@@ -42,17 +42,28 @@ If you use the docker image or the vagrant image, this will be pre-installed for
 
 * GNU make
 
-* nrfjprog for programming the nRF5340 DK, nRF52840 DK
+* nrfutil for programming the nRF5340 DK, nRF52840 DK and nRF52840 Dongle
 
-nrfjprog is supplied as part of the nRF Command Line Tools and can be downloaded from the following link:
+nrfutil (the Rust-based binary, which replaces the end-of-life nrfjprog and
+the deprecated Python nrfutil from PyPI) can be downloaded from:
 
-https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools
+https://www.nordicsemi.com/Products/Development-tools/nRF-Util
 
-* nrfutil for programming the nRF52840 Dongle
+After downloading the binary, install the required subcommands:
 
-nrfutil is available on PyPy: https://pypi.org/project/nrfutil/
+    nrfutil install device
 
-A typical way to install this would be using pip: `pip3 install nrfutil`
+For flashing the nRF52840 Dongle, the nRF5 SDK tools are also needed:
+
+    nrfutil install nrf5sdk-tools
+
+* jq
+
+The `.upload` targets use [jq](https://jqlang.org/) to select the attached
+device to program: filtering devkits by device family and looking up a
+device by `PORT=<serial port>` both require it. Without jq, uploads that
+need such a lookup fail with an error asking for an explicit
+`NRF_UPLOAD_SN=<serial number>`.
 
 ## Getting Started
 
@@ -84,13 +95,37 @@ set on the compilation command line:
 
 * `NRF_UPLOAD_SN=<serial number>`  
   Allows to choose a particular DK by its serial number (printed on the label).  
-  This is useful if you have more than one DK connected to your
-  PC and wish to flash a particular device using the `.upload` target. 
+  This is optional when exactly one DK of the targeted device family is
+  attached (devices of other families are ignored). With more than one
+  matching device connected, the `.upload` target refuses to program and
+  lists the attached serial numbers; select one with
+  `NRF_UPLOAD_SN=<serial number>` or use the `.upload-all` target to flash
+  all attached devices of the targeted family. The same applies to the
+  nRF52840 Dongle: with several dongles attached, select one with
+  `NRF_UPLOAD_SN` (the dongle keeps its USB serial number in both firmware
+  and bootloader mode).
+
+* `NRF_RECOVER=1`  
+  Runs `nrfutil device recover` on the selected device immediately before
+  programming. Use this to unlock a device that has enabled access port
+  protection (e.g. locked itself). **Warning: recovery performs a full chip
+  erase of the selected core.** It is therefore never done by default and
+  only when `NRF_RECOVER=1` is explicitly given on the make command line.
+  Works with both the `.upload` and `.upload-all` targets.
+
+* `PORT=<serial port>`  
+  Selects the device to program by one of its serial ports (as listed by
+  `tools/motelist` or `make motelist-all`), when `NRF_UPLOAD_SN` is not
+  given. Works for both DKs and dongles. Since `PORT` is also used by the
+  `login` target, the same variable selects the node for both programming
+  and serial output. Only a `PORT` given on the make command line selects
+  the device to program; a `PORT` from the environment is ignored for
+  device selection (but still used by `login`).
 
 * `BOARD={nrf5340/dk/application|nrf5340/dk/network|nrf52840/dk|nrf52840/dongle}`  
   Allows to specify if the which board and core (nrf5340 exclusive) is used.
   The default board is `nrf5340/dk/application`
-  Dongle images are built with a bootloader-specific linker file and should be flashed using the `.dfu-upload` target.
+  Dongle images are built with a bootloader-specific linker file and are flashed via the Nordic open bootloader (DFU) by the regular `.upload` target.
 
 * `NRF_NATIVE_USB=<0,1>`  
   Enables or disables the native USB support on boards that have USB support. 
@@ -114,13 +149,20 @@ as make target, e.g.:
 
     make TARGET=nrf hello-world.upload-all
 
-In order to flash the application binary to a single nRF52840 Dongle use `<application>.dfu-upload`
-as make target, e.g.: 
+The `.upload-all` target also works for nRF52840 Dongles: it triggers DFU
+mode on and flashes all attached dongles, e.g.:
 
-    make TARGET=nrf BOARD=nrf52840/dongle hello-world.dfu-upload PORT=/dev/ttyACM0
+    make TARGET=nrf BOARD=nrf52840/dongle hello-world.upload-all
 
-Where `PORT` is the name of the USB CDC-ACM port that the dongle is on.  
-The bootloader can be activated by pressing the RESET button once, until the red LED begins to pulse.
+Flashing a single nRF52840 Dongle uses the regular `.upload` target, e.g.:
+
+    make TARGET=nrf BOARD=nrf52840/dongle hello-world.upload
+
+The upload automatically triggers the DFU bootloader on a dongle running
+Contiki-NG firmware. For a dongle running other firmware, the bootloader
+can be activated manually by pressing the RESET button once, until the red
+LED begins to pulse. With more than one dongle attached, select one with
+`NRF_UPLOAD_SN=<serial number>` or `PORT=<serial port>`.
 
 Notes when using the nRF dongle: 
 * The serial output from the dongle can be accessed by attaching a USB to Serial converter to the pins described on the back of the board.

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get -qq update && \
     git-lfs \
     gosu \
     iputils-ping \
+    jq \
     less \
     libcanberra-gtk-module \
     libcoap2-bin \
@@ -159,8 +160,10 @@ RUN wget -nv https://sourceforge.net/projects/doxygen/files/rel-1.17.0/doxygen-1
     tar xf ccache-4.10.2-linux-x86_64.tar.xz -C ${HOME}/.local/bin --strip-components=1 ccache-4.10.2-linux-x86_64/ccache && \
     rm ccache-*-linux-x86_64.tar.xz
 
-# Install additional tools for the nRF5 SDK.
-RUN nrfutil install nrf5sdk-tools
+# Install the nrfutil subcommands used for programming Nordic devices:
+# "device" for nrfutil device list/program and "nrf5sdk-tools" for the
+# dongle DFU package generation.
+RUN nrfutil install device nrf5sdk-tools
 
 # By default, we use a Docker bind mount to share the repo with the host,
 # with Docker run option:

--- a/tools/nrf/dongle-dfu-trigger.py
+++ b/tools/nrf/dongle-dfu-trigger.py
@@ -50,14 +50,23 @@ arch/cpu/nrf/dev/usb-arch.c, which then drives the dongle's self-reset
 GPIO (P0.19) low to pin-reset the chip into the bootloader.
 
 Usage:
-  dongle-dfu-trigger.py                  # any dongle running the firmware
+  dongle-dfu-trigger.py                  # the single attached dongle
   dongle-dfu-trigger.py --serial-number <SN>
                                          # restrict to a specific dongle
+  dongle-dfu-trigger.py --list           # list serial numbers of all
+                                         # attached dongles and exit
 
 Exits 0 on success or "device already in bootloader" (idempotent),
-1 on hard errors.
+1 on a hard error: no dongle is attached (in firmware or bootloader
+mode), the detach could not be delivered, or - with --list - an
+attached dongle cannot be addressed by its serial number. Exits 2 when
+several dongles are attached and no serial number was given, 3 when
+the dongle state cannot be checked at all (pyusb or its libusb backend
+is not installed; the caller may choose to assume bootloader mode).
 """
 import argparse
+import errno
+import os
 import sys
 
 try:
@@ -65,11 +74,28 @@ try:
     import usb.util
 except ImportError:
     print("error: pyusb not installed (run: pip install pyusb)", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(3)
 
 VID = 0x1915
 APP_PID = 0x520F   # Contiki-NG dongle app w/ DFU trigger
 BL_PID = 0x521F    # Nordic open-bootloader in DFU mode
+
+
+def _usb_find(**kwargs):
+    """usb.core.find, reporting a missing libusb backend the same way
+    as a missing pyusb: the dongle state cannot be checked (exit 3)."""
+    try:
+        return usb.core.find(**kwargs)
+    except usb.core.NoBackendError:
+        print("error: no usb backend (libusb) available", file=sys.stderr)
+        sys.exit(3)
+
+
+def _get_serial(dev):
+    try:
+        return usb.util.get_string(dev, dev.iSerialNumber)
+    except (usb.core.USBError, ValueError):
+        return None
 
 
 def _match_serial(serial):
@@ -77,13 +103,17 @@ def _match_serial(serial):
     iSerialNumber descriptor equals ``serial``. ``None`` selects any."""
     if serial is None:
         return lambda d: True
+    return lambda d: _get_serial(d) == serial
 
-    def _check(d):
-        try:
-            return usb.util.get_string(d, d.iSerialNumber) == serial
-        except (usb.core.USBError, ValueError):
-            return False
-    return _check
+
+def _find_dongles():
+    """Return all attached dongles, in firmware or bootloader mode, as
+    a list of (device, pid) tuples."""
+    return [
+        (dev, pid)
+        for pid in (APP_PID, BL_PID)
+        for dev in _usb_find(find_all=True, idVendor=VID, idProduct=pid) or []
+    ]
 
 
 parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
@@ -91,21 +121,68 @@ parser.add_argument(
     "--serial-number",
     help="Restrict the trigger to the dongle with this USB serial number.",
 )
+parser.add_argument(
+    "--list", action="store_true",
+    help="List the serial numbers of all attached dongles and exit.",
+)
 args = parser.parse_args()
+
+if args.list:
+    # Every attached dongle must be addressable by a unique serial
+    # number, or the caller would silently program only a subset.
+    all_serials = [_get_serial(dev) for dev, _ in _find_dongles()]
+    if not all_serials:
+        print("error: no dongle found", file=sys.stderr)
+        sys.exit(1)
+    serials = [s for s in all_serials if s is not None]
+    if len(serials) < len(all_serials):
+        print(f"error: cannot read the serial number of "
+              f"{len(all_serials) - len(serials)} of {len(all_serials)} "
+              f"attached dongles", file=sys.stderr)
+        print("    (often insufficient USB permissions; see the udev rule\n"
+              "     in doc/platforms/nrf.md)", file=sys.stderr)
+        sys.exit(1)
+    duplicates = sorted({s for s in serials if serials.count(s) > 1})
+    if duplicates:
+        print("error: several dongles share a serial number: "
+              + ", ".join(duplicates), file=sys.stderr)
+        sys.exit(1)
+    print("\n".join(sorted(serials)))
+    sys.exit(0)
 
 match = _match_serial(args.serial_number)
 
+# Refuse to pick an arbitrary dongle: when no serial number is given and
+# more than one candidate dongle is attached (in firmware or bootloader
+# mode), the caller must select one. The serial number is preserved
+# across the firmware/bootloader mode switch.
+if args.serial_number is None:
+    candidates = _find_dongles()
+    if len(candidates) > 1:
+        print("error: more than one dongle is attached:", file=sys.stderr)
+        for dev, pid in candidates:
+            serial = _get_serial(dev) or "<unknown serial>"
+            mode = "bootloader" if pid == BL_PID else "firmware"
+            print(f"  {serial} ({mode} mode)", file=sys.stderr)
+        print("select one with --serial-number (make NRF_UPLOAD_SN=<serial>)",
+              file=sys.stderr)
+        sys.exit(2)
+
 # If the bootloader is already enumerated for our target, there's nothing to do.
-if usb.core.find(idVendor=VID, idProduct=BL_PID, custom_match=match) is not None:
+if _usb_find(idVendor=VID, idProduct=BL_PID, custom_match=match) is not None:
     print("Dongle already in DFU bootloader mode.")
     sys.exit(0)
 
-dev = usb.core.find(idVendor=VID, idProduct=APP_PID, custom_match=match)
+dev = _usb_find(idVendor=VID, idProduct=APP_PID, custom_match=match)
 if dev is None:
-    msg = f"no dongle with VID:PID {VID:04X}:{APP_PID:04X}"
+    msg = (f"no dongle with VID:PID {VID:04X}:{APP_PID:04X} (firmware) or "
+           f"{VID:04X}:{BL_PID:04X} (bootloader)")
     if args.serial_number:
         msg += f" and serial number {args.serial_number}"
     print(f"error: {msg} found", file=sys.stderr)
+    print("    (a dongle running firmware without DFU trigger support can be\n"
+          "     put in bootloader mode by pressing its RESET button)",
+          file=sys.stderr)
     sys.exit(1)
 
 bmRequestType = usb.util.build_request_type(
@@ -116,9 +193,13 @@ bmRequestType = usb.util.build_request_type(
 
 try:
     dev.ctrl_transfer(bmRequestType, 0x00, 0, 3, None, timeout=1000)
-except usb.core.USBError:
-    # Expected: the chip pin-resets in the middle of the control transfer.
-    pass
+except usb.core.USBError as e:
+    # Expected: the chip pin-resets in the middle of the control
+    # transfer. A permission or busy error, however, means the detach
+    # was never delivered.
+    if e.errno in (errno.EACCES, errno.EPERM, errno.EBUSY):
+        print(f"error: cannot send DFU detach request: {e}", file=sys.stderr)
+        sys.exit(1)
 
 print("DFU detach triggered.")
 sys.exit(0)

--- a/tools/nrf/dongle-dfu-trigger.py
+++ b/tools/nrf/dongle-dfu-trigger.py
@@ -201,5 +201,8 @@ except usb.core.USBError as e:
         print(f"error: cannot send DFU detach request: {e}", file=sys.stderr)
         sys.exit(1)
 
-print("DFU detach triggered.")
-sys.exit(0)
+print("DFU detach triggered.", flush=True)
+# The dongle has just dropped off the bus, and libusb (notably its macOS
+# IOKit backend) can hang while closing the vanished device handle
+# during interpreter teardown. Exit without running any finalizers.
+os._exit(0)

--- a/tools/nrf/nrf-serials
+++ b/tools/nrf/nrf-serials
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 RISE Research Institutes of Sweden AB
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Print the serial numbers (one per line) of all attached Nordic
+# Semiconductor J-Link debug probes, using "nrfutil device list".
+
+set -e
+
+PROGRAM="${0##*/}"
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM [-h] [--traits <traits>] [--port <serial port>] [device family]
+
+Print the serial numbers (one per line) of attached Nordic Semiconductor
+devices, using "nrfutil device list". By default, only J-Link debug
+probes are considered; use --traits to select other device types, e.g.
+"nordicDfu,nordicUsb" for DFU-capable dongles (the list is an OR filter).
+
+With --port, print the serial number of the device that owns the given
+serial port instead. Serial port lookup requires jq.
+
+When a device family (e.g. nrf52, nrf53) is given, only devkits of that
+family are listed. Family filtering requires jq and information from the
+devkit's board controller; devices whose family cannot be determined
+(e.g. external J-Link probes) are excluded when a family is given.
+
+Options:
+  --traits <traits>     Only consider devices with one of the given
+                        comma-separated device traits (default: jlink)
+  --port <serial port>  Print the serial number of the device owning
+                        the given serial port
+  -h, --help            Show this help and exit
+
+Environment:
+  NRFUTIL       The nrfutil binary to use (default: nrfutil)
+
+Exit status:
+  0  one or more serial numbers were printed
+  1  nrfutil is unavailable, no matching devices are attached, or jq is
+     required for the requested filtering but unavailable
+  2  invalid usage
+EOF
+}
+
+FAMILY=
+PORT=
+TRAITS=jlink
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --port)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "$PROGRAM: --port requires an argument" >&2
+                exit 2
+            fi
+            PORT="$2"
+            shift
+            ;;
+        --traits)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "$PROGRAM: --traits requires an argument" >&2
+                exit 2
+            fi
+            TRAITS="$2"
+            shift
+            ;;
+        -*)
+            echo "$PROGRAM: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            if [[ -n "$FAMILY" ]]; then
+                echo "$PROGRAM: too many arguments: $1" >&2
+                usage >&2
+                exit 2
+            fi
+            FAMILY="$1"
+            ;;
+    esac
+    shift
+done
+
+NRFUTIL="${NRFUTIL:-nrfutil}"
+
+# nrfutil device list reports the family as e.g. "NRF52_FAMILY".
+family_filter=""
+if [[ -n "$FAMILY" ]]; then
+    family_filter="$(echo "$FAMILY" | tr '[:lower:]' '[:upper:]')_FAMILY"
+fi
+
+if [[ -n "$PORT" ]]; then
+    # Serial port lookup: print the serial number of the device that
+    # owns the given serial port.
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "$PROGRAM: serial port lookup requires jq" >&2
+        exit 1
+    fi
+    device_output=$("$NRFUTIL" device list --traits "$TRAITS" --json-pretty --skip-overhead 2>/dev/null) || {
+        echo "$PROGRAM: failed to run \"$NRFUTIL device list\"" >&2
+        exit 1
+    }
+    serial_numbers=$(printf '%s\n' "$device_output" \
+        | jq -r --arg fam "$family_filter" --arg port "$PORT" \
+            '.devices[]?
+             | select($fam == "" or (.devkit.deviceFamily // "") == $fam)
+             | select(any(.serialPorts[]?; .comName == $port or .path == $port))
+             | .serialNumber // empty' \
+            2>/dev/null | sort -u)
+    if [[ -z "$serial_numbers" ]]; then
+        echo "$PROGRAM: no attached device with serial port $PORT found${family_filter:+ for family $FAMILY}" >&2
+        exit 1
+    fi
+    echo "$serial_numbers"
+    exit 0
+fi
+
+# The default traits filter jlink excludes USB-CDC-only devices (e.g.
+# dongles) that the J-Link-based program command cannot flash.
+device_output=$("$NRFUTIL" device list --traits "$TRAITS" --json-pretty --skip-overhead 2>/dev/null) || {
+    echo "$PROGRAM: failed to run \"$NRFUTIL device list\"" >&2
+    exit 1
+}
+
+# Extract serial numbers using jq (if available) or fall back to grep/sed
+if command -v jq >/dev/null 2>&1; then
+    serial_numbers=$(printf '%s\n' "$device_output" \
+        | jq -r --arg fam "$family_filter" \
+            '.devices[]? | select($fam == "" or (.devkit.deviceFamily // "") == $fam) | .serialNumber // empty' \
+            2>/dev/null | sort -u)
+else
+    # Family filtering must not silently degrade to listing all attached
+    # devices: a caller that asked for one family could then be handed a
+    # device of another.
+    if [[ -n "$family_filter" ]]; then
+        echo "$PROGRAM: family filtering requires jq" >&2
+        exit 1
+    fi
+    # Fallback without jq: extract "serialNumber": "<value>" pairs.
+    # Also matches serial numbers nested in serialPorts entries, but those
+    # duplicate the device serial number and are removed by sort -u.
+    serial_numbers=$(printf '%s\n' "$device_output" \
+        | grep -o '"serialNumber"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | sed 's/.*"serialNumber"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' \
+        | sort -u)
+fi
+
+if [[ -z "$serial_numbers" ]]; then
+    echo "$PROGRAM: no attached devices with traits $TRAITS found${family_filter:+ for family $FAMILY}" >&2
+    exit 1
+fi
+
+echo "$serial_numbers"


### PR DESCRIPTION
`nrfjprog` and the `nRF Command Line Tools` are end of life. This PR switches the nrf platform upload targets over to `nrfutil device`. 

### Programming via J-Link (DKs)

- NRF_UPLOAD_SN remains optional: a single attached device of the targeted family is selected automatically; with several matching devices the upload fails and lists the attached serial numbers.
- The device can also be selected with PORT=<serial port> as on most other platforms — the serial number is looked up from the serial port, and the same PORT value works for login.
- Devices are filtered by family (nrf52, nrf53, ...): uploads only consider devkits matching the target SoC, and .upload-all programs all attached devices of the right family, ignoring others.
- New opt-in recovery: `NRF_RECOVER=1` runs `nrfutil device recover` immediately before programming to unlock a protected device. Recovery performs a full chip erase, so it never runs by default. This addresses the same issue as #3118 but using on option instead of separate make rule.

### Dongle DFU upload

- The dongle DFU rules use the nrfutil syntax (nrfutil nrf5sdk-tools pkg generate / dfu usb-serial).
- Multiple attached dongles are supported: the DFU trigger refuses to pick an arbitrary dongle when several are attached (the dongle keeps its USB serial across the firmware/bootloader mode switch, so NRF_UPLOAD_SN and PORT select the dongle for both the trigger and program steps), and .upload-all triggers and flashes all attached dongles.
- Remove the legacy %.dfu-upload rule.