### PR TITLE
jsonparse: accept all JSON whitespace after literals

### DIFF
--- a/arch/dev/radio/cc1200/cc1200.c
+++ b/arch/dev/radio/cc1200/cc1200.c
@@ -95,15 +95,21 @@ static rtimer_clock_t sfd_timestamp = 0;
  * Minimum spacing between two SPI reads of the RX FIFO byte count in
  * pending_packet(). Tight pollers (e.g. CSMA's RTIMER_BUSYWAIT_UNTIL after a
  * unicast TX) would otherwise hammer the SPI bus and starve the RX IRQ chain
- * that needs the same bus to drain the incoming ACK. 300 us is the empirical
- * minimum that resolves the race on the CC2538 SoC at 32 MHz (the threshold
- * sits between 200 and 300 us on Zolertia Firefly); other host SoCs / SPI
- * clocks may need a different value.
+ * that needs the same bus to drain the incoming ACK. The threshold was
+ * originally measured between 200 and 300 us on the CC2538 SoC at 32 MHz, but
+ * 300 us is that measured minimum with no margin, and has since been observed
+ * to fail on Zolertia Firefly: nodes receive broadcast DIOs, but no unicast is
+ * ever acknowledged, so they never join a RPL DAG. Default to 500 us, which
+ * restores convergence on the same hardware. A larger window costs no
+ * latency: a delivered packet is reported from rx_pkt_len on every call, and
+ * only the fallback SPI peek at the FIFO byte count is rate-limited. Other
+ * host SoCs / SPI clocks may need a different value; override with
+ * CC1200_CONF_PENDING_POLL_THROTTLE_US.
  */
 #ifdef CC1200_CONF_PENDING_POLL_THROTTLE_US
 #define CC1200_PENDING_POLL_THROTTLE_US CC1200_CONF_PENDING_POLL_THROTTLE_US
 #else
-#define CC1200_PENDING_POLL_THROTTLE_US 300
+#define CC1200_PENDING_POLL_THROTTLE_US 500
 #endif
 /*
  * Set this parameter to 1 in order to use the MARC_STATE register when

--- a/doc/platforms/nrf.md
+++ b/doc/platforms/nrf.md
@@ -8,7 +8,8 @@ This port supports the PCA10095 (nRF5340-DK), PCA10059 (nRF52840-DONGLE) and PCA
 
 The following features have been implemented:
 * Support for the 802.15.4 mode of the radio, including IPv6 using 6LoWPAN
-* Support for both TSCH and CSMA
+* Support for both TSCH and CSMA (TSCH availability varies by SoC; see the
+  per-SoC sections below)
 * No dependency on the nRF5 SDK
 * Contiki-NG system clock and rtimers
 * UART driver
@@ -295,8 +296,15 @@ two nRF54L15 boards are flashed with the `.flash` target:
   board-specific `openocd.cfg` is selected automatically by the Makefile.
 * `nrf54l15/dk` — over its onboard SEGGER J-Link.
 
-**Current limitations.** Low-power modes, the watchdog driver, and the
-temperature sensor are not yet supported on the nRF54L15.
+**Current limitations.** TSCH is not supported on the nRF54L15. The
+`nrf_802154`-based radio driver does not implement
+`RADIO_PARAM_LAST_PACKET_TIMESTAMP`, which TSCH requires for time
+synchronisation, so TSCH aborts during initialisation with:
+
+    [ERR : TSCH] ! radio does not support getting last packet timestamp. Abort init.
+
+Use CSMA as the MAC layer (the default). Low-power modes, the watchdog driver,
+and the temperature sensor are also not yet supported on the nRF54L15.
 
 #### FLPR coprocessor
 

--- a/os/lib/json/jsonparse.c
+++ b/os/lib/json/jsonparse.c
@@ -70,6 +70,12 @@ pop(struct jsonparse_state *state)
   return true;
 }
 /*--------------------------------------------------------------------*/
+static bool
+is_whitespace(char c)
+{
+  return c == ' ' || c == '\n' || c == '\r' || c == '\t';
+}
+/*--------------------------------------------------------------------*/
 /* will pass by the value and store the start and length of the value for
    atomic types */
 /*--------------------------------------------------------------------*/
@@ -113,7 +119,8 @@ atomic(struct jsonparse_state *state, char type)
     default:              str = "";      break;
     }
 
-    while ((c = state->json[state->pos]) && c != ' ' && c != ',' && c != ']' && c != '}') {
+    while((c = state->json[state->pos]) && !is_whitespace(c) &&
+          c != ',' && c != ']' && c != '}') {
       state->pos++;
     }
 
@@ -134,10 +141,8 @@ atomic(struct jsonparse_state *state, char type)
 static void
 skip_ws(struct jsonparse_state *state)
 {
-  char c;
-
   while(state->pos < state->len &&
-        ((c = state->json[state->pos]) == ' ' || c == '\n')) {
+        is_whitespace(state->json[state->pos])) {
     state->pos++;
   }
 }

--- a/os/net/mac/tsch/tsch-packet.c
+++ b/os/net/mac/tsch/tsch-packet.c
@@ -103,6 +103,12 @@ tsch_packet_create_eack(uint8_t *buf, uint16_t buf_len,
     return -1;
   }
 
+  /* Init to zeros, like framer-802154 does before setting up params.
+     framer_802154_setup_params() deliberately does not zero the struct
+     and leaves some fields unset; with LLSEC enabled, residual stack
+     garbage in aux_hdr.security_control ends up determining the
+     auxiliary security header layout of the enhanced ACK. */
+  memset(&params, 0, sizeof(params));
   memset(eackbuf_attrs, 0, sizeof(eackbuf_attrs));
 
   tsch_packet_eackbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_ACKFRAME);

