### PR TITLE
nrf52840: fix the dongle button pin

### DIFF
--- a/arch/platform/nrf/nrf52840/dongle/nrf52840-dongle-def.h
+++ b/arch/platform/nrf/nrf52840/dongle/nrf52840-dongle-def.h
@@ -47,7 +47,7 @@
 #define PLATFORM_HAS_BUTTON             1
 #define PLATFORM_SUPPORTS_BUTTON_HAL    1
 /*---------------------------------------------------------------------------*/
-#define NRF_BUTTON1_PIN     16
+#define NRF_BUTTON1_PIN     6
 #define NRF_BUTTON1_PORT    1
 /*---------------------------------------------------------------------------*/
 #define NRF_LED1_PIN        6


### PR DESCRIPTION
The PCA10059 has SW1 on P1.06, but the unified nrf platform declares P1.16, so button-hal reports no events at all on the dongle. Both the legacy platform and Nordic's pca10059.h use P1.06.

Verified on hardware with examples/dev/button-hal: no output whatsoever while pressing SW1 before the change, clean press/release events after.