### PR TITLE
nrf5340: fix buttons in the TrustZone normal world

### DIFF
--- a/arch/cpu/nrf/nrfx_config_nrf5340_application.h
+++ b/arch/cpu/nrf/nrfx_config_nrf5340_application.h
@@ -140,6 +140,16 @@
 #if defined(NRF_TRUSTZONE_NONSECURE)
 #define NRF_GPIOTE        NRF_GPIOTE1
 #define GPIOTE_IRQHandler GPIOTE1_IRQHandler
+/*
+ * Since nrfx 3.2 the GPIOTE driver names its interrupt handler after the
+ * instance index rather than using GPIOTE_IRQHandler, and gpio-hal-arch.c asks
+ * for index 0, so the driver defines GPIOTE0_IRQHandler. In the normal world
+ * that index refers to GPIOTE1, and the driver correspondingly enables its
+ * interrupt, GPIOTE1_IRQn. Without this rename the handler is placed on the
+ * GPIOTE0 vector, the enabled interrupt reaches the default handler instead,
+ * and the first edge on a GPIO input hangs the CPU until the watchdog fires.
+ */
+#define GPIOTE0_IRQHandler GPIOTE1_IRQHandler
 #else
 #define NRF_GPIOTE        NRF_GPIOTE0
 #define GPIOTE_IRQHandler GPIOTE0_IRQHandler

--- a/arch/platform/nrf/platform.c
+++ b/arch/platform/nrf/platform.c
@@ -105,7 +105,18 @@ void
 platform_init_stage_two(void)
 {
   platform_init_board_stage_two();
+
+  /*
+   * There are two images of everything when building with TrustZone, and the
+   * normal world is the one that owns the buttons, through the non-secure
+   * GPIOTE instance. Initializing button-hal in the secure image as well would
+   * arm the secure instance on the same pins, and a button press would then
+   * raise a secure interrupt that nothing services, because the secure image
+   * has handed over to the normal world and no longer runs a scheduler.
+   */
+#if !defined(NRF_TRUSTZONE_SECURE)
   button_hal_init();
+#endif
 
   /* There are two images of everything when building with
    * TrustZone, and uarte can only be initialized once,


### PR DESCRIPTION
A button press hung the CPU until the watchdog reset the board. Two independent defects caused it.

The GPIOTE interrupt handler was placed on the wrong vector. Since nrfx 3.2 the driver names the handler after the instance index instead of using GPIOTE_IRQHandler, which the existing fixup renames, so the normal world got GPIOTE0_IRQHandler while the interrupt the driver enables is GPIOTE1_IRQn. Every edge therefore reached the default handler.

The secure image also initialized button-hal, arming the secure GPIOTE instance on the same pins. That interrupt has no scheduler to service it once the secure image hands over to the normal world.