### PR TITLE
examples/edhoc: fit client and server on RAM-constrained targets

### DIFF
--- a/examples/edhoc/edhoc-client/project-conf.h
+++ b/examples/edhoc/edhoc-client/project-conf.h
@@ -37,7 +37,7 @@
 #define EDHOC_CONF_CID 0x37
 
 /* CoAP configuration */
-#define COAP_MAX_OPEN_TRANSACTIONS   8
+#define COAP_MAX_OPEN_TRANSACTIONS   4
 #define COAP_MAX_OBSERVERS          8
 #define COAP_MAX_CHUNK_SIZE         300
 
@@ -63,5 +63,11 @@
 
 /* Server endpoint configuration */
 #define EDHOC_CONF_SERVER_EP "coap://[fd00::202:2:2:2]"
+
+/* Low Power Mode Configuration.
+   Cap the power mode at PM1 so that the whole SRAM is usable on cc2538-based
+   boards (in PM2 only the full-retention SRAM bank is available, which is too
+   small for this example). Matches the EDHOC server configuration. */
+#define LPM_CONF_MAX_PM 1
 
 #endif /* PROJECT_CONF_H_ */

--- a/examples/edhoc/edhoc-server/project-conf.h
+++ b/examples/edhoc/edhoc-server/project-conf.h
@@ -37,7 +37,7 @@
 #define EDHOC_CONF_CID 0x32
 
 /* CoAP configuration */
-#define COAP_MAX_OPEN_TRANSACTIONS   8
+#define COAP_MAX_OPEN_TRANSACTIONS   4
 #define COAP_MAX_OBSERVERS          8
 #define COAP_MAX_CHUNK_SIZE         300
 


### PR DESCRIPTION
The EDHOC client and server examples failed to link on the most RAM-constrained platforms:

- cc26x0-cc13x0: SRAM overflow for both examples.
- zoul/remote-revb: .bss did not fit in the full-retention SRAM (FRSRAM) for the client.

Two example-only configuration fixes:

- Reduce COAP_MAX_OPEN_TRANSACTIONS from 8 to 4 (the default) in both examples. A single EDHOC exchange does not need eight concurrent CoAP transactions, and each reserves a COAP_MAX_CHUNK_SIZE buffer.
- Add LPM_CONF_MAX_PM 1 to the client, matching the server. Capping the power mode at PM1 avoids the PM2 restriction where only the smaller full-retention SRAM bank is available on cc2538-based boards.

Both examples now build for cc26x0-cc13x0 and zoul/remote-revb, with no change to the EDHOC protocol configuration.