### PR TITLE
nrf: enable the instruction cache at boot on the nRF54L series

### DIFF
--- a/arch/cpu/nrf/nrf54l15/nrf54l15-conf.h
+++ b/arch/cpu/nrf/nrf54l15/nrf54l15-conf.h
@@ -43,6 +43,18 @@
 #define WATCHDOG_CONF_ENABLE 0
 #endif
 
+/*
+ * Enable the instruction cache at boot. The SoC executes from wait-stated
+ * RRAM, so code-fetch-bound work runs several times slower uncached.
+ * Set 0 to run uncached, e.g. for cycle-exact profiling of code-fetch
+ * behavior.
+ */
+#ifdef NRF_CONF_ICACHE
+#define NRF_ICACHE_ENABLED NRF_CONF_ICACHE
+#else
+#define NRF_ICACHE_ENABLED 1
+#endif
+
 /* Enable extended HardFault handler with register dump. */
 #ifndef NRF_CONF_HARDFAULT_HANDLER_EXTENDED
 #define NRF_CONF_HARDFAULT_HANDLER_EXTENDED 1

--- a/arch/cpu/nrf/nrf54l15/nrf54l15-conf.h
+++ b/arch/cpu/nrf/nrf54l15/nrf54l15-conf.h
@@ -43,6 +43,16 @@
 #define WATCHDOG_CONF_ENABLE 0
 #endif
 
+/*
+ * Enable the instruction cache at boot. The SoC executes from wait-stated
+ * RRAM, so code-fetch-bound work runs several times slower uncached.
+ * Set 0 to run uncached, e.g. for cycle-exact profiling of code-fetch
+ * behavior.
+ */
+#ifndef NRF_CONF_ICACHE_ENABLE
+#define NRF_CONF_ICACHE_ENABLE 1
+#endif
+
 /* Enable extended HardFault handler with register dump. */
 #ifndef NRF_CONF_HARDFAULT_HANDLER_EXTENDED
 #define NRF_CONF_HARDFAULT_HANDLER_EXTENDED 1

--- a/arch/platform/nrf/platform.c
+++ b/arch/platform/nrf/platform.c
@@ -76,9 +76,26 @@ platform_init_board_stage_two(void)
 {
 }
 /*---------------------------------------------------------------------------*/
+static void
+icache_init(void)
+{
+#if defined(NRF_ICACHE) && NRF_ICACHE_ENABLED
+  /*
+   * Enable the instruction cache, on SoCs that have the ICACHE peripheral
+   * and have not opted out (see NRF_CONF_ICACHE). Invalidate before
+   * enabling: ENABLE performs no invalidation of its own, and the cache
+   * memory is undefined at power-on and stale after a warm reset over
+   * rewritten code, such as a firmware update.
+   */
+  NRF_ICACHE->TASKS_INVALIDATECACHE = 1;
+  NRF_ICACHE->ENABLE = CACHE_ENABLE_ENABLE_Enabled;
+#endif /* defined(NRF_ICACHE) && NRF_ICACHE_ENABLED */
+}
+/*---------------------------------------------------------------------------*/
 void
 platform_init_stage_one(void)
 {
+  icache_init();
   gpio_hal_init();
   platform_init_board();
   leds_init();

--- a/arch/platform/nrf/platform.c
+++ b/arch/platform/nrf/platform.c
@@ -56,11 +56,23 @@
 #include "nrfx_config.h"
 #include "usb.h"
 
+#ifdef NRF_ICACHE
+#include "hal/nrf_cache.h"
+#endif
+
 /*---------------------------------------------------------------------------*/
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "NRF"
 #define LOG_LEVEL LOG_LEVEL_MAIN
+/*---------------------------------------------------------------------------*/
+/*
+ * Only the SoCs with an ICACHE peripheral define this in their CPU
+ * configuration header, so provide an off default for the others.
+ */
+#ifndef NRF_CONF_ICACHE_ENABLE
+#define NRF_CONF_ICACHE_ENABLE 0
+#endif
 /*---------------------------------------------------------------------------*/
 #if NRF_HARDFAULT_HANDLER_EXTENDED
 void hardfault_print_saved_crash(void);
@@ -76,9 +88,31 @@ platform_init_board_stage_two(void)
 {
 }
 /*---------------------------------------------------------------------------*/
+static void
+icache_init(void)
+{
+#if defined(NRF_ICACHE) && NRF_CONF_ICACHE_ENABLE
+  /*
+   * Enable the instruction cache, on SoCs that have the ICACHE peripheral
+   * and have not opted out (see NRF_CONF_ICACHE_ENABLE). Enabling performs
+   * no invalidation of its own, and the reset state of the cache memory is
+   * not documented, so invalidate first rather than risk serving a line
+   * left over from code that a firmware update has since rewritten. The
+   * invalidate task runs asynchronously; wait for it before enabling.
+   */
+  nrf_cache_invalidate(NRF_ICACHE);
+#if NRF_CACHE_HAS_STATUS
+  while(nrf_cache_busy_check(NRF_ICACHE)) {
+  }
+#endif
+  nrf_cache_enable(NRF_ICACHE);
+#endif /* defined(NRF_ICACHE) && NRF_CONF_ICACHE_ENABLE */
+}
+/*---------------------------------------------------------------------------*/
 void
 platform_init_stage_one(void)
 {
+  icache_init();
   gpio_hal_init();
   platform_init_board();
   leds_init();


### PR DESCRIPTION
The nRF54L series executes in place from wait-stated RRAM, with a standalone ICACHE peripheral in front of it that is disabled at reset. Nothing enabled it, so every application ran with the CPU stalling on raw RRAM code fetches.

Enable it in platform_init_stage_one(), invalidating first: the cache memory is undefined at power-on and stale after a warm reset over rewritten code, such as a firmware update. The code is gated on the NRF_ICACHE peripheral macro, which only the nRF54L series defines, and on a new NRF_CONF_ICACHE option (default on; set 0 to run uncached, e.g. for cycle-exact profiling of code-fetch behavior).

Measured on an nRF54L15 at 128 MHz (DWT cycle counter, deterministic across runs):

  trial-division prime count   10359465 -> 4879210 cycles   2.1x
  byte-wise checksum loop       3694455 ->  718717 cycles   5.1x