### PR TITLE
mqtt: fix Variable Byte Integer decoding and omitted MQTT-5 header fields

### DIFF
--- a/os/net/app-layer/mqtt/mqtt-prop.c
+++ b/os/net/app-layer/mqtt/mqtt-prop.c
@@ -252,6 +252,7 @@ void
 mqtt_prop_decode_input_props(struct mqtt_connection *conn)
 {
   uint8_t prop_len_bytes;
+  uint32_t vhdr_len;
 
   DBG("MQTT - Parsing input properties\n");
 
@@ -263,9 +264,22 @@ mqtt_prop_decode_input_props(struct mqtt_connection *conn)
 
   DBG("MQTT - Getting length\n");
 
+  /*
+   * The property length can only be decoded from the bytes that have actually
+   * been received into the input buffer. The remaining length does not
+   * describe those: it counts the whole packet, of which a PUBLISH topic is
+   * consumed from the input stream without being buffered here, and of which
+   * a large PUBLISH arrives one buffer at a time.
+   */
+  vhdr_len = conn->in_packet.payload_start - conn->in_packet.payload;
+  if(conn->in_packet.payload_pos <= vhdr_len) {
+    DBG("MQTT - Error, no input property bytes received\n");
+    return;
+  }
+
   prop_len_bytes =
     mqtt_decode_var_byte_int(conn->in_packet.payload_start,
-                             conn->in_packet.remaining_length - (conn->in_packet.payload_start - conn->in_packet.payload),
+                             conn->in_packet.payload_pos - vhdr_len,
                              NULL, NULL, &conn->in_packet.properties_len);
 
   if(prop_len_bytes == 0) {

--- a/os/net/app-layer/mqtt/mqtt.c
+++ b/os/net/app-layer/mqtt/mqtt.c
@@ -59,6 +59,8 @@
 #include "lib/list.h"
 #include "sys/cc.h"
 
+#include <inttypes.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -383,6 +385,7 @@ mqtt_decode_var_byte_int(const uint8_t *input_data_ptr,
   uint8_t read_bytes = 0;
   uint8_t byte_in;
   uint32_t multiplier = 1;
+  uint32_t value = 0;
   uint32_t input_pos_0 = 0;
 
   if(input_pos == NULL) {
@@ -391,8 +394,29 @@ mqtt_decode_var_byte_int(const uint8_t *input_data_ptr,
 
   *dest = 0;
 
+  /*
+   * A caller that has fewer bytes than it expected can compute a negative
+   * length. The bounds check below is made in the unsigned domain, where such
+   * a length would become a very large bound and admit reads past the input,
+   * so reject it here instead.
+   */
+  if(input_data_len <= 0) {
+    DBG("MQTT - No input to decode a Variable Byte Integer from\n");
+    return 0;
+  }
+
   do {
-    if(*input_pos >= input_data_len) {
+    /*
+     * A Variable Byte Integer is encoded using at most four bytes. Stop
+     * before consuming a fifth one, so that a rejected integer does not
+     * advance the parse position past the bytes it was encoded in.
+     */
+    if(read_bytes == MQTT_MAX_REMAINING_LENGTH_BYTES) {
+      DBG("MQTT - Received more than 4 byte 'Variable Byte Integer'\n");
+      return 0;
+    }
+
+    if(*input_pos >= (uint32_t)input_data_len) {
       return 0;
     }
 
@@ -404,14 +428,23 @@ mqtt_decode_var_byte_int(const uint8_t *input_data_ptr,
     read_bytes++;
     DBG("MQTT - Read Variable Byte Integer byte %i\n", byte_in);
 
-    if(read_bytes > 4) {
-      DBG("Received more than 4 byte 'Variable Byte Integer'.");
-      return 0;
-    }
-
-    *dest += (byte_in & 127) * multiplier;
+    value += (uint32_t)(byte_in & 127) * multiplier;
     multiplier *= 128;
   } while((byte_in & 128) != 0);
+
+  /*
+   * A Variable Byte Integer encodes values up to 268435455, whereas the
+   * destination holds 16 bits. Report a value that does not fit as an error
+   * rather than storing a truncated one, which would make the peer appear to
+   * have sent a much shorter packet than it did.
+   */
+  if(value > UINT16_MAX) {
+    DBG("MQTT - Variable Byte Integer %" PRIu32 " exceeds the supported "
+        "maximum of %u\n", value, (unsigned)UINT16_MAX);
+    return 0;
+  }
+
+  *dest = (uint16_t)value;
 
   return read_bytes;
 }

--- a/os/net/app-layer/mqtt/mqtt.c
+++ b/os/net/app-layer/mqtt/mqtt.c
@@ -1345,6 +1345,10 @@ handle_auth(struct mqtt_connection *conn)
 static void
 parse_vhdr(struct mqtt_connection *conn)
 {
+#if MQTT_5
+  uint16_t vhdr_len;
+#endif
+
   conn->in_packet.payload_start = conn->in_packet.payload;
 
   /* Some message types include a packet identifier */
@@ -1364,6 +1368,8 @@ parse_vhdr(struct mqtt_connection *conn)
   }
 
 #if MQTT_5
+  vhdr_len = conn->in_packet.payload_start - conn->in_packet.payload;
+
   /* CONNACK, PUBACK, PUBREC, PUBREL, PUBCOMP, DISCONNECT and AUTH have a single
    * Reason Code as part of the Variable Header.
    * SUBACK and UNSUBACK contain a list of one or more Reason Codes in the Payload.
@@ -1376,9 +1382,22 @@ parse_vhdr(struct mqtt_connection *conn)
   case MQTT_FHDR_MSG_TYPE_PUBCOMP:
   case MQTT_FHDR_MSG_TYPE_DISCONNECT:
   case MQTT_FHDR_MSG_TYPE_AUTH:
-    conn->in_packet.reason_code = conn->in_packet.payload_start[0];
+    /*
+     * The Reason Code is omitted when it is 0x00 and there are no properties,
+     * in which case the packet ends after the preceding Variable Header
+     * fields. A PUBACK acknowledging an ordinary QoS 1 publication is the
+     * common case; see Section 3.4.2.1 of the MQTT 5.0 specification. Reading
+     * a Reason Code that the peer did not send would take it from a byte that
+     * was never received.
+     */
+    if(conn->in_packet.remaining_length > vhdr_len) {
+      conn->in_packet.reason_code = conn->in_packet.payload_start[0];
+      conn->in_packet.payload_start += 1;
+      vhdr_len += 1;
+    } else {
+      conn->in_packet.reason_code = MQTT_VHDR_RC_SUCCES_OR_NORMAL;
+    }
     conn->in_packet.has_reason_code = 1;
-    conn->in_packet.payload_start += 1;
     break;
 
   default:
@@ -1386,7 +1405,13 @@ parse_vhdr(struct mqtt_connection *conn)
     break;
   }
 
-  if(!conn->in_packet.has_props) {
+  /*
+   * The Property Length is omitted along with the Reason Code, and is then
+   * taken to be zero. Decoding it in that case would read past the end of the
+   * packet as well.
+   */
+  if(!conn->in_packet.has_props &&
+     conn->in_packet.remaining_length > vhdr_len) {
     mqtt_prop_decode_input_props(conn);
   }
 #endif
@@ -1546,6 +1571,13 @@ parse_next:
 
 #if MQTT_5
       if(!conn->in_packet.has_props) {
+        /*
+         * The Variable Header of a PUBLISH is consumed from the input stream
+         * without being buffered, so the properties start at the first
+         * buffered byte. parse_vhdr() has not run at this point, because the
+         * packet continues past this full buffer.
+         */
+        conn->in_packet.payload_start = conn->in_packet.payload;
         mqtt_prop_decode_input_props(conn);
       }
 

--- a/os/net/app-layer/mqtt/mqtt.c
+++ b/os/net/app-layer/mqtt/mqtt.c
@@ -1485,7 +1485,16 @@ parse_next:
                                &conn->in_packet.remaining_length);
 
     if(remaining_length_bytes == 0) {
+      /*
+       * The length of this packet is not known, so where the next one starts
+       * is not known either: everything that follows would be parsed as
+       * arbitrary packets. Nothing can be recovered from the connection, and
+       * the parse position cannot be resumed on the next segment, so close it
+       * and let the application reconnect on a known state.
+       */
+      PRINTF("MQTT - Error, could not decode the remaining length\n");
       call_event(conn, MQTT_EVENT_ERROR, NULL);
+      abort_connection(conn);
       return 0;
     }
 

--- a/os/net/app-layer/mqtt/mqtt.h
+++ b/os/net/app-layer/mqtt/mqtt.h
@@ -766,6 +766,22 @@ void mqtt_encode_var_byte_int(uint8_t *vbi_out,
                               uint8_t *vbi_bytes,
                               uint32_t val);
 /*---------------------------------------------------------------------------*/
+/**
+ * \brief Decode a Variable Byte Integer from received input.
+ * \param input_data_ptr The received input.
+ * \param input_data_len The number of bytes received. A value of zero or
+ *        less denotes that there is nothing to decode.
+ * \param input_pos Position to start decoding at, advanced past the bytes
+ *        that were decoded. NULL to decode from the start of the input.
+ * \param pkt_byte_count Incremented once per decoded byte, or NULL.
+ * \param dest The decoded value, set to zero unless the decoding succeeds.
+ * \return The number of bytes the integer was encoded in, or zero on error.
+ *
+ * The decoding fails if the input ends before the integer does, if the
+ * encoding exceeds the four bytes that MQTT allows, or if the encoded value
+ * exceeds the range of the destination. The parse position is never advanced
+ * past the bytes that the integer was encoded in.
+ */
 uint8_t mqtt_decode_var_byte_int(const uint8_t *input_data_ptr,
                                  int input_data_len,
                                  uint32_t *input_pos,

--- a/tests/08-native-runs/25-mqtt-prop/test-mqtt-prop.c
+++ b/tests/08-native-runs/25-mqtt-prop/test-mqtt-prop.c
@@ -37,6 +37,10 @@
  *         must be rejected rather than used to read past the input, so each
  *         decoder is fed both a well-formed property and a property whose
  *         declared length overruns the input.
+ *
+ *         The Variable Byte Integer decoder that reads those lengths is
+ *         tested directly as well, both for the bounds it places on the input
+ *         and for the range of the values it accepts.
  * \author
  *         Nicolas Tsiftes <nicolas.tsiftes@ri.se>
  */
@@ -244,6 +248,88 @@ UNIT_TEST(test_vbi)
   UNIT_TEST_END();
 }
 /*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_vbi_decoder_bounds,
+                   "Variable Byte Integer decoder input bounds");
+UNIT_TEST(test_vbi_decoder_bounds)
+{
+  /* Four continuation bytes, so that the decoder reads as far as it may */
+  static const uint8_t input[] = { 0x80, 0x80, 0x80, 0x80, 0x01 };
+  uint32_t input_pos;
+  uint16_t dest;
+
+  UNIT_TEST_BEGIN();
+
+  /*
+   * A caller that subtracts the bytes it has already parsed from a length
+   * that does not cover them arrives at a negative number of bytes. Nothing
+   * may be read in that case: comparing the parse position against such a
+   * length in the unsigned domain would turn it into a bound of four billion
+   * bytes.
+   */
+  input_pos = 0;
+  UNIT_TEST_ASSERT(mqtt_decode_var_byte_int(input, -1, &input_pos, NULL,
+                                            &dest) == 0);
+  UNIT_TEST_ASSERT(input_pos == 0);
+  UNIT_TEST_ASSERT(dest == 0);
+
+  input_pos = 0;
+  UNIT_TEST_ASSERT(mqtt_decode_var_byte_int(input, 0, &input_pos, NULL,
+                                            &dest) == 0);
+  UNIT_TEST_ASSERT(input_pos == 0);
+
+  /* An integer that continues past the received input is incomplete */
+  input_pos = 0;
+  UNIT_TEST_ASSERT(mqtt_decode_var_byte_int(input, 2, &input_pos, NULL,
+                                            &dest) == 0);
+
+  /*
+   * An encoding using more than the four bytes that MQTT allows is rejected
+   * without consuming the fifth byte, which belongs to whatever follows.
+   */
+  input_pos = 0;
+  UNIT_TEST_ASSERT(mqtt_decode_var_byte_int(input, sizeof(input), &input_pos,
+                                            NULL, &dest) == 0);
+  UNIT_TEST_ASSERT(input_pos == 4);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_vbi_decoder_range,
+                   "Variable Byte Integer decoder value range");
+UNIT_TEST(test_vbi_decoder_range)
+{
+  /* The largest value that fits the destination, encoded in three bytes */
+  static const uint8_t max_value[] = { 0xFF, 0xFF, 0x03 };
+  /* One more than that */
+  static const uint8_t too_large[] = { 0x80, 0x80, 0x04 };
+  /* A four-byte encoding of 65538, whose low 16 bits are 2 */
+  static const uint8_t wrapping[] = { 0x82, 0x80, 0x04, 0x00 };
+  uint16_t dest;
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT(mqtt_decode_var_byte_int(max_value, sizeof(max_value),
+                                            NULL, NULL, &dest) ==
+                   sizeof(max_value));
+  UNIT_TEST_ASSERT(dest == 65535);
+
+  /*
+   * A Variable Byte Integer holds values that the 16-bit destination does
+   * not. Truncating one would make a peer that declared a packet of 65538
+   * bytes appear to have sent 2, leaving the rest of it to be parsed as
+   * further packets.
+   */
+  UNIT_TEST_ASSERT(mqtt_decode_var_byte_int(too_large, sizeof(too_large),
+                                            NULL, NULL, &dest) == 0);
+  UNIT_TEST_ASSERT(dest == 0);
+
+  UNIT_TEST_ASSERT(mqtt_decode_var_byte_int(wrapping, sizeof(wrapping),
+                                            NULL, NULL, &dest) == 0);
+  UNIT_TEST_ASSERT(dest == 0);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
 PROCESS_THREAD(test_process, ev, data)
 {
   PROCESS_BEGIN();
@@ -256,12 +342,16 @@ PROCESS_THREAD(test_process, ev, data)
   UNIT_TEST_RUN(test_binary_data);
   UNIT_TEST_RUN(test_utf8_pair);
   UNIT_TEST_RUN(test_vbi);
+  UNIT_TEST_RUN(test_vbi_decoder_bounds);
+  UNIT_TEST_RUN(test_vbi_decoder_range);
 
   if(!UNIT_TEST_PASSED(test_utf8) ||
      !UNIT_TEST_PASSED(test_fixed_len_int) ||
      !UNIT_TEST_PASSED(test_binary_data) ||
      !UNIT_TEST_PASSED(test_utf8_pair) ||
-     !UNIT_TEST_PASSED(test_vbi)) {
+     !UNIT_TEST_PASSED(test_vbi) ||
+     !UNIT_TEST_PASSED(test_vbi_decoder_bounds) ||
+     !UNIT_TEST_PASSED(test_vbi_decoder_range)) {
     printf("=check-me= FAILED\n");
     printf("---\n");
   }


### PR DESCRIPTION
Fixes #3227.

mqtt_decode_var_byte_int() compared an unsigned parse position against a signed input length, so the usual arithmetic conversions turned a negative length into a bound of four billion bytes and the guard never fired. It also accumulated into a 16-bit destination, storing a Remaining Length of 65536 + n as n, and applied the four-byte limit on the encoding only after consuming a fifth byte.

parse_vhdr() consumed the MQTT-5 Reason Code and Property Length regardless of the remaining length, although a packet omits both when the Reason Code is 0x00 and there are no properties, which is what a broker sends to acknowledge an ordinary QoS 1 publication. It therefore read a Reason Code that was never sent and handed the property decoder a negative length. The property decoder separately derived its bound from the remaining length rather than from the bytes actually buffered, which differ for a PUBLISH.

Behaviour change: a Remaining Length that cannot be decoded now closes the connection rather than raising MQTT_EVENT_ERROR and continuing to parse, since where the next packet begins is no longer known.