### PR TITLE
nrf54l15: wire the XIAO user button into button-hal

### DIFF
--- a/arch/platform/nrf/nrf54l15/xiao/board-buttons.c
+++ b/arch/platform/nrf/nrf54l15/xiao/board-buttons.c
@@ -14,19 +14,11 @@
 
 #include "contiki.h"
 #include "dev/button-hal.h"
-
-/* Stub implementations to avoid nrfx v2.x API dependency */
-#include <stddef.h>
-
-/* Provide empty button list */
-button_hal_button_t *button_hal_buttons[] = { NULL };
-unsigned char button_hal_button_cnt = 0;
-
-/* Stub for v2.x API compatibility */
 /*---------------------------------------------------------------------------*/
-void
-nrfx_gpiote_in_event_enable(unsigned int pin, unsigned char enable)
-{
-  /* Stub - no buttons to enable */
-}
+/* The onboard user button pulls P0.0 low while pressed. */
+BUTTON_HAL_BUTTON(usr_btn, "User", XIAO_NRF54L15_BUTTON_PORT,
+                  XIAO_NRF54L15_BUTTON_PIN, GPIO_HAL_PIN_CFG_PULL_UP,
+                  BUTTON_HAL_ID_USER_BUTTON, true);
+/*---------------------------------------------------------------------------*/
+BUTTON_HAL_BUTTONS(&usr_btn);
 /*---------------------------------------------------------------------------*/

--- a/arch/platform/nrf/nrf54l15/xiao/xiao-nrf54l15-conf.h
+++ b/arch/platform/nrf/nrf54l15/xiao/xiao-nrf54l15-conf.h
@@ -15,8 +15,6 @@
 /* RTIMER_SECOND is defined by the OS based on RTIMER_ARCH_SECOND */
 /* which should come from the CPU/platform architecture files */
 
-/* Disable button-hal for now (no buttons defined, and needs v3.x API updates) */
-#define BUTTON_HAL_CONF_ENABLED 0
 /* Temporarily disable watchdog until we implement feeding it */
 #define WATCHDOG_CONF_ENABLE 0
 

--- a/arch/platform/nrf/nrf54l15/xiao/xiao-nrf54l15-def.h
+++ b/arch/platform/nrf/nrf54l15/xiao/xiao-nrf54l15-def.h
@@ -28,6 +28,15 @@
 #define XIAO_NRF54L15_BUTTON_PORT    0
 #define XIAO_NRF54L15_BUTTON_PIN     0
 
+/*
+ * The onboard user button is exposed through button-hal (board-buttons.c).
+ * PLATFORM_SUPPORTS_BUTTON_HAL matters as well: code that consults it
+ * otherwise selects the legacy button_sensor API, which this board does not
+ * implement.
+ */
+#define PLATFORM_HAS_BUTTON          1
+#define PLATFORM_SUPPORTS_BUTTON_HAL 1
+
 #define XIAO_NRF54L15_UART_INSTANCE  20 /* UART20 */
 #define XIAO_NRF54L15_UART_TX_PORT   1
 #define XIAO_NRF54L15_UART_TX_PIN    9


### PR DESCRIPTION
The board exported an empty button-hal list and left PLATFORM_SUPPORTS_BUTTON_HAL unset, so services fell back to the legacy button_sensor API that the board does not implement, breaking the link of examples/rpl-border-router for BOARD=nrf54l15/xiao.

The XIAO does have a user button, on P0.0, active low with a pull-up, as the board's own XIAO_NRF54L15_BUTTON_PORT/_PIN macros record. Register it and declare PLATFORM_HAS_BUTTON alongside PLATFORM_SUPPORTS_BUTTON_HAL. Drop the stubbed nrfx_gpiote_in_event_enable(): it belongs to the nrfx v2.x path, while nRF54L15 builds use v3.2+, and nothing referenced it. Also drop BUTTON_HAL_CONF_ENABLED, which is read nowhere in the tree.