### PR TITLE
SHA-256: Account for integer overflow in HKDF

### DIFF
--- a/os/lib/sha-256.c
+++ b/os/lib/sha-256.c
@@ -424,7 +424,7 @@ sha_256_hkdf_expand(const uint8_t *prk, size_t prk_len,
   n = okm_len / SHA_256_DIGEST_LENGTH
       + (okm_len % SHA_256_DIGEST_LENGTH ? 1 : 0);
 
-  for(i = 1; i <= n; i++) {
+  for(i = 1; (i <= n) && i; i++) {
     sha_256_hmac_init(prk, prk_len);
     if(i != 1) {
       sha_256_hmac_update(t_i, sizeof(t_i));

--- a/tests/08-native-runs/14-sha-256/test-sha-256.c
+++ b/tests/08-native-runs/14-sha-256/test-sha-256.c
@@ -447,6 +447,21 @@ UNIT_TEST(sha_256_hkdf)
   UNIT_TEST_END();
 }
 /*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(sha_256_hkdf_max, "SHA-256 HKDF max");
+UNIT_TEST(sha_256_hkdf_max)
+{
+  UNIT_TEST_BEGIN();
+
+  uint8_t prk[128];
+  uint8_t okm[255 * SHA_256_DIGEST_LENGTH];
+  /* ensure that this does not cause an infinite loop */
+  UNIT_TEST_ASSERT(sha_256_hkdf_expand(prk, sizeof(prk),
+                                       NULL, 0,
+                                       okm, sizeof(okm)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
 PROCESS_THREAD(test_process, ev, data)
 {
   PROCESS_BEGIN();
@@ -459,12 +474,14 @@ PROCESS_THREAD(test_process, ev, data)
   UNIT_TEST_RUN(sha_256_hash_shorthand);
   UNIT_TEST_RUN(sha_256_hmac);
   UNIT_TEST_RUN(sha_256_hkdf);
+  UNIT_TEST_RUN(sha_256_hkdf_max);
 
   if(!UNIT_TEST_PASSED(sha_256_hash_stepwise)
      || !UNIT_TEST_PASSED(sha_256_hash_with_checkpoint)
      || !UNIT_TEST_PASSED(sha_256_hash_shorthand)
      || !UNIT_TEST_PASSED(sha_256_hmac)
-     || !UNIT_TEST_PASSED(sha_256_hkdf)) {
+     || !UNIT_TEST_PASSED(sha_256_hkdf)
+     || !UNIT_TEST_PASSED(sha_256_hkdf_max)) {
     printf("=check-me= FAILED\n");
     printf("---\n");
   }


### PR DESCRIPTION
This fixes an infinite loop when `n` is at its maximum of 255.