### PR TITLE
CoAP: fix stale example client address and a no-op test comparison

### DIFF
--- a/examples/coap/coap-example-client/coap-example-client.c
+++ b/examples/coap/coap-example-client/coap-example-client.c
@@ -55,7 +55,9 @@
 #define LOG_LEVEL  LOG_LEVEL_APP
 
 /* FIXME: This server address is hard-coded for Cooja and link-local for unconnected border router. */
-#define SERVER_EP "coap://[fe80::212:7402:0002:0202]"
+/* Cooja mote 2: arch/platform/cooja/platform.c repeats the mote ID across the
+   link-layer address, giving 0002.0002.0002.0002 for mote 2. */
+#define SERVER_EP "coap://[fe80::202:2:2:2]"
 
 #define TOGGLE_INTERVAL 10
 

--- a/tests/08-native-runs/09-native-coap.sh
+++ b/tests/08-native-runs/09-native-coap.sh
@@ -27,7 +27,7 @@ for TARGET in .well-known/core test/push; do
   cat coap.log >> $BASENAME.log
   # Fetch coap status code (not $? because this is piped)
   SUCCESS=`grep -c '2.05' coap.log`
-  if [ $SUCCESS -gt 0 ]; then
+  if [ "${SUCCESS:-0}" -gt 0 ]; then
     printf "> OK\n"
     OKCOUNT+=1
   else

--- a/tests/08-native-runs/09-native-coap.sh
+++ b/tests/08-native-runs/09-native-coap.sh
@@ -27,7 +27,7 @@ for TARGET in .well-known/core test/push; do
   cat coap.log >> $BASENAME.log
   # Fetch coap status code (not $? because this is piped)
   SUCCESS=`grep -c '2.05' coap.log`
-  if [ $SUCCESS > 0 ]; then
+  if [ $SUCCESS -gt 0 ]; then
     printf "> OK\n"
     OKCOUNT+=1
   else


### PR DESCRIPTION
Two small, independent CoAP fixes found while testing the CoAP row of #3190 on hardware. Neither is urgent — CoAP itself works, verified end-to-end on hardware (9/9 requests over a real 802.15.4 path). These are a test that can't fail and an example that can't connect.

### 1. `09-native-coap.sh` cannot fail

```sh
if [ $SUCCESS > 0 ]; then
```

That is a redirection, not a comparison: it runs `test $SUCCESS` with stdout sent to a file named `0`. `grep -c` always prints a number, so the operand is never empty and the branch is taken for a count of 0 exactly as for 1. `OKCOUNT` then always reaches `TESTCOUNT`, the only `exit 1` is unreachable, and there is no `set -e` — so the script always exits 0, even if `coap-client` is missing or the server never starts. It also leaves a stray empty file named `0` behind.

Fixed with `-gt`.

**Nothing was masked by this.** The two endpoints the test checks both answer 2.05 today, and the `Makefile.compile-test` rule around it still caught build failures, so the row had quietly become a build-only test for `coap-example-server`. The cost was lost signal, not a live defect.

It is also a regression rather than a day-one bug — the 2017 original (01d06c30d) used `if [ $SUCCESS == 1 ]`, which works; cbe7082c1 (2019-10-12) loosened it to "greater than zero" with the wrong operator. Dead since October 2019.

I swept the rest of the suite: this is the only occurrence. Every other test asserts on an exit status, where the mistake isn't expressible, and the Cooja `.csc` scripts are JavaScript, where `>` is a real comparison.

### 2. `coap-example-client` points at a server that cannot exist

`SERVER_EP` held `fe80::212:7402:0002:0202`, whose EUI-64 is
`00:12:74:02:00:02:02:02` — the Moteiv OUI `00:12:74`, i.e. a Tmote Sky DS2411
serial. The `FIXME` above it says "hard-coded for Cooja", and that was exactly
right: this is the address Cooja gives an **emulated Sky mote 2**.

That addressing is still live today. An emulated Sky mote 1 in current
Contiki-NG boots as:

```
[INFO: Main      ] Node ID: 1
[INFO: Main      ] Link-layer address: 0012.7401.0001.0101
[INFO: Main      ] Tentative link-local IPv6 address: fe80::212:7401:1:101
```

so mote 2 is `fe80::212:7402:2:202` — the hard-coded value. The same scheme is
asserted by `tests/17-tun-rpl-br/03-border-router-sky.csc`, which pings
`fd00::0212:7404:0004:0404` (mote 4).

**So why is it broken?** Because the server can no longer *be* a Sky mote:
`examples/coap/coap-example-server/Makefile` (and the client's) carry
`PLATFORMS_EXCLUDE = sky z1`, on code-size grounds. The address is therefore
unreachable in any buildable configuration — not because no mote can hold it,
but because no mote that can run `coap-example-server` can.

The mote type these examples *can* use is the native `cooja` one, and it
addresses differently: `arch/platform/cooja/platform.c:set_lladdr()` repeats
the mote ID across the link-layer address, so mote 2 is `0002.0002.0002.0002`,
link-local `fe80::202:2:2:2`. That is what this patch uses.

Verified in Cooja with two native motes: with the old address the client gets
no responses and times out; with the new one every request is answered
(`.well-known/core` returns the full link-format listing). Builds clean for
`native`, and `strings` confirms the new address is the one compiled in. The
`FIXME` stays — the address is still hard-coded, just no longer pointing at a
mote type these examples cannot be built for.

Nothing in the tree executes this example (compile-only in CI, and no
simulation uses it), which is why it went unnoticed. The test in item 1
exercises `coap-example-server` with libcoap as the client, not this example.

Targets `release-5.2`: both are small fixes to things that ship broken today.
