### PR TITLE
uip6: fix uip_len validation to account for the IPv6 header size

### DIFF
--- a/os/net/ipv6/uip6.c
+++ b/os/net/ipv6/uip6.c
@@ -1237,7 +1237,7 @@ uip_process(uint8_t flag)
    * packet header, the packet has been padded, and we set uip_len to
    * the correct value.
    */
-  if(uip_len < uipbuf_get_len_field(UIP_IP_BUF)) {
+  if(uipbuf_get_len_field(UIP_IP_BUF) > uip_len - UIP_IPH_LEN) {
     UIP_STAT(++uip_stat.ip.drop);
     LOG_ERR("packet shorter than reported in IP header\n");
     goto drop;


### PR DESCRIPTION
## Summary

`uip_process()` validates that the genuinely-received `uip_len` is not
smaller than the packet size claimed by the IPv6 header before trusting
that header. The check omits `UIP_IPH_LEN` (the 40-byte fixed IPv6
header size):

```c
if(uip_len < uipbuf_get_len_field(UIP_IP_BUF)) {
  ...
  goto drop;
}
```

`uipbuf_get_len_field()` returns only the IPv6 "Payload Length" field
(bytes *after* the 40-byte header), while `uip_len` at this point is the
number of bytes actually received, header included. Two lines later the
same payload-length field is used again, this time correctly adjusted:

```c
uip_len = uipbuf_get_len_field(UIP_IP_BUF) + UIP_IPH_LEN;
```

Because the earlier guard is missing the same `+ UIP_IPH_LEN` term, a
header whose Payload-Length field overstates the true payload by up to
40 bytes passes the check, and `uip_len` is then set 40 bytes past what
was actually received. Downstream code (e.g. the extension-header walk
in `uipbuf_get_last_header()`) trusts `uip_len` as the boundary of valid
data, so up to 40 bytes of stale/adjacent buffer memory can be treated
as this packet's payload.

This addresses #2402.

## Fix

Compare the payload length against `uip_len - UIP_IPH_LEN`, avoiding an
addition that could overflow on 16-bit targets while checking the same
quantity used two lines later:

```c
if(uipbuf_get_len_field(UIP_IP_BUF) > uip_len - UIP_IPH_LEN) {
```

This is a minimal, one-line change with no behavioral effect other than
correctly rejecting packets that claim more payload than was actually
received. Legitimate packets (exact-length, and link-layer padded, as
already described by the function's own comment) are accepted
identically to before.

## Testing

- Built `examples/hello-world` for `TARGET=native` with the fix applied;
  compiles and links cleanly.
- Wrote and ran a standalone C harness modeling the exact guard/recompute
  sequence with the real struct layout and macro values
  (`UIP_IPH_LEN=40`, `UIP_BUFSIZE=1280`):
  - A forged header (genuinely received 100 bytes = 40-byte header + 60
    real payload bytes, but header claims Payload-Length=90) is accepted
    by the current check and produces `uip_len=130`, i.e. 30 bytes past
    what was actually received. With the fix, the same forged packet is
    dropped.
  - A second forged-header scenario at a smaller size reproduces the
    same pattern and is likewise dropped by the fix.
  - Two regression scenarios: an exact-length legitimate packet, and a
    link-layer-padded legitimate packet (the case the existing code
    comment explicitly describes) are accepted identically before and
    after the fix, confirming no regression.

## Disclosure

Generative AI (Claude, Anthropic) was used to help investigate this
issue and implement the fix. All changes were reviewed by the human
submitter (94xhn) before submission.