--- a/tests/08-native-runs/26-jsonparse.sh
+++ b/tests/08-native-runs/26-jsonparse.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+./run-one.sh 26-jsonparse

--- a/tests/08-native-runs/26-jsonparse/Makefile
+++ b/tests/08-native-runs/26-jsonparse/Makefile
@@ -1,0 +1,10 @@
+CONTIKI_PROJECT = test-jsonparse
+all: $(CONTIKI_PROJECT)
+
+TARGET = native
+
+MODULES += os/lib/json
+MODULES += os/services/unit-test
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/26-jsonparse/test-jsonparse.c
+++ b/tests/08-native-runs/26-jsonparse/test-jsonparse.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, Giridhar Pavan.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Unit tests for the JSON parser.
+ * \author
+ *         Giridhar Pavan
+ */
+
+#include "contiki.h"
+#include "lib/json/jsonparse.h"
+#include "unit-test.h"
+
+#include <stdio.h>
+#include <string.h>
+
+PROCESS(run_tests, "JSON parser unit tests");
+AUTOSTART_PROCESSES(&run_tests);
+
+/*---------------------------------------------------------------------------*/
+static int
+parse_literal(const char *literal, int literal_type, char whitespace)
+{
+  struct jsonparse_state state;
+  char json[32];
+  int len;
+
+  len = snprintf(json, sizeof(json), "{\"value\":%s%c}", literal, whitespace);
+  if(len < 0 || len >= sizeof(json)) {
+    return 0;
+  }
+
+  jsonparse_setup(&state, json, len);
+
+  return jsonparse_next(&state) == '{' &&
+         jsonparse_next(&state) == JSON_TYPE_PAIR_NAME &&
+         jsonparse_next(&state) == literal_type &&
+         jsonparse_next(&state) == '}';
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_literal_whitespace,
+                   "Parse true, false, and null before JSON whitespace");
+UNIT_TEST(test_literal_whitespace)
+{
+  static const struct {
+    const char *text;
+    int type;
+  } literals[] = {
+    { "true", JSON_TYPE_TRUE },
+    { "false", JSON_TYPE_FALSE },
+    { "null", JSON_TYPE_NULL },
+  };
+  static const char whitespace[] = { ' ', '\n', '\r', '\t' };
+  unsigned int i;
+  unsigned int j;
+
+  UNIT_TEST_BEGIN();
+
+  for(i = 0; i < sizeof(literals) / sizeof(literals[0]); i++) {
+    for(j = 0; j < sizeof(whitespace) / sizeof(whitespace[0]); j++) {
+      UNIT_TEST_ASSERT(parse_literal(literals[i].text, literals[i].type,
+                                     whitespace[j]));
+    }
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(run_tests, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+
+  UNIT_TEST_RUN(test_literal_whitespace);
+
+  printf("=check-me= DONE\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -29,5 +29,6 @@ tests/08-native-runs/21-coffee-validation/native:./21-coffee-validation.sh \
 tests/08-native-runs/23-uiplib/native:./23-uiplib.sh \
 tests/08-native-runs/21-dbg-io/native:./21-dbg-io.sh \
 tests/08-native-runs/25-mqtt-prop/native:./25-mqtt-prop.sh \
+tests/08-native-runs/26-jsonparse/native:./26-jsonparse.sh \
 
 include ../Makefile.compile-test


### PR DESCRIPTION
Fixes #3194.

## Summary

`jsonparse` stopped scanning `true`, `false`, and `null` only at a space or a structural delimiter. A literal followed by line feed was therefore read together with the next line and rejected. Carriage return and tab were also not handled consistently because `skip_ws()` recognized only space and line feed.

This adds one shared JSON-whitespace predicate for the four characters defined by RFC 8259: space, line feed, carriage return, and tab. Both atomic literal scanning and whitespace skipping now use it.

The new native unit test covers `true`, `false`, and `null` followed by each of those four whitespace characters and is registered in the existing `08-native-runs` suite.

## Advantages

- Valid pretty-printed JSON parses consistently across all legal JSON whitespace.
- Literal scanning and whitespace skipping use the same definition, preventing a terminator from being accepted by one parser stage but rejected by the next.
- Invalid literal suffixes remain rejected.

## Disadvantages

- The native test adds a small amount of CI build time.

## Validation

- Pre-fix native test failed on the line-feed case after the space case passed.
- Post-fix direct native run passed all 12 literal/whitespace combinations.
- `tests/08-native-runs/26-jsonparse.sh` completed with `TEST OK`.
- A clean rebuild and integrated run passed on top of `release-5.2`.
- `git diff --check` passed.

## AI-assisted contribution disclosure

AI assistance was used to inspect the parser flow, identify that the issue's suggested scanner-only change would still leave carriage return and tab unsupported by `skip_ws()`, and prepare the focused source and test changes. I manually reproduced the failure before editing, reviewed the final five-file diff, ran the repository-native test path, rebased onto the required `release-5.2` branch, and repeated a clean build and test run.
