### PR TITLE
link-stats: Refactor creation of link_stats structs

### DIFF
--- a/os/net/link-stats.c
+++ b/os/net/link-stats.c
@@ -86,6 +86,20 @@ NBR_TABLE(struct link_stats, link_stats);
 struct ctimer periodic_timer;
 
 /*---------------------------------------------------------------------------*/
+static struct link_stats *
+create_link_stats(const linkaddr_t *lladdr)
+{
+  struct link_stats *stats = nbr_table_add_lladdr(link_stats,
+                                                  lladdr,
+                                                  NBR_TABLE_REASON_LINK_STATS,
+                                                  NULL);
+  if(stats == NULL) {
+    return NULL;
+  }
+  stats->rssi = LINK_STATS_RSSI_UNKNOWN;
+  return stats;
+}
+/*---------------------------------------------------------------------------*/
 /* Returns the neighbor's link stats */
 const struct link_stats *
 link_stats_from_lladdr(const linkaddr_t *lladdr)
@@ -140,7 +154,6 @@ guess_etx_from_rssi(const struct link_stats *stats)
 void
 link_stats_packet_sent(const linkaddr_t *lladdr, int status, int numtx)
 {
-  struct link_stats *stats;
 #if !LINK_STATS_ETX_FROM_PACKET_COUNT
   uint16_t packet_etx;
   uint8_t ewma_alpha;
@@ -151,7 +164,7 @@ link_stats_packet_sent(const linkaddr_t *lladdr, int status, int numtx)
     return;
   }
 
-  stats = nbr_table_get_from_lladdr(link_stats, lladdr);
+  struct link_stats *stats = nbr_table_get_from_lladdr(link_stats, lladdr);
   if(stats == NULL) {
     /* If transmission failed, do not add the neighbor, as the neighbor might not exist anymore */
     if(status != MAC_TX_OK) {
@@ -159,11 +172,10 @@ link_stats_packet_sent(const linkaddr_t *lladdr, int status, int numtx)
     }
 
     /* Add the neighbor */
-    stats = nbr_table_add_lladdr(link_stats, lladdr, NBR_TABLE_REASON_LINK_STATS, NULL);
+    stats = create_link_stats(lladdr);
     if(stats == NULL) {
       return; /* No space left, return */
     }
-    stats->rssi = LINK_STATS_RSSI_UNKNOWN;
   }
 
   if(status == MAC_TX_QUEUE_FULL) {
@@ -232,17 +244,15 @@ link_stats_packet_sent(const linkaddr_t *lladdr, int status, int numtx)
 void
 link_stats_input_callback(const linkaddr_t *lladdr)
 {
-  struct link_stats *stats;
   int16_t packet_rssi = packetbuf_attr(PACKETBUF_ATTR_RSSI);
 
-  stats = nbr_table_get_from_lladdr(link_stats, lladdr);
+  struct link_stats *stats = nbr_table_get_from_lladdr(link_stats, lladdr);
   if(stats == NULL) {
     /* Add the neighbor */
-    stats = nbr_table_add_lladdr(link_stats, lladdr, NBR_TABLE_REASON_LINK_STATS, NULL);
+    stats = create_link_stats(lladdr);
     if(stats == NULL) {
       return; /* No space left, return */
     }
-    stats->rssi = LINK_STATS_RSSI_UNKNOWN;
   }
 
   if(stats->rssi == LINK_STATS_RSSI_UNKNOWN) {


### PR DESCRIPTION
These changes avoid some duplicate code in `link-stats.c`.