### PR TITLE
tsch: fix uninitialized frame params in enhanced ACK creation

### DIFF
--- a/os/net/mac/tsch/tsch-packet.c
+++ b/os/net/mac/tsch/tsch-packet.c
@@ -103,6 +103,12 @@ tsch_packet_create_eack(uint8_t *buf, uint16_t buf_len,
     return -1;
   }
 
+  /* Init to zeros, like framer-802154 does before setting up params.
+     framer_802154_setup_params() deliberately does not zero the struct
+     and leaves some fields unset; with LLSEC enabled, residual stack
+     garbage in aux_hdr.security_control ends up determining the
+     auxiliary security header layout of the enhanced ACK. */
+  memset(&params, 0, sizeof(params));
   memset(eackbuf_attrs, 0, sizeof(eackbuf_attrs));
 
   tsch_packet_eackbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_ACKFRAME);


### PR DESCRIPTION
tsch_packet_create_eack() left its frame802154_t params struct uninitialized on the stack. framer_802154_setup_params() deliberately does not zero the struct (callers may pre-set fields) and, when LLSEC802154_USES_FRAME_COUNTER is enabled, never writes aux_hdr.security_control.frame_counter_suppression or .frame_counter_size — those are only assigned in the frame-counter-less branch.

With TSCH link-layer security enabled, those two bits of stack garbage then determine the auxiliary security header layout of every enhanced ACK: field_len() adds 4-5 bytes for a frame counter whenever the suppression bit happens to be zero, and the garbage bits are serialized into the security control byte. The result is enhanced ACKs whose layout and MIC coverage vary with whatever the stack contained; receivers drop them ("failed to parse ACK"), no unicast survives, and nodes never acquire an RPL parent.

This is the root cause of the long-standing intermittent failure of tests/07-simulation-base/21-cooja-rpl-tsch-security.csc (the timeout increase in 85ded25d0 from 2022 addressed a symptom). The simulation is fully deterministic under a fixed random seed, but the stack contents behind the uninitialized struct vary per process, so the same seed passed or failed depending on the run — which is also why the failure was environment-dependent (frequent on Linux/gcc x86_64, rare-to-never on some other toolchains).

The fix zero-initializes params, exactly like framer-802154.c create_frame() does before calling framer_802154_setup_params().

Verification:
- On a Linux/gcc 13 x86_64 host, the unmodified test failed 14 of 15 runs with random seed 1; with the fix it passes consistently.
- Built with gcc -ftrivial-auto-var-init=pattern (all locals filled with 0xAA), the test fails deterministically without the fix and passes with it, confirming the uninitialized read is the sole cause.
- Per-file bisection with -ftrivial-auto-var-init isolated the problem to tsch-packet.c before the variable was identified.