### PR TITLE
rpl-lite: bound DAO Target option prefix length to prevent stack overflow

### DIFF
--- a/os/net/routing/rpl-lite/rpl-icmp6.c
+++ b/os/net/routing/rpl-lite/rpl-icmp6.c
@@ -552,6 +552,11 @@ dao_input(void)
           goto discard;
         }
         dao.prefixlen = buffer[i + 3];
+        if(dao.prefixlen > 8 * sizeof(dao.prefix)) {
+          LOG_WARN("dao_input: invalid target prefix length %u, discard\n",
+                   dao.prefixlen);
+          goto discard;
+        }
         if(4 + (dao.prefixlen + 7) / CHAR_BIT != len) {
           LOG_WARN("dao_input: invalid target option, len %u != %u, discard\n",
                    len, 4 + (dao.prefixlen + 7) / CHAR_BIT);


### PR DESCRIPTION
In dao_input(), the DAO Target option's prefix length is read straight from the packet (attacker-controlled, 0-255) and used to size a memcpy into dao.prefix, a 16-byte uip_ipaddr_t. The existing length check only ties the option length to prefixlen; it never caps prefixlen at 128, so a crafted option with prefixlen up to 255 copies up to 32 bytes and overflows the stack-allocated rpl_dao struct by up to 16 bytes.

RPL-Lite is the default routing protocol and dao_input() processes inbound DAOs from any node in the DODAG, so this is network-reachable and unauthenticated.

Reject prefixlen greater than 8 * sizeof(dao.prefix) before the memcpy.