### PR TITLE
Feature/nrf spi driver

### DIFF
--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -127,6 +127,16 @@ ifeq ($(NRF_WITH_SPI),1)
 
   CFLAGS += -DNRFX_SPIM_ENABLED=1
   CFLAGS += $(foreach i,$(NRF_SPI_IDS),-DNRFX_SPIM$(i)_ENABLED=1)
+
+  # nRF52840 anomaly 198: SPIM3 transmit data can be silently corrupted.
+  # nrfx carries the workaround but defaults it off, and SPIM3 is the only
+  # instance on this SoC that reaches 16 and 32 Mbps -- so it is exactly the
+  # one picked for a fast device. Enable it whenever SPIM3 is in use.
+  ifneq ($(filter 3,$(NRF_SPI_IDS)),)
+    ifeq ($(CPU_FAMILY),nrf52840)
+      CFLAGS += -DNRFX_SPIM3_NRF52840_ANOMALY_198_WORKAROUND_ENABLED=1
+    endif
+  endif
   CFLAGS += -DNRF_SPI_CONF_CONTROLLER_COUNT=$(words $(NRF_SPI_IDS))
   CFLAGS += -DNRF_SPI_CONF_CONTROLLER0_ID=$(word 1,$(NRF_SPI_IDS))
   ifneq ($(word 2,$(NRF_SPI_IDS)),)

--- a/arch/cpu/nrf/Makefile.nrf
+++ b/arch/cpu/nrf/Makefile.nrf
@@ -67,6 +67,76 @@ NRFX_C_SRCS += $(NRFX_ROOT)/drivers/src/nrfx_uarte.c
 NRFX_C_SRCS += $(NRFX_ROOT)/drivers/src/nrfx_usbreg.c
 NRFX_C_SRCS += $(NRFX_ROOT)/drivers/src/nrfx_ipc.c
 
+# SPI (SPIM) support through the Contiki-NG SPI HAL (os/dev/spi.h). Built
+# by default on the application cores with one SPIM instance that does not
+# collide with the console UART; unused, it costs a few hundred bytes since
+# the linker drops what is not referenced. NRF_WITH_SPI=0 leaves it out.
+#
+# NRF_SPI_INSTANCES lists the nRF SPIM instance ids to enable, in logical
+# controller order, so the first entry becomes controller 0. The id is the
+# number in the peripheral name: SPIM00 is 00, SPIM22 is 22. Ids may be
+# separated by spaces or commas; commas let the list be passed as a single
+# make argument, e.g. NRF_SPI_INSTANCES=00,22.
+ifeq ($(CPU_FAMILY),nrf5340_network)
+  # The network core's only SPIM shares its SERIAL slot with the console
+  # UARTE, and no board in the tree uses SPI there.
+  NRF_WITH_SPI ?= 0
+else
+  NRF_WITH_SPI ?= 1
+endif
+ifeq ($(NRF_WITH_SPI),1)
+  # SPIM instances that exist on each SoC, and a default that does not
+  # collide with the console UART (see arch/cpu/nrf/dev/spi-arch.h).
+  ifeq ($(CPU_FAMILY),nrf52840)
+    NRF_SPI_VALID_IDS := 0 1 2 3
+    NRF_SPI_INSTANCES ?= 0
+  else ifeq ($(CPU_FAMILY),nrf5340_application)
+    NRF_SPI_VALID_IDS := 0 1 2 3 4
+    NRF_SPI_INSTANCES ?= 1
+  else ifeq ($(CPU_FAMILY),nrf54l15)
+    NRF_SPI_VALID_IDS := 00 20 21 22 30
+    NRF_SPI_INSTANCES ?= 00
+  else
+    $(error NRF_WITH_SPI=1 is not supported for CPU_FAMILY=$(CPU_FAMILY))
+  endif
+
+  # Normalize into a private variable rather than reassigning
+  # NRF_SPI_INSTANCES: a value given on the make command line overrides any
+  # assignment made here, which would leave the commas in place.
+  NRF_SPI_COMMA := ,
+  NRF_SPI_IDS := $(subst $(NRF_SPI_COMMA), ,$(NRF_SPI_INSTANCES))
+
+  ifeq ($(words $(NRF_SPI_IDS)),0)
+    $(error NRF_WITH_SPI=1 but NRF_SPI_INSTANCES is empty)
+  endif
+  ifneq ($(filter-out 1 2 3,$(words $(NRF_SPI_IDS))),)
+    $(error NRF_SPI_INSTANCES supports at most 3 instances, got $(NRF_SPI_IDS))
+  endif
+  ifneq ($(filter-out $(NRF_SPI_VALID_IDS),$(NRF_SPI_IDS)),)
+    $(error NRF_SPI_INSTANCES=$(NRF_SPI_IDS): $(CPU_FAMILY) has SPIM instances $(NRF_SPI_VALID_IDS))
+  endif
+  # Each instance backs one logical controller. Listing one twice would give
+  # the two controllers separate locks over the same peripheral, so nothing
+  # serialises them and the second nrfx_spim_init() fails as already done.
+  ifneq ($(words $(sort $(NRF_SPI_IDS))),$(words $(NRF_SPI_IDS)))
+    $(error NRF_SPI_INSTANCES=$(NRF_SPI_IDS): each SPIM instance can back only one controller)
+  endif
+
+  CONTIKI_CPU_SOURCEFILES += spi-arch.c
+  NRFX_C_SRCS += $(NRFX_ROOT)/drivers/src/nrfx_spim.c
+
+  CFLAGS += -DNRFX_SPIM_ENABLED=1
+  CFLAGS += $(foreach i,$(NRF_SPI_IDS),-DNRFX_SPIM$(i)_ENABLED=1)
+  CFLAGS += -DNRF_SPI_CONF_CONTROLLER_COUNT=$(words $(NRF_SPI_IDS))
+  CFLAGS += -DNRF_SPI_CONF_CONTROLLER0_ID=$(word 1,$(NRF_SPI_IDS))
+  ifneq ($(word 2,$(NRF_SPI_IDS)),)
+    CFLAGS += -DNRF_SPI_CONF_CONTROLLER1_ID=$(word 2,$(NRF_SPI_IDS))
+  endif
+  ifneq ($(word 3,$(NRF_SPI_IDS)),)
+    CFLAGS += -DNRF_SPI_CONF_CONTROLLER2_ID=$(word 3,$(NRF_SPI_IDS))
+  endif
+endif
+
 NRFX_C_SRCS += $(NRFX_ROOT)/soc/nrfx_atomic.c
 
 NRFX_C_SRCS += $(NRFX_ROOT)/helpers/nrfx_flag32_allocator.c
@@ -80,6 +150,7 @@ CONTIKI_SOURCEFILES += $(notdir $(NRFX_C_SRCS))
 CONTIKI_SOURCEFILES += $(notdir $(NRFX_ASM_SRCS))
 
 $(OBJECTDIR)/nrfx_uarte.o: CFLAGS += -Wno-error=unused-variable
+$(OBJECTDIR)/nrfx_spim.o: CFLAGS += -Wno-error=unused-variable
 
 #includes common to all targets
 NRFX_INC_PATHS += .

