### PR TITLE
Fix Orchestra incorrect handling of TSCH time-source change

### DIFF
--- a/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-ns.c
+++ b/os/services/orchestra/orchestra-rule-unicast-per-neighbor-rpl-ns.c
@@ -130,17 +130,6 @@ select_packet(uint16_t *slotframe, uint16_t *timeslot, uint16_t *channel_offset)
 }
 /*---------------------------------------------------------------------------*/
 static void
-new_time_source(const struct tsch_neighbor *old, const struct tsch_neighbor *new)
-{
-  if(new != old) {
-    const linkaddr_t *old_addr = tsch_queue_get_nbr_address(old);
-    const linkaddr_t *new_addr = tsch_queue_get_nbr_address(new);
-    remove_uc_link(old_addr);
-    add_uc_link(new_addr);
-  }
-}
-/*---------------------------------------------------------------------------*/
-static void
 init(uint16_t sf_handle)
 {
   uint16_t rx_timeslot;
@@ -159,7 +148,7 @@ init(uint16_t sf_handle)
 /*---------------------------------------------------------------------------*/
 struct orchestra_rule unicast_per_neighbor_rpl_ns = {
   init,
-  new_time_source,
+  NULL,
   select_packet,
   NULL,
   NULL,

--- a/tests/07-simulation-base/29-rpl-tsch-orchestra-time-source-change-ns.csc
+++ b/tests/07-simulation-base/29-rpl-tsch-orchestra-time-source-change-ns.csc
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf version="2023090101">
+  <simulation>
+    <title>RPL non-storing Orchestra TSCH forwarding after time-source change</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <description>RPL+TSCH+Orchestra node</description>
+      <source>[CONFIG_DIR]/code-orchestra-txrx/node.c</source>
+      <commands>$(MAKE) TARGET=cooja clean
+    $(MAKE) -j$(CPUS) node.cooja TARGET=cooja DEFINES=TEST_CONF_TX_NODE_ID=1,TEST_CONF_RX_NODE_ID=3,TEST_CONF_TX_START_SECONDS=360,TEST_CONF_REQUIRED_RX_COUNT=10</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <mote>
+        <interface_config>
+          org.contikios.cooja.interfaces.Position
+          <pos x="50.000000" y="50.000000" />
+        </interface_config>
+        <interface_config>
+          org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+          <id>1</id>
+        </interface_config>
+      </mote>
+      <mote>
+        <interface_config>
+          org.contikios.cooja.interfaces.Position
+          <pos x="50.000000" y="140.000000" />
+        </interface_config>
+        <interface_config>
+          org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+          <id>2</id>
+        </interface_config>
+      </mote>
+      <mote>
+        <interface_config>
+          org.contikios.cooja.interfaces.Position
+          <pos x="50.000000" y="95.000000" />
+        </interface_config>
+        <interface_config>
+          org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+          <id>3</id>
+        </interface_config>
+      </mote>
+    </motetype>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>/*
+ * Test for Orchestra/RPL non-storing forwarding after a time-source change.
+ *
+ * Phase 1: the root (node 1) is out of range of node 2. Node 3 joins the
+ * root directly and relays its EBs; node 2 associates through node 3 and
+ * selects it as its TSCH time source and RPL parent. Orchestra allocates a
+ * Tx cell at hash(node 3) on node 2. The topology is root -- node 3 -- node 2.
+ *
+ * Phase 2: the root moves into range of node 2 but out of range of node 3.
+ * Node 2 switches its TSCH time source and RPL parent to the root.
+ * Orchestra's new_time_source() removes the Tx cell at hash(node 3) and
+ * installs one at hash(root). Node 3 simultaneously loses its path to the
+ * root and reparents to node 2, becoming its RPL child.
+ *
+ * The test then verifies that the root can still reach node 3 by forwarding
+ * ten application packets through node 2. This exercises whether Orchestra
+ * correctly maintains or re-installs the Tx cell needed to reach node 3 after
+ * the time-source change.
+ *
+ * This showcases issue 3158, where the cell removed by new_time_source()
+ * is never reinstated, select_packet() pins frames to timeslot hash(node 3)
+ * where no Tx link exists, and the queue fills up.
+ */
+TIMEOUT(1200000, log.testFailed());
+
+/* Move the root into node 2's range once the network has settled. */
+GENERATE_MSG(300000, "move-root");
+
+while(true) {
+  YIELD();
+  if(msg.equals("move-root")) {
+    log.log("Moving root (node 1) into range of node 2\n");
+    sim.getMoteWithID(1).getInterfaces().getPosition().setCoordinates(95, 140, 0);
+  } else if(id == 3 &amp;&amp; msg.contains("Received all test packets")) {
+    log.log("Node 3 received ten test packets\n");
+    log.testOK();
+  }
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <bounds x="400" y="0" height="400" width="600" />
+  </plugin>
+</simconf>

--- a/tests/07-simulation-base/code-orchestra-txrx/Makefile
+++ b/tests/07-simulation-base/code-orchestra-txrx/Makefile
@@ -1,0 +1,21 @@
+CONTIKI_PROJECT = node
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../..
+
+MAKE_WITH_STORING_ROUTING ?= 0
+
+MAKE_MAC = MAKE_MAC_TSCH
+MODULES += $(CONTIKI_NG_SERVICES_DIR)/orchestra
+
+ORCHESTRA_UNICAST_RULE = &unicast_per_neighbor_rpl_ns
+
+ifeq ($(MAKE_WITH_STORING_ROUTING),1)
+MAKE_ROUTING = MAKE_ROUTING_RPL_CLASSIC
+CFLAGS += -DRPL_CONF_MOP=RPL_MOP_STORING_NO_MULTICAST
+ORCHESTRA_UNICAST_RULE = &unicast_per_neighbor_rpl_storing
+endif
+
+CFLAGS += -DORCHESTRA_CONF_RULES="{&eb_per_time_source,$(ORCHESTRA_UNICAST_RULE),&default_common}"
+
+include $(CONTIKI)/Makefile.include

--- a/tests/07-simulation-base/code-orchestra-txrx/node.c
+++ b/tests/07-simulation-base/code-orchestra-txrx/node.c
@@ -1,0 +1,125 @@
+#include "contiki.h"
+#include "net/ipv6/simple-udp.h"
+#include "net/ipv6/uip-ds6.h"
+#include "net/netstack.h"
+#include "net/routing/routing.h"
+#include "sys/log.h"
+#include "sys/node-id.h"
+
+#include <inttypes.h>
+
+#define LOG_MODULE "Delivery"
+#define LOG_LEVEL LOG_LEVEL_INFO
+
+#define UDP_PORT 61618
+
+/* Which node sends the test packets */
+#ifndef TEST_CONF_TX_NODE_ID
+#define TEST_CONF_TX_NODE_ID 1
+#endif
+
+/* Which node receives and counts them */
+#ifndef TEST_CONF_RX_NODE_ID
+#define TEST_CONF_RX_NODE_ID 3
+#endif
+
+/* Send to the destination's link-local address instead of its global address.
+ * This produces a direct layer-2 unicast to the neighbor, bypassing RPL
+ * routing, so it exercises the scheduler's handling of a neighbor that is
+ * neither our RPL parent nor one of our children. */
+#ifndef TEST_CONF_USE_LINKLOCAL
+#define TEST_CONF_USE_LINKLOCAL 0
+#endif
+
+#ifndef TEST_CONF_TX_START_SECONDS
+#define TEST_CONF_TX_START_SECONDS 360
+#endif
+
+#ifndef TEST_CONF_TX_INTERVAL_SECONDS
+#define TEST_CONF_TX_INTERVAL_SECONDS 10
+#endif
+
+#ifndef TEST_CONF_REQUIRED_RX_COUNT
+#define TEST_CONF_REQUIRED_RX_COUNT 10
+#endif
+
+static struct simple_udp_connection udp_connection;
+
+PROCESS(node_process, "Orchestra delivery test");
+AUTOSTART_PROCESSES(&node_process);
+
+static void
+receiver(struct simple_udp_connection *connection,
+         const uip_ipaddr_t *sender_addr,
+         uint16_t sender_port,
+         const uip_ipaddr_t *receiver_addr,
+         uint16_t receiver_port,
+         const uint8_t *data,
+         uint16_t datalen)
+{
+  static uint32_t rx_count;
+
+  if(node_id != TEST_CONF_RX_NODE_ID) {
+    return;
+  }
+
+  rx_count++;
+  LOG_INFO("Received test packet %" PRIu32 " of %u\n",
+           rx_count, TEST_CONF_REQUIRED_RX_COUNT);
+  if(rx_count == TEST_CONF_REQUIRED_RX_COUNT) {
+    LOG_INFO("Received all test packets\n");
+  }
+}
+
+static void
+build_node_addr(uip_ipaddr_t *addr, unsigned int nid)
+{
+  /* A Cooja mote's link-layer address repeats its node id, so its interface
+   * identifier is 0200+id:id:id:id (the U/L bit is flipped in the first byte). */
+#if TEST_CONF_USE_LINKLOCAL
+  uip_ip6addr(addr, 0xfe80, 0, 0, 0, 0x0200 + nid, nid, nid, nid);
+#else
+  const uip_ipaddr_t *prefix = uip_ds6_default_prefix();
+  uip_ip6addr_copy(addr, prefix);
+  addr->u16[4] = UIP_HTONS(0x200 + nid);
+  addr->u16[5] = UIP_HTONS(nid);
+  addr->u16[6] = UIP_HTONS(nid);
+  addr->u16[7] = UIP_HTONS(nid);
+#endif
+}
+
+PROCESS_THREAD(node_process, event, data)
+{
+  static struct etimer timer;
+  static uint32_t sequence;
+
+  PROCESS_BEGIN();
+
+  if(node_id == 1) {
+    NETSTACK_ROUTING.root_start();
+  }
+  NETSTACK_MAC.on();
+
+  simple_udp_register(&udp_connection, UDP_PORT, NULL, UDP_PORT, receiver);
+
+  etimer_set(&timer, TEST_CONF_TX_START_SECONDS * CLOCK_SECOND);
+  PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+
+  while(1) {
+    if(node_id == TEST_CONF_TX_NODE_ID) {
+      uip_ipaddr_t destination;
+
+      build_node_addr(&destination, TEST_CONF_RX_NODE_ID);
+      sequence++;
+      LOG_INFO("Sending test packet %" PRIu32 " to node %u\n", sequence,
+               (unsigned)TEST_CONF_RX_NODE_ID);
+      simple_udp_sendto(&udp_connection, &sequence, sizeof(sequence),
+                        &destination);
+    }
+
+    etimer_set(&timer, TEST_CONF_TX_INTERVAL_SECONDS * CLOCK_SECOND);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+  }
+
+  PROCESS_END();
+}

--- a/tests/07-simulation-base/code-orchestra-txrx/project-conf.h
+++ b/tests/07-simulation-base/code-orchestra-txrx/project-conf.h
@@ -1,0 +1,8 @@
+/* node.c starts the MAC explicitly via NETSTACK_MAC.on(). */
+#define TSCH_CONF_AUTOSTART 0
+
+/* Keep RPL parent changes and TSCH association visible, so that a failing
+ * run in CI carries enough context to diagnose it. Per-slot TSCH logging
+ * stays off: it is very verbose and is lossy under load. */
+#define LOG_CONF_LEVEL_RPL              LOG_LEVEL_WARN
+#define LOG_CONF_LEVEL_MAC              LOG_LEVEL_INFO


### PR DESCRIPTION
The issue is described and discussed in #3160 and #3158, and is relevant for receiver-based Orchestra combined with RPL non-storing mode. In short, when losing a node as time source, the Orchestra non-storing unicast rule will remove the unicast TX link to thenode, even though it may still be our neighbor. For future transmissions, the rule still selects the (now gone) TX link to be used, causing the packets to stay in the queue forever.

This PR
1. Removes all special handling of time source and rather let the adding/removing of neighbors alone handle the add/remove links. I got a few worries/TODOs, so I am marking the PR as a draft for now. In particular: 1) Will this cause links to stay in the schedule for too long (i.e. how long is a neighbor in the table after we lose connection to it), 2) Are there any ordering issues, e.g. is it possible to be a time source but not a neighbor for some time?
2. Adds a test simulation which reproduces the issue. The test fails without the fix.

The issue and solution was first proposed by @kkrentz in #3160.