### PR TITLE
sixtop: do not read enum members of sixp_pkt_code_t built from a uint8_t

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,6 @@ jobs:
                 test: nat64-standalone
               - os: macos-15-intel
                 test: coap-lwm2m
-              # Failed simulations for no obvious reason, Cooja issue?
-              - os: macos-15-intel
-                test: ieee802154
 
     # Default job name is too long to be visible in the "Checks" tab.
     name: ${{ matrix.test }}/${{ matrix.os == 'macos-15-intel' && 'macos-x64' || matrix.os }}

--- a/os/net/mac/tsch/sixtop/sixp-pkt.c
+++ b/os/net/mac/tsch/sixtop/sixp-pkt.c
@@ -84,11 +84,11 @@ static int32_t
 get_cell_options_offset(sixp_pkt_type_t type, sixp_pkt_code_t code)
 {
   if(type == SIXP_PKT_TYPE_REQUEST &&
-     (code.cmd == SIXP_PKT_CMD_ADD ||
-      code.cmd == SIXP_PKT_CMD_DELETE ||
-      code.cmd == SIXP_PKT_CMD_RELOCATE ||
-      code.cmd == SIXP_PKT_CMD_COUNT ||
-      code.cmd == SIXP_PKT_CMD_LIST)) {
+     (code.value == SIXP_PKT_CMD_ADD ||
+      code.value == SIXP_PKT_CMD_DELETE ||
+      code.value == SIXP_PKT_CMD_RELOCATE ||
+      code.value == SIXP_PKT_CMD_COUNT ||
+      code.value == SIXP_PKT_CMD_LIST)) {
     return sizeof(sixp_pkt_metadata_t);
   }
   return -1;
@@ -1126,7 +1126,14 @@ sixp_pkt_create(sixp_pkt_type_t type, sixp_pkt_code_t code,
   /* copy information of a sending packet into pkt if necessary */
   if(pkt != NULL) {
     pkt->type = type;
-    pkt->code = code;
+    /*
+     * sixp_pkt_code_t is a union of an enum and a uint8_t; callers commonly
+     * build it with (sixp_pkt_code_t)(uint8_t)x, which only defines the
+     * first byte. Copy only the defined byte and zero the rest so that
+     * reading pkt->code.cmd/.rc afterwards is well defined.
+     */
+    memset(&pkt->code, 0, sizeof(pkt->code));
+    pkt->code.value = code.value;
     pkt->sfid = sfid;
     pkt->seqno = seqno;
     pkt->body = body;

--- a/os/net/mac/tsch/sixtop/sixp-trans.c
+++ b/os/net/mac/tsch/sixtop/sixp-trans.c
@@ -208,8 +208,8 @@ determine_trans_mode(const sixp_pkt_t *req)
    * either Add or Delete AND its cell_list is empty. Otherwise, 2-step.
    */
   if(req->type == SIXP_PKT_TYPE_REQUEST &&
-     (req->code.cmd == SIXP_PKT_CMD_ADD ||
-      req->code.cmd == SIXP_PKT_CMD_DELETE) &&
+     (req->code.value == SIXP_PKT_CMD_ADD ||
+      req->code.value == SIXP_PKT_CMD_DELETE) &&
      sixp_pkt_get_cell_list(req->type, (sixp_pkt_code_t)req->code.value,
                             NULL, &cell_list_len,
                             req->body, req->body_len) == 0 &&

--- a/os/net/mac/tsch/sixtop/sixp.c
+++ b/os/net/mac/tsch/sixtop/sixp.c
@@ -502,7 +502,7 @@ sixp_output(sixp_pkt_type_t type, sixp_pkt_code_t code, uint8_t sfid,
        * handled mistakenly for the next request when the previous
        * transaction is expired.
        */
-      if(code.cmd == SIXP_PKT_CMD_CLEAR) {
+      if(code.value == SIXP_PKT_CMD_CLEAR) {
         LOG_INFO("6P: sixp_output() reset nbr's next_seqno by CLEAR Request\n");
         sixp_nbr_reset_next_seqno(nbr);
       } else {


### PR DESCRIPTION
`sixp_pkt_code_t` is a union of two int-sized enums and a `uint8_t`. Codes are routinely built as `(sixp_pkt_code_t)(uint8_t)x` (253 times in `test-sixp-pkt.c` alone, and in `sixp.c`), which only defines the first byte. Comparing such a value via `.cmd`/`.rc` reads all four bytes, so the result depends on whatever the compiler left on the stack: gcc happens to zero it, clang does not.

Effect: with firmware built by clang (macOS), `13-ieee802154/04-cooja-test-sixp-pkt` fails all five `sixp_pkt_{set,get}_cell_options(*)` checks plus `sixp_pkt_create(valid_packet)`, and `07-cooja-test-sixp` fails "next_seqno is reset by sending CLEAR". The 6P log shows it directly: `cannot set cell_options [type=0, code=1], invalid type` — a REQUEST/ADD rejected. This is the "Failed simulations for no obvious reason, Cooja issue?" behind the `ieee802154` macOS exclusion in `build.yml`.

Fix: compare `.value` where the code was passed by value (`get_cell_options_offset`, `sixp_output`, `sixp_trans_alloc`), and have `sixp_pkt_create()` copy only the defined byte into `pkt->code`. `sixp_pkt_parse()` was already fine (it memsets `pkt` first). Most of `sixp-pkt.c` had been converted to `.value` earlier; these were the remaining spots.

With this, `13-ieee802154` passes 10/10 on macOS x64 and arm64, so the macOS exclusion of that directory in the CI workflow is removed here as well.
