### PR TITLE
tests/17-tun-rpl-br: do not require an ARM cross toolchain for tunslip6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
               # No arm-none-eabi-gcc installed.
               - os: macos-15-intel
                 test: compile-arm-ports
-              # Uses zoul as dummy target, fails on missing arm-none-eabi-gcc.
-              # Tests/build system should be fixed.
+              # The two native-border-router tests (07, 09) get 100% ping
+              # loss on macOS; the other six pass.
               - os: macos-15-intel
                 test: tun-rpl-br
               # tests/utils.sh: kill_bg contains ps --ppid (not portable).

--- a/tests/17-tun-rpl-br/04-border-router-traceroute.sh
+++ b/tests/17-tun-rpl-br/04-border-router-traceroute.sh
@@ -15,16 +15,20 @@ WAIT_TIME=60
 # The expected hop count
 TARGETHOPS=4
 
+# mtr needs raw sockets; CI on Linux runs as root, macOS runners have sudo.
+SUDO=""
+[ "$(id -u)" -eq 0 ] || SUDO=sudo
+
 # Connect to the simulation
 echo "Starting tunslip6"
-make -C $CONTIKI/examples/rpl-border-router connect-router-cooja TARGET=zoul &
+make -C $CONTIKI/examples/rpl-border-router connect-router-cooja TARGET=cooja &
 MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME
 
 echo "Running mtr (traceroute)"
 # IPv6, 5 hops max, no DNS lookups, 3 pings each, output with report mode.
-mtr -6 -m 5 -n -c 3 -r $IPADDR | tee $BASENAME.scriptlog
+$SUDO mtr -6 -m 5 -n -c 3 -r $IPADDR | tee $BASENAME.scriptlog
 # Fetch mtr status code (not $? because this is piped)
 STATUS=${PIPESTATUS[0]}
 HOPS=`grep -e "^ " $BASENAME.scriptlog | wc -l`
@@ -32,6 +36,7 @@ rm -f $BASENAME.scriptlog
 
 echo "Closing tunslip6"
 kill $MPID
+$SUDO pkill -f "tunslip6 -a 127.0.0.1" 2>/dev/null
 
 if [ $STATUS -eq 0 ] && [ $HOPS -eq $TARGETHOPS ] ; then
   printf "%-32s TEST OK\n" "$BASENAME" > $BASENAME.testlog

--- a/tests/17-tun-rpl-br/test-border-router.sh
+++ b/tests/17-tun-rpl-br/test-border-router.sh
@@ -23,7 +23,7 @@ COUNT=5
 
 # Connect to the simulation
 echo "Starting tunslip6"
-make -C $CONTIKI/examples/rpl-border-router connect-router-cooja TARGET=zoul &
+make -C $CONTIKI/examples/rpl-border-router connect-router-cooja TARGET=cooja &
 MPID=$!
 printf "Waiting for network formation (%d seconds)\n" "$WAIT_TIME"
 sleep $WAIT_TIME


### PR DESCRIPTION
The embedded border-router host scripts (`test-border-router.sh`, `04-border-router-traceroute.sh`) run `make connect-router-cooja TARGET=zoul` only to build and start **tunslip6** — a host tool. `Makefile.include` refuses any `TARGET` whose compiler is missing, so on a host without `arm-none-eabi-gcc` the scripts die before tunslip6 starts. This is the "Uses zoul as dummy target, fails on missing arm-none-eabi-gcc. Tests/build system should be fixed." exclusion of `tun-rpl-br` on macOS in `build.yml`.

`TARGET=cooja` needs only the host gcc and selects the same `Makefile.embedded`, so use that instead.

`04-border-router-traceroute` also runs `mtr`, which needs raw sockets: CI on Linux runs as root, the macOS runners have passwordless sudo — use `sudo` when not root, and `pkill` the root-owned tunslip6 at the end so it cannot hold the TUN device for the next test.

Result on macOS (first revision of this PR ran the directory there): 6 of 8 tests pass — all tunslip6-based ones, traceroute included. The two `native-border-router` tests (07, 09) still fail with 100 % ping loss, so the macOS exclusion is kept with an updated reason; that is a separate `border-router.native`/Cooja issue on macOS (the same tests pass on the same runner with a different simulator).
