### PR TITLE
z1: only use a numeric motelist serial number for SERIALNUM

### DIFF
--- a/arch/platform/z1/Makefile.common
+++ b/arch/platform/z1/Makefile.common
@@ -43,13 +43,13 @@ ifeq ($(HOST_OS),Darwin)
       BSL_FILETYPE = -I
       MOTES = $(shell $(MOTELIST) -b z1 -c 2>&- | \
               cut -f 2 -d ,)
+      # Only accept a purely numeric serial number: with no mote attached
+      # the motelist output can be a message whose last characters are not
+      # a number, and they would end up in CFLAGS and break the build.
       REFNUM = $(shell $(MOTELIST) -c 2>&- | \
-               cut -f 1 -d , | tail -c5 | sed 's/^0*//')
+               cut -f 1 -d , | tail -c5 | sed 's/^0*//' | grep -E '^[0-9]+$$')
       ifneq (,$(REFNUM))
-        # No device fo-und
-        ifeq (,$(findstring und, $(REFNUM)))
-          CFLAGS += -DSERIALNUM=$(REFNUM:0%=%)
-        endif
+        CFLAGS += -DSERIALNUM=$(REFNUM)
       endif
   endif
 else
@@ -65,12 +65,9 @@ else
               perl -ne 'print $$1 . " " if(m-(/dev/\w+)-);')
       CMOTES=$(MOTES)
       REFNUM = $(shell $(MOTELIST) -c 2>&- | \
-               cut -f 1 -d , | tail -c5 | sed 's/^0*//')
+               cut -f 1 -d , | tail -c5 | sed 's/^0*//' | grep -E '^[0-9]+$$')
       ifneq (,$(REFNUM))
-        # No device fo-und
-        ifeq (,$(findstring und, $(REFNUM)))
-          CFLAGS += -DSERIALNUM=$(REFNUM)
-        endif
+        CFLAGS += -DSERIALNUM=$(REFNUM)
       endif
     endif
 endif


### PR DESCRIPTION
`arch/platform/z1/Makefile.common` takes the last five characters of the `motelist` output as the Z1 product ID and puts them into `CFLAGS` as `-DSERIALNUM=…`. The only guard is a check for the substring `und` ("No devices found").

On the GitHub `macos-15-intel` runners, which have a Silicon Labs USB-serial port, `motelist-zolertia-macos -c` prints a mangled serial column:

```
*':,/dev/tty.SLAB*':,(none)
```

and every z1 build dies in the shell:

```
ccache msp430-gcc ... -mmcu=msp430f2617  -DSERIALNUM=*': -DMAC_CONF_WITH_CSMA=1 ...
/bin/sh: -c: line 0: unexpected EOF while looking for matching `''
make: *** [../../Makefile.include:565: build/z1/obj/leds.o] Error 2
```

Accept only a purely numeric `REFNUM`, on both macOS and Linux. (Found because the three z1 simulations in `07-simulation-base` were being skipped for missing firmware when the suite was run on macOS.)
