### PR TITLE
ipso-objects: write On/Off (5850) as a Boolean, not an Integer

### DIFF
--- a/os/services/ipso-objects/ipso-control-template.c
+++ b/os/services/ipso-objects/ipso-control-template.c
@@ -134,8 +134,12 @@ lwm2m_callback(lwm2m_object_instance_t *object, lwm2m_context_t *ctx)
   if(ctx->operation == LWM2M_OP_READ) {
     switch(ctx->resource_id) {
     case IPSO_ONOFF:
-      v = ipso_control_is_on(control) ? 1 : 0;
-      break;
+      /* 5850 (On/Off) is a Boolean in the IPSO registry, so it must be written
+         with the boolean writer. Writing it as an integer makes the typed
+         encodings (TLV, JSON, SenML) carry the wrong datatype on the wire,
+         which servers that validate against the object model reject. */
+      lwm2m_object_write_boolean(ctx, ipso_control_is_on(control) ? 1 : 0);
+      return LWM2M_STATUS_OK;
     case IPSO_DIMMER:
       v = ipso_control_get_value(control);
       break;


### PR DESCRIPTION
Resource 5850 (On/Off) is defined as a Boolean in the IPSO/OMA object registry, but ipso_control_template's READ handler funnelled it through the same lwm2m_object_write_int() as the Integer resources 5851 (Dimmer) and 5852 (On Time).

Plain-text reads are untyped, so a single-resource read looks correct and the server applies its own model. The typed encodings carry the datatype on the wire, so reading the whole instance sends 5850 as an Integer and a server that validates against the object model rejects the response. With Leshan:

  GET /3311/0 -> Value of type Integer does not match the given datatype
                 BOOLEAN

while GET /3311/0/5850 on the same node returned a correct BOOLEAN.

lwm2m_object_write_boolean() already exists and simply was not used here. This affects every object built on the control template, i.e. IPSO Light Control (3311) and LED Control (3312).

Verified on hardware with an nRF54L15 running examples/lwm2m-ipso-objects against Leshan: whole-instance reads of /3311/0 failed 3/3 before and succeed 3/3 after, with 5850 correctly typed BOOLEAN; single-resource reads are unchanged, and a write is reflected in the instance read.