### PR TITLE
doc/nrf: document that TSCH is unsupported on the nRF54L15

### DIFF
--- a/doc/platforms/nrf.md
+++ b/doc/platforms/nrf.md
@@ -8,7 +8,8 @@ This port supports the PCA10095 (nRF5340-DK), PCA10059 (nRF52840-DONGLE) and PCA
 
 The following features have been implemented:
 * Support for the 802.15.4 mode of the radio, including IPv6 using 6LoWPAN
-* Support for both TSCH and CSMA
+* Support for both TSCH and CSMA (TSCH availability varies by SoC; see the
+  per-SoC sections below)
 * No dependency on the nRF5 SDK
 * Contiki-NG system clock and rtimers
 * UART driver
@@ -295,8 +296,15 @@ two nRF54L15 boards are flashed with the `.flash` target:
   board-specific `openocd.cfg` is selected automatically by the Makefile.
 * `nrf54l15/dk` — over its onboard SEGGER J-Link.
 
-**Current limitations.** Low-power modes, the watchdog driver, and the
-temperature sensor are not yet supported on the nRF54L15.
+**Current limitations.** TSCH is not supported on the nRF54L15. The
+`nrf_802154`-based radio driver does not implement
+`RADIO_PARAM_LAST_PACKET_TIMESTAMP`, which TSCH requires for time
+synchronisation, so TSCH aborts during initialisation with:
+
+    [ERR : TSCH] ! radio does not support getting last packet timestamp. Abort init.
+
+Use CSMA as the MAC layer (the default). Low-power modes, the watchdog driver,
+and the temperature sensor are also not yet supported on the nRF54L15.
 
 #### FLPR coprocessor
 


### PR DESCRIPTION
Found during 5.2 release testing on an nRF54L15-DK and a Seeed XIAO nRF54L15.

## What happens

Building `examples/6tisch/simple-node` for `TARGET=nrf BOARD=nrf54l15/dk` succeeds, the banner reports `- MAC: TSCH`, and `rpl-set-root 1` reports success — but the node never forms a network:

```
TSCH status:
-- Is coordinator: 1
-- Is associated: 0
```

with no TSCH logging at all, even at `log mac 4`. The reason is printed once at boot, before the banner:

```
[ERR : TSCH] ! radio does not support getting last packet timestamp. Abort init.
```

## Why

`arch/cpu/nrf/nrf54l15/Makefile.nrf54l15` deliberately replaces the generic driver:

```make
# Remove the generic nRF radio driver (doesn't work for nRF54L15).
CONTIKI_CPU_SOURCEFILES := $(filter-out nrf-ieee-driver-arch.c,$(CONTIKI_CPU_SOURCEFILES))
```

with `nrf-ieee-driver-nrf54l15.c`, a wrapper around Nordic's `nrf_802154` library. The generic `nrf-ieee-driver-arch.c` implements `RADIO_PARAM_LAST_PACKET_TIMESTAMP` (returning `timestamps.sfd`); the nRF54L15 wrapper's `get_object()` returns `RADIO_RESULT_NOT_SUPPORTED`. `tsch_init()` probes exactly that capability, because TSCH needs SFD timestamps for time synchronisation, and aborts.

The failure itself is clean and the error message is accurate — the gap is purely documentation. The port's feature list says "Support for both TSCH and CSMA", so there is nothing to warn a user off before they hit it at run time.

## This change

Documentation only, no code:

- Records the limitation in the nRF54L15 section, alongside the existing notes on low-power modes, the watchdog and the temperature sensor.
- Qualifies the port-level feature list to point at the per-SoC sections.

This mirrors how the analogous nRF5340 IPC-radio limitation is already documented in the same file ("**Limitations:** TSCH is not supported over the IPC radio driver…").

Implementing `RADIO_PARAM_LAST_PACKET_TIMESTAMP` in the nRF54L15 driver is feasible — `nrf_802154` does expose RX timestamps — but that is a feature plus TSCH timing validation, so it belongs in a later cycle rather than during the release freeze.

## Verified

CSMA is unaffected on this SoC: `rpl-udp` between an nRF54L15-DK (server/root) and a Seeed XIAO nRF54L15 (client) exchanged 12/12 requests and responses in both directions with `Tx/Rx/MissedTx: 10/10/0` — no loss, no retries.