### PR TITLE
tests: drop snmp-server/sky from the compile matrix

### DIFF
--- a/tests/01-compile-base/Makefile
+++ b/tests/01-compile-base/Makefile
@@ -56,7 +56,6 @@ dev/dht11/native \
 dev/dht11/sky \
 dev/dht11/z1 \
 snmp-server/native \
-snmp-server/sky \
 snmp-server/z1 \
 hello-world/msp-exp430fr5969 \
 


### PR DESCRIPTION
The snmp-server example no longer fits the Tmote Sky (MSP430F1611, 48 KB ROM / 10 KB RAM) and overflows at link, breaking the compile-base CI job. The z1 target (MSP430F2617, ~92 KB ROM) keeps msp430 build coverage for SNMP, and snmp-server/cc2538dk in 02-compile-arm-ports covers an ARM MCU, so removing the sky entry loses no meaningful coverage.