### PR TITLE
cooja: update to latest Cooja (requires Java 25)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,12 +209,12 @@ jobs:
         # Check outcome of the test
         ./tests/check-test.sh `pwd`/tests/??-${{ matrix.test }}
 
-    # Pre-install a Java 21 on macOS to avoid 503 responses in Gradle.
-    - name: Setup Java 21
+    # Pre-install a Java 25 on macOS to avoid 503 responses in Gradle.
+    - name: Setup Java 25
       if: matrix.os == 'macos-15-intel'
       uses: actions/setup-java@v5
       with:
-        java-version: 21
+        java-version: 25
         distribution: 'zulu'
 
     - name: Execute tests

--- a/doc/getting-started/Toolchain-installation-on-Linux.md
+++ b/doc/getting-started/Toolchain-installation-on-Linux.md
@@ -57,10 +57,12 @@ If desired, a script to compile MSP430 GCC 4.7.2 from source can be found [here]
 
 ### Install Java for the Cooja network simulator
 
+Cooja requires JDK 25. On recent Ubuntu versions it can be installed with apt:
+
 ```bash
-$ sudo apt install default-jdk ant
+$ sudo apt install openjdk-25-jdk
 $ update-alternatives --config java
-There is only one alternative in link group java (providing /usr/bin/java): /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+There is only one alternative in link group java (providing /usr/bin/java): /usr/lib/jvm/java-25-openjdk-amd64/bin/java
 Nothing to configure.
 ```
 

--- a/doc/getting-started/Toolchain-installation-on-macOS.md
+++ b/doc/getting-started/Toolchain-installation-on-macOS.md
@@ -53,10 +53,10 @@ ARM GCC version 10.3 is known to work. You can also try using a newer version, b
 The best way to achieve this on OS X is through homebrew, using a formula provided in a tap. Follow the instructions here: https://github.com/tgtakaoka/homebrew-mspgcc
 
 ### Install Java JDK for the Cooja network simulator
-Nothing exciting here, just download and install Java for OSX. You will need the JDK 21, not just the runtime. You can also install Java using Homebrew:
+Nothing exciting here, just download and install Java for OSX. You will need the JDK 25, not just the runtime. You can also install Java using Homebrew:
 
 ```bash
-brew install openjdk@21
+brew install openjdk@25
 ```
 
 ### Install a CoAP client (libcoap)

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -17,7 +17,7 @@ USER root
 # libcanberra-gtk-module: remove warning message from renode.
 # libcoap2-bin: used by regression tests.
 # libgl1-mesa-glx: required by Simplicity Commander
-# libxtst6: required for GraalVM/Java17 to run Cooja in GUI mode.
+# libxtst6: required for GraalVM/Java to run Cooja in GUI mode.
 # mosquitto: used by the regression tests.
 # mtr-tiny: used by the regression tests.
 # net-tools: used by the regression tests.
@@ -70,7 +70,7 @@ RUN apt-get -qq update && \
     > /dev/null && \
   apt-get -qq clean
 
-ARG JAVA_VERSION=21
+ARG JAVA_VERSION=25
 RUN wget -nv https://download.oracle.com/graalvm/${JAVA_VERSION}/latest/graalvm-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz && \
   tar xf graalvm-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz -C /usr/local --strip-components=1 --no-same-owner && \
   rm -f graalvm*gz


### PR DESCRIPTION
Updates the tools/cooja submodule to the latest version, which requires JDK 25. Adjusts the build and documentation accordingly:
- Bump CI (build.yml) and the Docker GraalVM version from Java 21 to 25
- Update the Linux and macOS toolchain installation docs to install JDK 25
