### PR TITLE
storage/antelope: roll back index references on storage failure

### DIFF
--- a/os/storage/antelope/index.c
+++ b/os/storage/antelope/index.c
@@ -134,10 +134,12 @@ index_create(index_type_t index_type, relation_t *rel, attribute_t *attr)
 
   if(index->descriptor_file[0] != '\0' &&
      DB_ERROR(storage_put_index(index))) {
-    api->destroy(index);
-    memb_free(&index_memb, index);
     PRINTF("DB: Failed to store index data in file \"%s\"\n",
            index->descriptor_file);
+    api->destroy(index);
+    attr->index = NULL;
+    list_remove(indices, index);
+    memb_free(&index_memb, index);
     return DB_INDEX_ERROR;
   }
 


### PR DESCRIPTION
index_create() published the index to attr->index and the global indices list before storage_put_index(), but the failure path only freed the pool slot, leaving both references dangling. Mirror the cleanup ordering of index_release(): clear attr->index and unlink from the list before freeing, and log before the free.

Fixes #3182 