### PR TITLE
build: extend GCC 12/13 warning workarounds to GCC 14 and later

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -162,17 +162,11 @@ ifneq ($(MAKECMDGOALS),clean)
   GCC_MINOR_VERSION := $(word 2,$(subst ., ,$(GCC_VERSION)))
 
   ifeq ("$(CC)","arm-none-eabi-gcc")
-    # Silence some warnings when using GCC 12.
-    ifeq (12,$(GCC_MAJOR_VERSION))
-      # Disable -Warray-bounds false positives.
-      CFLAGS += --param=min-pagesize=0
-      # FIXME: Investigate if the warning can be re-enabled.
-      # https://www.redhat.com/en/blog/linkers-warnings-about-executable-stacks-and-segments
-      LDFLAGS += -Wl,--no-warn-rwx-segments
-    endif
-    ifeq (13,$(GCC_MAJOR_VERSION))
-      # Disable -Warray-bounds false positives. Supposed to be improved
-      # in GCC 13 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578).
+    # Silence some warnings when using GCC 12 or later.
+    GCC_GEQ_12 := $(shell expr $(GCC_MAJOR_VERSION) \>= 12)
+    ifeq (1,$(GCC_GEQ_12))
+      # Disable -Warray-bounds false positives
+      # (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578).
       CFLAGS += --param=min-pagesize=0
       # FIXME: Investigate if the warning can be re-enabled.
       # https://www.redhat.com/en/blog/linkers-warnings-about-executable-stacks-and-segments


### PR DESCRIPTION
With Arm GNU Toolchain 14+ (e.g. 15.2.Rel1), linking fails on platforms that use `-Wl,--fatal-warnings` (nrf, gecko) because the binutils warning `LOAD segment with RWX permissions` is only suppressed for GCC 12 and 13 in `Makefile.include`.

This applies the existing GCC 12/13 workarounds (`--param=min-pagesize=0`, `-Wl,--no-warn-rwx-segments`) for GCC 12 or later instead of special-casing each major version, so new toolchain majors do not re-break the build.

Tested with arm-none-eabi-gcc 15.2.1: hello-world, rpl-udp, dev/leds, 6tisch/simple-node, dev/button-hal and dev/gpio-hal now build for all nrf boards (nrf52840/dk, nrf5340/dk/application+network, nrf54l15/dk) and gecko, which all failed to link before. No flag changes for GCC 12/13, so CI behavior is unchanged.

Found while doing release testing for 5.2 (#3190).