### PR TITLE
cc1200: raise pending_packet() poll throttle default to 500 us

### DIFF
--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -95,15 +95,21 @@ static rtimer_clock_t sfd_timestamp = 0;
  * Minimum spacing between two SPI reads of the RX FIFO byte count in
  * pending_packet(). Tight pollers (e.g. CSMA's RTIMER_BUSYWAIT_UNTIL after a
  * unicast TX) would otherwise hammer the SPI bus and starve the RX IRQ chain
- * that needs the same bus to drain the incoming ACK. 300 us is the empirical
- * minimum that resolves the race on the CC2538 SoC at 32 MHz (the threshold
- * sits between 200 and 300 us on Zolertia Firefly); other host SoCs / SPI
- * clocks may need a different value.
+ * that needs the same bus to drain the incoming ACK. The threshold was
+ * originally measured between 200 and 300 us on the CC2538 SoC at 32 MHz, but
+ * 300 us is that measured minimum with no margin, and has since been observed
+ * to fail on Zolertia Firefly: nodes receive broadcast DIOs, but no unicast is
+ * ever acknowledged, so they never join a RPL DAG. Default to 500 us, which
+ * restores convergence on the same hardware. A larger window costs no
+ * latency: a delivered packet is reported from rx_pkt_len on every call, and
+ * only the fallback SPI peek at the FIFO byte count is rate-limited. Other
+ * host SoCs / SPI clocks may need a different value; override with
+ * CC1200_CONF_PENDING_POLL_THROTTLE_US.
  */
 #ifdef CC1200_CONF_PENDING_POLL_THROTTLE_US
 #define CC1200_PENDING_POLL_THROTTLE_US CC1200_CONF_PENDING_POLL_THROTTLE_US
 #else
-#define CC1200_PENDING_POLL_THROTTLE_US 300
+#define CC1200_PENDING_POLL_THROTTLE_US 500
 #endif
 /*
  * Set this parameter to 1 in order to use the MARC_STATE register when


### PR DESCRIPTION
The default SPI poll throttle in `pending_packet()` is 300 us, described in the code as "the empirical minimum that resolves the race" (the threshold was measured between 200 and 300 us). Shipping the measured minimum leaves no margin, and it has since been observed to fail on the same hardware it was tuned on.

## Symptom

On a Zolertia Firefly with the CC1200 sub-GHz radio (802.15.4g 863-870 MHz FSK 50 kbps, CSMA), at 300 us a joining node receives the root's multicast DIOs but no unicast is ever acknowledged, so it never acquires a parent:

```
client: [INFO: App] Not reachable yet          (indefinitely)
root:   [RPL] nbr: fe80::...:ee9a  65535, 486 => 65535 -- 8  f  (last tx 2 min ago)
```

This is the same SPI starvation described in f25bffd65: CSMA busy-waits on `pending_packet()` after a unicast TX, and the SPI reads of the RX FIFO byte count starve the RX IRQ chain that needs the same bus to drain the incoming ACK. Broadcast traffic is unaffected, which is exactly why DIOs arrive while DAOs are never acknowledged.

## With 500 us

The same two nodes converge and stay stable:

```
client: req_sent=17  resp_recv=17   status0=17  status2=0  dup=0
root:   req_recv=17  resp_sent=17   status0=17  status2=0  dup=0
        [App] Tx/Rx/MissedTx: 20/20/0
        [RPL] nbr: fe80::...:ded4  128, 173 => 301 -- 16 rbafp (last tx 0 min ago)
```

Every packet delivered on the first attempt, no retransmissions, no duplicate detections, and a link metric that improves over time (185 -> 150) instead of degrading toward the retry cap.

Verified as A/B/A on the same pair of boards with rpl-udp, changing only this value: 500 us works, 300 us fails, 500 us works again. Logging configuration held constant across all three runs (MAC at WARN, RPL at INFO), so the difference is not observer effect from UART output.

## Cost

None measurable. `pending_packet()` reports a delivered packet from `rx_pkt_len` on every call, before any throttling; only the fallback SPI peek at the FIFO byte count is rate-limited, and that is the access that starves the ISR. Deployments needing a different value can still override with `CC1200_CONF_PENDING_POLL_THROTTLE_US`.