### PR TITLE
lwm2m: fix undefined behavior in queue-mode update notification (#1597)

### DIFF
--- a/os/services/lwm2m/lwm2m-rd-client.c
+++ b/os/services/lwm2m/lwm2m-rd-client.c
@@ -894,10 +894,15 @@ lwm2m_rd_client_fsm_execute_queue_mode_awake(lwm2m_session_info_t *session_info)
 }
 /*---------------------------------------------------------------------------*/
 void
-lwm2m_rd_client_fsm_execute_queue_mode_update(lwm2m_session_info_t *session_info)
+lwm2m_rd_client_fsm_execute_queue_mode_update(void)
 {
+  lwm2m_session_info_t *session_info = (lwm2m_session_info_t *)list_head(session_info_list);
+
   coap_timer_stop(&rd_timer);
-  session_info->rd_state = QUEUE_MODE_SEND_UPDATE;
+  while(session_info != NULL) {
+    session_info->rd_state = QUEUE_MODE_SEND_UPDATE;
+    session_info = session_info->next;
+  }
   periodic_process(&rd_timer);
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/lwm2m/lwm2m-rd-client.h
+++ b/os/services/lwm2m/lwm2m-rd-client.h
@@ -131,8 +131,8 @@ void lwm2m_rd_client_set_session_callback(lwm2m_session_info_t *session_info, se
 #if LWM2M_QUEUE_MODE_ENABLED
 uint8_t lwm2m_rd_client_is_client_awake(void);
 void lwm2m_rd_client_restart_client_awake_timer(void);
-void lwm2m_rd_client_fsm_execute_queue_mode_awake();
-void lwm2m_rd_client_fsm_execute_queue_mode_update();
+void lwm2m_rd_client_fsm_execute_queue_mode_awake(lwm2m_session_info_t *session_info);
+void lwm2m_rd_client_fsm_execute_queue_mode_update(void);
 #endif
 
 #endif /* LWM2M_RD_CLIENT_H_ */


### PR DESCRIPTION
Fixes #1597.

## Problem

`lwm2m_rd_client_fsm_execute_queue_mode_update()` is declared in `lwm2m-rd-client.h` with an empty parameter list:

```c
void lwm2m_rd_client_fsm_execute_queue_mode_update();
```

In C, `()` means "unspecified arguments", not "no arguments" - it disables argument-count/type checking at call sites in other translation units. The function's actual definition in `lwm2m-rd-client.c` takes a `lwm2m_session_info_t *session_info` parameter and dereferences it unconditionally:

```c
void
lwm2m_rd_client_fsm_execute_queue_mode_update(lwm2m_session_info_t *session_info)
{
  coap_timer_stop(&rd_timer);
  session_info->rd_state = QUEUE_MODE_SEND_UPDATE;
  periodic_process(&rd_timer);
}
```

Its only call site, in `lwm2m-engine.c`'s `lwm2m_notify_object_observers()` (reacting to an observable resource change while the client is asleep in queue mode), calls it with **zero** arguments:

```c
lwm2m_rd_client_fsm_execute_queue_mode_update();
```

Since the header's weak declaration suppresses the mismatch check, this compiles without any warning under a normal build. At runtime, `session_info` inside the function body is whatever value happens to occupy the register/stack slot the calling convention uses for the first argument - never a value the caller actually passed - so `session_info->rd_state = ...` writes through an effectively uninitialized pointer. This matches the crash/undefined behavior described in the issue.

## Fix

Change the function to take no parameters and instead update the `rd_state` of **every** registered session, mirroring the exact list-walking pattern already used by the sibling function `lwm2m_rd_client_set_update_rd()` a few dozen lines above it in the same file (iterate `list_head(session_info_list)` via `->next`):

```c
void
lwm2m_rd_client_fsm_execute_queue_mode_update(void)
{
  lwm2m_session_info_t *session_info = (lwm2m_session_info_t *)list_head(session_info_list);

  coap_timer_stop(&rd_timer);
  while(session_info != NULL) {
    session_info->rd_state = QUEUE_MODE_SEND_UPDATE;
    session_info = session_info->next;
  }
  periodic_process(&rd_timer);
}
```

This is more correct than just passing a single `session_info` through the call site anyway: the notification this function reacts to is a generic "an observed resource changed" event with no particular session in scope, so all registered sessions (a client can be registered with multiple LwM2M servers) need to be woken up to send their update, not just an arbitrary one.

Also updated the header declaration to `(void)`, and gave the sibling `lwm2m_rd_client_fsm_execute_queue_mode_awake()` its real prototype (`lwm2m_session_info_t *session_info`) instead of an empty parameter list, since it sits in the same `#if LWM2M_QUEUE_MODE_ENABLED` block and has the identical latent-prototype problem, even though its two call sites (both within `lwm2m-rd-client.c`, where `session_info` is already in scope) happen to pass the correct argument today.

## Verification

I don't have a full Contiki-NG native/hardware build set up in this environment, so I verified this in two ways:

1. **Confirmed the parameter-count mismatch is real**: compiled a minimal multi-file C reproduction of the exact pattern (a header with an empty-parens declaration, an implementation taking a pointer argument in one translation unit, a caller passing zero arguments in another) with `gcc -std=c99 -Wall` - it compiles cleanly with **no warning** about the mismatch. Adding `-Wstrict-prototypes` does flag the declaration as "not a prototype" (the root enabling cause), consistent with why this went uncaught under a normal build.

2. **Verified the fix's logic**: wrote a standalone C harness mirroring `session_info_list`/`lwm2m_session_info_t`'s actual layout (`next` as the first struct member, matching this project's `LIST()` convention) with 3 mock sessions. After the fix, `lwm2m_rd_client_fsm_execute_queue_mode_update()` correctly sets `rd_state = QUEUE_MODE_SEND_UPDATE` on all 3 sessions (not just one), confirming the list-walk correctly notifies every registered session.

## Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission.
