### PR TITLE
mqtt: bound MQTT-5 property decoders against received input length

### DIFF
--- a/os/net/app-layer/mqtt/mqtt-prop.c
+++ b/os/net/app-layer/mqtt/mqtt-prop.c
@@ -293,14 +293,26 @@ mqtt_prop_decode_input_props(struct mqtt_connection *conn)
 /*---------------------------------------------------------------------------*/
 static uint32_t
 decode_prop_utf8(struct mqtt_connection *conn,
-                 uint8_t *buf_in,
+                 uint8_t *buf_in, uint32_t buf_in_len,
                  uint8_t *data)
 {
   uint32_t len;
 
+  /* The 2-byte length prefix must be present in the received input */
+  if(buf_in_len < MQTT_STRING_LEN_SIZE) {
+    DBG("MQTT - Error, truncated UTF8 string property\n");
+    return 0;
+  }
+
   len = (buf_in[0] << 8) + buf_in[1];
 
   DBG("MQTT - Decoding %d-char UTF8 string property\n", len);
+
+  /* The declared string must fit within the received input */
+  if(len + MQTT_STRING_LEN_SIZE > buf_in_len) {
+    DBG("MQTT - Error, UTF8 string property exceeds input\n");
+    return 0;
+  }
 
   /* Include NULL terminator in destination */
   if((len + MQTT_STRING_LEN_SIZE + 1) > MQTT_PROP_MAX_PROP_LENGTH) {
@@ -317,7 +329,7 @@ decode_prop_utf8(struct mqtt_connection *conn,
 /*---------------------------------------------------------------------------*/
 static uint32_t
 decode_prop_fixed_len_int(struct mqtt_connection *conn,
-                          uint8_t *buf_in, int len,
+                          uint8_t *buf_in, uint32_t buf_in_len, int len,
                           uint8_t *data)
 {
   int8_t i;
@@ -327,6 +339,12 @@ decode_prop_fixed_len_int(struct mqtt_connection *conn,
 
   if(len > MQTT_PROP_MAX_PROP_LENGTH) {
     DBG("MQTT - Error, property too long (max %i bytes)", MQTT_PROP_MAX_PROP_LENGTH);
+    return 0;
+  }
+
+  /* All declared value bytes must be present in the received input */
+  if((uint32_t)len > buf_in_len) {
+    DBG("MQTT - Error, int property exceeds input\n");
     return 0;
   }
 
@@ -348,7 +366,7 @@ decode_prop_fixed_len_int(struct mqtt_connection *conn,
 /*---------------------------------------------------------------------------*/
 static uint32_t
 decode_prop_vbi(struct mqtt_connection *conn,
-                uint8_t *buf_in,
+                uint8_t *buf_in, uint32_t buf_in_len,
                 uint8_t *data)
 {
   uint8_t prop_len_bytes;
@@ -358,8 +376,12 @@ decode_prop_vbi(struct mqtt_connection *conn,
   /* All integer input properties will be returned as uint32_t */
   memset(data, 0, 4);
 
+  /* A Variable Byte Integer is at most 4 bytes, but never read past
+   * the bytes actually received in the input.
+   */
   prop_len_bytes =
-    mqtt_decode_var_byte_int(buf_in, 4, NULL, NULL, (uint16_t *)data);
+    mqtt_decode_var_byte_int(buf_in, buf_in_len < 4 ? buf_in_len : 4,
+                             NULL, NULL, (uint16_t *)data);
 
   if(prop_len_bytes == 0) {
     DBG("MQTT - Error decoding Variable Byte Integer\n");
@@ -376,12 +398,18 @@ decode_prop_vbi(struct mqtt_connection *conn,
 /*---------------------------------------------------------------------------*/
 static uint32_t
 decode_prop_binary_data(struct mqtt_connection *conn,
-                        uint8_t *buf_in,
+                        uint8_t *buf_in, uint32_t buf_in_len,
                         uint8_t *data)
 {
-  uint8_t data_len;
+  uint32_t data_len;
 
   DBG("MQTT - Decoding Binary Data property\n");
+
+  /* The 2-byte length prefix must be present in the received input */
+  if(buf_in_len < MQTT_STRING_LEN_SIZE) {
+    DBG("MQTT - Error, truncated Binary Data property\n");
+    return 0;
+  }
 
   data_len = (buf_in[0] << 8) + buf_in[1];
 
@@ -390,30 +418,57 @@ decode_prop_binary_data(struct mqtt_connection *conn,
     return 0;
   }
 
-  if((data_len + 2) > MQTT_PROP_MAX_PROP_LENGTH) {
+  /* The declared data must fit within the received input */
+  if(data_len + MQTT_STRING_LEN_SIZE > buf_in_len) {
+    DBG("MQTT - Error, Binary Data property exceeds input\n");
+    return 0;
+  }
+
+  if((data_len + MQTT_STRING_LEN_SIZE) > MQTT_PROP_MAX_PROP_LENGTH) {
     DBG("MQTT - Error, property too long (max %i bytes)", MQTT_PROP_MAX_PROP_LENGTH);
     return 0;
   }
 
-  memcpy(data, buf_in, data_len + 2);
+  memcpy(data, buf_in, data_len + MQTT_STRING_LEN_SIZE);
 
-  return data_len + 2;
+  return data_len + MQTT_STRING_LEN_SIZE;
 }
 /*---------------------------------------------------------------------------*/
 static uint32_t
 decode_prop_utf8_pair(struct mqtt_connection *conn,
-                      uint8_t *buf_in,
+                      uint8_t *buf_in, uint32_t buf_in_len,
                       uint8_t *data)
 {
   uint32_t len1;
   uint32_t len2;
   uint32_t total_len;
 
+  /* The first 2-byte length prefix must be present in the received input */
+  if(buf_in_len < MQTT_STRING_LEN_SIZE) {
+    DBG("MQTT - Error, truncated UTF8 string pair property\n");
+    return 0;
+  }
+
   len1 = (buf_in[0] << 8) + buf_in[1];
+
+  /* The first string and the second length prefix must be present before
+   * they are read below, otherwise len2 would be read out of bounds.
+   */
+  if(len1 + 2 * MQTT_STRING_LEN_SIZE > buf_in_len) {
+    DBG("MQTT - Error, UTF8 string pair property exceeds input\n");
+    return 0;
+  }
+
   len2 = (buf_in[len1 + MQTT_STRING_LEN_SIZE] << 8) + buf_in[len1 + MQTT_STRING_LEN_SIZE + 1];
   total_len = len1 + len2;
 
   DBG("MQTT - Decoding %d-char UTF8 string pair property (%i + %i)\n", total_len, len1, len2);
+
+  /* The full pair must fit within the received input */
+  if(total_len + 2 * MQTT_STRING_LEN_SIZE > buf_in_len) {
+    DBG("MQTT - Error, UTF8 string pair property exceeds input\n");
+    return 0;
+  }
 
   if((total_len + 2 * MQTT_STRING_LEN_SIZE) > MQTT_PROP_MAX_PROP_LENGTH) {
     DBG("MQTT - Error, property too long (max %i bytes)", MQTT_PROP_MAX_PROP_LENGTH);
@@ -428,7 +483,8 @@ decode_prop_utf8_pair(struct mqtt_connection *conn,
 /*---------------------------------------------------------------------------*/
 uint32_t
 parse_prop(struct mqtt_connection *conn,
-           mqtt_vhdr_prop_t prop_id, uint8_t *buf_in, uint8_t *data)
+           mqtt_vhdr_prop_t prop_id, uint8_t *buf_in, uint32_t buf_in_len,
+           uint8_t *data)
 {
   switch(prop_id) {
   case MQTT_VHDR_PROP_PAYLOAD_FMT_IND:
@@ -439,18 +495,18 @@ parse_prop(struct mqtt_connection *conn,
   case MQTT_VHDR_PROP_WILD_SUB_AVAIL:
   case MQTT_VHDR_PROP_SUB_ID_AVAIL:
   case MQTT_VHDR_PROP_SHARED_SUB_AVAIL: {
-    return decode_prop_fixed_len_int(conn, buf_in, 1, data);
+    return decode_prop_fixed_len_int(conn, buf_in, buf_in_len, 1, data);
   }
   case MQTT_VHDR_PROP_RECEIVE_MAX:
   case MQTT_VHDR_PROP_TOPIC_ALIAS_MAX:
   case MQTT_VHDR_PROP_SERVER_KEEP_ALIVE: {
-    return decode_prop_fixed_len_int(conn, buf_in, 2, data);
+    return decode_prop_fixed_len_int(conn, buf_in, buf_in_len, 2, data);
   }
   case MQTT_VHDR_PROP_MSG_EXP_INT:
   case MQTT_VHDR_PROP_SESS_EXP_INT:
   case MQTT_VHDR_PROP_WILL_DELAY_INT:
   case MQTT_VHDR_PROP_MAX_PKT_SZ: {
-    return decode_prop_fixed_len_int(conn, buf_in, 4, data);
+    return decode_prop_fixed_len_int(conn, buf_in, buf_in_len, 4, data);
   }
   case MQTT_VHDR_PROP_CONTENT_TYPE:
   case MQTT_VHDR_PROP_RESP_TOPIC:
@@ -459,17 +515,17 @@ parse_prop(struct mqtt_connection *conn,
   case MQTT_VHDR_PROP_RESP_INFO:
   case MQTT_VHDR_PROP_SERVER_REFERENCE:
   case MQTT_VHDR_PROP_REASON_STRING: {
-    return decode_prop_utf8(conn, buf_in, data);
+    return decode_prop_utf8(conn, buf_in, buf_in_len, data);
   }
   case MQTT_VHDR_PROP_CORRELATION_DATA:
   case MQTT_VHDR_PROP_AUTH_DATA: {
-    return decode_prop_binary_data(conn, buf_in, data);
+    return decode_prop_binary_data(conn, buf_in, buf_in_len, data);
   }
   case MQTT_VHDR_PROP_SUB_ID: {
-    return decode_prop_vbi(conn, buf_in, data);
+    return decode_prop_vbi(conn, buf_in, buf_in_len, data);
   }
   case MQTT_VHDR_PROP_USER_PROP: {
-    return decode_prop_utf8_pair(conn, buf_in, data);
+    return decode_prop_utf8_pair(conn, buf_in, buf_in_len, data);
   }
   default:
     DBG("MQTT - Error, no such property '%i'", prop_id);
@@ -487,6 +543,10 @@ mqtt_get_next_in_prop(struct mqtt_connection *conn,
   uint32_t prop_len;
   uint8_t prop_id_len_bytes;
   uint16_t prop_id_decode;
+  uint32_t props_offset;
+  uint32_t props_avail;
+  uint32_t props_consumed;
+  uint32_t buf_remaining;
 
   if(!conn->in_packet.has_props) {
     DBG("MQTT - Message has no input properties");
@@ -497,22 +557,52 @@ mqtt_get_next_in_prop(struct mqtt_connection *conn,
       conn->in_packet.properties_len,
       *conn->in_packet.curr_props_pos);
 
-  if((conn->in_packet.curr_props_pos - conn->in_packet.props_start)
-     >= conn->in_packet.properties_len) {
+  /*
+   * Determine how many bytes may safely be read from the current parsing
+   * position. Bound by both the declared properties length and the number
+   * of bytes actually received into the input buffer, so a malformed
+   * property length cannot drive reads past the received data. The
+   * computation is done on offsets rather than pointers, so that a
+   * malformed length never forms a pointer outside the input buffer.
+   */
+  props_offset =
+    (uint32_t)(conn->in_packet.props_start - conn->in_packet.payload);
+  if(conn->in_packet.payload_pos <= props_offset) {
     DBG("MQTT - Message has no more input properties\n");
     return 0;
   }
 
+  props_avail = conn->in_packet.payload_pos - props_offset;
+  if(conn->in_packet.properties_len < props_avail) {
+    props_avail = conn->in_packet.properties_len;
+  }
+
+  props_consumed =
+    (uint32_t)(conn->in_packet.curr_props_pos - conn->in_packet.props_start);
+  if(props_consumed >= props_avail) {
+    DBG("MQTT - Message has no more input properties\n");
+    return 0;
+  }
+
+  buf_remaining = props_avail - props_consumed;
+
   prop_id_len_bytes =
     mqtt_decode_var_byte_int(conn->in_packet.curr_props_pos,
-                             conn->in_packet.properties_len - (conn->in_packet.curr_props_pos - conn->in_packet.props_start),
+                             buf_remaining,
                              NULL, NULL, (uint16_t *)&prop_id_decode);
+
+  if(prop_id_len_bytes == 0 || prop_id_len_bytes >= buf_remaining) {
+    DBG("MQTT - Error decoding property ID (out of bounds)\n");
+    return 0;
+  }
 
   *prop_id = prop_id_decode;
 
   DBG("MQTT - Decoded property ID %i (encoded using %i bytes)\n", *prop_id, prop_id_len_bytes);
 
-  prop_len = parse_prop(conn, *prop_id, conn->in_packet.curr_props_pos + 1, data);
+  prop_len = parse_prop(conn, *prop_id,
+                        conn->in_packet.curr_props_pos + prop_id_len_bytes,
+                        buf_remaining - prop_id_len_bytes, data);
 
   DBG("MQTT - Decoded property len %i bytes\n", prop_len);
 

--- a/tests/08-native-runs/25-mqtt-prop.sh
+++ b/tests/08-native-runs/25-mqtt-prop.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+./run-one.sh 25-mqtt-prop

--- a/tests/08-native-runs/25-mqtt-prop/Makefile
+++ b/tests/08-native-runs/25-mqtt-prop/Makefile
@@ -1,0 +1,12 @@
+CONTIKI_PROJECT = test-mqtt-prop
+all: $(CONTIKI_PROJECT)
+
+TARGET ?= native
+
+CONTIKI = ../../..
+
+include $(CONTIKI)/Makefile.dir-variables
+MODULES += $(CONTIKI_NG_APP_LAYER_DIR)/mqtt
+MODULES += os/services/unit-test
+
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/25-mqtt-prop/project-conf.h
+++ b/tests/08-native-runs/25-mqtt-prop/project-conf.h
@@ -1,0 +1,12 @@
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+/* The input property decoders under test exist only in MQTT version 5. */
+#define MQTT_CONF_VERSION MQTT_PROTOCOL_VERSION_5
+
+/* The MQTT implementation is built on TCP sockets, which are not compiled
+ * in by default. No connection is made by this test.
+ */
+#define UIP_CONF_TCP 1
+
+#endif /* PROJECT_CONF_H_ */

--- a/tests/08-native-runs/25-mqtt-prop/test-mqtt-prop.c
+++ b/tests/08-native-runs/25-mqtt-prop/test-mqtt-prop.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Unit test of the MQTT-5 input property decoders.
+ *
+ *         The decoders take the length of each property from the received
+ *         packet. A declared length that exceeds the bytes actually received
+ *         must be rejected rather than used to read past the input, so each
+ *         decoder is fed both a well-formed property and a property whose
+ *         declared length overruns the input.
+ * \author
+ *         Nicolas Tsiftes <nicolas.tsiftes@ri.se>
+ */
+
+#include "contiki.h"
+#include "net/app-layer/mqtt/mqtt.h"
+#include "net/app-layer/mqtt/mqtt-prop.h"
+#include "unit-test.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Log configuration */
+#include "sys/log.h"
+#define LOG_MODULE "test-mqtt-prop"
+#define LOG_LEVEL LOG_LEVEL_NONE
+
+PROCESS(test_process, "test");
+AUTOSTART_PROCESSES(&test_process);
+
+static struct mqtt_connection conn;
+
+/*---------------------------------------------------------------------------*/
+/*
+ * A property that is rejected still advances the parse position past its
+ * property identifier, so this is what a rejected property section consumes.
+ */
+#define PROP_REJECTED 1
+
+/*
+ * Present props[0..props_len-1] as the property section of a received PUBLISH,
+ * of which only the first recv_len bytes have arrived. Declaring more property
+ * bytes than have been received is how a malformed packet drives a decoder
+ * past the input, and is also what a property section straddling a full input
+ * buffer looks like.
+ *
+ * Returns the number of property bytes consumed by a full parse: the length of
+ * the section when every property was accepted, and PROP_REJECTED when the
+ * first property was rejected.
+ */
+static uint32_t
+parse_props(const uint8_t *props, uint8_t props_len, uint8_t recv_len)
+{
+  uint8_t *section;
+
+  memset(&conn, 0, sizeof(conn));
+
+  /* The property section is preceded by its length, encoded as a Variable
+   * Byte Integer. Lengths below 128 occupy a single byte.
+   */
+  section = &conn.in_packet.payload[MQTT_INPUT_BUFF_SIZE - (props_len + 1)];
+  section[0] = props_len;
+  memcpy(&section[1], props, props_len);
+
+  conn.in_packet.fhdr = MQTT_FHDR_MSG_TYPE_PUBLISH;
+  conn.in_packet.payload_start = section;
+  conn.in_packet.remaining_length = MQTT_INPUT_BUFF_SIZE;
+  /* Bytes received: everything up to and including the encoded length, plus
+   * the requested number of property bytes.
+   */
+  conn.in_packet.payload_pos =
+    (section - conn.in_packet.payload) + 1 + recv_len;
+
+  mqtt_prop_decode_input_props(&conn);
+  if(!conn.in_packet.has_props) {
+    return 0;
+  }
+
+  /*
+   * Walk every property in the section. This is the only public entry point
+   * that dispatches to all of the decoders; the DEBUG_MQTT gating inside it
+   * affects printing only, not decoding.
+   */
+  mqtt_prop_print_input_props(&conn);
+
+  return conn.in_packet.curr_props_pos - conn.in_packet.props_start;
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_utf8, "UTF-8 string property");
+UNIT_TEST(test_utf8)
+{
+  /*
+   * MQTT_VHDR_PROP_CONTENT_TYPE, then a 20-character string. The string is
+   * short enough to fit the destination buffer, so nothing but the input
+   * length can reject it once fewer bytes than that have been received.
+   */
+  static const uint8_t str[] = {
+    0x03, 0x00, 0x14,
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+    'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't'
+  };
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT(parse_props(str, sizeof(str), sizeof(str)) == sizeof(str));
+  /* The declared string extends past the received input */
+  UNIT_TEST_ASSERT(parse_props(str, sizeof(str), 6) == PROP_REJECTED);
+  /* Only one byte of the two-byte length prefix has been received */
+  UNIT_TEST_ASSERT(parse_props(str, sizeof(str), 2) == PROP_REJECTED);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_fixed_len_int, "Fixed-length integer property");
+UNIT_TEST(test_fixed_len_int)
+{
+  /* MQTT_VHDR_PROP_SESS_EXP_INT, a four-byte integer */
+  static const uint8_t valid[] = { 0x11, 0x00, 0x00, 0x00, 0x2A };
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT(parse_props(valid, sizeof(valid), sizeof(valid)) ==
+                   sizeof(valid));
+  /* The same property, with the last two value bytes not yet received */
+  UNIT_TEST_ASSERT(parse_props(valid, sizeof(valid), sizeof(valid) - 2) ==
+                   PROP_REJECTED);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_binary_data, "Binary data property");
+UNIT_TEST(test_binary_data)
+{
+  /* MQTT_VHDR_PROP_CORRELATION_DATA, then 20 bytes of data */
+  static const uint8_t data_prop[] = {
+    0x09, 0x00, 0x14,
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+    0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13
+  };
+  /*
+   * A declared length of 259 bytes, which a uint8_t data_len truncates to the
+   * 3 bytes that follow it.
+   */
+  static const uint8_t truncating[] = { 0x09, 0x01, 0x03, 0xAA, 0xBB, 0xCC };
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT(parse_props(data_prop, sizeof(data_prop),
+                               sizeof(data_prop)) == sizeof(data_prop));
+  /* The declared data extends past the received input */
+  UNIT_TEST_ASSERT(parse_props(data_prop, sizeof(data_prop), 6) ==
+                   PROP_REJECTED);
+  /* Only one byte of the two-byte length prefix has been received */
+  UNIT_TEST_ASSERT(parse_props(data_prop, sizeof(data_prop), 2) ==
+                   PROP_REJECTED);
+  UNIT_TEST_ASSERT(parse_props(truncating, sizeof(truncating),
+                               sizeof(truncating)) == PROP_REJECTED);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_utf8_pair, "UTF-8 string pair property");
+UNIT_TEST(test_utf8_pair)
+{
+  /* MQTT_VHDR_PROP_USER_PROP, then the string pair "ab" / "cd" */
+  static const uint8_t valid[] = {
+    0x26, 0x00, 0x02, 'a', 'b', 0x00, 0x02, 'c', 'd'
+  };
+  /*
+   * A first string whose declared length places the second length prefix past
+   * the received input. This is the case that read buf_in[len1 + 2] before any
+   * bounds check, with len1 taken from the packet.
+   */
+  static const uint8_t overlong_first[] = {
+    0x26, 0x00, 0x0C, 'a', 'b'
+  };
+  /* A well-formed first string, but a second one that overruns the input */
+  static const uint8_t overlong_second[] = {
+    0x26, 0x00, 0x02, 'a', 'b', 0x00, 0x0C, 'c', 'd'
+  };
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT(parse_props(valid, sizeof(valid), sizeof(valid)) ==
+                   sizeof(valid));
+  UNIT_TEST_ASSERT(parse_props(overlong_first, sizeof(overlong_first),
+                               sizeof(overlong_first)) == PROP_REJECTED);
+  UNIT_TEST_ASSERT(parse_props(overlong_second, sizeof(overlong_second),
+                               sizeof(overlong_second)) == PROP_REJECTED);
+  /* Truncated after the first string, before the second length prefix */
+  UNIT_TEST_ASSERT(parse_props(valid, sizeof(valid), 5) == PROP_REJECTED);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_vbi, "Variable Byte Integer property");
+UNIT_TEST(test_vbi)
+{
+  /* MQTT_VHDR_PROP_SUB_ID, then the value 1 in a single byte */
+  static const uint8_t valid[] = { 0x0B, 0x01 };
+  /*
+   * A Variable Byte Integer whose continuation bits ask for more bytes than
+   * the input holds.
+   */
+  static const uint8_t unterminated[] = { 0x0B, 0x80, 0x80, 0x80 };
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT(parse_props(valid, sizeof(valid), sizeof(valid)) ==
+                   sizeof(valid));
+  UNIT_TEST_ASSERT(parse_props(unterminated, sizeof(unterminated), 2) ==
+                   PROP_REJECTED);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(test_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(test_utf8);
+  UNIT_TEST_RUN(test_fixed_len_int);
+  UNIT_TEST_RUN(test_binary_data);
+  UNIT_TEST_RUN(test_utf8_pair);
+  UNIT_TEST_RUN(test_vbi);
+
+  if(!UNIT_TEST_PASSED(test_utf8) ||
+     !UNIT_TEST_PASSED(test_fixed_len_int) ||
+     !UNIT_TEST_PASSED(test_binary_data) ||
+     !UNIT_TEST_PASSED(test_utf8_pair) ||
+     !UNIT_TEST_PASSED(test_vbi)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
+  printf("=check-me= DONE\n");
+  printf("---\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -28,5 +28,6 @@ tests/08-native-runs/20-random/native:./20-random.sh \
 tests/08-native-runs/21-coffee-validation/native:./21-coffee-validation.sh \
 tests/08-native-runs/23-uiplib/native:./23-uiplib.sh \
 tests/08-native-runs/21-dbg-io/native:./21-dbg-io.sh \
+tests/08-native-runs/25-mqtt-prop/native:./25-mqtt-prop.sh \
 
 include ../Makefile.compile-test


### PR DESCRIPTION
The MQTT-5 property decoders validated copies only against the destination size (MQTT_PROP_MAX_PROP_LENGTH), never against the bytes actually received, so a property with an over-long declared length read past the end of the input. Worst case: decode_prop_utf8_pair() read buf_in[len1 + 2] before any bounds check, with len1 taken from the packet.

Thread the available input length from mqtt_get_next_in_prop() through parse_prop() into every decoder and reject a property whose declared length exceeds it. The available length is bounded by the bytes actually received (payload_pos), so a malformed length cannot drive reads past the received data. Also widen decode_prop_binary_data()'s data_len to uint32_t, which as a uint8_t truncated the 16-bit length prefix.