--- a/arch/cpu/nrf/dev/spi-arch.c
+++ b/arch/cpu/nrf/dev/spi-arch.c
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup nrf-spi
+ * @{
+ *
+ * \file
+ *         SPI HAL implementation for the nRF, on top of nrfx_spim.
+ *
+ *         nrfx is driven in blocking mode (no event handler), which keeps
+ *         this layer synchronous as os/dev/spi.h expects. Chip select is
+ *         not handed to SPIM: os/dev/spi.c drives it as a GPIO through
+ *         spi_select()/spi_deselect(), so ss_pin is left unconnected here
+ *         and the pin is configured as a GPIO output instead.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/spi.h"
+#include "dev/gpio-hal.h"
+#include "sys/mutex.h"
+
+#if SPI_CONTROLLER_COUNT > 0
+
+#include "nrfx_config.h"
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+#include "nrfx_spim.h"
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#include <stdint.h>
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+#include "sys/cc.h"
+#include "sys/log.h"
+#define LOG_MODULE "spi-arch"
+#ifdef LOG_CONF_LEVEL_SPI
+#define LOG_LEVEL LOG_CONF_LEVEL_SPI
+#else
+/* A failed nrfx_spim_init() is otherwise only seen as "could not acquire". */
+#define LOG_LEVEL LOG_LEVEL_ERR
+#endif
+/*---------------------------------------------------------------------------*/
+/*
+ * Map each logical controller index to an nrfx SPIM instance. The ids come
+ * from the platform (see spi-arch.h); NRFX_SPIM_INSTANCE() pastes them into
+ * NRF_SPIMxx and NRFX_SPIMxx_INST_IDX.
+ */
+static const nrfx_spim_t spim_instance[SPI_CONTROLLER_COUNT] = {
+  NRFX_SPIM_INSTANCE(NRF_SPI_CONF_CONTROLLER0_ID),
+#if SPI_CONTROLLER_COUNT > 1
+  NRFX_SPIM_INSTANCE(NRF_SPI_CONF_CONTROLLER1_ID),
+#endif
+#if SPI_CONTROLLER_COUNT > 2
+  NRFX_SPIM_INSTANCE(NRF_SPI_CONF_CONTROLLER2_ID),
+#endif
+};
+/*---------------------------------------------------------------------------*/
+/*
+ * Highest bit rate each instance can produce. Only the high-speed instance
+ * of an SoC (SPIM3 on the nRF52840, SPIM4 on the nRF5340, SPIM00 on the
+ * nRF54L15) does 16 and 32 Mbps; the others stop at 8. nrfx validates the
+ * frequency against the SoC, not the instance, so asking a slow instance for
+ * 16 Mbps is accepted and then misprogrammed. The MDK publishes the limit
+ * per instance as SPIMn_MAX_DATARATE, in Mbps.
+ */
+#define SPIM_MAX_BIT_RATE(id) \
+  ((uint32_t)NRFX_CONCAT_3(SPIM, id, _MAX_DATARATE) * 1000000UL)
+
+static const uint32_t spim_max_bit_rate[SPI_CONTROLLER_COUNT] = {
+  SPIM_MAX_BIT_RATE(NRF_SPI_CONF_CONTROLLER0_ID),
+#if SPI_CONTROLLER_COUNT > 1
+  SPIM_MAX_BIT_RATE(NRF_SPI_CONF_CONTROLLER1_ID),
+#endif
+#if SPI_CONTROLLER_COUNT > 2
+  SPIM_MAX_BIT_RATE(NRF_SPI_CONF_CONTROLLER2_ID),
+#endif
+};
+/*---------------------------------------------------------------------------*/
+typedef struct {
+  mutex_t lock;
+  const spi_device_t *owner;
+  /*
+   * The configuration currently loaded into the SPIM, if any. The
+   * peripheral stays initialized between acquires, so a device whose
+   * configuration matches skips nrfx_spim_init() and the pin setup
+   * entirely; only the first acquire, or a device with a different
+   * configuration, pays for it. Compared by content, not by pointer:
+   * callers may build spi_device_t on the stack (spi-flash's bit-rate
+   * probe does), so the same address can carry a different setup. Chip
+   * select is not part of the comparison: it is a plain GPIO, so devices
+   * sharing a controller but not a CS pin alternate without a reinit.
+   *
+   * Between acquires the SPIM is disabled (ENABLE register only), which
+   * is what the HAL asks of a release, at the cost of two register writes.
+   */
+  bool configured;
+  spi_device_t config;
+} spi_arch_lock_t;
+
+static spi_arch_lock_t bus[SPI_CONTROLLER_COUNT];
+/*---------------------------------------------------------------------------*/
+/*
+ * Staging buffers for transfers that EasyDMA cannot service directly, i.e.
+ * a write buffer outside Data RAM, or bytes that must be clocked out and
+ * discarded (ignore_len).
+ */
+/*
+ * Longest single EasyDMA transfer per instance: the MDK gives the MAXCNT
+ * register width as SPIMn_EASYDMA_MAXCNT_SIZE, in bits.
+ */
+#define SPIM_EASYDMA_MAX_LEN(id) \
+  ((1UL << NRFX_CONCAT_3(SPIM, id, _EASYDMA_MAXCNT_SIZE)) - 1)
+
+static const uint32_t spim_easydma_max_len[SPI_CONTROLLER_COUNT] = {
+  SPIM_EASYDMA_MAX_LEN(NRF_SPI_CONF_CONTROLLER0_ID),
+#if SPI_CONTROLLER_COUNT > 1
+  SPIM_EASYDMA_MAX_LEN(NRF_SPI_CONF_CONTROLLER1_ID),
+#endif
+#if SPI_CONTROLLER_COUNT > 2
+  SPIM_EASYDMA_MAX_LEN(NRF_SPI_CONF_CONTROLLER2_ID),
+#endif
+};
+
+static uint8_t stage_tx[NRF_SPI_CHUNK_SIZE];
+static uint8_t stage_rx[NRF_SPI_CHUNK_SIZE];
+/*---------------------------------------------------------------------------*/
+/*
+ * Rounds a requested bit rate down to one the controller can actually
+ * produce.
+ *
+ * nrfx rejects an unachievable rate outright (NRFX_ERROR_INVALID_PARAM), so
+ * without this a device that asks for its own rated maximum -- 20 MHz for an
+ * ENC28J60, say -- fails to open rather than running slightly slower.
+ *
+ * Rounds down, so a device's rated maximum is not exceeded. The one exception
+ * is a request below the slowest rate the controller can produce, which is
+ * clamped to that slowest rate because the hardware has nothing lower.
+ */
+static uint32_t
+resolve_bit_rate(unsigned controller, uint32_t requested)
+{
+  const nrfx_spim_t *inst = &spim_instance[controller];
+
+  /* Never ask an instance for more than it can produce. */
+  if(requested == 0 || requested > spim_max_bit_rate[controller]) {
+    requested = spim_max_bit_rate[controller];
+  }
+
+#if NRF_SPIM_HAS_PRESCALER
+  uint32_t base = NRFX_SPIM_BASE_FREQUENCY_GET(inst);
+  uint32_t min = NRF_SPIM_PRESCALER_MIN_GET(inst->p_reg);
+  uint32_t max = NRF_SPIM_PRESCALER_MAX_GET(inst->p_reg);
+  uint32_t prescaler;
+
+  /* Round the divisor up so the resulting rate does not exceed the request. */
+  prescaler = (base + requested - 1) / requested;
+
+  /* The divisor must be even. */
+  prescaler += prescaler & 1;
+
+  if(prescaler < min) {
+    prescaler = min + (min & 1);
+  }
+  if(prescaler > max) {
+    prescaler = max - (max & 1);
+  }
+
+  return base / prescaler;
+#else /* NRF_SPIM_HAS_PRESCALER */
+  /* Fixed steps: pick the highest one not above the request. */
+  static const uint32_t steps[] = {
+    32000000, 16000000, 8000000, 4000000, 2000000, 1000000, 500000, 250000,
+    125000
+  };
+  unsigned i;
+
+  (void)inst;
+
+  for(i = 0; i < sizeof(steps) / sizeof(steps[0]); i++) {
+    if(requested >= steps[i]) {
+      return steps[i];
+    }
+  }
+
+  return steps[sizeof(steps) / sizeof(steps[0]) - 1];
+#endif /* NRF_SPIM_HAS_PRESCALER */
+}
+/*---------------------------------------------------------------------------*/
+static nrf_spim_mode_t
+spi_mode(const spi_device_t *dev)
+{
+  if(dev->spi_pol == 0) {
+    return dev->spi_pha == 0 ? NRF_SPIM_MODE_0 : NRF_SPIM_MODE_1;
+  }
+  return dev->spi_pha == 0 ? NRF_SPIM_MODE_2 : NRF_SPIM_MODE_3;
+}
+/*---------------------------------------------------------------------------*/
+/* Everything the SPIM itself is programmed from; CS is a separate GPIO. */
+static bool
+same_config(const spi_device_t *a, const spi_device_t *b)
+{
+  return a->port_spi_sck == b->port_spi_sck &&
+         a->pin_spi_sck == b->pin_spi_sck &&
+         a->port_spi_mosi == b->port_spi_mosi &&
+         a->pin_spi_mosi == b->pin_spi_mosi &&
+         a->port_spi_miso == b->port_spi_miso &&
+         a->pin_spi_miso == b->pin_spi_miso &&
+         a->spi_bit_rate == b->spi_bit_rate &&
+         a->spi_pha == b->spi_pha &&
+         a->spi_pol == b->spi_pol;
+}
+/*---------------------------------------------------------------------------*/
+bool
+spi_arch_has_lock(const spi_device_t *dev)
+{
+  if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
+    return false;
+  }
+
+  return bus[dev->spi_controller].owner == dev;
+}
+/*---------------------------------------------------------------------------*/
+bool
+spi_arch_is_bus_locked(const spi_device_t *dev)
+{
+  if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
+    return false;
+  }
+
+  return bus[dev->spi_controller].owner != NULL;
+}
+/*---------------------------------------------------------------------------*/
+spi_status_t
+spi_arch_lock_and_open(const spi_device_t *dev)
+{
+  nrfx_spim_config_t config;
+  nrfx_err_t err;
+  spi_arch_lock_t *b;
+
+  if(dev == NULL || dev->spi_controller >= SPI_CONTROLLER_COUNT) {
+    return SPI_DEV_STATUS_EINVAL;
+  }
+
+  b = &bus[dev->spi_controller];
+
+  if(mutex_try_lock(&b->lock) == false) {
+    return SPI_DEV_STATUS_BUS_LOCKED;
+  }
+
+  /*
+   * CS is driven by os/dev/spi.c as a plain GPIO. Configure it on every
+   * acquire (two GPIO writes) and leave it deasserted (high, active low).
+   */
+  gpio_hal_arch_pin_set_output(SPI_DEVICE_PORT(cs, dev), dev->pin_spi_cs);
+  gpio_hal_arch_set_pin(SPI_DEVICE_PORT(cs, dev), dev->pin_spi_cs);
+
+  if(b->configured && same_config(&b->config, dev)) {
+    /* Same setup as last time: the SPIM is already programmed for it. */
+    nrf_spim_enable(spim_instance[dev->spi_controller].p_reg);
+    b->owner = dev;
+    return SPI_DEV_STATUS_OK;
+  }
+
+  if(b->configured) {
+    /* A different setup was loaded; nrfx needs uninit before a new init. */
+    nrfx_spim_uninit(&spim_instance[dev->spi_controller]);
+    b->configured = false;
+  }
+
+  config = (nrfx_spim_config_t)NRFX_SPIM_DEFAULT_CONFIG(
+    NRF_GPIO_PIN_MAP(SPI_DEVICE_PORT(sck, dev), dev->pin_spi_sck),
+    NRF_GPIO_PIN_MAP(SPI_DEVICE_PORT(mosi, dev), dev->pin_spi_mosi),
+    NRF_GPIO_PIN_MAP(SPI_DEVICE_PORT(miso, dev), dev->pin_spi_miso),
+    NRF_SPIM_PIN_NOT_CONNECTED);
+
+  config.frequency = resolve_bit_rate(dev->spi_controller, dev->spi_bit_rate);
+  config.mode = spi_mode(dev);
+  /*
+   * Pad short writes with zeroes rather than the nrfx default of 0xff, to
+   * match the behaviour of the other Contiki-NG SPI arch implementations.
+   */
+  config.orc = 0x00;
+
+  /* Blocking mode: no event handler. */
+  err = nrfx_spim_init(&spim_instance[dev->spi_controller], &config,
+                       NULL, NULL);
+  if(err != NRFX_SUCCESS) {
+    LOG_ERR("nrfx_spim_init failed: 0x%08lx\n", (unsigned long)err);
+    mutex_unlock(&b->lock);
+    return SPI_DEV_STATUS_CLOSED;
+  }
+
+  b->owner = dev;
+  b->config = *dev;
+  b->configured = true;
+
+  return SPI_DEV_STATUS_OK;
+}
+/*---------------------------------------------------------------------------*/
+spi_status_t
+spi_arch_close_and_unlock(const spi_device_t *dev)
+{
+  spi_arch_lock_t *b;
+
+  if(!spi_arch_has_lock(dev)) {
+    return SPI_DEV_STATUS_BUS_NOT_OWNED;
+  }
+
+  b = &bus[dev->spi_controller];
+
+  /*
+   * Leave the SPIM initialized (see spi_arch_lock_t): an ENC28J60 acquires
+   * once per register access, and tearing the peripheral down each time
+   * cost more than the transfer. Disabling it is enough for the HAL's
+   * low-power expectation and is a single register write. (nRF52840 SPIM3
+   * keeps drawing current after disable, anomaly 195; nrfx works around
+   * that only in uninit, so that instance does not gain from this.)
+   */
+  nrf_spim_disable(spim_instance[dev->spi_controller].p_reg);
+  b->owner = NULL;
+  mutex_unlock(&b->lock);
+
+  return SPI_DEV_STATUS_OK;
+}
+/*---------------------------------------------------------------------------*/
+static spi_status_t
+xfer(const nrfx_spim_t *inst, const uint8_t *tx, size_t tx_len,
+     uint8_t *rx, size_t rx_len)
+{
+  nrfx_spim_xfer_desc_t desc = NRFX_SPIM_XFER_TRX(tx, tx_len, rx, rx_len);
+  nrfx_err_t err = nrfx_spim_xfer(inst, &desc, 0);
+
+  if(err != NRFX_SUCCESS) {
+    LOG_ERR("nrfx_spim_xfer failed: 0x%08lx\n", (unsigned long)err);
+    return SPI_DEV_STATUS_TRANSFER_ERR;
+  }
+
+  return SPI_DEV_STATUS_OK;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Slow path: stage the transfer through RAM buffers, a chunk at a time.
+ * Used when the write buffer is not DMA-reachable, or when bytes have to be
+ * clocked out and thrown away.
+ */
+static spi_status_t
+transfer_staged(const nrfx_spim_t *inst,
+                const uint8_t *write_buf, int wlen,
+                uint8_t *inbuf, int rlen, int total)
+{
+  int done = 0;
+
+  while(done < total) {
+    int n = total - done;
+    int i;
+    spi_status_t status;
+
+    if(n > NRF_SPI_CHUNK_SIZE) {
+      n = NRF_SPI_CHUNK_SIZE;
+    }
+
+    for(i = 0; i < n; i++) {
+      int idx = done + i;
+      stage_tx[i] = idx < wlen ? write_buf[idx] : 0;
+    }
+
+    status = xfer(inst, stage_tx, n, stage_rx, n);
+    if(status != SPI_DEV_STATUS_OK) {
+      return status;
+    }
+
+    for(i = 0; i < n; i++) {
+      int idx = done + i;
+      if(idx < rlen) {
+        inbuf[idx] = stage_rx[i];
+      }
+    }
+
+    done += n;
+  }
+
+  return SPI_DEV_STATUS_OK;
+}
+/*---------------------------------------------------------------------------*/
+spi_status_t
+spi_arch_transfer(const spi_device_t *dev,
+                  const uint8_t *write_buf, int wlen,
+                  uint8_t *inbuf, int rlen,
+                  int ignore_len)
+{
+  const nrfx_spim_t *inst;
+  int total;
+
+  if(!spi_arch_has_lock(dev)) {
+    return SPI_DEV_STATUS_BUS_NOT_OWNED;
+  }
+
+  if(write_buf == NULL && wlen > 0) {
+    return SPI_DEV_STATUS_EINVAL;
+  }
+  if(inbuf == NULL && rlen > 0) {
+    return SPI_DEV_STATUS_EINVAL;
+  }
+  if(wlen < 0 || rlen < 0 || ignore_len < 0) {
+    return SPI_DEV_STATUS_EINVAL;
+  }
+
+  total = MAX(rlen + ignore_len, wlen);
+  if(total == 0) {
+    return SPI_DEV_STATUS_OK;
+  }
+
+  inst = &spim_instance[dev->spi_controller];
+
+  /*
+   * Fast path: nothing to discard, both buffers are where EasyDMA can
+   * reach them, and the lengths fit the 16-bit MAXCNT registers. nrfx
+   * clocks max(wlen, rlen) bytes, padding the shorter side, which is
+   * exactly the contract of this function when ignore_len is 0.
+   */
+  if(ignore_len == 0 &&
+     wlen <= spim_easydma_max_len[dev->spi_controller] &&
+     rlen <= spim_easydma_max_len[dev->spi_controller] &&
+     (wlen == 0 || nrfx_is_in_ram(write_buf)) &&
+     (rlen == 0 || nrfx_is_in_ram(inbuf))) {
+    return xfer(inst, write_buf, wlen, inbuf, rlen);
+  }
+
+  return transfer_staged(inst, write_buf, wlen, inbuf, rlen, total);
+}
+/*---------------------------------------------------------------------------*/
+#endif /* SPI_CONTROLLER_COUNT > 0 */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ */

--- a/arch/cpu/nrf/dev/spi-arch.c
+++ b/arch/cpu/nrf/dev/spi-arch.c
@@ -155,6 +155,14 @@ static const uint32_t spim_easydma_max_len[SPI_CONTROLLER_COUNT] = {
 #endif
 };
 
+/*
+ * One pair of staging buffers is shared by every controller. A transfer runs
+ * to completion inside spi_arch_transfer() -- nrfx is driven in blocking mode
+ * -- and Contiki-NG processes are cooperatively scheduled, so a second
+ * transfer cannot begin while one is using these. That also means the SPI HAL
+ * must not be called from an interrupt handler, which is true of it anyway:
+ * the bus lock is a plain mutex with no interrupt masking.
+ */
 static uint8_t stage_tx[NRF_SPI_CHUNK_SIZE];
 static uint8_t stage_rx[NRF_SPI_CHUNK_SIZE];
 /*---------------------------------------------------------------------------*/
@@ -180,7 +188,30 @@ resolve_bit_rate(unsigned controller, uint32_t requested)
     requested = spim_max_bit_rate[controller];
   }
 
-#if NRF_SPIM_HAS_PRESCALER
+/*
+ * Mirror nrfx's own order in spim_frequency_valid_check(): it tests
+ * NRF_SPIM_HAS_FREQUENCY first and only then NRF_SPIM_HAS_PRESCALER. Picking
+ * the other order here would compute a rate on a different rule from the one
+ * nrfx validates it against, and nrfx would then reject our own answer.
+ */
+#if NRF_SPIM_HAS_FREQUENCY
+  /* Fixed steps: pick the highest one not above the request. */
+  static const uint32_t steps[] = {
+    32000000, 16000000, 8000000, 4000000, 2000000, 1000000, 500000, 250000,
+    125000
+  };
+  unsigned i;
+
+  (void)inst;
+
+  for(i = 0; i < sizeof(steps) / sizeof(steps[0]); i++) {
+    if(requested >= steps[i]) {
+      return steps[i];
+    }
+  }
+
+  return steps[sizeof(steps) / sizeof(steps[0]) - 1];
+#elif NRF_SPIM_HAS_PRESCALER
   uint32_t base = NRFX_SPIM_BASE_FREQUENCY_GET(inst);
   uint32_t min = NRF_SPIM_PRESCALER_MIN_GET(inst->p_reg);
   uint32_t max = NRF_SPIM_PRESCALER_MAX_GET(inst->p_reg);
@@ -200,24 +231,9 @@ resolve_bit_rate(unsigned controller, uint32_t requested)
   }
 
   return base / prescaler;
-#else /* NRF_SPIM_HAS_PRESCALER */
-  /* Fixed steps: pick the highest one not above the request. */
-  static const uint32_t steps[] = {
-    32000000, 16000000, 8000000, 4000000, 2000000, 1000000, 500000, 250000,
-    125000
-  };
-  unsigned i;
-
-  (void)inst;
-
-  for(i = 0; i < sizeof(steps) / sizeof(steps[0]); i++) {
-    if(requested >= steps[i]) {
-      return steps[i];
-    }
-  }
-
-  return steps[sizeof(steps) / sizeof(steps[0]) - 1];
-#endif /* NRF_SPIM_HAS_PRESCALER */
+#else
+#error "SPIM instance has neither a frequency register nor a prescaler"
+#endif
 }
 /*---------------------------------------------------------------------------*/
 static nrf_spim_mode_t
