### PR TITLE
Fix Orchestra incorrectly selecting link not in TSCH schedule for RPL storing mode

### DIFF
--- a/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
+++ b/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
@@ -92,15 +92,9 @@ neighbor_has_uc_link(const linkaddr_t *linkaddr)
     return 0;
   }
 
-  if(!ORCHESTRA_UNICAST_SENDER_BASED) {
-    /* With the receiver-based Orchestra,
-     * all nodes have a link installed at their own timeslot */
-    return 1;
-  }
-
   if(linkaddr_cmp(&orchestra_parent_linkaddr, linkaddr)) {
-    /* The node is our parent */
-    return orchestra_parent_knows_us ? 1 : 0;
+    /* Our parent node. It has a link if it knows us, or is receiver-based */
+    return orchestra_parent_knows_us || (!ORCHESTRA_UNICAST_SENDER_BASED ? 1 : 0);
   }
 
   if(nbr_table_get_from_lladdr(nbr_routes, (linkaddr_t *)linkaddr) != NULL) {

--- a/tests/07-simulation-base/30-rpl-tsch-orchestra-unicast-without-dedicated-cell-storing.csc
+++ b/tests/07-simulation-base/30-rpl-tsch-orchestra-unicast-without-dedicated-cell-storing.csc
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf version="2023090101">
+  <simulation>
+    <title>RPL storing mode Orchestra TSCH unicast to neighbour without dedicated cell</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <description>RPL+TSCH+Orchestra node</description>
+      <source>[CONFIG_DIR]/code-orchestra-txrx/node.c</source>
+      <commands>$(MAKE) TARGET=cooja clean
+$(MAKE) -j$(CPUS) node.cooja TARGET=cooja MAKE_WITH_STORING_ROUTING=1 DEFINES=TEST_CONF_TX_NODE_ID=2,TEST_CONF_RX_NODE_ID=3,TEST_CONF_USE_LINKLOCAL=1,TEST_CONF_TX_START_SECONDS=180,TEST_CONF_TX_INTERVAL_SECONDS=10,TEST_CONF_REQUIRED_RX_COUNT=10</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <mote>
+        <interface_config>
+          org.contikios.cooja.interfaces.Position
+          <pos x="50.000000" y="50.000000" />
+        </interface_config>
+        <interface_config>
+          org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+          <id>1</id>
+        </interface_config>
+      </mote>
+      <mote>
+        <interface_config>
+          org.contikios.cooja.interfaces.Position
+          <pos x="50.000000" y="80.000000" />
+        </interface_config>
+        <interface_config>
+          org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+          <id>2</id>
+        </interface_config>
+      </mote>
+      <mote>
+        <interface_config>
+          org.contikios.cooja.interfaces.Position
+          <pos x="50.000000" y="20.000000" />
+        </interface_config>
+        <interface_config>
+          org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+          <id>3</id>
+        </interface_config>
+      </mote>
+    </motetype>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>/*
+ * Simulation of a unicast transmission to a link-local-reachable neighbour
+ * for which no dedicated TSCH unicast cell exists.
+ *
+ * Node 2 and node 3 both join the DODAG as direct children of the root while
+ * out of range of each other, so neither can become the other's RPL parent.
+ * Node 3 is then moved next to node 2. The two are now neighbours and
+ * link-local reachable, but remain siblings: neither is the other's RPL
+ * parent or child, and neither holds a unicast cell dedicated to the other.
+ *
+ * Node 2 then sends application packets directly to node 3's link-local
+ * address. Such link-local unicasts bypass RPL routing and are sent as
+ * layer-2 unicasts straight to the neighbour.
+ * The same situation arises in normal RPL operation whenever a node sends
+ * a unicast DIO probe to a link-local-reachable neighbour.
+ *
+ * This showcases issue 3158 where Orchestra selects a dedicated unicast slot
+ * that is not present in the schedule. The frames pile up in the TSCH queue
+ * and are never transmitted. Correct behaviour is to use the common slotframe.
+ */
+TIMEOUT(560000, log.testFailed());
+
+GENERATE_MSG(120000, "move-node-3");
+
+while(true) {
+  YIELD();
+
+  if(msg.equals("move-node-3")) {
+    log.log("Moving node 3 into range of its sibling node 2\n");
+    sim.getMoteWithID(3).getInterfaces().getPosition().setCoordinates(80, 50, 0);
+  }
+
+  if(id == 3 &amp;&amp; msg.contains("Received all test packets")) {
+    log.log("Node 3 received all test packets from its sibling node 2\n");
+    log.testOK();
+  }
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <bounds x="400" y="0" height="400" width="600" />
+  </plugin>
+</simconf>

--- a/tests/07-simulation-base/code-orchestra-txrx/Makefile
+++ b/tests/07-simulation-base/code-orchestra-txrx/Makefile
@@ -1,0 +1,21 @@
+CONTIKI_PROJECT = node
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../..
+
+MAKE_WITH_STORING_ROUTING ?= 0
+
+MAKE_MAC = MAKE_MAC_TSCH
+MODULES += $(CONTIKI_NG_SERVICES_DIR)/orchestra
+
+ORCHESTRA_UNICAST_RULE = &unicast_per_neighbor_rpl_ns
+
+ifeq ($(MAKE_WITH_STORING_ROUTING),1)
+MAKE_ROUTING = MAKE_ROUTING_RPL_CLASSIC
+CFLAGS += -DRPL_CONF_MOP=RPL_MOP_STORING_NO_MULTICAST
+ORCHESTRA_UNICAST_RULE = &unicast_per_neighbor_rpl_storing
+endif
+
+CFLAGS += -DORCHESTRA_CONF_RULES="{&eb_per_time_source,$(ORCHESTRA_UNICAST_RULE),&default_common}"
+
+include $(CONTIKI)/Makefile.include

--- a/tests/07-simulation-base/code-orchestra-txrx/node.c
+++ b/tests/07-simulation-base/code-orchestra-txrx/node.c
@@ -1,0 +1,125 @@
+#include "contiki.h"
+#include "net/ipv6/simple-udp.h"
+#include "net/ipv6/uip-ds6.h"
+#include "net/netstack.h"
+#include "net/routing/routing.h"
+#include "sys/log.h"
+#include "sys/node-id.h"
+
+#include <inttypes.h>
+
+#define LOG_MODULE "Delivery"
+#define LOG_LEVEL LOG_LEVEL_INFO
+
+#define UDP_PORT 61618
+
+/* Which node sends the test packets */
+#ifndef TEST_CONF_TX_NODE_ID
+#define TEST_CONF_TX_NODE_ID 1
+#endif
+
+/* Which node receives and counts them */
+#ifndef TEST_CONF_RX_NODE_ID
+#define TEST_CONF_RX_NODE_ID 3
+#endif
+
+/* Send to the destination's link-local address instead of its global address.
+ * This produces a direct layer-2 unicast to the neighbor, bypassing RPL
+ * routing, so it exercises the scheduler's handling of a neighbor that is
+ * neither our RPL parent nor one of our children. */
+#ifndef TEST_CONF_USE_LINKLOCAL
+#define TEST_CONF_USE_LINKLOCAL 0
+#endif
+
+#ifndef TEST_CONF_TX_START_SECONDS
+#define TEST_CONF_TX_START_SECONDS 360
+#endif
+
+#ifndef TEST_CONF_TX_INTERVAL_SECONDS
+#define TEST_CONF_TX_INTERVAL_SECONDS 10
+#endif
+
+#ifndef TEST_CONF_REQUIRED_RX_COUNT
+#define TEST_CONF_REQUIRED_RX_COUNT 10
+#endif
+
+static struct simple_udp_connection udp_connection;
+
+PROCESS(node_process, "Orchestra delivery test");
+AUTOSTART_PROCESSES(&node_process);
+
+static void
+receiver(struct simple_udp_connection *connection,
+         const uip_ipaddr_t *sender_addr,
+         uint16_t sender_port,
+         const uip_ipaddr_t *receiver_addr,
+         uint16_t receiver_port,
+         const uint8_t *data,
+         uint16_t datalen)
+{
+  static uint32_t rx_count;
+
+  if(node_id != TEST_CONF_RX_NODE_ID) {
+    return;
+  }
+
+  rx_count++;
+  LOG_INFO("Received test packet %" PRIu32 " of %u\n",
+           rx_count, TEST_CONF_REQUIRED_RX_COUNT);
+  if(rx_count == TEST_CONF_REQUIRED_RX_COUNT) {
+    LOG_INFO("Received all test packets\n");
+  }
+}
+
+static void
+build_node_addr(uip_ipaddr_t *addr, unsigned int nid)
+{
+  /* A Cooja mote's link-layer address repeats its node id, so its interface
+   * identifier is 0200+id:id:id:id (the U/L bit is flipped in the first byte). */
+#if TEST_CONF_USE_LINKLOCAL
+  uip_ip6addr(addr, 0xfe80, 0, 0, 0, 0x0200 + nid, nid, nid, nid);
+#else
+  const uip_ipaddr_t *prefix = uip_ds6_default_prefix();
+  uip_ip6addr_copy(addr, prefix);
+  addr->u16[4] = UIP_HTONS(0x200 + nid);
+  addr->u16[5] = UIP_HTONS(nid);
+  addr->u16[6] = UIP_HTONS(nid);
+  addr->u16[7] = UIP_HTONS(nid);
+#endif
+}
+
+PROCESS_THREAD(node_process, event, data)
+{
+  static struct etimer timer;
+  static uint32_t sequence;
+
+  PROCESS_BEGIN();
+
+  if(node_id == 1) {
+    NETSTACK_ROUTING.root_start();
+  }
+  NETSTACK_MAC.on();
+
+  simple_udp_register(&udp_connection, UDP_PORT, NULL, UDP_PORT, receiver);
+
+  etimer_set(&timer, TEST_CONF_TX_START_SECONDS * CLOCK_SECOND);
+  PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+
+  while(1) {
+    if(node_id == TEST_CONF_TX_NODE_ID) {
+      uip_ipaddr_t destination;
+
+      build_node_addr(&destination, TEST_CONF_RX_NODE_ID);
+      sequence++;
+      LOG_INFO("Sending test packet %" PRIu32 " to node %u\n", sequence,
+               (unsigned)TEST_CONF_RX_NODE_ID);
+      simple_udp_sendto(&udp_connection, &sequence, sizeof(sequence),
+                        &destination);
+    }
+
+    etimer_set(&timer, TEST_CONF_TX_INTERVAL_SECONDS * CLOCK_SECOND);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+  }
+
+  PROCESS_END();
+}

--- a/tests/07-simulation-base/code-orchestra-txrx/project-conf.h
+++ b/tests/07-simulation-base/code-orchestra-txrx/project-conf.h
@@ -1,0 +1,8 @@
+/* node.c starts the MAC explicitly via NETSTACK_MAC.on(). */
+#define TSCH_CONF_AUTOSTART 0
+
+/* Keep RPL parent changes and TSCH association visible, so that a failing
+ * run in CI carries enough context to diagnose it. Per-slot TSCH logging
+ * stays off: it is very verbose and is lossy under load. */
+#define LOG_CONF_LEVEL_RPL              LOG_LEVEL_WARN
+#define LOG_CONF_LEVEL_MAC              LOG_LEVEL_INFO


### PR DESCRIPTION
The issue is described and discussed in #3160 and #3158, and is relevant for receiver-based Orchestra combined with RPL storing mode. Introduced in #1520, Orchestra may have a packet try to use a link which is not in the schedule. This causes the packet to stay in the queue forever, eventually filling the queue and blocking all traffic to the neighbor.

In short, the receiver-based storing-mode Orchestra adds TX links to children and parents, but not to neighboring siblings. Therefore, link–local traffic to siblings (not using the global IP and being routed via parent), should utilize links from the common slotframe. However, after #1520, Orchestra wrongly assumes it has a TX link to the neighbor, and selects it to be used. Example of such link-local traffic is RPL DIO probes.

This PR
1. Fixes the issue by basically reverting the relevant part of #1520, so that the common slotframe is utilized.
2. Adds a test simulation that showcases a link-local packet transmission - the test fails without the fix.

(There are some related but more long-term issues still open such as 1) Making a general catch for all orchestra rules not to select a link which is not in the schedule, 2) Evaluating and considering if all neighbors should have dedicated TX links (as with non-storing mode) (see [discussion](https://github.com/contiki-ng/contiki-ng/pull/3160#issuecomment-4929569628)).)