@@ -380,17 +396,28 @@ xfer(const nrfx_spim_t *inst, const uint8_t *tx, size_t tx_len,
 static spi_status_t
 transfer_staged(const nrfx_spim_t *inst,
                 const uint8_t *write_buf, int wlen,
-                uint8_t *inbuf, int rlen, int total)
+                uint8_t *inbuf, int rlen, int total,
+                uint32_t max_len)
 {
   int done = 0;
+  int chunk = NRF_SPI_CHUNK_SIZE;
+
+  /*
+   * The staging buffers cap the chunk, but so does the instance's EasyDMA
+   * MAXCNT width: NRF_SPI_CONF_CHUNK_SIZE is configurable and an instance
+   * with a narrow MAXCNT would otherwise be handed a too-long transfer.
+   */
+  if((uint32_t)chunk > max_len) {
+    chunk = (int)max_len;
+  }
 
   while(done < total) {
     int n = total - done;
     int i;
     spi_status_t status;
 
-    if(n > NRF_SPI_CHUNK_SIZE) {
-      n = NRF_SPI_CHUNK_SIZE;
+    if(n > chunk) {
+      n = chunk;
     }
 
     for(i = 0; i < n; i++) {
@@ -444,23 +471,34 @@ spi_arch_transfer(const spi_device_t *dev,
     return SPI_DEV_STATUS_OK;
   }
 
+  /*
+   * A read destination outside Data RAM cannot be rescued by staging: the
+   * staged path would land the bytes with a CPU store to that same address.
+   * Only a write buffer benefits from staging, because const data commonly
+   * lives in flash, which EasyDMA cannot read but the CPU can.
+   */
+  if(rlen > 0 && !nrfx_is_in_ram(inbuf)) {
+    LOG_ERR("read buffer is not in RAM\n");
+    return SPI_DEV_STATUS_EINVAL;
+  }
+
   inst = &spim_instance[dev->spi_controller];
 
   /*
-   * Fast path: nothing to discard, both buffers are where EasyDMA can
-   * reach them, and the lengths fit the 16-bit MAXCNT registers. nrfx
-   * clocks max(wlen, rlen) bytes, padding the shorter side, which is
-   * exactly the contract of this function when ignore_len is 0.
+   * Fast path: nothing to discard, the write buffer is where EasyDMA can
+   * reach it, and the lengths fit the instance's MAXCNT. nrfx clocks
+   * max(wlen, rlen) bytes, padding the shorter side, which is exactly the
+   * contract of this function when ignore_len is 0.
    */
   if(ignore_len == 0 &&
      wlen <= spim_easydma_max_len[dev->spi_controller] &&
      rlen <= spim_easydma_max_len[dev->spi_controller] &&
-     (wlen == 0 || nrfx_is_in_ram(write_buf)) &&
-     (rlen == 0 || nrfx_is_in_ram(inbuf))) {
+     (wlen == 0 || nrfx_is_in_ram(write_buf))) {
     return xfer(inst, write_buf, wlen, inbuf, rlen);
   }
 
-  return transfer_staged(inst, write_buf, wlen, inbuf, rlen, total);
+  return transfer_staged(inst, write_buf, wlen, inbuf, rlen, total,
+                         spim_easydma_max_len[dev->spi_controller]);
 }
 /*---------------------------------------------------------------------------*/
 #endif /* SPI_CONTROLLER_COUNT > 0 */

--- a/arch/cpu/nrf/dev/spi-arch.h
+++ b/arch/cpu/nrf/dev/spi-arch.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup nrf
+ * @{
+ *
+ * \addtogroup nrf-dev Device drivers
+ * @{
+ *
+ * \addtogroup nrf-spi SPI driver
+ * @{
+ *
+ * \file
+ *         SPI HAL arch header for the nRF, on top of nrfx_spim.
+ *
+ * Logical SPI controllers (the spi_controller field of spi_device_t) are
+ * indices 0..SPI_CONTROLLER_COUNT-1. Each index is mapped to an nRF SPIM
+ * instance id by NRF_SPI_CONF_CONTROLLERn_ID. The instance id is the
+ * number in the peripheral name, so SPIM00 is 00 and SPIM22 is 22.
+ *
+ * The corresponding NRFX_SPIMxx_ENABLED must also be defined, otherwise
+ * nrfx does not emit the instance and the build fails on a missing
+ * NRFX_SPIMxx_INST_IDX.
+ *
+ * \note Choosing an instance is not free. On SoCs where peripherals are
+ * grouped into SERIAL slots (nRF5340, nRF54L), SPIMn and UARTEn in the same
+ * slot share one interrupt vector, so only one of them can be built. Picking
+ * the instance that collides with the console UART fails at link time with a
+ * duplicate SERIALn_IRQHandler rather than at runtime. Known-good choices:
+ *
+ * - nRF54L15: SPIM00 or SPIM22. SPIM20 collides with the DK console
+ *   (UARTE20), and SPIM21 would collide with UARTE21.
+ * - nRF5340 application core: SPIM1 and up. SPIM0 collides with UARTE0.
+ * - nRF52840: no such grouping; SPIM0 coexists with UARTE0.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef SPI_ARCH_H_
+#define SPI_ARCH_H_
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Chunk size used when a transfer has to be staged through a RAM
+ * bounce buffer.
+ *
+ * SPIM uses EasyDMA, which can only reach the Data RAM region. A transfer
+ * whose write buffer is in flash, or which has to clock out bytes that are
+ * read and discarded, is split into chunks of this size and staged through
+ * static buffers. Transfers that need no staging bypass this entirely and
+ * are handed to nrfx in one piece, so this size does not cap throughput on
+ * the common path.
+ */
+#ifdef NRF_SPI_CONF_CHUNK_SIZE
+#define NRF_SPI_CHUNK_SIZE NRF_SPI_CONF_CHUNK_SIZE
+#else
+#define NRF_SPI_CHUNK_SIZE 64
+#endif
+/*---------------------------------------------------------------------------*/
+#endif /* SPI_ARCH_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ * @}
+ */

--- a/arch/cpu/nrf/nrf-def.h
+++ b/arch/cpu/nrf/nrf-def.h
@@ -84,6 +84,15 @@
 #define GPIO_HAL_CONF_ARCH_HDR_PATH          "gpio-hal-arch.h"
 #define GPIO_HAL_CONF_ARCH_SW_TOGGLE         0
 /*---------------------------------------------------------------------------*/
+/*
+ * NRF_SPI_CONF_CONTROLLER_COUNT is defined by Makefile.nrf unless the build
+ * sets NRF_WITH_SPI=0, in which case the SPI HAL compiles out entirely.
+ */
+#ifdef NRF_SPI_CONF_CONTROLLER_COUNT
+#define SPI_CONF_CONTROLLER_COUNT NRF_SPI_CONF_CONTROLLER_COUNT
+#define SPI_HAL_CONF_ARCH_HDR_PATH "spi-arch.h"
+#endif /* NRF_SPI_CONF_CONTROLLER_COUNT */
+/*---------------------------------------------------------------------------*/
 #ifndef TSCH_CONF_HW_FRAME_FILTERING
 #define TSCH_CONF_HW_FRAME_FILTERING  0
 #endif /* TSCH_CONF_HW_FRAME_FILTERING */

--- a/arch/dev/ethernet/enc28j60/enc28j60-arch-spi-hal.c
+++ b/arch/dev/ethernet/enc28j60/enc28j60-arch-spi-hal.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         ENC28J60 SPI arch layer on top of the SPI HAL (os/dev/spi.h).
+ *
+ *         Unlike the per-board arch files, this one is platform independent:
+ *         it works on any CPU that implements the SPI HAL, and a board only
+ *         has to supply the pin defines below. Enable it by defining
+ *         ENC28J60_CONF_USE_SPI_HAL as 1.
+ *
+ *         The bus is acquired for the duration of a chip-select assertion
+ *         rather than held forever, so the ENC28J60 can share a controller
+ *         with other devices. The driver keeps CS asserted across a whole
+ *         register access or packet transfer, so this is one acquire per
+ *         transaction, not per byte.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+
+#if ENC28J60_CONF_USE_SPI_HAL
+
+#include "dev/spi.h"
+#include "dev/gpio-hal.h"
+#include "enc28j60.h"
+
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+#include "sys/log.h"
+#define LOG_MODULE "enc-spi"
+/*
+ * Errors on by default: a failed bus acquire in select() otherwise turns
+ * into every register read returning zero with nothing to say why.
+ */
+#ifdef LOG_CONF_LEVEL_ENC28J60_SPI
+#define LOG_LEVEL LOG_CONF_LEVEL_ENC28J60_SPI
+#else
+#define LOG_LEVEL LOG_LEVEL_ERR
+#endif
+/*---------------------------------------------------------------------------*/
+#ifndef ETH_SPI_CONTROLLER
+#define ETH_SPI_CONTROLLER 0
+#endif
+
+/*
+ * The ENC28J60 is specified for up to 20 MHz. The SPI arch layer rounds a
+ * request down to what the chosen controller instance can produce, so a
+ * higher value here is capped rather than rejected. 8 MHz is what the
+ * non-high-speed SPIM instances top out at anyway, and it is reliable on
+ * jumper wires.
+ */
+#ifndef ETH_SPI_BIT_RATE
+#define ETH_SPI_BIT_RATE 8000000
+#endif
+
+#if !defined(ETH_SPI_CLK_PORT) || !defined(ETH_SPI_CLK_PIN) || \
+    !defined(ETH_SPI_MOSI_PORT) || !defined(ETH_SPI_MOSI_PIN) || \
+    !defined(ETH_SPI_MISO_PORT) || !defined(ETH_SPI_MISO_PIN) || \
+    !defined(ETH_SPI_CSN_PORT) || !defined(ETH_SPI_CSN_PIN)
+#error "ENC28J60 SPI HAL arch: define ETH_SPI_{CLK,MOSI,MISO,CSN}_{PORT,PIN}"
+#endif
+/*---------------------------------------------------------------------------*/
+/*
+ * Set while the bus is held between select and deselect. A failed acquire
+ * is logged once in select; the transfers that follow return 0 quietly
+ * instead of logging once per byte for the rest of the transaction.
+ */
+static bool bus_held;
+/*---------------------------------------------------------------------------*/
+static const spi_device_t enc28j60_spi = {
+  .port_spi_sck = ETH_SPI_CLK_PORT,
+  .pin_spi_sck = ETH_SPI_CLK_PIN,
+  .port_spi_mosi = ETH_SPI_MOSI_PORT,
+  .pin_spi_mosi = ETH_SPI_MOSI_PIN,
+  .port_spi_miso = ETH_SPI_MISO_PORT,
+  .pin_spi_miso = ETH_SPI_MISO_PIN,
+  .port_spi_cs = ETH_SPI_CSN_PORT,
+  .pin_spi_cs = ETH_SPI_CSN_PIN,
+  .spi_bit_rate = ETH_SPI_BIT_RATE,
+  /* The ENC28J60 requires SPI mode 0. */
+  .spi_pha = 0,
+  .spi_pol = 0,
+  .spi_controller = ETH_SPI_CONTROLLER,
+};
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_init(void)
+{
+#if defined(ETH_RESET_PORT) && defined(ETH_RESET_PIN)
+  /*
+   * Drive RESET high (deasserted). The module has a pull-up, so leaving the
+   * pin unconnected works too; driving it lets the board hold the chip in
+   * reset if it ever needs to.
+   */
+  gpio_hal_arch_pin_set_output(ETH_RESET_PORT, ETH_RESET_PIN);
+  gpio_hal_arch_set_pin(ETH_RESET_PORT, ETH_RESET_PIN);
+#endif
+
+  /*
+   * Open and close the bus once so the pins are configured and a
+   * misconfigured controller is reported here rather than at the first
+   * register read.
+   */
+  if(spi_acquire(&enc28j60_spi) != SPI_DEV_STATUS_OK) {
+    LOG_ERR("could not acquire the SPI bus\n");
+    return;
+  }
+  spi_release(&enc28j60_spi);
+}
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_select(void)
+{
+  if(spi_acquire(&enc28j60_spi) != SPI_DEV_STATUS_OK) {
+    LOG_ERR("could not acquire the SPI bus\n");
+    bus_held = false;
+    return;
+  }
+  bus_held = true;
+  spi_select(&enc28j60_spi);
+}
+/*---------------------------------------------------------------------------*/
+void
+enc28j60_arch_spi_deselect(void)
+{
+  if(!bus_held) {
+    return;
+  }
+  spi_deselect(&enc28j60_spi);
+  spi_release(&enc28j60_spi);
+  bus_held = false;
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+enc28j60_arch_spi_write(uint8_t output)
+{
+  uint8_t input = 0;
+
+  if(!bus_held) {
+    return 0;
+  }
+
+  if(spi_transfer(&enc28j60_spi, &output, 1, &input, 1, 0)
+     != SPI_DEV_STATUS_OK) {
+    LOG_ERR("transfer failed\n");
+    return 0;
+  }
+
+  return input;
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+enc28j60_arch_spi_read(void)
+{
+  return enc28j60_arch_spi_write(0);
+}
+/*---------------------------------------------------------------------------*/
+#endif /* ENC28J60_CONF_USE_SPI_HAL */

--- a/arch/dev/ethernet/enc28j60/enc28j60-arch-spi-hal.c
+++ b/arch/dev/ethernet/enc28j60/enc28j60-arch-spi-hal.c
@@ -37,10 +37,16 @@
  *         has to supply the pin defines below. Enable it by defining
  *         ENC28J60_CONF_USE_SPI_HAL as 1.
  *
+ *         Note the cost model: the enc28j60 driver's arch interface moves one
+ *         byte per call, so each byte here becomes its own SPI HAL transfer
+ *         and, on nRF, its own EasyDMA transaction. That is the interface's
+ *         shape, not something this layer can batch. It is why the practical
+ *         limit on throughput is the driver rather than the bus clock.
+ *
  *         The bus is acquired for the duration of a chip-select assertion
  *         rather than held forever, so the ENC28J60 can share a controller
  *         with other devices. The driver keeps CS asserted across a whole
- *         register access or packet transfer, so this is one acquire per
+ *         register access or packet transfer, so the *lock* is taken once per
  *         transaction, not per byte.
  * \author
  *         Joakim Eriksson <joakim.eriksson@ri.se>

--- a/doc/platforms/nrf-ip64-ethernet.md
+++ b/doc/platforms/nrf-ip64-ethernet.md
@@ -1,0 +1,192 @@
+# IPv4 uplink for the nRF: ENC28J60 + IP64
+
+How to give an nRF board an Ethernet uplink with an ENC28J60 module and turn
+it into a self-contained border router: RPL root on the 802.15.4 side, NAT64
+and DNS64 on the IPv4 side, no Linux host in the data path.
+
+Verified end to end on an nRF54L15 DK with a HanRun HR911105A module, with a
+Seeed XIAO nRF54L15 as a mesh node.
+
+## What you need
+
+* An nRF board with a free SPI instance and four spare GPIOs.
+* An ENC28J60 module. These are 3.1-3.6 V parts; some vendor listings say 5 V
+  in their pin tables, which is wrong.
+* Four jumpers plus power and ground.
+
+Nothing needs to be soldered, and the module's `INT`, `RESET`, `WOL` and
+`CLKOUT` pins stay unconnected: the driver polls on a 1-tick etimer and
+soft-resets over SPI.
+
+## Set the GPIO voltage first
+
+**The nRF54L15 DK ships with VDD at 1.8 V.** An ENC28J60 will not run at that
+voltage. Raise it before connecting anything, in nRF Connect for Desktop ->
+Board Configurator: select the DK, set VDD to **3300 mV**, and write the
+config. It persists across power cycles.
+
+Do not use 3000 mV, the value most guides show as their example -- it is below
+the ENC28J60's 3.1 V minimum.
+
+Powering the module from a separate 3.3 V supply while the DK is still at
+1.8 V is worse than not working: the module's `SO` output would drive 3.3 V
+into a 1.8 V nRF pin.
+
+## Wiring, nRF54L15 DK
+
+Header **PORT P1**, the middle of the three GPIO headers. It is a dual-row
+header; read the printed pin numbers rather than counting positions.
+
+| Module | DK       | Signal                  |
+|--------|----------|-------------------------|
+| `SCK`  | `P1.11`  | SPI clock               |
+| `SI`   | `P1.06`  | MOSI, DK to module      |
+| `SO`   | `P1.07`  | MISO, module to DK      |
+| `CS`   | `P1.12`  | Chip select, active low |
+| `VCC`  | `VDDIO`  | 3.3 V, see above        |
+| `GND`  | `GND`    |                         |
+
+Module pin names are from the module's point of view, which is why `SI` takes
+the DK's MOSI and `SO` feeds its MISO. Swapping those two is the most common
+miswire.
+
+### Why these pins
+
+PORT P1 only brings out P1.04 to P1.14 -- the DK silkscreen puts the others in
+parentheses, meaning they need a board modification. Of the eleven that remain,
+the console UART (P1.04/05), three buttons (P1.08/09/13) and two LEDs
+(P1.10/14) already claim seven, leaving exactly four pins for four signals.
+
+That is also why chip select is on P1.12 rather than P1.10, where Nordic's own
+devicetree places this SPI's CS: P1.10 is an LED on this board.
+
+SPIM22 is the instance behind the expansion header. SPIM00 drives the on-board
+flash, and SPIM20 shares a SERIAL slot with the console UART, so enabling it
+fails at link time with a duplicate `SERIAL20_IRQHandler`.
+
+## Configuration
+
+`WITH_IP64=1` pulls in `os/services/ip64`. The board or example must then
+supply three things:
+
+1. `NRF_SPI_INSTANCES`, to pick the SPIM instance the module is wired to
+   (the SPI driver itself is built by default).
+2. `MODULES += $(CONTIKI_NG_DRIVERS_ETHERNET_DIR)/enc28j60`.
+3. `CFLAGS += -DUIP_FALLBACK_INTERFACE=ip64_uip_fallback_interface`.
+
+plus an `ip64-conf.h` on the include path selecting the Ethernet driver, and
+`ENC28J60_CONF_USE_SPI_HAL 1` with the `ETH_SPI_*` pin defines.
+`examples/platform-specific/nrf/ip64-router` has all of this.
+
+The ENC28J60 arch layer used here is
+`arch/dev/ethernet/enc28j60/enc28j60-arch-spi-hal.c`, which sits on the SPI HAL
+rather than on a CPU's registers, so it works on any platform implementing
+`os/dev/spi.h` -- a board only supplies pin defines.
+
+## Bringing it up
+
+Work outwards, so each step isolates one layer.
+
+### 1. The SPI bus
+
+    cd examples/platform-specific/nrf/spi-flash
+    make TARGET=nrf BOARD=nrf54l15/dk spi-flash.upload
+
+Talks to the DK's on-board flash on SPIM00, so it proves the SPI driver before
+any external wiring exists. Expect a JEDEC ID of `c2 28 17`.
+
+### 2. The ENC28J60
+
+    cd examples/platform-specific/nrf/enc28j60-test
+    make TARGET=nrf BOARD=nrf54l15/dk enc28j60-test.upload
+
+Probes the chip before handing it to the driver, because `enc28j60_init()`
+waits for `ESTAT.CLKRDY` in a loop with no timeout -- on a miswired board it
+hangs silently. A good run:
+
+    ESTAT:    01  OK (CLKRDY set)
+    EREVID:   06  OK (silicon rev B7)
+    reg r/w:  5a  OK
+    MAC r/w:  02:de:ad:be:ef:01  OK
+    ENC28J60 OK
+
+`ff` everywhere means nothing is driving MISO: check MISO, CS, and that `SI`
+and `SO` are not swapped. `00` everywhere means MISO is stuck low, usually
+power or ground. Anything else points at SCK or too high a bit rate.
+
+With a cable in a live switch it then prints received frames.
+
+### 3. The router
+
+    cd examples/platform-specific/nrf/ip64-router
+    make TARGET=nrf BOARD=nrf54l15/dk ip64-router.upload
+
+Becomes the RPL root and brings up IP64. It reports the address DHCP gives it:
+
+    IPv4 address acquired:
+      address   192.168.101.103
+      netmask   255.255.255.0
+      gateway   192.168.101.1
+
+At that point the board answers pings from your LAN.
+
+The example can also prove the translator without a second board. Define
+`NAT64_TEST_ADDR` to an IPv4 host running `nc -u -l 7777` and the router sends
+UDP through its own NAT64 prefix: a locally generated packet to an off-link,
+unroutable destination takes the same uIP fallback path
+(`tcpip.c: output_fallback`) that a forwarded one does.
+
+### 4. A mesh node
+
+    cd examples/platform-specific/nrf/nat64-node
+    make TARGET=nrf BOARD=nrf54l15/xiao nat64-node.flash
+
+Joins the RPL network and, with `NAT64_TEST_ADDR` defined in its
+`project-conf.h` the same way as for the router, sends UDP to that IPv4 host.
+This exercises what the router's self-test cannot: the forwarding hop, and a
+per-source entry in ip64's address map. With both probes enabled, a listener
+sees one IPv4 source address and two distinct mapped ports. Neither probe is
+on by default, so a stock build does not send traffic to anyone's LAN.
+
+It also resolves a hostname through DNS64, pointing the resolver at a public
+IPv4 DNS server via the NAT64 prefix:
+
+    DNS64 OK: leshan.eclipseprojects.io -> 64:ff9b::23.97.187.154
+
+Use this rather than hardcoding IPv4 literals in NAT64 form; those go stale.
+
+## Things that will cost you time
+
+**Reading the DK console needs DTR.** P1.06 and P1.07 double as the on-board
+debugger's UART RTS/CTS. Once the ENC28J60 is wired to them, a terminal that
+does not assert DTR reads zero bytes at every baud rate -- indistinguishable
+from dead firmware. Open both VCOM ports, read the second at 115200, and assert
+DTR and RTS. If output is still missing, halt the core over J-Link and resolve
+the PC: `platform_idle` means the firmware is fine and the capture path is not.
+
+**Firmware that prints once at boot loses it.** The banner is emitted while the
+debugger is still resetting the target. Print periodically instead, or pulse
+reset only after the serial port is open.
+
+**Keep the bus slow to start.** 4 MHz is reliable on jumper wires. At 8 MHz a
+`ESTAT` of `02` instead of `01` -- a one-bit shift -- means MISO is being
+sampled too early; that is signal integrity, not a driver fault. Short leads
+with ground returns, or moving MOSI/MISO off the debugger's pins with
+`BUTTON_HAL_CONF_ENABLED 0`, raise the ceiling. Throughput is bounded by the
+driver's 1-tick receive poll anyway.
+
+**RPL join takes about a minute.** A node printing "waiting to join" for 40
+seconds has not failed.
+
+**An ENC28J60 draws well over 100 mA with the link up.** If the board browns
+out when the cable goes in, power the module separately and tie the grounds --
+with the DK at 3.3 V the logic levels still match.
+
+## Status of os/services/ip64
+
+`ip64` had no runtime test and no functional commits for years, and the Zoul
+Orion was the only board in the tree that could run it. Everything above was
+brought up against that code as-is; the translator, the address map, the DHCP
+client and DNS64 all work. Treat unexplained behaviour as plausibly a latent
+bug in the module rather than in your wiring, and note that the examples here
+are the only runtime coverage it has.

--- a/doc/platforms/nrf-ip64-ethernet.md
+++ b/doc/platforms/nrf-ip64-ethernet.md
@@ -148,12 +148,14 @@ per-source entry in ip64's address map. With both probes enabled, a listener
 sees one IPv4 source address and two distinct mapped ports. Neither probe is
 on by default, so a stock build does not send traffic to anyone's LAN.
 
-It also resolves a hostname through DNS64, pointing the resolver at a public
-IPv4 DNS server via the NAT64 prefix:
+Defining `NAT64_LOOKUP_NAME` additionally resolves that hostname through
+DNS64, pointing the resolver at a public IPv4 DNS server via the NAT64 prefix
+(`NAT64_DNS_SERVER`, Google's by default):
 
     DNS64 OK: leshan.eclipseprojects.io -> 64:ff9b::23.97.187.154
 
-Use this rather than hardcoding IPv4 literals in NAT64 form; those go stale.
+Prefer this over hardcoding IPv4 literals in NAT64 form; those go stale. It is
+off by default because it sends a query to a third-party resolver.
 
 ## Things that will cost you time
 

--- a/doc/platforms/nrf.md
+++ b/doc/platforms/nrf.md
@@ -318,6 +318,38 @@ For the full guide — toolchain setup (the FLPR needs an RV32EMC RISC-V GCC),
 build/deploy steps, the boot sequence, and the `hello-vpr` / `flpr-host`
 examples — see the [nrf-vpr platform documentation](nrf-vpr.md).
 
+### SPI
+
+The nRF port implements the Contiki-NG SPI HAL (`os/dev/spi.h`) on top of
+`nrfx_spim`. It is built by default on the application cores with one SPIM
+instance (SPIM0 on the nRF52840, SPIM1 on the nRF5340 application core, SPIM00
+on the nRF54L15), so a `spi_device_t` on those pins works with no makefile
+changes; unused, it costs a few hundred bytes. To use other or additional
+instances, list the ids in `NRF_SPI_INSTANCES`, in logical controller order;
+an id that does not exist on the SoC is rejected with a message listing the
+ones that do, and listing one twice is rejected too. `NRF_WITH_SPI=0` leaves
+SPI out. The nRF5340 network core has no SPI support: its only SPIM shares
+SERIAL0 with the console UARTE, so `NRF_WITH_SPI=1` is rejected there.
+
+Instance choice is constrained on SoCs that group peripherals into SERIAL
+slots. SPIMn and UARTEn in the same slot share an interrupt vector, so
+selecting the one that collides with the console UART fails at link time with a
+duplicate `SERIALn_IRQHandler`. Known-good choices are documented in
+`arch/cpu/nrf/dev/spi-arch.h`: SPIM00 or SPIM22 on the nRF54L15, SPIM1 and up
+on the nRF5340 application core, and any instance on the nRF52840.
+
+`examples/platform-specific/nrf/spi-flash` brings the bus up against the
+nRF54L15 DK's on-board flash, which is useful when wiring a new peripheral:
+it fails on the driver rather than on your jumper wires.
+
+### Ethernet and IPv4 (IP64)
+
+With an ENC28J60 module on SPI, an nRF board can act as a self-contained
+border router — RPL root on the 802.15.4 side, NAT64 and DNS64 on the IPv4
+side, with no host in the data path. See the
+[ENC28J60 / IP64 documentation](nrf-ip64-ethernet.md) for wiring, the GPIO
+voltage change the nRF54L15 DK needs first, and a bring-up sequence.
+
 ## Support
 
 For bug reports or/and suggestions please open a github issue.

--- a/doc/platforms/nrf.md
+++ b/doc/platforms/nrf.md
@@ -338,8 +338,8 @@ duplicate `SERIALn_IRQHandler`. Known-good choices are documented in
 `arch/cpu/nrf/dev/spi-arch.h`: SPIM00 or SPIM22 on the nRF54L15, SPIM1 and up
 on the nRF5340 application core, and any instance on the nRF52840.
 
-`examples/platform-specific/nrf/spi-flash` brings the bus up against the
-nRF54L15 DK's on-board flash, which is useful when wiring a new peripheral:
+`examples/platform-specific/nrf/spi-flash` brings the bus up against a DK's
+on-board MX25R6435F flash, which is useful when wiring a new peripheral:
 it fails on the driver rather than on your jumper wires.
 
 ### Ethernet and IPv4 (IP64)

--- a/examples/platform-specific/nrf/enc28j60-test/Makefile
+++ b/examples/platform-specific/nrf/enc28j60-test/Makefile
@@ -1,0 +1,20 @@
+CONTIKI_PROJECT = enc28j60-test
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../../..
+
+PLATFORMS_ONLY = nrf
+# The pin defaults are the nRF54L15 DK's PORT P1 header.
+BOARDS_ONLY = nrf54l15/dk
+
+# Pull in the ENC28J60 driver and the SPI-HAL arch layer by name rather than
+# adding the whole module: the module also contains the IP64 glue driver,
+# which needs the IP64 service. This test deliberately stops at the chip.
+PROJECTDIRS += $(CONTIKI)/arch/dev/ethernet/enc28j60
+PROJECT_SOURCEFILES += enc28j60.c enc28j60-arch-spi-hal.c
+
+# SPIM22 is the nRF54L15 DK's expansion-header SPI. SPIM00 is taken by the
+# on-board flash, and SPIM20 shares a SERIAL slot with the console UART.
+NRF_SPI_INSTANCES = 22
+
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/nrf/enc28j60-test/enc28j60-test.c
+++ b/examples/platform-specific/nrf/enc28j60-test/enc28j60-test.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \file
+ *         Bring-up test for an ENC28J60 Ethernet module.
+ *
+ *         Probes the chip over SPI before handing it to the driver: soft
+ *         reset, wait for the oscillator, read the revision ID, then read
+ *         back a register that was just written. Only if all of that passes
+ *         does it call enc28j60_init(), which spins forever waiting for
+ *         ESTAT.CLKRDY if the chip is not answering.
+ *
+ *         Once initialised it reports every frame the chip receives, so a
+ *         cable into a live switch is enough to show the RX path working
+ *         end to end.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "enc28j60.h"
+
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+/* SPI opcodes, section 4.2 of the datasheet. */
+#define CMD_RCR 0x00 /* Read Control Register */
+#define CMD_WCR 0x40 /* Write Control Register */
+#define CMD_BFS 0x80 /* Bit Field Set */
+#define CMD_BFC 0xa0 /* Bit Field Clear */
+#define CMD_SRC 0xff /* System Reset (soft reset) */
+
+/* Registers that are mapped into every bank. */
+#define ESTAT   0x1d
+#define ECON1   0x1f
+
+#define ESTAT_CLKRDY 0x01
+#define ECON1_BSEL   0x03
+
+/* Bank 3. */
+#define EREVID  0x12
+/*
+ * MAC address registers, also bank 3. Unlike EREVID these are MAC registers,
+ * so a read clocks out a dummy byte before the data (datasheet 4.2.1). That
+ * makes them the only part of this test that exercises the dummy-byte path.
+ */
+#define MAADR1  0x04
+#define MAADR2  0x05
+#define MAADR3  0x02
+#define MAADR4  0x03
+#define MAADR5  0x00
+#define MAADR6  0x01
+/* Bank 0, and writable, so it doubles as a register read/write check. */
+#define EWRPTL  0x02
+/*---------------------------------------------------------------------------*/
+static uint8_t
+readreg(uint8_t reg)
+{
+  uint8_t r;
+
+  enc28j60_arch_spi_select();
+  enc28j60_arch_spi_write(CMD_RCR | (reg & 0x1f));
+  /* EREVID, ESTAT, ECON1 and EWRPTL are all ETH registers: no dummy byte. */
+  r = enc28j60_arch_spi_read();
+  enc28j60_arch_spi_deselect();
+
+  return r;
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t
+readreg_mac(uint8_t reg)
+{
+  uint8_t r;
+
+  enc28j60_arch_spi_select();
+  enc28j60_arch_spi_write(CMD_RCR | (reg & 0x1f));
+  /* MAC and MII registers return a dummy byte first. */
+  enc28j60_arch_spi_read();
+  r = enc28j60_arch_spi_read();
+  enc28j60_arch_spi_deselect();
+
+  return r;
+}
+/*---------------------------------------------------------------------------*/
+static void
+writereg(uint8_t reg, uint8_t data)
+{
+  enc28j60_arch_spi_select();
+  enc28j60_arch_spi_write(CMD_WCR | (reg & 0x1f));
+  enc28j60_arch_spi_write(data);
+  enc28j60_arch_spi_deselect();
+}
+/*---------------------------------------------------------------------------*/
+static void
+setbank(uint8_t bank)
+{
+  enc28j60_arch_spi_select();
+  enc28j60_arch_spi_write(CMD_BFC | ECON1);
+  enc28j60_arch_spi_write(ECON1_BSEL);
+  enc28j60_arch_spi_deselect();
+
+  enc28j60_arch_spi_select();
+  enc28j60_arch_spi_write(CMD_BFS | ECON1);
+  enc28j60_arch_spi_write(bank & ECON1_BSEL);
+  enc28j60_arch_spi_deselect();
+}
+/*---------------------------------------------------------------------------*/
+static void
+softreset(void)
+{
+  enc28j60_arch_spi_select();
+  enc28j60_arch_spi_write(CMD_SRC);
+  enc28j60_arch_spi_deselect();
+}
+/*---------------------------------------------------------------------------*/
+static void
+explain(uint8_t v)
+{
+  if(v == 0x00) {
+    printf("  all zeroes: MISO is stuck low. Check MISO, and that the\n"
+           "  module has 3.3 V on VCC and a common ground.\n");
+  } else if(v == 0xff) {
+    printf("  all ones: nothing is driving MISO. Check MISO and CS, and\n"
+           "  that SI/SO are not swapped (SI takes MOSI, SO feeds MISO).\n");
+  } else {
+    printf("  unexpected value: check SCK, and try a lower ETH_SPI_BIT_RATE.\n");
+  }
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Returns non-zero if the chip answers plausibly. Deliberately does not use
+ * anything from enc28j60.c, so a failure here is about the wiring and the SPI
+ * driver rather than about the Ethernet driver.
+ */
+static int
+probe(void)
+{
+  uint8_t rev;
+  uint8_t estat;
+  uint8_t readback;
+  int i;
+
+  enc28j60_arch_spi_init();
+
+  softreset();
+  /* Errata #2: wait at least 1 ms after a soft reset before any access. */
+  clock_delay_usec(2000);
+
+  /* The oscillator start-up is specified as 300 us; allow far more. */
+  estat = 0;
+  for(i = 0; i < 100; i++) {
+    estat = readreg(ESTAT);
+    if(estat != 0x00 && estat != 0xff && (estat & ESTAT_CLKRDY)) {
+      break;
+    }
+    clock_delay_usec(1000);
+  }
+
+  printf("  ESTAT:    %02x", estat);
+  if(estat != 0x00 && estat != 0xff && (estat & ESTAT_CLKRDY)) {
+    printf("  OK (CLKRDY set)\n");
+  } else {
+    printf("  FAIL (no CLKRDY)\n");
+    explain(estat);
+    return 0;
+  }
+
+  setbank(3);
+  rev = readreg(EREVID);
+  printf("  EREVID:   %02x", rev);
+  if(rev != 0x00 && rev != 0xff) {
+    printf("  OK (silicon rev B%u)\n", rev == 2 ? 1 : (rev == 6 ? 7 : rev));
+  } else {
+    printf("  FAIL\n");
+    explain(rev);
+    return 0;
+  }
+
+  /*
+   * Write and read back a scratch register. The revision ID alone can be
+   * right by luck on a marginal bus; a value we chose cannot.
+   */
+  setbank(0);
+  writereg(EWRPTL, 0x5a);
+  readback = readreg(EWRPTL);
+  printf("  reg r/w:  %02x", readback);
+  if(readback == 0x5a) {
+    printf("  OK\n");
+  } else {
+    printf("  FAIL (wrote 5a)\n");
+    explain(readback);
+    return 0;
+  }
+
+  /*
+   * Write a MAC address and read it back. The ENC28J60 has no factory MAC of
+   * its own -- these registers come up undefined and the host is expected to
+   * supply one -- so this is a round-trip check, not an identity read. Its
+   * value is that MAC registers need the dummy byte that ETH registers do not,
+   * so it covers an access pattern nothing above does, across six registers
+   * whose addresses are deliberately not in order.
+   *
+   * enc28j60_init() soft-resets the chip and writes its own MAC afterwards,
+   * so nothing here is left behind.
+   */
+  {
+    static const uint8_t probe_mac[6] = {
+      0x02, 0xde, 0xad, 0xbe, 0xef, 0x01
+    };
+    static const uint8_t maadr[6] = {
+      MAADR1, MAADR2, MAADR3, MAADR4, MAADR5, MAADR6
+    };
+    uint8_t got[6];
+    int ok = 1;
+
+    setbank(3);
+    for(i = 0; i < 6; i++) {
+      writereg(maadr[i], probe_mac[i]);
+    }
+    for(i = 0; i < 6; i++) {
+      got[i] = readreg_mac(maadr[i]);
+      if(got[i] != probe_mac[i]) {
+        ok = 0;
+      }
+    }
+
+    printf("  MAC r/w:  %02x:%02x:%02x:%02x:%02x:%02x",
+           got[0], got[1], got[2], got[3], got[4], got[5]);
+    if(ok) {
+      printf("  OK\n");
+    } else {
+      printf("  FAIL (wrote %02x:%02x:%02x:%02x:%02x:%02x)\n",
+             probe_mac[0], probe_mac[1], probe_mac[2],
+             probe_mac[3], probe_mac[4], probe_mac[5]);
+      printf("  a one-byte shift here usually means the dummy byte on MAC\n"
+             "  register reads is being mishandled\n");
+      return 0;
+    }
+  }
+
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+PROCESS(enc28j60_test_process, "ENC28J60 test");
+AUTOSTART_PROCESSES(&enc28j60_test_process);
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(enc28j60_test_process, ev, data)
+{
+  static uint8_t mac[6] = { 0x02, 0x00, 0x00, 0x00, 0x00, 0x01 };
+  static uint8_t buf[1518];
+  static struct etimer periodic;
+  static unsigned long frames;
+  static unsigned ticks;
+  static int ok;
+
+  PROCESS_BEGIN();
+
+  printf("\nENC28J60 test\n");
+  printf("  controller %u, %u Hz\n",
+         (unsigned)ETH_SPI_CONTROLLER, (unsigned)ETH_SPI_BIT_RATE);
+  printf("  SCK P%u.%02u  MOSI P%u.%02u  MISO P%u.%02u  CS P%u.%02u\n",
+         ETH_SPI_CLK_PORT, ETH_SPI_CLK_PIN,
+         ETH_SPI_MOSI_PORT, ETH_SPI_MOSI_PIN,
+         ETH_SPI_MISO_PORT, ETH_SPI_MISO_PIN,
+         ETH_SPI_CSN_PORT, ETH_SPI_CSN_PIN);
+
+  ok = probe();
+  if(!ok) {
+    printf("ENC28J60 NOT FOUND\n");
+    PROCESS_EXIT();
+  }
+  printf("ENC28J60 OK\n");
+
+  /*
+   * Safe to call now: enc28j60_init() waits for ESTAT.CLKRDY in a loop with
+   * no timeout, which the probe above has already shown will be satisfied.
+   */
+  printf("initialising driver, MAC %02x:%02x:%02x:%02x:%02x:%02x\n",
+         mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  enc28j60_init(mac);
+
+  printf("polling for frames -- plug the module into a switch\n");
+  frames = 0;
+  ticks = 0;
+  while(1) {
+    int len;
+
+    etimer_set(&periodic, CLOCK_SECOND / 8);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&periodic));
+
+    len = enc28j60_read(buf, sizeof(buf));
+    if(len > 0) {
+      frames++;
+      printf("rx %lu: %d bytes, dst %02x:%02x:%02x:%02x:%02x:%02x "
+             "type %02x%02x\n", frames, len,
+             buf[0], buf[1], buf[2], buf[3], buf[4], buf[5],
+             buf[12], buf[13]);
+    }
+
+    /*
+     * Heartbeat every ~5 s. Without it the firmware is silent until a frame
+     * arrives, which is indistinguishable from a crash or a dead capture
+     * path -- and it means the state can be read at any time without
+     * resetting the board to catch a one-shot banner.
+     */
+    if(++ticks >= 40) {
+      ticks = 0;
+      printf("alive: %lu frames so far%s\n", frames,
+             frames == 0 ? " (no cable, or nothing on the link yet)" : "");
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/nrf/enc28j60-test/project-conf.h
+++ b/examples/platform-specific/nrf/enc28j60-test/project-conf.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         Project configuration for the enc28j60-test example.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+/*---------------------------------------------------------------------------*/
+/* Use the platform-independent ENC28J60 arch layer on top of the SPI HAL. */
+#define ENC28J60_CONF_USE_SPI_HAL 1
+/*---------------------------------------------------------------------------*/
+/*
+ * Wiring for the nRF54L15 DK expansion header, marked "PORT P1" on the board.
+ * Only P1.04 through P1.14 are brought out, and of those the console UART
+ * (P1.04/P1.05), the buttons (P1.08/P1.09/P1.13) and LED2/LED4
+ * (P1.10/P1.14) are already spoken for. That leaves the three SPI22 signals
+ * and P1.12, which is why CS is on P1.12 and not on P1.10 as Zephyr's
+ * devicetree has it.
+ *
+ * RESET is deliberately not wired: the module pulls it up, and the driver
+ * issues a soft reset over SPI. Define ETH_RESET_PORT/ETH_RESET_PIN if you
+ * do connect it.
+ */
+#define ETH_SPI_CONTROLLER   0    /* logical controller 0 -> SPIM22 */
+
+#define ETH_SPI_CLK_PORT     1
+#define ETH_SPI_CLK_PIN     11
+#define ETH_SPI_MOSI_PORT    1
+#define ETH_SPI_MOSI_PIN     6
+#define ETH_SPI_MISO_PORT    1
+#define ETH_SPI_MISO_PIN     7
+#define ETH_SPI_CSN_PORT     1
+#define ETH_SPI_CSN_PIN     12
+
+/* The ENC28J60 is rated for 20 MHz; start slow while bringing the wiring up. */
+#define ETH_SPI_BIT_RATE     4000000
+/*---------------------------------------------------------------------------*/
+#endif /* PROJECT_CONF_H_ */

--- a/examples/platform-specific/nrf/ip64-router/Makefile
+++ b/examples/platform-specific/nrf/ip64-router/Makefile
@@ -1,0 +1,23 @@
+CONTIKI_PROJECT = ip64-router
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../../..
+
+PLATFORMS_ONLY = nrf
+# The pin defaults are the nRF54L15 DK's PORT P1 header.
+BOARDS_ONLY = nrf54l15/dk
+
+include $(CONTIKI)/Makefile.dir-variables
+
+# The ENC28J60 driver plus its IP64 glue, and the SPI-HAL arch layer.
+MODULES += $(CONTIKI_NG_DRIVERS_ETHERNET_DIR)/enc28j60
+
+# SPIM22 is the nRF54L15 DK's expansion-header SPI. SPIM00 is taken by the
+# on-board flash, and SPIM20 shares a SERIAL slot with the console UART.
+NRF_SPI_INSTANCES = 22
+
+# Pull in os/services/ip64 and point uIP's fallback interface at it.
+WITH_IP64 = 1
+CFLAGS += -DUIP_FALLBACK_INTERFACE=ip64_uip_fallback_interface
+
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/nrf/ip64-router/ip64-conf.h
+++ b/examples/platform-specific/nrf/ip64-router/ip64-conf.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         IP64 configuration for the ip64-router example.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef IP64_CONF_H
+#define IP64_CONF_H
+/*---------------------------------------------------------------------------*/
+#include "ip64/ip64-eth-interface.h"
+#include "enc28j60-ip64-driver.h"
+/*---------------------------------------------------------------------------*/
+#define IP64_CONF_UIP_FALLBACK_INTERFACE  ip64_eth_interface
+#define IP64_CONF_INPUT                   ip64_eth_interface_input
+#define IP64_CONF_ETH_DRIVER              enc28j60_ip64_driver
+/*---------------------------------------------------------------------------*/
+/* Acquire the IPv4 address, gateway and netmask over DHCP. */
+#define IP64_CONF_DHCP                    1
+/*---------------------------------------------------------------------------*/
+#endif /* IP64_CONF_H */

--- a/examples/platform-specific/nrf/ip64-router/ip64-router.c
+++ b/examples/platform-specific/nrf/ip64-router/ip64-router.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \file
+ *         An IP64 border router: RPL root on the 802.15.4 side, NAT64 and
+ *         an IPv4 uplink over an ENC28J60 on the Ethernet side.
+ *
+ *         Functionally this is the stock examples/ip64-router, with a status
+ *         report added. The stock example prints nothing at all, which during
+ *         bring-up is indistinguishable from a hang -- and the one thing you
+ *         most want to see is whether DHCP ever returned an address.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "contiki-net.h"
+#include "ip64/ip64.h"
+#include "net/netstack.h"
+#include "net/routing/routing.h"
+#include "sys/autostart.h"
+#include "net/ipv6/simple-udp.h"
+#include "net/ipv6/ip64-addr.h"
+#include "net/ipv6/uip-debug.h"
+
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+#define REPORT_INTERVAL (CLOCK_SECOND * 5)
+/*---------------------------------------------------------------------------*/
+/*
+ * Optional self-test of the translator. The router sends a UDP datagram to an
+ * IPv4 host through its own NAT64 prefix, which exercises ip64_6to4() without
+ * needing a second node on the mesh: a locally generated packet to an
+ * off-link, unroutable destination takes the same uIP fallback path
+ * (tcpip.c output_fallback) that a forwarded one does.
+ *
+ * Set NAT64_TEST_ADDR to an IPv4 host running a UDP listener, e.g.
+ *   nc -u -l 7777
+ */
+#ifdef NAT64_TEST_ADDR
+#ifndef NAT64_TEST_PORT
+#define NAT64_TEST_PORT 7777
+#endif
+/*
+ * Indirection so NAT64_TEST_ADDR's four octets are macro-expanded before
+ * uip_nat64addr() counts its arguments.
+ */
+#define NAT64_SET_DEST(addr, ...) uip_nat64addr(addr, __VA_ARGS__)
+
+static struct simple_udp_connection nat64_conn;
+#endif
+/*---------------------------------------------------------------------------*/
+PROCESS(router_node_process, "IP64 router");
+AUTOSTART_PROCESSES(&router_node_process);
+/*---------------------------------------------------------------------------*/
+static void
+print_ip4(const char *label, const uip_ip4addr_t *a)
+{
+  printf("  %-9s %u.%u.%u.%u\n", label,
+         a->u8[0], a->u8[1], a->u8[2], a->u8[3]);
+}
+/*---------------------------------------------------------------------------*/
+#ifdef NAT64_TEST_ADDR
+static void
+nat64_reply(struct simple_udp_connection *c, const uip_ipaddr_t *sender_addr,
+            uint16_t sender_port, const uip_ipaddr_t *receiver_addr,
+            uint16_t receiver_port, const uint8_t *data, uint16_t datalen)
+{
+  printf("NAT64 reply: %u bytes from ", datalen);
+  uip_debug_ipaddr_print(sender_addr);
+  printf("\n");
+}
+#endif
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(router_node_process, ev, data)
+{
+  static struct etimer periodic;
+  static int was_configured;
+#ifdef NAT64_TEST_ADDR
+  static uip_ipaddr_t nat64_dest;
+  static unsigned long sent;
+#endif
+
+  PROCESS_BEGIN();
+
+  printf("\nIP64 router starting\n");
+
+  /* Set us up as a RPL root node. */
+  NETSTACK_ROUTING.root_start();
+  printf("  RPL root started\n");
+
+  /* Initialize the IP64 module so we'll start translating packets. */
+  ip64_init();
+  printf("  IP64 initialised, waiting for DHCP on the Ethernet side\n");
+
+  was_configured = 0;
+  while(1) {
+    etimer_set(&periodic, REPORT_INTERVAL);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&periodic));
+
+    if(ip64_hostaddr_is_configured()) {
+      if(!was_configured) {
+        was_configured = 1;
+        printf("IPv4 address acquired:\n");
+        print_ip4("address", ip64_get_hostaddr());
+        print_ip4("netmask", ip64_get_netmask());
+        print_ip4("gateway", ip64_get_draddr());
+        printf("router is up -- IPv6 nodes can now reach IPv4 hosts\n");
+#ifdef NAT64_TEST_ADDR
+        NAT64_SET_DEST(&nat64_dest, NAT64_TEST_ADDR);
+        simple_udp_register(&nat64_conn, NAT64_TEST_PORT, NULL,
+                            NAT64_TEST_PORT, nat64_reply);
+        printf("NAT64 self-test: sending UDP to ");
+        uip_debug_ipaddr_print(&nat64_dest);
+        printf(" port %u\n", NAT64_TEST_PORT);
+#endif
+      }
+#ifdef NAT64_TEST_ADDR
+      {
+        char msg[64];
+        int len = snprintf(msg, sizeof(msg),
+                           "hello from contiki-ng via NAT64 #%lu\n", ++sent);
+        simple_udp_sendto(&nat64_conn, msg, len, &nat64_dest);
+        printf("NAT64 self-test: sent #%lu (%d bytes)\n", sent, len);
+      }
+#endif
+    } else {
+      if(was_configured) {
+        was_configured = 0;
+        printf("IPv4 address lost, waiting for DHCP again\n");
+      } else {
+        printf("waiting for DHCP (no IPv4 address yet)\n");
+      }
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/nrf/ip64-router/project-conf.h
+++ b/examples/platform-specific/nrf/ip64-router/project-conf.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         Project configuration for the ip64-router example.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+/*---------------------------------------------------------------------------*/
+/* Use the platform-independent ENC28J60 arch layer on top of the SPI HAL. */
+#define ENC28J60_CONF_USE_SPI_HAL 1
+/*---------------------------------------------------------------------------*/
+/*
+ * Wiring for the nRF54L15 DK expansion header, marked "PORT P1" on the board.
+ * Only P1.04 through P1.14 are brought out, and of those the console UART
+ * (P1.04/P1.05), the buttons (P1.08/P1.09/P1.13) and LED2/LED4
+ * (P1.10/P1.14) are already spoken for. That leaves the three SPI22 signals
+ * and P1.12, which is why CS is on P1.12 and not on P1.10 as Zephyr's
+ * devicetree has it.
+ *
+ * RESET is deliberately not wired: the module pulls it up, and the driver
+ * issues a soft reset over SPI. Define ETH_RESET_PORT/ETH_RESET_PIN if you
+ * do connect it.
+ */
+#define ETH_SPI_CONTROLLER   0    /* logical controller 0 -> SPIM22 */
+
+#define ETH_SPI_CLK_PORT     1
+#define ETH_SPI_CLK_PIN     11
+#define ETH_SPI_MOSI_PORT    1
+#define ETH_SPI_MOSI_PIN     6
+#define ETH_SPI_MISO_PORT    1
+#define ETH_SPI_MISO_PIN     7
+#define ETH_SPI_CSN_PORT     1
+#define ETH_SPI_CSN_PIN     12
+
+/* The ENC28J60 is rated for 20 MHz; start slow while bringing the wiring up. */
+#define ETH_SPI_BIT_RATE     4000000
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/* IP64 translates TCP as well as UDP, so uIP needs TCP compiled in. */
+#define UIP_CONF_TCP 1
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+/*
+ * Optional NAT64 self-test: with NAT64_TEST_ADDR defined, the router sends a
+ * UDP datagram every few seconds to that IPv4 host through its own NAT64
+ * prefix. Off by default; enable it by defining the target as four
+ * comma-separated octets and running a listener there with  nc -u -l 7777
+ *
+ *   #define NAT64_TEST_ADDR  192, 168, 1, 10
+ *   #define NAT64_TEST_PORT  7777
+ */
+/*---------------------------------------------------------------------------*/
+#endif /* PROJECT_CONF_H_ */

--- a/examples/platform-specific/nrf/lwm2m-nat64/Makefile
+++ b/examples/platform-specific/nrf/lwm2m-nat64/Makefile
@@ -1,0 +1,21 @@
+CONTIKI_PROJECT = example-ipso-objects
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../../..
+
+PLATFORMS_ONLY = nrf
+
+# Reuse the stock LwM2M/IPSO example sources; only the configuration differs.
+LWM2M_EXAMPLE = $(CONTIKI)/examples/lwm2m-ipso-objects
+PROJECTDIRS += $(LWM2M_EXAMPLE)
+CONTIKI_SOURCEFILES += example-ipso-temperature.c
+
+# The local project-conf.h (picked up by Makefile.include) sets the NAT64
+# server address, then defers to the stock basic configuration.
+
+include $(CONTIKI)/Makefile.dir-variables
+MODULES += $(CONTIKI_NG_APP_LAYER_DIR)/coap
+MODULES += $(CONTIKI_NG_SERVICES_DIR)/lwm2m
+MODULES += $(CONTIKI_NG_SERVICES_DIR)/ipso-objects
+
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/nrf/lwm2m-nat64/project-conf.h
+++ b/examples/platform-specific/nrf/lwm2m-nat64/project-conf.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         Project configuration for the lwm2m-nat64 example.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+/*---------------------------------------------------------------------------*/
+/*
+ * Register with the public Eclipse Leshan demo server through the IP64
+ * border router's NAT64 translator.
+ *
+ * The address embeds Leshan's IPv4 address in the well-known NAT64 prefix
+ * 64:ff9b::/96 (RFC 6052). It is a literal because the node has no DNS64
+ * resolver configured, so re-derive it if Leshan moves:
+ *
+ *     dig +short leshan.eclipseprojects.io A
+ *     printf '64:ff9b::%02x%02x:%02x%02x\n' <the four octets>
+ *
+ * 23.97.187.154 -> 64:ff9b::1761:bb9a   (checked 2026-08-30)
+ */
+#ifndef LWM2M_SERVER_ADDRESS
+#define LWM2M_SERVER_ADDRESS "coap://[64:ff9b::1761:bb9a]"
+#endif
+/*---------------------------------------------------------------------------*/
+/* Everything else follows the stock non-DTLS configuration. */
+#include "project-conf-basic.h"
+/*---------------------------------------------------------------------------*/
+/*
+ * Override the stock endpoint name, which is "Contiki-NG-Test". On the public
+ * Leshan demo server that is near-certain to collide with someone else's
+ * device, and two clients registering under one name fight over the
+ * registration. Defined unconditionally upstream, hence the undef.
+ *
+ * Keep it to 19 characters: lwm2m-rd-client.c copies the name into a
+ * default_ep[20] and truncates the rest without saying so, which would
+ * quietly undo the point of overriding it.
+ */
+#undef LWM2M_ENGINE_CLIENT_ENDPOINT_NAME
+#define LWM2M_ENGINE_CLIENT_ENDPOINT_NAME "contiki-ng-l15-xiao"
+/*---------------------------------------------------------------------------*/
+#endif /* PROJECT_CONF_H_ */

--- a/examples/platform-specific/nrf/nat64-node/Makefile
+++ b/examples/platform-specific/nrf/nat64-node/Makefile
@@ -1,0 +1,11 @@
+CONTIKI_PROJECT = nat64-node
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../../..
+
+PLATFORMS_ONLY = nrf
+
+include $(CONTIKI)/Makefile.dir-variables
+MODULES += $(CONTIKI_NG_SERVICES_DIR)/resolv
+
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/nrf/nat64-node/nat64-node.c
+++ b/examples/platform-specific/nrf/nat64-node/nat64-node.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \file
+ *         A mesh node that talks to an IPv4 host through the IP64 border
+ *         router's NAT64 translator.
+ *
+ *         This is the other half of the ip64-router test. The router can
+ *         already prove the translator with its own traffic, but only a real
+ *         node exercises the parts unique to forwarding: the RPL hop into the
+ *         router, and a per-source entry in ip64's address map.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "contiki-net.h"
+#include "net/netstack.h"
+#include "net/routing/routing.h"
+#include "net/ipv6/simple-udp.h"
+#include "net/ipv6/ip64-addr.h"
+#include "net/ipv6/uip-debug.h"
+#include "net/ipv6/uip-nameserver.h"
+#include "resolv.h"
+#include "sys/autostart.h"
+
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+/*
+ * Optional UDP probe. With NAT64_TEST_ADDR defined as four comma-separated
+ * octets, the node sends a datagram every SEND_INTERVAL to that IPv4 host
+ * through the border router's NAT64 prefix; run  nc -u -l 7777  there to see
+ * it arrive. Off by default so an in-tree build does not talk to anyone's
+ * LAN. The DNS64 lookup below runs regardless.
+ */
+#ifdef NAT64_TEST_ADDR
+#ifndef NAT64_TEST_PORT
+#define NAT64_TEST_PORT 7777
+#endif
+#endif
+
+#define SEND_INTERVAL (CLOCK_SECOND * 5)
+
+/*
+ * DNS64 test. The node is pointed at a public IPv4 DNS server reached through
+ * the NAT64 prefix; ip64 spots UDP to port 53 and rewrites the AAAA query into
+ * an A query on the way out, then synthesises an AAAA record from the A answer
+ * on the way back (ip64.c 6to4/4to6 -> ip64-dns64.c). A successful lookup
+ * therefore returns a 64:ff9b:: address that can be used directly, which is
+ * what removes the need to hardcode any IPv4 literal.
+ */
+#ifndef NAT64_DNS_SERVER
+#define NAT64_DNS_SERVER 8, 8, 8, 8
+#endif
+#ifndef NAT64_LOOKUP_NAME
+#define NAT64_LOOKUP_NAME "leshan.eclipseprojects.io"
+#endif
+
+/* Expand the octets before uip_nat64addr() counts its arguments. */
+#define NAT64_SET_DEST(addr, ...) uip_nat64addr(addr, __VA_ARGS__)
+/*---------------------------------------------------------------------------*/
+#ifdef NAT64_TEST_ADDR
+static struct simple_udp_connection conn;
+#endif
+/*---------------------------------------------------------------------------*/
+PROCESS(nat64_node_process, "NAT64 node");
+AUTOSTART_PROCESSES(&nat64_node_process);
+/*---------------------------------------------------------------------------*/
+#ifdef NAT64_TEST_ADDR
+static void
+rx(struct simple_udp_connection *c, const uip_ipaddr_t *sender_addr,
+   uint16_t sender_port, const uip_ipaddr_t *receiver_addr,
+   uint16_t receiver_port, const uint8_t *data, uint16_t datalen)
+{
+  printf("reply: %u bytes from ", datalen);
+  uip_debug_ipaddr_print(sender_addr);
+  printf("\n");
+}
+#endif /* NAT64_TEST_ADDR */
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(nat64_node_process, ev, data)
+{
+  static struct etimer periodic;
+#ifdef NAT64_TEST_ADDR
+  static uip_ipaddr_t dest;
+  static unsigned long sent;
+#endif
+  static int joined;
+  static uip_ipaddr_t dns;
+  static int dns_asked;
+  static int dns_done;
+
+  PROCESS_BEGIN();
+
+  printf("\nNAT64 node starting\n");
+#ifdef NAT64_TEST_ADDR
+  NAT64_SET_DEST(&dest, NAT64_TEST_ADDR);
+  printf("  UDP probe target ");
+  uip_debug_ipaddr_print(&dest);
+  printf(" port %u\n", NAT64_TEST_PORT);
+
+  simple_udp_register(&conn, NAT64_TEST_PORT, NULL, NAT64_TEST_PORT, rx);
+  sent = 0;
+#endif
+
+  joined = 0;
+  while(1) {
+    etimer_set(&periodic, SEND_INTERVAL);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&periodic));
+
+    if(!NETSTACK_ROUTING.node_is_reachable()) {
+      if(joined) {
+        joined = 0;
+        printf("left the RPL network\n");
+      } else {
+        printf("waiting to join the RPL network...\n");
+      }
+      continue;
+    }
+
+    if(!joined) {
+      joined = 1;
+      printf("joined the RPL network -- sending through NAT64 now\n");
+
+      /* Point the resolver at an IPv4 DNS server via the NAT64 prefix. */
+      NAT64_SET_DEST(&dns, NAT64_DNS_SERVER);
+      uip_nameserver_update(&dns, UIP_NAMESERVER_INFINITE_LIFETIME);
+      printf("DNS64: nameserver set to ");
+      uip_debug_ipaddr_print(&dns);
+      printf("\n");
+    }
+
+    if(joined && !dns_asked) {
+      dns_asked = 1;
+      printf("DNS64: looking up %s\n", NAT64_LOOKUP_NAME);
+      resolv_query(NAT64_LOOKUP_NAME);
+    }
+
+    if(dns_asked && !dns_done) {
+      uip_ipaddr_t *resolved = NULL;
+      resolv_status_t st = resolv_lookup(NAT64_LOOKUP_NAME, &resolved);
+
+      if(st == RESOLV_STATUS_CACHED && resolved != NULL) {
+        dns_done = 1;
+        printf("DNS64 OK: %s -> ", NAT64_LOOKUP_NAME);
+        uip_debug_ipaddr_print(resolved);
+        printf("\n");
+      } else if(st == RESOLV_STATUS_NOT_FOUND || st == RESOLV_STATUS_ERROR) {
+        dns_done = 1;
+        printf("DNS64 FAILED for %s (status %d)\n", NAT64_LOOKUP_NAME, st);
+      } else {
+        printf("DNS64: resolving... (status %d)\n", st);
+      }
+    }
+
+#ifdef NAT64_TEST_ADDR
+    {
+      char msg[64];
+      int len = snprintf(msg, sizeof(msg),
+                         "hello from a mesh node via NAT64 #%lu\n", ++sent);
+      simple_udp_sendto(&conn, msg, len, &dest);
+      printf("sent #%lu (%d bytes)\n", sent, len);
+    }
+#endif
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/platform-specific/nrf/nat64-node/nat64-node.c
+++ b/examples/platform-specific/nrf/nat64-node/nat64-node.c
@@ -75,13 +75,17 @@
  * on the way back (ip64.c 6to4/4to6 -> ip64-dns64.c). A successful lookup
  * therefore returns a 64:ff9b:: address that can be used directly, which is
  * what removes the need to hardcode any IPv4 literal.
+ *
+ * Off by default, like the UDP probe above: it sends traffic to a third-party
+ * resolver, which is not something an example should do unasked. Define
+ * NAT64_LOOKUP_NAME to enable it, and NAT64_DNS_SERVER to choose the resolver
+ * rather than taking the default below.
  */
+#ifdef NAT64_LOOKUP_NAME
 #ifndef NAT64_DNS_SERVER
 #define NAT64_DNS_SERVER 8, 8, 8, 8
 #endif
-#ifndef NAT64_LOOKUP_NAME
-#define NAT64_LOOKUP_NAME "leshan.eclipseprojects.io"
-#endif
+#endif /* NAT64_LOOKUP_NAME */
 
 /* Expand the octets before uip_nat64addr() counts its arguments. */
 #define NAT64_SET_DEST(addr, ...) uip_nat64addr(addr, __VA_ARGS__)
@@ -113,9 +117,11 @@ PROCESS_THREAD(nat64_node_process, ev, data)
   static unsigned long sent;
 #endif
   static int joined;
+#ifdef NAT64_LOOKUP_NAME
   static uip_ipaddr_t dns;
   static int dns_asked;
   static int dns_done;
+#endif
 
   PROCESS_BEGIN();
 
@@ -149,14 +155,17 @@ PROCESS_THREAD(nat64_node_process, ev, data)
       joined = 1;
       printf("joined the RPL network -- sending through NAT64 now\n");
 
+#ifdef NAT64_LOOKUP_NAME
       /* Point the resolver at an IPv4 DNS server via the NAT64 prefix. */
       NAT64_SET_DEST(&dns, NAT64_DNS_SERVER);
       uip_nameserver_update(&dns, UIP_NAMESERVER_INFINITE_LIFETIME);
       printf("DNS64: nameserver set to ");
       uip_debug_ipaddr_print(&dns);
       printf("\n");
+#endif /* NAT64_LOOKUP_NAME */
     }
 
+#ifdef NAT64_LOOKUP_NAME
     if(joined && !dns_asked) {
       dns_asked = 1;
       printf("DNS64: looking up %s\n", NAT64_LOOKUP_NAME);
@@ -179,6 +188,7 @@ PROCESS_THREAD(nat64_node_process, ev, data)
         printf("DNS64: resolving... (status %d)\n", st);
       }
     }
+#endif /* NAT64_LOOKUP_NAME */
 
 #ifdef NAT64_TEST_ADDR
     {

--- a/examples/platform-specific/nrf/nat64-node/project-conf.h
+++ b/examples/platform-specific/nrf/nat64-node/project-conf.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \file
+ *         Project configuration for the nat64-node example.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+/*---------------------------------------------------------------------------*/
+/* mDNS would answer locally; we want queries to actually leave via DNS64. */
+#define RESOLV_CONF_SUPPORTS_MDNS 0
+/*---------------------------------------------------------------------------*/
+#endif /* PROJECT_CONF_H_ */

--- a/examples/platform-specific/nrf/spi-flash/Makefile
+++ b/examples/platform-specific/nrf/spi-flash/Makefile
@@ -1,0 +1,13 @@
+CONTIKI_PROJECT = spi-flash
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../../..
+
+PLATFORMS_ONLY = nrf
+
+# Bring up the SPI HAL on SPIM00, which is where the nRF54L15 DK's onboard
+# MX25R6435F flash sits.
+# SPI is on by default with the SoC's default SPIM instance, which can drive
+# the flash pins on every DK.
+
+include $(CONTIKI)/Makefile.include

--- a/examples/platform-specific/nrf/spi-flash/spi-flash.c
+++ b/examples/platform-specific/nrf/spi-flash/spi-flash.c
@@ -101,7 +101,17 @@
 #else
 #error "No default SPI flash pins for this SoC; set SPI_FLASH_CONF_*"
 #endif
-#endif
+#else /* SPI_FLASH_CONF_SCK_PORT */
+/* A board that overrides one pin must give all eight. */
+#define SPI_FLASH_SCK_PORT   SPI_FLASH_CONF_SCK_PORT
+#define SPI_FLASH_SCK_PIN    SPI_FLASH_CONF_SCK_PIN
+#define SPI_FLASH_MOSI_PORT  SPI_FLASH_CONF_MOSI_PORT
+#define SPI_FLASH_MOSI_PIN   SPI_FLASH_CONF_MOSI_PIN
+#define SPI_FLASH_MISO_PORT  SPI_FLASH_CONF_MISO_PORT
+#define SPI_FLASH_MISO_PIN   SPI_FLASH_CONF_MISO_PIN
+#define SPI_FLASH_CS_PORT    SPI_FLASH_CONF_CS_PORT
+#define SPI_FLASH_CS_PIN     SPI_FLASH_CONF_CS_PIN
+#endif /* SPI_FLASH_CONF_SCK_PORT */
 
 /* The MX25R6435F is rated for 8 MHz in low-power mode. */
 #ifndef SPI_FLASH_CONF_BIT_RATE

--- a/examples/platform-specific/nrf/spi-flash/spi-flash.c
+++ b/examples/platform-specific/nrf/spi-flash/spi-flash.c
@@ -31,14 +31,18 @@
  * \file
  *         Bring-up test for the nRF SPI (SPIM) driver.
  *
- *         Reads the JEDEC ID and the SFDP signature from the SPI NOR flash
- *         on the nRF54L15 DK (MX25R6435F on SPI00) and reports whether the
+ *         Reads the JEDEC ID and the SFDP signature from the on-board
+ *         MX25R6435F SPI NOR flash of a Nordic DK and reports whether the
  *         values match what the part should return. Nothing is written, so
  *         this is safe to run against a flash holding data.
  *
  *         The point of testing against this device rather than a loopback
  *         is that it is already wired on the board: a wrong answer is the
  *         driver's fault, not the bench's.
+ *
+ *         Verified on hardware on the nRF54L15 DK. The nRF5340 and nRF52840
+ *         defaults below are taken from the board documentation and are
+ *         build-tested only.
  * \author
  *         Joakim Eriksson <joakim.eriksson@ri.se>
  */
@@ -49,7 +53,7 @@
 #include <stdio.h>
 #include <string.h>
 /*---------------------------------------------------------------------------*/
-/* Board wiring. Defaults are the nRF54L15 DK's onboard MX25R6435F. */
+/* Board wiring. Defaults are the on-board MX25R6435F of each Nordic DK. */
 #ifndef SPI_FLASH_CONF_CONTROLLER
 #define SPI_FLASH_CONTROLLER 0
 #else
@@ -57,8 +61,14 @@
 #endif
 
 /*
- * Pins of the on-board MX25R6435F on each Nordic DK. It sits on the QSPI
- * pins; SCK/CSN plus IO0 (MOSI) and IO1 (MISO) drive it in plain SPI mode.
+ * Pins of the on-board MX25R6435F on each Nordic DK. Which bus it hangs off
+ * differs by board:
+ *
+ *   nRF54L15 DK  - a plain SPI device on SPIM00, so nothing special applies.
+ *   nRF5340 DK,  - wired to the QSPI peripheral's pins. The part is an
+ *   nRF52840 DK    ordinary SPI NOR, so a SPIM can drive it over SCK/CSN
+ *                  plus IO0 as MOSI and IO1 as MISO, provided QSPI itself
+ *                  is not also driving those pins.
  */
 #ifndef SPI_FLASH_CONF_SCK_PORT
 #if defined(NRF54L15_XXAA)

--- a/examples/platform-specific/nrf/spi-flash/spi-flash.c
+++ b/examples/platform-specific/nrf/spi-flash/spi-flash.c
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \file
+ *         Bring-up test for the nRF SPI (SPIM) driver.
+ *
+ *         Reads the JEDEC ID and the SFDP signature from the SPI NOR flash
+ *         on the nRF54L15 DK (MX25R6435F on SPI00) and reports whether the
+ *         values match what the part should return. Nothing is written, so
+ *         this is safe to run against a flash holding data.
+ *
+ *         The point of testing against this device rather than a loopback
+ *         is that it is already wired on the board: a wrong answer is the
+ *         driver's fault, not the bench's.
+ * \author
+ *         Joakim Eriksson <joakim.eriksson@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/spi.h"
+
+#include <stdio.h>
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+/* Board wiring. Defaults are the nRF54L15 DK's onboard MX25R6435F. */
+#ifndef SPI_FLASH_CONF_CONTROLLER
+#define SPI_FLASH_CONTROLLER 0
+#else
+#define SPI_FLASH_CONTROLLER SPI_FLASH_CONF_CONTROLLER
+#endif
+
+/*
+ * Pins of the on-board MX25R6435F on each Nordic DK. It sits on the QSPI
+ * pins; SCK/CSN plus IO0 (MOSI) and IO1 (MISO) drive it in plain SPI mode.
+ */
+#ifndef SPI_FLASH_CONF_SCK_PORT
+#if defined(NRF54L15_XXAA)
+#define SPI_FLASH_SCK_PORT   2
+#define SPI_FLASH_SCK_PIN    1
+#define SPI_FLASH_MOSI_PORT  2
+#define SPI_FLASH_MOSI_PIN   2
+#define SPI_FLASH_MISO_PORT  2
+#define SPI_FLASH_MISO_PIN   4
+#define SPI_FLASH_CS_PORT    2
+#define SPI_FLASH_CS_PIN     5
+#elif defined(NRF5340_XXAA_APPLICATION)
+#define SPI_FLASH_SCK_PORT   0
+#define SPI_FLASH_SCK_PIN    17
+#define SPI_FLASH_MOSI_PORT  0
+#define SPI_FLASH_MOSI_PIN   13
+#define SPI_FLASH_MISO_PORT  0
+#define SPI_FLASH_MISO_PIN   14
+#define SPI_FLASH_CS_PORT    0
+#define SPI_FLASH_CS_PIN     18
+#elif defined(NRF52840_XXAA)
+#define SPI_FLASH_SCK_PORT   0
+#define SPI_FLASH_SCK_PIN    19
+#define SPI_FLASH_MOSI_PORT  0
+#define SPI_FLASH_MOSI_PIN   20
+#define SPI_FLASH_MISO_PORT  0
+#define SPI_FLASH_MISO_PIN   21
+#define SPI_FLASH_CS_PORT    0
+#define SPI_FLASH_CS_PIN     17
+#else
+#error "No default SPI flash pins for this SoC; set SPI_FLASH_CONF_*"
+#endif
+#endif
+
+/* The MX25R6435F is rated for 8 MHz in low-power mode. */
+#ifndef SPI_FLASH_CONF_BIT_RATE
+#define SPI_FLASH_BIT_RATE 8000000
+#else
+#define SPI_FLASH_BIT_RATE SPI_FLASH_CONF_BIT_RATE
+#endif
+/*---------------------------------------------------------------------------*/
+/* Expected JEDEC ID of the MX25R6435F: Macronix, 0x28, 64 Mbit. */
+#define EXPECTED_MANUFACTURER 0xc2
+#define EXPECTED_TYPE         0x28
+#define EXPECTED_CAPACITY     0x17
+/*---------------------------------------------------------------------------*/
+#define CMD_READ_JEDEC_ID 0x9f
+#define CMD_READ_SFDP     0x5a
+/*---------------------------------------------------------------------------*/
+static const spi_device_t flash = {
+  .port_spi_sck = SPI_FLASH_SCK_PORT,
+  .pin_spi_sck = SPI_FLASH_SCK_PIN,
+  .port_spi_mosi = SPI_FLASH_MOSI_PORT,
+  .pin_spi_mosi = SPI_FLASH_MOSI_PIN,
+  .port_spi_miso = SPI_FLASH_MISO_PORT,
+  .pin_spi_miso = SPI_FLASH_MISO_PIN,
+  .port_spi_cs = SPI_FLASH_CS_PORT,
+  .pin_spi_cs = SPI_FLASH_CS_PIN,
+  .spi_bit_rate = SPI_FLASH_BIT_RATE,
+  .spi_pha = 0,
+  .spi_pol = 0,
+  .spi_controller = SPI_FLASH_CONTROLLER,
+};
+/*---------------------------------------------------------------------------*/
+PROCESS(spi_flash_process, "nRF SPI flash test");
+AUTOSTART_PROCESSES(&spi_flash_process);
+/*---------------------------------------------------------------------------*/
+static bool
+read_jedec_id(uint8_t *id)
+{
+  const uint8_t cmd = CMD_READ_JEDEC_ID;
+
+  if(spi_acquire(&flash) != SPI_DEV_STATUS_OK) {
+    printf("FAIL: could not acquire the SPI bus\n");
+    return false;
+  }
+
+  spi_select(&flash);
+  /* Write the opcode, then clock in three ID bytes. */
+  if(spi_transfer(&flash, &cmd, 1, NULL, 0, 0) != SPI_DEV_STATUS_OK ||
+     spi_transfer(&flash, NULL, 0, id, 3, 0) != SPI_DEV_STATUS_OK) {
+    spi_deselect(&flash);
+    spi_release(&flash);
+    printf("FAIL: JEDEC ID transfer error\n");
+    return false;
+  }
+  spi_deselect(&flash);
+
+  spi_release(&flash);
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Repeats the JEDEC ID read with the opcode in a flash-resident buffer.
+ *
+ * EasyDMA can only reach Data RAM, so a write buffer in flash must be staged
+ * through a RAM bounce buffer by the driver. This is the failure mode that
+ * silently corrupts transfers rather than erroring, so it is worth an explicit
+ * test: the answer must match the RAM-buffer read byte for byte.
+ */
+static bool
+read_jedec_id_from_flash_buf(uint8_t *id)
+{
+  /* static const lands in .rodata, i.e. flash, not RAM. */
+  static const uint8_t cmd = CMD_READ_JEDEC_ID;
+
+  if(spi_acquire(&flash) != SPI_DEV_STATUS_OK) {
+    printf("FAIL: could not acquire the SPI bus\n");
+    return false;
+  }
+
+  spi_select(&flash);
+  if(spi_transfer(&flash, &cmd, 1, NULL, 0, 0) != SPI_DEV_STATUS_OK ||
+     spi_transfer(&flash, NULL, 0, id, 3, 0) != SPI_DEV_STATUS_OK) {
+    spi_deselect(&flash);
+    spi_release(&flash);
+    printf("FAIL: flash-buffer JEDEC ID transfer error\n");
+    return false;
+  }
+  spi_deselect(&flash);
+
+  spi_release(&flash);
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Reads the SFDP signature at address 0.
+ *
+ * The opcode and 3 address bytes are followed by one dummy byte before data
+ * starts, so the dummy is appended to the write phase: ignore_len in the SPI
+ * HAL discards trailing bytes, not leading ones.
+ *
+ * The read then asks for 8 bytes but keeps only the first 4, which exercises
+ * the ignore_len path and, with it, the staged (bounce-buffered) transfer.
+ */
+static bool
+read_sfdp_signature(uint8_t *sig)
+{
+  const uint8_t cmd[5] = { CMD_READ_SFDP, 0x00, 0x00, 0x00, 0x00 };
+
+  if(spi_acquire(&flash) != SPI_DEV_STATUS_OK) {
+    printf("FAIL: could not acquire the SPI bus\n");
+    return false;
+  }
+
+  spi_select(&flash);
+  if(spi_transfer(&flash, cmd, sizeof(cmd), NULL, 0, 0) != SPI_DEV_STATUS_OK ||
+     spi_transfer(&flash, NULL, 0, sig, 4, 4) != SPI_DEV_STATUS_OK) {
+    spi_deselect(&flash);
+    spi_release(&flash);
+    printf("FAIL: SFDP transfer error\n");
+    return false;
+  }
+  spi_deselect(&flash);
+
+  spi_release(&flash);
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Probes which bit rates the controller accepts, and exercises a staged
+ * transfer longer than NRF_SPI_CHUNK_SIZE so the chunking loop is covered.
+ *
+ * The SPI arch layer rounds a requested bit rate down to the nearest one the
+ * instance can produce and never rejects it, so this normally prints "ok"
+ * for every entry; the value shown is what was requested, not what the
+ * clock came out as. The point is to prove that each requested rate still
+ * yields a correct JEDEC ID -- a wrong answer at a high rate is a signal
+ * integrity ceiling to know about before wiring a faster device. "rej" is
+ * only reached if the open itself fails.
+ */
+static void
+probe_bit_rates(void)
+{
+  static const uint32_t rates[] = {
+    1000000, 2000000, 4000000, 8000000, 16000000, 20000000, 32000000
+  };
+  unsigned i;
+
+  printf("  bit rates (requested, driver rounds down):");
+  for(i = 0; i < sizeof(rates) / sizeof(rates[0]); i++) {
+    spi_device_t probe = flash;
+    probe.spi_bit_rate = rates[i];
+
+    if(spi_acquire(&probe) == SPI_DEV_STATUS_OK) {
+      uint8_t id[3];
+      const uint8_t cmd = CMD_READ_JEDEC_ID;
+      bool ok;
+
+      spi_select(&probe);
+      ok = spi_transfer(&probe, &cmd, 1, NULL, 0, 0) == SPI_DEV_STATUS_OK &&
+           spi_transfer(&probe, NULL, 0, id, 3, 0) == SPI_DEV_STATUS_OK &&
+           id[0] == EXPECTED_MANUFACTURER;
+      spi_deselect(&probe);
+      spi_release(&probe);
+
+      printf(" %lu:%s", (unsigned long)(rates[i] / 1000000),
+             ok ? "ok" : "bad");
+    } else {
+      printf(" %lu:rej", (unsigned long)(rates[i] / 1000000));
+    }
+  }
+  printf(" (MHz)\n");
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Reads a whole SFDP table with a discard tail, so the staged path has to
+ * loop over several chunks rather than fitting in one.
+ */
+static bool
+read_sfdp_long(void)
+{
+  const uint8_t cmd[5] = { CMD_READ_SFDP, 0x00, 0x00, 0x00, 0x00 };
+  static uint8_t buf[200];
+  bool ok;
+
+  if(spi_acquire(&flash) != SPI_DEV_STATUS_OK) {
+    return false;
+  }
+
+  spi_select(&flash);
+  /* 200 kept + 56 discarded = 256 bytes clocked, well over the chunk size. */
+  ok = spi_transfer(&flash, cmd, sizeof(cmd), NULL, 0, 0) == SPI_DEV_STATUS_OK &&
+       spi_transfer(&flash, NULL, 0, buf, sizeof(buf), 56) == SPI_DEV_STATUS_OK;
+  spi_deselect(&flash);
+  spi_release(&flash);
+
+  if(!ok) {
+    printf("  long SFDP: transfer error\n");
+    return false;
+  }
+
+  printf("  long SFDP: %02x %02x %02x %02x ... %02x %02x",
+         buf[0], buf[1], buf[2], buf[3], buf[198], buf[199]);
+  if(buf[0] == 'S' && buf[1] == 'F' && buf[2] == 'D' && buf[3] == 'P') {
+    printf("  OK (%u B staged)\n", (unsigned)(sizeof(buf) + 56));
+    return true;
+  }
+  printf("  MISMATCH\n");
+  return false;
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(spi_flash_process, ev, data)
+{
+  static uint8_t id[3];
+  static uint8_t id2[3];
+  static uint8_t sig[4];
+  static int failures;
+  static struct etimer periodic;
+
+  PROCESS_BEGIN();
+
+  /*
+   * The report is repeated rather than printed once at boot, so that it
+   * survives a debugger-triggered reset and so a terminal can be attached
+   * at any time. It also means wiring can be changed and the result
+   * re-read without reflashing.
+   */
+  while(1) {
+
+    failures = 0;
+
+    /* Report the configuration rather than leaving it to be inferred. */
+    printf("\nnRF SPI flash test\n");
+    printf("  controller %u, %lu Hz, mode %u%u\n",
+           (unsigned)flash.spi_controller,
+           (unsigned long)flash.spi_bit_rate,
+           (unsigned)flash.spi_pol, (unsigned)flash.spi_pha);
+    printf("  SCK P%u.%02u  MOSI P%u.%02u  MISO P%u.%02u  CS P%u.%02u\n",
+           SPI_FLASH_SCK_PORT, SPI_FLASH_SCK_PIN,
+           SPI_FLASH_MOSI_PORT, SPI_FLASH_MOSI_PIN,
+           SPI_FLASH_MISO_PORT, SPI_FLASH_MISO_PIN,
+           SPI_FLASH_CS_PORT, SPI_FLASH_CS_PIN);
+
+    if(read_jedec_id(id)) {
+      printf("  JEDEC ID: %02x %02x %02x", id[0], id[1], id[2]);
+      if(id[0] == EXPECTED_MANUFACTURER && id[1] == EXPECTED_TYPE &&
+         id[2] == EXPECTED_CAPACITY) {
+        printf("  OK (MX25R6435F)\n");
+      } else {
+        printf("  MISMATCH (expected %02x %02x %02x)\n",
+               EXPECTED_MANUFACTURER, EXPECTED_TYPE, EXPECTED_CAPACITY);
+        if((id[0] == 0x00 && id[1] == 0x00 && id[2] == 0x00) ||
+           (id[0] == 0xff && id[1] == 0xff && id[2] == 0xff)) {
+          printf("  all-%s usually means MISO is not connected, CS is wrong,\n"
+                 "  or the flash is not powered\n",
+                 id[0] == 0 ? "zeroes" : "ones");
+        }
+        failures++;
+      }
+    } else {
+      failures++;
+    }
+
+    if(read_jedec_id_from_flash_buf(id2)) {
+      printf("  flash-buf: %02x %02x %02x", id2[0], id2[1], id2[2]);
+      if(id2[0] == id[0] && id2[1] == id[1] && id2[2] == id[2]) {
+        printf("  OK (DMA staging)\n");
+      } else {
+        printf("  MISMATCH (RAM buffer gave %02x %02x %02x)\n",
+               id[0], id[1], id[2]);
+        failures++;
+      }
+    } else {
+      failures++;
+    }
+
+    if(read_sfdp_signature(sig)) {
+      printf("  SFDP:     %02x %02x %02x %02x", sig[0], sig[1], sig[2], sig[3]);
+      /* "SFDP" in ASCII. */
+      if(sig[0] == 'S' && sig[1] == 'F' && sig[2] == 'D' && sig[3] == 'P') {
+        printf("  OK\n");
+      } else {
+        printf("  MISMATCH (expected 53 46 44 50)\n");
+        failures++;
+      }
+    } else {
+      failures++;
+    }
+
+    if(!read_sfdp_long()) {
+      failures++;
+    }
+
+    probe_bit_rates();
+
+    printf("%s\n", failures == 0 ? "SPI OK" : "SPI FAILED");
+
+    etimer_set(&periodic, CLOCK_SECOND * 5);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&periodic));
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/os/services/ip64/ip64-conf-example.h
+++ b/os/services/ip64/ip64-conf-example.h
@@ -32,13 +32,28 @@
 #ifndef IP64_CONF_H
 #define IP64_CONF_H
 
-#include "ip64/ip64-tap-driver.h"
 #include "ip64/ip64-eth-interface.h"
+
+/*
+ * The Ethernet driver. Two are available in the tree:
+ *
+ *   enc28j60_ip64_driver  - Microchip ENC28J60 over SPI, from
+ *                           arch/dev/ethernet/enc28j60. Add that directory to
+ *                           MODULES and include enc28j60-ip64-driver.h.
+ *   ip64_null_driver      - discards everything, from ip64-null-driver.h.
+ *                           Useful to get a build going before the hardware
+ *                           driver is ready.
+ *
+ * For a complete, working configuration see
+ * examples/platform-specific/nrf/ip64-router or
+ * arch/platform/zoul/orion/ip64-conf.h.
+ */
+#include "enc28j60-ip64-driver.h"
 
 #define IP64_CONF_UIP_FALLBACK_INTERFACE    ip64_eth_interface
 #define IP64_CONF_INPUT                     ip64_eth_interface_input
 
-#define IP64_CONF_ETH_DRIVER                ip64_tap_driver
+#define IP64_CONF_ETH_DRIVER                enc28j60_ip64_driver
 
 /* 
  * In contrast to the mandatory parameters above, IP64_CONF_DHCP is an 

--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -162,6 +162,14 @@ platform-specific/cc26x0-cc13x0/base-demo/simplelink:BOARD=sensortag/cc1350 \
 platform-specific/cc26x0-cc13x0/base-demo/simplelink:BOARD=sensortag/cc1352r1 \
 platform-specific/nrf/ipc-radio-service/nrf:BOARD=nrf5340/dk/network \
 platform-specific/nrf/ipc-radio-service/nrf:BOARD=nrf5340/dk/network:NRF_802154=1 \
+platform-specific/nrf/spi-flash/nrf:BOARD=nrf54l15/dk \
+platform-specific/nrf/spi-flash/nrf:BOARD=nrf54l15/dk:NRF_SPI_INSTANCES=00,22 \
+platform-specific/nrf/spi-flash/nrf:BOARD=nrf52840/dk:NRF_SPI_INSTANCES=0 \
+platform-specific/nrf/spi-flash/nrf:BOARD=nrf5340/dk/application:NRF_SPI_INSTANCES=1 \
+platform-specific/nrf/enc28j60-test/nrf:BOARD=nrf54l15/dk \
+platform-specific/nrf/ip64-router/nrf:BOARD=nrf54l15/dk \
+platform-specific/nrf/nat64-node/nrf:BOARD=nrf54l15/xiao \
+platform-specific/nrf/lwm2m-nat64/nrf:BOARD=nrf54l15/xiao \
 platform-specific/nrf/start-network-core/nrf:BOARD=nrf5340/dk/application \
 platform-specific/nrf/start-network-core/nrf:BOARD=nrf5340/dk/network \
 platform-specific/nrf/trustzone/nrf:BOARD=nrf5340/dk/application \


### PR DESCRIPTION
The `nrf` CPU had no SPI support at all — no `spi-arch.c` anywhere under
`arch/cpu/nrf`, and `nrfx_spim.c` vendored but never built. This adds that
driver, and then two things it unblocks: a platform-independent ENC28J60 arch
layer, and an IP64 border router that gives an nRF board an IPv4 uplink.

Everything is additive (`+2300/-0` apart from two small hook-ups in
`Makefile.nrf` and `nrf-def.h`, and a fix to a broken IP64 config example).
Existing nRF application-core builds gain the SPI HAL, at 336 bytes of text
when unused; `NRF_WITH_SPI=0` opts out.

### 1. SPI driver

A blocking implementation of `os/dev/spi.h` on top of `nrfx_spim`. Built by
default on the application cores with one SPIM instance (SPIM0 / SPIM1 /
SPIM00), like the other CPU ports build their `spi-arch.c`; `NRF_SPI_INSTANCES`
selects other or additional instances, and `NRF_WITH_SPI=0` compiles the HAL
out along with `nrfx_spim.c`.

Three things worth a reviewer's attention:

**EasyDMA reachability.** Transfers whose write buffer is outside Data RAM, or
which discard bytes, are staged through a static RAM buffer a chunk at a time;
everything else goes straight to EasyDMA. A flash-resident write buffer would
otherwise corrupt silently rather than fail — the test deliberately covers this
with a command buffer in `.rodata`.

**Bit rates are rounded down, and capped per instance.** nrfx rejects a rate its
prescaler cannot produce (`NRFX_ERROR_INVALID_PARAM`), so without this a device
asking for its own rated maximum fails to open rather than running slightly
slower. 20 MHz — the ENC28J60's maximum — is one such rate on the nRF54L15.
Only the high-speed instance of each SoC (SPIM3 on the nRF52840, SPIM4 on the
nRF5340, SPIM00 on the nRF54L15) does 16 and 32 Mbps, and nrfx validates the
frequency against the SoC rather than the instance, so the driver also caps a
request at the instance's `SPIMn_MAX_DATARATE` from the MDK.

**Instance choice is constrained.** On SoCs that group peripherals into SERIAL
slots, SPIMn and UARTEn in the same slot share an interrupt vector, so selecting
the one that collides with the console UART fails at link time with a duplicate
`SERIALn_IRQHandler`. Known-good choices are documented in `spi-arch.h`. When
`NRF_SPI_INSTANCES` is not given the build picks a per-SoC default (SPIM0,
SPIM1, SPIM00), and an id that does not exist on the SoC is rejected with a
message listing the valid ones instead of an nrfx compile error. The nRF5340
network core has no SPI: its only SPIM shares SERIAL0 with the console UARTE
(enabling it gives `multiple definition of SERIAL0_IRQHandler`), and no board
in the tree uses SPI there, so `NRF_WITH_SPI=1` is an explicit error on it.

Chip select is left to `os/dev/spi.c`, which drives it as a GPIO, so `ss_pin` is
not handed to SPIM.

The SPIM stays initialized between acquires. An acquire whose configuration
matches the one already loaded skips `nrfx_spim_init()` and the pin setup;
only the first acquire, or one with a different configuration, pays for
uninit and init. The comparison is by content, since callers may build the
`spi_device_t` on the stack (the flash test's bit-rate probe does), and it
excludes chip select, which is a plain GPIO written on every acquire, so
devices sharing a controller do not thrash the SPIM. Release disables the
SPIM (ENABLE register only) and acquire re-enables it, which is what the
HAL asks of a release without redoing the pin configuration.

### 2. ENC28J60 on the SPI HAL

The two existing ENC28J60 arch layers are per-board copies under
`arch/platform/zoul/orion`, written against cc2538 registers and the legacy
`spix_*` API. That is why the driver has only ever worked on one board: a new
platform had to copy a file rather than supply a configuration.

`enc28j60-arch-spi-hal.c` implements the same five functions on `os/dev/spi.h`
instead, so it works on any CPU implementing the SPI HAL — a board supplies pin
defines and nothing else. Compiled out unless `ENC28J60_CONF_USE_SPI_HAL` is
set, so existing Orion builds are untouched.

### 3. IP64 border router

`os/services/ip64` had no runtime test and no functional commits in years, and
the Zolertia Orion was the only board in the tree that could run it. This adds a
second: an nRF54L15 DK with an ENC28J60 becomes a self-contained border router —
RPL root on the 802.15.4 side, NAT64 and DNS64 on the IPv4 side, no host in the
data path.

`os/services/ip64` itself is unchanged. It turned out to work correctly on first
real use; the only fix here is to `ip64-conf-example.h`, which included
`ip64/ip64-tap-driver.h` and selected `ip64_tap_driver` — neither of which has
ever existed in this repository's history, so a user copying the documented
example got a compile error. It now names a driver that exists.

The router example reports the address DHCP gives it. The stock
`examples/ip64-router` prints nothing at all, which during bring-up is
indistinguishable from a hang.

### Testing

Hardware, an nRF54L15 DK with a HanRun HR911105A module and a Seeed XIAO
nRF54L15 as a mesh node:

| Layer | Result |
|---|---|
| SPI | JEDEC ID `c2 28 17` from the DK's on-board MX25R6435F, both transfer paths (including a `.rodata` write buffer and a 256-byte staged transfer), 1–32 MHz |
| ENC28J60 | silicon rev B7, register and MAC round-trips, Ethernet frames received |
| IPv4 uplink | DHCP lease from a home router, pings answered from the LAN |
| NAT64 | UDP delivered to an IPv4 host from both the router and a mesh node (both probes are opt-in via `NAT64_TEST_ADDR`) — one IPv4 source address, two distinct mapped ports, so the per-source address map allocates correctly |
| DNS64 | `leshan.eclipseprojects.io` → `64:ff9b::23.97.187.154`, matching an independent lookup |
| LwM2M | live registration on the public Eclipse Leshan demo server through the translator, with IPSO temperature notifications flowing back |

Builds for `nrf54l15/dk`, `nrf54l15/xiao`, `nrf52840/dk` and
`nrf5340/dk/application`, and with two SPI controllers enabled. All of it is
added to `tests/02-compile-arm-ports` so it cannot rot the way
`enc28j60-arch-spi.c` did — that file has not been part of any build since it
was added in 2016.

### Changed in response to review

The history is squashed into the nine commits above, so these are folded into
the code they belong to rather than appearing as fixups:

* **SPI is built by default** on the application cores rather than opt-in. The
  opt-in existed only to avoid the SERIAL-slot IRQ collision described above;
  the per-SoC default instances remove that hazard, every other CPU port
  builds its `spi-arch.c` unconditionally, and the cost when unused is 336
  bytes of text. `NRF_WITH_SPI=0` opts out, and the examples no longer set
  anything for SPI. The nRF5340 network core is the exception and errors out.
* **Bit rate capped per instance**, from the MDK's `SPIMn_MAX_DATARATE`: only
  the high-speed instance of each SoC does 16/32 Mbps, and nrfx validates the
  frequency against the SoC rather than the instance.
* **The SPIM is no longer re-initialized on every acquire.** It stays
  configured between acquires and is only disabled/enabled, so a device like
  the ENC28J60 — which acquires once per register access — no longer pays a
  full peripheral setup per transaction. Chip select is excluded from the
  configuration comparison, so two devices on one controller alternate without
  a reinit.
* **Failures are visible.** `spi-arch.c` logs at ERR by default
  (`LOG_CONF_LEVEL_SPI` overrides) so a failed `nrfx_spim_init()` shows its
  error code, and the ENC28J60 glue reports a failed acquire once instead of
  once per byte for the rest of the transaction.
* **No example sends traffic anywhere by default.** The router self-test and
  the mesh node's UDP probe were pointed at a private LAN address every five
  seconds in every build; both now require `NAT64_TEST_ADDR`. The DNS64 lookup
  and the public Leshan default stay, since reaching an external IPv4 service
  is what those examples demonstrate; both are `#ifndef`-overridable.
* **Board scope.** `spi-flash` has per-SoC pin defaults for the on-board flash
  of all three DKs (port 2 does not exist on the nRF52840/nRF5340);
  `enc28j60-test` and `ip64-router` are `BOARDS_ONLY = nrf54l15/dk`, matching
  the P1 header they are wired to.
* Single-DMA length limit from `SPIMn_EASYDMA_MAXCNT_SIZE`; `MAX()` from
  `sys/cc.h`; per-SoC instance validation; corrected `spi-flash` probe comment
  and rate print; redundant `PROJECT_CONF_PATH` dropped.

Agreed as separate work, not done here: a bounded `ESTAT.CLKRDY` wait in
`enc28j60.c`, and a bulk read/write extension to the ENC28J60 arch API.

A later automated-review pass added three more, folded into the same commits:
`NRF_SPI_INSTANCES` now rejects a repeated instance id (two logical
controllers over one peripheral would have separate locks and serialise
nothing); the LwM2M endpoint name is kept inside the RD client's 19-character
limit, which had been silently dropping its `-xiao` suffix; and the platform
doc called SPI on the nRF5340 network core opt-in when the build rejects it
outright.

Re-verified on the nRF54L15 DK after these changes: `spi-flash` passes every
check including the 1–32 MHz bit-rate probe, and `enc28j60-test` on SPIM22
reads ESTAT, EREVID, a register and a written MAC back correctly. Every one of
the nine commits builds on its own.

### Not covered

* Only SPI mode 0 and instances SPIM00/SPIM22 have been exercised on hardware;
  modes 1–3, bus contention, and runtime use on nRF52840/nRF5340 are untested.
* IP64 still has no *runtime* CI coverage — these examples are compile-tested
  only.
* 4 MHz is the practical SPI ceiling on jumper wires. At 8 MHz `ESTAT` reads
  `02` instead of `01`, a one-bit shift from sampling MISO too early; that is
  signal integrity, not the driver. Throughput is bounded by the ENC driver's
  1-tick receive poll anyway.
* `examples/ip64-router` remains Orion-only; the nRF router is a separate
  example because the generic one cannot carry board-specific ENC pins.

### Noticed in passing, not fixed here

* `lwm2m-rd-client.c:118` — `static char default_ep[20]` silently truncates
  every LwM2M endpoint name to 19 characters, with no named constant and no
  warning. On a public server that is a real collision hazard. The example
  here stays within the limit rather than working around it.
* `doc/tutorials/LWM2M-and-IPSO-Objects.md` hardcodes `64:ff9b::527:53ce`
  (`5.39.83.206`) for Leshan, which now answers on `23.97.187.154`. DNS64
  removes the need for such literals entirely.





