### PR TITLE
ip64: add end-to-end tests, and fix the native build

### DIFF
--- a/doc/platforms/zolertia/Zolertia-Orion-Ethernet-Router.md
+++ b/doc/platforms/zolertia/Zolertia-Orion-Ethernet-Router.md
@@ -26,7 +26,7 @@ In a nutshell the Orion Router packs the following features:
 * Indoor enclosure
 * Layout 40.29 x 73.75 mm
 
-There are ready-to-use examples at `examples/zolertia/zoul/orion`, showing how to deploy an IP64 border router, and connect to services such as [IFTTT (If This Then That)](https://ifttt.com).
+There are ready-to-use examples at `examples/platform-specific/zoul/orion`, showing how to deploy an IP64 border router, and connect to services such as [IFTTT (If This Then That)](https://ifttt.com).
 
 ## Orion Technical documentation
 

--- a/os/services/ip64/Makefile.ip64
+++ b/os/services/ip64/Makefile.ip64
@@ -1,0 +1,5 @@
+# ip64-slip-interface.c calls into a platform SLIP driver that not every
+# platform has. The native platform is one: Makefile.native excludes slip.c,
+# so an ip64 build for native fails to link on slip_write() and friends even
+# when it uses the Ethernet interface and never reaches the SLIP code.
+MODULES_SOURCES_EXCLUDES_NATIVE += ip64-slip-interface.c

--- a/os/services/ip64/ip64-dhcpc.c
+++ b/os/services/ip64/ip64-dhcpc.c
@@ -352,6 +352,9 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
 #define MAX_TICKS (~((clock_time_t)0) / 2)
 #define MAX_TICKS32 (~((uint32_t)0))
 #define IMIN(a, b) ((a) < (b) ? (a) : (b))
+/* Longest interval accepted by a single etimer_set() call: at most half the
+   clock_time_t range, but never more than the remaining time can hold. */
+#define MAX_INTERVAL ((uint32_t)IMIN(MAX_TICKS, (clock_time_t)MAX_TICKS32))
 
   if((uip_ntohs(s.lease_time[0])*65536ul + uip_ntohs(s.lease_time[1]))*CLOCK_SECOND/2
      <= MAX_TICKS32) {
@@ -362,7 +365,7 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
   }
 
   while(s.ticks > 0) {
-    ticks = IMIN(s.ticks, MAX_TICKS);
+    ticks = IMIN(s.ticks, MAX_INTERVAL);
     s.ticks -= ticks;
     etimer_set(&s.etimer, ticks);
     PT_YIELD_UNTIL(&s.pt, etimer_expired(&s.etimer));
@@ -383,7 +386,7 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
       PT_YIELD(&s.pt);
     }
     send_request();
-    ticks = IMIN(s.ticks / 2, MAX_TICKS);
+    ticks = IMIN(s.ticks / 2, MAX_INTERVAL);
     s.ticks -= ticks;
     etimer_set(&s.etimer, ticks);
     do {

--- a/tests/08-native-runs/26-ip64.sh
+++ b/tests/08-native-runs/26-ip64.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+./run-one.sh 26-ip64

--- a/tests/08-native-runs/26-ip64/Makefile
+++ b/tests/08-native-runs/26-ip64/Makefile
@@ -1,0 +1,19 @@
+CONTIKI_PROJECT = test-ip64
+all: $(CONTIKI_PROJECT)
+
+TARGET ?= native
+
+CONTIKI = ../../..
+
+WITH_IP64 = 1
+MODULES += os/services/unit-test
+
+PROJECT_SOURCEFILES += ip64-test-driver.c
+
+# Same wiring as arch/platform/zoul/orion/Makefile.orion.
+CFLAGS += -DUIP_FALLBACK_INTERFACE=ip64_uip_fallback_interface
+# Make ip64 the only off-link path, as on a border router.
+CFLAGS += -DNATIVE_WITH_IPV6_DEFAULT_ROUTE=0
+CFLAGS += -I$(CURDIR)
+
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/26-ip64/README.md
+++ b/tests/08-native-runs/26-ip64/README.md
@@ -1,0 +1,38 @@
+# ip64 end-to-end test
+
+Exercises the `os/services/ip64` NAT64 service on the native target, with the
+ENC28J60 driver replaced by a capture driver (`ip64-test-driver.c`). No
+hardware, tun device, Cooja instance, or superuser privileges are needed.
+
+The build mirrors the module's only supported hardware deployment,
+`arch/platform/zoul/orion`: the same `ip64-conf.h` shape and the same
+`-DUIP_FALLBACK_INTERFACE=ip64_uip_fallback_interface` that
+`Makefile.orion` sets.
+
+## What the test covers
+
+| Test | Path exercised |
+|------|----------------|
+| `arp_resolution` | uIP fallback dispatch, `ip64-arp` request generation |
+| `udp_round_trip` | `ip64_6to4`, address-mapping allocation and reverse lookup, `ip64_4to6`, delivery to a UDP socket |
+| `forwarded_flow` | Forwarding from the IPv6 network: a packet injected as a mote's is translated out under a mapping of its own, distinct from the router's |
+| `dns64_rewrite` | `ip64_dns64_6to4` (AAAA to A) and `ip64_dns64_4to6` (A to AAAA) |
+| `icmp_echo` | ICMP translation in both directions: an IPv4 ping reaches the local IPv6 host and its reply is translated back |
+| `inbound_ports` | Inbound port handling: delivery to the local host below `EPHEMERAL_PORTRANGE`, and the drop of ephemeral-port traffic that matches no mapping |
+
+Outbound packets come from ordinary `simple_udp` sockets and are collected
+through the fallback interface. Inbound packets are handed to
+`ip64_eth_interface_input()` as Ethernet frames, exactly as a driver would
+deliver them.
+
+## What it does not cover
+
+- The ENC28J60 driver and its SPI glue, which have no native equivalent.
+- The DHCPv4 client: the test configures the IPv4 address statically
+  (`IP64_CONF_DHCP 0`).
+- TCP, and the ip64 special-ports translation of inbound traffic.
+- The return leg to a mote: a translated reply leaves over the radio, where
+  the test cannot observe it, so `forwarded_flow` checks the mapping entry
+  that `ip64_4to6()` resolves a reply against instead of the packet itself.
+- The CC2538-based Orion target. Cooja cannot emulate CC2538, so no
+  simulator-based test can cover the deployed binary either.

--- a/tests/08-native-runs/26-ip64/README.md
+++ b/tests/08-native-runs/26-ip64/README.md
@@ -9,6 +9,10 @@ The build mirrors the module's only supported hardware deployment,
 `-DUIP_FALLBACK_INTERFACE=ip64_uip_fallback_interface` that
 `Makefile.orion` sets.
 
+For a test that puts ip64 on a real IPv4 network instead, and drives it from
+software on the host that knows nothing about NAT64, see
+`tests/08-native-runs/27-ip64-tap`.
+
 ## What the test covers
 
 | Test | Path exercised |

--- a/tests/08-native-runs/26-ip64/ip64-conf.h
+++ b/tests/08-native-runs/26-ip64/ip64-conf.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * ip64 configuration for the native test. Mirrors
+ * arch/platform/zoul/orion/ip64-conf.h, with the ENC28J60 driver replaced by
+ * a capture driver so the test can run without hardware.
+ */
+
+#ifndef IP64_CONF_H
+#define IP64_CONF_H
+
+#include "ip64/ip64-eth-interface.h"
+#define IP64_CONF_UIP_FALLBACK_INTERFACE ip64_eth_interface
+#define IP64_CONF_INPUT                  ip64_eth_interface_input
+
+#include "ip64-test-driver.h"
+#define IP64_CONF_ETH_DRIVER             ip64_test_driver
+
+/* The test configures the IPv4 address statically instead of over DHCP. */
+#define IP64_CONF_DHCP 0
+
+#endif /* IP64_CONF_H */

--- a/tests/08-native-runs/26-ip64/ip64-test-driver.c
+++ b/tests/08-native-runs/26-ip64/ip64-test-driver.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *   Capture driver for the ip64 test.
+ */
+
+#include "ip64-test-driver.h"
+
+#include <string.h>
+
+uint8_t ip64_test_driver_buf[IP64_TEST_DRIVER_BUFSIZE];
+uint16_t ip64_test_driver_len;
+unsigned ip64_test_driver_count;
+
+/*---------------------------------------------------------------------------*/
+void
+ip64_test_driver_reset(void)
+{
+  ip64_test_driver_len = 0;
+  ip64_test_driver_count = 0;
+}
+/*---------------------------------------------------------------------------*/
+static void
+init(void)
+{
+  ip64_test_driver_reset();
+}
+/*---------------------------------------------------------------------------*/
+static int
+output(uint8_t *packet, uint16_t packet_len)
+{
+  ip64_test_driver_count++;
+  ip64_test_driver_len = packet_len > IP64_TEST_DRIVER_BUFSIZE ?
+    IP64_TEST_DRIVER_BUFSIZE : packet_len;
+  memcpy(ip64_test_driver_buf, packet, ip64_test_driver_len);
+  return packet_len;
+}
+/*---------------------------------------------------------------------------*/
+const struct ip64_driver ip64_test_driver = { init, output };
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/26-ip64/ip64-test-driver.h
+++ b/tests/08-native-runs/26-ip64/ip64-test-driver.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *   Capture driver for the ip64 test: stands in for an Ethernet chip by
+ *   recording the frames that ip64 transmits, so the test can inspect them.
+ */
+
+#ifndef IP64_TEST_DRIVER_H
+#define IP64_TEST_DRIVER_H
+
+#include <stdint.h>
+
+/*
+ * Note: ip64-driver.h is not self-contained; it uses uint8_t and uint16_t
+ * without including <stdint.h>, so that header must come first.
+ */
+#include "ip64/ip64-driver.h"
+
+#define IP64_TEST_DRIVER_BUFSIZE 1600
+
+/* The most recently transmitted frame, and how many have been sent. */
+extern uint8_t ip64_test_driver_buf[IP64_TEST_DRIVER_BUFSIZE];
+extern uint16_t ip64_test_driver_len;
+extern unsigned ip64_test_driver_count;
+
+extern const struct ip64_driver ip64_test_driver;
+
+void ip64_test_driver_reset(void);
+
+#endif /* IP64_TEST_DRIVER_H */

--- a/tests/08-native-runs/26-ip64/test-ip64.c
+++ b/tests/08-native-runs/26-ip64/test-ip64.c
@@ -1,0 +1,847 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *   End-to-end test of the ip64 NAT64 translation service.
+ *
+ *   The module is exercised through its real entry points, with the ENC28J60
+ *   driver replaced by a capture driver, so no hardware, tun device, or
+ *   superuser privileges are needed. Outbound packets are produced by a
+ *   regular UDP socket and picked up through the uIP fallback interface;
+ *   inbound packets are handed to ip64_eth_interface_input() as Ethernet
+ *   frames, exactly as an Ethernet driver would deliver them.
+ *
+ *   Covered: uIP fallback dispatch, ARP resolution, IPv6-to-IPv4 and
+ *   IPv4-to-IPv6 header translation, forwarding of a flow from a node behind
+ *   the router, address-mapping allocation and reverse lookup, DNS64
+ *   rewriting in both directions, ICMP echo translation, and the inbound
+ *   port handling. Not covered: the ENC28J60 driver itself, the
+ *   DHCPv4 client, and TCP.
+ *
+ */
+
+#include "contiki.h"
+#include "contiki-net.h"
+#include "net/ipv6/simple-udp.h"
+#include "net/ipv6/uip.h"
+#include "net/ipv6/uiplib.h"
+#include "net/ipv6/ip64-addr.h"
+
+#include "ip64/ip64.h"
+#include "ip64/ip64-addrmap.h"
+#include "ip64/ip64-eth.h"
+#include "ip64/ip64-eth-interface.h"
+
+#include "ip64-test-driver.h"
+#include "unit-test.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LOCAL_PORT      3000
+#define SERVER_PORT     5000
+#define DNS_LOCAL_PORT  3053
+#define DNS_PORT        53
+/* Below EPHEMERAL_PORTRANGE in ip64.c: reachable without a mapping. */
+#define SERVICE_PORT    780
+/* Source port of the flow that arrives from the simulated mote. */
+#define MOTE_PORT       4711
+
+#define REQUEST         "PING-IP64"
+#define REPLY           "PONG-IP64"
+
+#define IPV6_HDRLEN     40
+#define IPV4_HDRLEN     20
+#define UDP_HDRLEN      8
+#define ICMP_ECHO_HDRLEN 8
+
+/* uIP has no IPv4 protocol numbers, so the ICMPv4 ones are defined here. */
+#define IP_PROTO_ICMPV4 1
+#define ICMP_ECHO_REPLY 0
+#define ICMP_ECHO       8
+
+#define ECHO_ID         0xbeef
+#define ECHO_SEQNO      7
+
+#define ARP_REQUEST     1
+#define ARP_REPLY       2
+
+#define DNS_TYPE_A      1
+#define DNS_TYPE_AAAA  28
+
+/* Offsets into the DNS test messages below: a 12-byte header, a 13-byte
+   name ("example.com"), then the 4-byte type and class fields. */
+#define DNS_QUESTION_TYPE_OFFSET (12 + 13)
+#define DNS_ANSWER_OFFSET        (12 + 13 + 4 + 2)
+
+/* Upper bound on the time the stack may take to produce a result. Every path
+   the test drives is synchronous, so the waits below normally return without
+   sleeping; the timer only keeps a packet that never arrives from hanging the
+   test, leaving the assertion that follows to report the failure. */
+#define SETTLE_TIME (CLOCK_SECOND / 4)
+
+/* IPv4 configuration, standing in for a DHCP lease. */
+static uip_ip4addr_t hostaddr;
+static uip_ip4addr_t netmask;
+static uip_ip4addr_t draddr;
+/* The IPv4 server, reached over IPv6 as 64:ff9b::c000:20a. */
+static uip_ip4addr_t serveraddr;
+/* A node in the IPv6 network behind the router, standing in for a mote. */
+static uip_ip6addr_t moteaddr;
+
+static struct simple_udp_connection conn;
+static struct simple_udp_connection dnsconn;
+static struct simple_udp_connection serviceconn;
+
+static bool reply_received;
+static bool dns_rewritten;
+static bool service_delivered;
+
+/* MAC address the test answers ARP requests with. */
+static const uint8_t router_mac[6] = { 0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01 };
+
+/* A query for "example.com" of type AAAA. */
+static const uint8_t dns_query[] = {
+  0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+  0x00, 0x1c, 0x00, 0x01
+};
+
+/* The matching response, carrying one A record for 93.184.216.34. The
+   answer names the question through a compression pointer. */
+static const uint8_t dns_response[] = {
+  0x12, 0x34, 0x81, 0x80, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+  7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+  0x00, 0x01, 0x00, 0x01,
+  0xc0, 0x0c,
+  0x00, 0x01, 0x00, 0x01,
+  0x00, 0x00, 0x0e, 0x10,
+  0x00, 0x04,
+  93, 184, 216, 34
+};
+
+struct eth_hdr {
+  uint8_t dest[6];
+  uint8_t src[6];
+  uint16_t type;
+};
+
+struct arp_hdr {
+  struct eth_hdr ethhdr;
+  uint16_t hwtype;
+  uint16_t protocol;
+  uint8_t hwlen;
+  uint8_t protolen;
+  uint16_t opcode;
+  uint8_t shwaddr[6];
+  uip_ip4addr_t sipaddr;
+  uint8_t dhwaddr[6];
+  uip_ip4addr_t dipaddr;
+};
+
+struct ipv6_hdr {
+  uint8_t vtc;
+  uint8_t tcflow;
+  uint16_t flow;
+  uint8_t len[2];
+  uint8_t nxthdr;
+  uint8_t hoplim;
+  uip_ip6addr_t srcipaddr;
+  uip_ip6addr_t destipaddr;
+};
+
+struct ipv4_hdr {
+  uint8_t vhl;
+  uint8_t tos;
+  uint8_t len[2];
+  uint8_t ipid[2];
+  uint8_t ipoffset[2];
+  uint8_t ttl;
+  uint8_t proto;
+  uint16_t ipchksum;
+  uip_ip4addr_t srcipaddr;
+  uip_ip4addr_t destipaddr;
+};
+
+struct udp_hdr {
+  uint16_t srcport;
+  uint16_t destport;
+  uint16_t udplen;
+  uint16_t udpchksum;
+};
+
+struct icmp_echo_hdr {
+  uint8_t type;
+  uint8_t icode;
+  uint16_t icmpchksum;
+  uint16_t id;
+  uint16_t seqno;
+};
+
+static uint8_t frame[512];
+static struct etimer settle_timer;
+
+PROCESS(test_ip64_process, "ip64 end-to-end test");
+AUTOSTART_PROCESSES(&test_ip64_process);
+
+UNIT_TEST_REGISTER(arp_resolution,
+                   "ARP resolution precedes the first translated packet");
+UNIT_TEST_REGISTER(udp_round_trip,
+                   "UDP is translated out to IPv4 and back to the socket");
+UNIT_TEST_REGISTER(forwarded_flow,
+                   "A flow forwarded from a mote is mapped to the mote");
+UNIT_TEST_REGISTER(dns64_rewrite,
+                   "DNS64 rewrites AAAA to A and the A answer back to AAAA");
+UNIT_TEST_REGISTER(icmp_echo,
+                   "An IPv4 ping is answered by the local IPv6 host");
+UNIT_TEST_REGISTER(inbound_ports,
+                   "Inbound packets reach the local host only below the "
+                   "ephemeral port range");
+
+/*---------------------------------------------------------------------------*/
+/* One's complement sum, as used for IPv4 and UDP checksums. */
+static uint16_t
+chksum(uint16_t sum, const uint8_t *data, uint16_t len)
+{
+  const uint8_t *last_byte = data + len - 1;
+  uint16_t t;
+
+  while(data < last_byte) {
+    t = (data[0] << 8) + data[1];
+    sum += t;
+    if(sum < t) {
+      sum++;
+    }
+    data += 2;
+  }
+
+  if(data == last_byte) {
+    t = data[0] << 8;
+    sum += t;
+    if(sum < t) {
+      sum++;
+    }
+  }
+
+  return sum;
+}
+/*---------------------------------------------------------------------------*/
+static void
+udp_received(struct simple_udp_connection *c, const uip_ipaddr_t *sender_addr,
+             uint16_t sender_port, const uip_ipaddr_t *receiver_addr,
+             uint16_t receiver_port, const uint8_t *data, uint16_t datalen)
+{
+  if(datalen == strlen(REPLY) && memcmp(data, REPLY, datalen) == 0) {
+    reply_received = true;
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* Records the packets that ip64 sent to the local host without a mapping. */
+static void
+service_received(struct simple_udp_connection *c,
+                 const uip_ipaddr_t *sender_addr, uint16_t sender_port,
+                 const uip_ipaddr_t *receiver_addr, uint16_t receiver_port,
+                 const uint8_t *data, uint16_t datalen)
+{
+  uip_ip6addr_t expected_sender;
+
+  ip64_addr_4to6(&serveraddr, &expected_sender);
+
+  if(datalen == strlen(REQUEST) && memcmp(data, REQUEST, datalen) == 0 &&
+     uip_ipaddr_cmp(sender_addr, &expected_sender)) {
+    service_delivered = true;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+dns_received(struct simple_udp_connection *c, const uip_ipaddr_t *sender_addr,
+             uint16_t sender_port, const uip_ipaddr_t *receiver_addr,
+             uint16_t receiver_port, const uint8_t *data, uint16_t datalen)
+{
+  const uint8_t *answer;
+  uip_ip4addr_t recorded_addr;
+  uip_ip6addr_t expected_addr;
+
+  /* The A record must have become an AAAA record, which is 12 bytes
+     longer because the address grows from 4 to 16 bytes. */
+  if(datalen != sizeof(dns_response) + 12) {
+    printf("DNS response has length %u, expected %u\n",
+           datalen, (unsigned)sizeof(dns_response) + 12);
+    return;
+  }
+
+  answer = &data[DNS_ANSWER_OFFSET];
+  uip_ipaddr(&recorded_addr, 93, 184, 216, 34);
+  ip64_addr_4to6(&recorded_addr, &expected_addr);
+
+  if((answer[0] << 8) + answer[1] == DNS_TYPE_AAAA &&
+     (answer[8] << 8) + answer[9] == sizeof(uip_ip6addr_t) &&
+     memcmp(&answer[10], &expected_addr, sizeof(uip_ip6addr_t)) == 0) {
+    dns_rewritten = true;
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* Fill in the Ethernet header of a frame sent by the IPv4 router. */
+static void
+fill_eth_hdr(struct eth_hdr *eth, uint16_t type)
+{
+  memcpy(eth->dest, ip64_eth_addr.addr, sizeof(eth->dest));
+  memcpy(eth->src, router_mac, sizeof(eth->src));
+  eth->type = uip_htons(type);
+}
+/*---------------------------------------------------------------------------*/
+/* Fill in an IPv4 header, including its checksum. */
+static void
+fill_ipv4_hdr(struct ipv4_hdr *ip, const uip_ip4addr_t *src,
+              const uip_ip4addr_t *dst, uint8_t proto, uint16_t ip_len)
+{
+  memset(ip, 0, IPV4_HDRLEN);
+  ip->vhl = 0x45;
+  ip->len[0] = ip_len >> 8;
+  ip->len[1] = ip_len & 0xff;
+  ip->ttl = 64;
+  ip->proto = proto;
+  uip_ip4addr_copy(&ip->srcipaddr, src);
+  uip_ip4addr_copy(&ip->destipaddr, dst);
+  ip->ipchksum = ~uip_htons(chksum(0, (uint8_t *)ip, IPV4_HDRLEN));
+}
+/*---------------------------------------------------------------------------*/
+/* Build an Ethernet-framed IPv4 UDP packet. Returns the frame length. */
+static uint16_t
+build_ipv4_udp(uint8_t *buf, const uip_ip4addr_t *src,
+               const uip_ip4addr_t *dst, uint16_t srcport, uint16_t destport,
+               const uint8_t *payload, uint16_t payload_len)
+{
+  struct ipv4_hdr *ip = (struct ipv4_hdr *)&buf[sizeof(struct eth_hdr)];
+  struct udp_hdr *udp = (struct udp_hdr *)((uint8_t *)ip + IPV4_HDRLEN);
+  uint16_t ip_len = IPV4_HDRLEN + UDP_HDRLEN + payload_len;
+  uint16_t sum;
+
+  fill_eth_hdr((struct eth_hdr *)buf, IP64_ETH_TYPE_IP);
+  fill_ipv4_hdr(ip, src, dst, UIP_PROTO_UDP, ip_len);
+
+  udp->srcport = uip_htons(srcport);
+  udp->destport = uip_htons(destport);
+  udp->udplen = uip_htons(UDP_HDRLEN + payload_len);
+  udp->udpchksum = 0;
+  memcpy((uint8_t *)udp + UDP_HDRLEN, payload, payload_len);
+
+  /* The UDP checksum covers the IPv4 pseudo header. */
+  sum = UDP_HDRLEN + payload_len + UIP_PROTO_UDP;
+  sum = chksum(sum, (uint8_t *)&ip->srcipaddr, 2 * sizeof(uip_ip4addr_t));
+  sum = chksum(sum, (uint8_t *)udp, UDP_HDRLEN + payload_len);
+  udp->udpchksum = ~uip_htons(sum);
+  if(udp->udpchksum == 0) {
+    udp->udpchksum = 0xffff;
+  }
+
+  return sizeof(struct eth_hdr) + ip_len;
+}
+/*---------------------------------------------------------------------------*/
+/* Build an Ethernet-framed IPv4 ICMP echo request. Returns the frame
+   length. */
+static uint16_t
+build_ipv4_icmp_echo(uint8_t *buf, const uip_ip4addr_t *src,
+                     const uip_ip4addr_t *dst, uint16_t id, uint16_t seqno,
+                     const uint8_t *payload, uint16_t payload_len)
+{
+  struct ipv4_hdr *ip = (struct ipv4_hdr *)&buf[sizeof(struct eth_hdr)];
+  struct icmp_echo_hdr *icmp =
+    (struct icmp_echo_hdr *)((uint8_t *)ip + IPV4_HDRLEN);
+  uint16_t ip_len = IPV4_HDRLEN + ICMP_ECHO_HDRLEN + payload_len;
+
+  fill_eth_hdr((struct eth_hdr *)buf, IP64_ETH_TYPE_IP);
+  fill_ipv4_hdr(ip, src, dst, IP_PROTO_ICMPV4, ip_len);
+
+  icmp->type = ICMP_ECHO;
+  icmp->icode = 0;
+  icmp->icmpchksum = 0;
+  icmp->id = uip_htons(id);
+  icmp->seqno = uip_htons(seqno);
+  memcpy((uint8_t *)icmp + ICMP_ECHO_HDRLEN, payload, payload_len);
+
+  /* Unlike UDP, the ICMPv4 checksum covers no pseudo header. */
+  icmp->icmpchksum = ~uip_htons(chksum(0, (uint8_t *)icmp,
+                                       ICMP_ECHO_HDRLEN + payload_len));
+
+  return sizeof(struct eth_hdr) + ip_len;
+}
+/*---------------------------------------------------------------------------*/
+/* Check a captured IPv4 UDP frame the way the receiving IPv4 host would: the
+   lengths have to agree with one another and with the frame, and the UDP
+   checksum, which covers the pseudo header, has to verify. Without this the
+   tests would accept a packet no real host would. */
+static bool
+ipv4_udp_is_valid(const uint8_t *buf, uint16_t len)
+{
+  const struct ipv4_hdr *ip =
+    (const struct ipv4_hdr *)&buf[sizeof(struct eth_hdr)];
+  const struct udp_hdr *udp =
+    (const struct udp_hdr *)((const uint8_t *)ip + IPV4_HDRLEN);
+  uint16_t ip_len = (ip->len[0] << 8) + ip->len[1];
+  uint16_t udp_len = uip_ntohs(udp->udplen);
+  uint16_t sum;
+
+  if(len != sizeof(struct eth_hdr) + ip_len ||
+     ip_len != IPV4_HDRLEN + udp_len ||
+     udp_len < UDP_HDRLEN) {
+    return false;
+  }
+
+  sum = udp_len + UIP_PROTO_UDP;
+  sum = chksum(sum, (const uint8_t *)&ip->srcipaddr,
+               2 * sizeof(uip_ip4addr_t));
+  sum = chksum(sum, (const uint8_t *)udp, udp_len);
+
+  return sum == 0xffff;
+}
+/*---------------------------------------------------------------------------*/
+/* Hand uIP an IPv6 UDP packet as if it had arrived over the radio from a
+   node behind the router, so that the router forwards it towards the IPv4
+   network. This is what a mote's traffic looks like to ip64, and it is the
+   only way to produce a flow whose IPv6 address is not the router's own. */
+static void
+inject_from_mote(const uip_ip6addr_t *src, const uip_ip6addr_t *dst,
+                 uint16_t srcport, uint16_t destport,
+                 const uint8_t *payload, uint16_t payload_len)
+{
+  struct ipv6_hdr *ip = (struct ipv6_hdr *)uip_buf;
+  struct udp_hdr *udp = (struct udp_hdr *)&uip_buf[IPV6_HDRLEN];
+  uint16_t udp_len = UDP_HDRLEN + payload_len;
+  uint16_t sum;
+
+  memset(ip, 0, IPV6_HDRLEN);
+  ip->vtc = 0x60;
+  ip->len[0] = udp_len >> 8;
+  ip->len[1] = udp_len & 0xff;
+  ip->nxthdr = UIP_PROTO_UDP;
+  /* High enough to survive the decrement that forwarding applies. */
+  ip->hoplim = 64;
+  uip_ipaddr_copy(&ip->srcipaddr, src);
+  uip_ipaddr_copy(&ip->destipaddr, dst);
+
+  udp->srcport = uip_htons(srcport);
+  udp->destport = uip_htons(destport);
+  udp->udplen = uip_htons(udp_len);
+  udp->udpchksum = 0;
+  memcpy((uint8_t *)udp + UDP_HDRLEN, payload, payload_len);
+
+  /* The UDP checksum covers the IPv6 pseudo header. */
+  sum = udp_len + UIP_PROTO_UDP;
+  sum = chksum(sum, (uint8_t *)&ip->srcipaddr, 2 * sizeof(uip_ip6addr_t));
+  sum = chksum(sum, (uint8_t *)udp, udp_len);
+  udp->udpchksum = ~uip_htons(sum);
+  if(udp->udpchksum == 0) {
+    udp->udpchksum = 0xffff;
+  }
+
+  uip_len = IPV6_HDRLEN + udp_len;
+  tcpip_input();
+}
+/*---------------------------------------------------------------------------*/
+static void
+inject_arp_reply(void)
+{
+  uint8_t buf[sizeof(struct arp_hdr)];
+  struct arp_hdr *arp = (struct arp_hdr *)buf;
+
+  memset(buf, 0, sizeof(buf));
+  memcpy(arp->ethhdr.dest, ip64_eth_addr.addr, sizeof(arp->ethhdr.dest));
+  memcpy(arp->ethhdr.src, router_mac, sizeof(arp->ethhdr.src));
+  arp->ethhdr.type = UIP_HTONS(IP64_ETH_TYPE_ARP);
+  arp->hwtype = UIP_HTONS(1);
+  arp->protocol = UIP_HTONS(IP64_ETH_TYPE_IP);
+  arp->hwlen = sizeof(arp->shwaddr);
+  arp->protolen = sizeof(uip_ip4addr_t);
+  arp->opcode = UIP_HTONS(ARP_REPLY);
+  memcpy(arp->shwaddr, router_mac, sizeof(arp->shwaddr));
+  uip_ip4addr_copy(&arp->sipaddr, &draddr);
+  memcpy(arp->dhwaddr, ip64_eth_addr.addr, sizeof(arp->dhwaddr));
+  uip_ip4addr_copy(&arp->dipaddr, &hostaddr);
+
+  ip64_eth_interface_input(buf, sizeof(buf));
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(arp_resolution)
+{
+  uip_ipaddr_t dest;
+  const struct arp_hdr *arp;
+  static const uint8_t broadcast_mac[6] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+  };
+
+  UNIT_TEST_BEGIN();
+
+  ip64_addr_4to6(&serveraddr, &dest);
+
+  /* The ARP cache is empty, so ip64 must ask for the router's MAC address
+     before it can transmit anything. */
+  ip64_test_driver_reset();
+  simple_udp_sendto(&conn, REQUEST, strlen(REQUEST), &dest);
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt,
+                ip64_test_driver_count > 0 || etimer_expired(&settle_timer));
+
+  UNIT_TEST_ASSERT(ip64_test_driver_count == 1);
+  UNIT_TEST_ASSERT(ip64_test_driver_len >= sizeof(struct arp_hdr));
+
+  arp = (const struct arp_hdr *)ip64_test_driver_buf;
+  UNIT_TEST_ASSERT(arp->ethhdr.type == UIP_HTONS(IP64_ETH_TYPE_ARP));
+  UNIT_TEST_ASSERT(memcmp(arp->ethhdr.dest, broadcast_mac,
+                          sizeof(broadcast_mac)) == 0);
+  UNIT_TEST_ASSERT(arp->opcode == UIP_HTONS(ARP_REQUEST));
+
+  /* The server is off link, so the request must ask for the MAC address of
+     the default router rather than that of the server. */
+  UNIT_TEST_ASSERT(uip_ip4addr_cmp(&arp->dipaddr, &draddr));
+  UNIT_TEST_ASSERT(uip_ip4addr_cmp(&arp->sipaddr, &hostaddr));
+  UNIT_TEST_ASSERT(memcmp(arp->shwaddr, ip64_eth_addr.addr,
+                          sizeof(arp->shwaddr)) == 0);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(udp_round_trip)
+{
+  uip_ipaddr_t dest;
+  const struct eth_hdr *eth;
+  const struct ipv4_hdr *ip;
+  const struct udp_hdr *udp;
+  uint16_t mapped_port;
+  uint16_t len;
+
+  UNIT_TEST_BEGIN();
+
+  ip64_addr_4to6(&serveraddr, &dest);
+
+  ip64_test_driver_reset();
+  simple_udp_sendto(&conn, REQUEST, strlen(REQUEST), &dest);
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt,
+                ip64_test_driver_count > 0 || etimer_expired(&settle_timer));
+
+  UNIT_TEST_ASSERT(ip64_test_driver_count == 1);
+  UNIT_TEST_ASSERT(ip64_test_driver_len >=
+                   sizeof(struct eth_hdr) + IPV4_HDRLEN + UDP_HDRLEN);
+
+  eth = (const struct eth_hdr *)ip64_test_driver_buf;
+  ip = (const struct ipv4_hdr *)&ip64_test_driver_buf[sizeof(struct eth_hdr)];
+  udp = (const struct udp_hdr *)((const uint8_t *)ip + IPV4_HDRLEN);
+
+  /* Now that the ARP cache is populated, the packet must go out as IPv4
+     to the router's MAC address. */
+  UNIT_TEST_ASSERT(eth->type == UIP_HTONS(IP64_ETH_TYPE_IP));
+  UNIT_TEST_ASSERT(memcmp(eth->dest, router_mac, sizeof(eth->dest)) == 0);
+
+  UNIT_TEST_ASSERT(uip_ip4addr_cmp(&ip->srcipaddr, &hostaddr));
+  UNIT_TEST_ASSERT(uip_ip4addr_cmp(&ip->destipaddr, &serveraddr));
+  UNIT_TEST_ASSERT(ip->proto == UIP_PROTO_UDP);
+  UNIT_TEST_ASSERT(chksum(0, (const uint8_t *)ip, IPV4_HDRLEN) == 0xffff);
+
+  UNIT_TEST_ASSERT(uip_ntohs(udp->destport) == SERVER_PORT);
+  UNIT_TEST_ASSERT(memcmp((const uint8_t *)udp + UDP_HDRLEN,
+                          REQUEST, strlen(REQUEST)) == 0);
+  UNIT_TEST_ASSERT(ipv4_udp_is_valid(ip64_test_driver_buf,
+                                     ip64_test_driver_len));
+
+  /* The source port is translated, so the reply has to be addressed to the
+     mapped port for the reverse lookup to find the flow. */
+  mapped_port = uip_ntohs(udp->srcport);
+
+  reply_received = false;
+  len = build_ipv4_udp(frame, &serveraddr, &hostaddr, SERVER_PORT, mapped_port,
+                       (const uint8_t *)REPLY, strlen(REPLY));
+  ip64_eth_interface_input(frame, len);
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt,
+                reply_received || etimer_expired(&settle_timer));
+
+  UNIT_TEST_ASSERT(reply_received);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(forwarded_flow)
+{
+  uip_ipaddr_t dest;
+  const struct ipv4_hdr *ip;
+  const struct udp_hdr *udp;
+  const struct ip64_addrmap_entry *m;
+  uint16_t mapped_port;
+
+  UNIT_TEST_BEGIN();
+
+  ip64_addr_4to6(&serveraddr, &dest);
+
+  /* The router already has a mapping of its own, from udp_round_trip, so the
+     mote's flow has to be told apart from it. */
+  ip64_test_driver_reset();
+  inject_from_mote(&moteaddr, &dest, MOTE_PORT, SERVER_PORT,
+                   (const uint8_t *)REQUEST, strlen(REQUEST));
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt,
+                ip64_test_driver_count > 0 || etimer_expired(&settle_timer));
+
+  UNIT_TEST_ASSERT(ip64_test_driver_count == 1);
+  UNIT_TEST_ASSERT(ip64_test_driver_len >=
+                   sizeof(struct eth_hdr) + IPV4_HDRLEN + UDP_HDRLEN);
+
+  ip = (const struct ipv4_hdr *)&ip64_test_driver_buf[sizeof(struct eth_hdr)];
+  udp = (const struct udp_hdr *)((const uint8_t *)ip + IPV4_HDRLEN);
+
+  /* The mote's packet leaves as IPv4 from the router's own address, which is
+     the whole point of the translation. */
+  UNIT_TEST_ASSERT(ip->proto == UIP_PROTO_UDP);
+  UNIT_TEST_ASSERT(uip_ip4addr_cmp(&ip->srcipaddr, &hostaddr));
+  UNIT_TEST_ASSERT(uip_ip4addr_cmp(&ip->destipaddr, &serveraddr));
+  UNIT_TEST_ASSERT(chksum(0, (const uint8_t *)ip, IPV4_HDRLEN) == 0xffff);
+  UNIT_TEST_ASSERT(uip_ntohs(udp->destport) == SERVER_PORT);
+  UNIT_TEST_ASSERT(memcmp((const uint8_t *)udp + UDP_HDRLEN,
+                          REQUEST, strlen(REQUEST)) == 0);
+  UNIT_TEST_ASSERT(ipv4_udp_is_valid(ip64_test_driver_buf,
+                                     ip64_test_driver_len));
+
+  /* A reply would be resolved through the mapped port, so that lookup has to
+     yield the mote rather than the router: ip64_4to6() takes the destination
+     of the translated packet straight from this entry. */
+  mapped_port = uip_ntohs(udp->srcport);
+  m = ip64_addrmap_lookup_port(mapped_port, UIP_PROTO_UDP);
+  UNIT_TEST_ASSERT(m != NULL);
+  UNIT_TEST_ASSERT(uip_ipaddr_cmp(&m->ip6addr, &moteaddr));
+  UNIT_TEST_ASSERT(m->ip6port == MOTE_PORT);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(dns64_rewrite)
+{
+  uip_ipaddr_t dest;
+  const struct ipv4_hdr *ip;
+  const struct udp_hdr *udp;
+  const uint8_t *dns;
+  uint16_t mapped_dns_port;
+  uint16_t len;
+
+  UNIT_TEST_BEGIN();
+
+  /* The DNS server is the default router, which is already in the ARP
+     cache at this point. */
+  ip64_addr_4to6(&draddr, &dest);
+
+  ip64_test_driver_reset();
+  simple_udp_sendto(&dnsconn, dns_query, sizeof(dns_query), &dest);
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt,
+                ip64_test_driver_count > 0 || etimer_expired(&settle_timer));
+
+  UNIT_TEST_ASSERT(ip64_test_driver_count == 1);
+  UNIT_TEST_ASSERT(ip64_test_driver_len >= sizeof(struct eth_hdr) +
+                   IPV4_HDRLEN + UDP_HDRLEN + sizeof(dns_query));
+
+  ip = (const struct ipv4_hdr *)&ip64_test_driver_buf[sizeof(struct eth_hdr)];
+  udp = (const struct udp_hdr *)((const uint8_t *)ip + IPV4_HDRLEN);
+  dns = (const uint8_t *)udp + UDP_HDRLEN;
+
+  /* An IPv4 server cannot answer a AAAA query, so the question type must
+     have been rewritten on the way out. */
+  UNIT_TEST_ASSERT((dns[DNS_QUESTION_TYPE_OFFSET] << 8) +
+                   dns[DNS_QUESTION_TYPE_OFFSET + 1] == DNS_TYPE_A);
+
+  /* The rewrite changed the payload, so the checksum had to be recomputed
+     over the new bytes. */
+  UNIT_TEST_ASSERT(ipv4_udp_is_valid(ip64_test_driver_buf,
+                                     ip64_test_driver_len));
+
+  mapped_dns_port = uip_ntohs(udp->srcport);
+
+  dns_rewritten = false;
+  len = build_ipv4_udp(frame, &draddr, &hostaddr, DNS_PORT, mapped_dns_port,
+                       dns_response, sizeof(dns_response));
+  ip64_eth_interface_input(frame, len);
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt,
+                dns_rewritten || etimer_expired(&settle_timer));
+
+  /* The A record must come back as an AAAA record holding the NAT64
+     representation of the recorded IPv4 address. */
+  UNIT_TEST_ASSERT(dns_rewritten);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(icmp_echo)
+{
+  const struct ipv4_hdr *ip;
+  const struct icmp_echo_hdr *icmp;
+  uint16_t len;
+
+  UNIT_TEST_BEGIN();
+
+  /* An IPv4 host pings the IPv4 address of the router. ip64 passes echo
+     requests on to the local IPv6 host, whose reply must come back out as
+     ICMPv4 without any mapping being involved. */
+  ip64_test_driver_reset();
+  len = build_ipv4_icmp_echo(frame, &serveraddr, &hostaddr, ECHO_ID,
+                             ECHO_SEQNO, (const uint8_t *)REQUEST,
+                             strlen(REQUEST));
+  ip64_eth_interface_input(frame, len);
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt,
+                ip64_test_driver_count > 0 || etimer_expired(&settle_timer));
+
+  /* The reply carries the same payload as the request, so it has the same
+     size as the frame that was injected. */
+  UNIT_TEST_ASSERT(ip64_test_driver_count == 1);
+  UNIT_TEST_ASSERT(ip64_test_driver_len == sizeof(struct eth_hdr) +
+                   IPV4_HDRLEN + ICMP_ECHO_HDRLEN + strlen(REQUEST));
+
+  ip = (const struct ipv4_hdr *)&ip64_test_driver_buf[sizeof(struct eth_hdr)];
+  icmp = (const struct icmp_echo_hdr *)((const uint8_t *)ip + IPV4_HDRLEN);
+
+  UNIT_TEST_ASSERT(ip->proto == IP_PROTO_ICMPV4);
+  UNIT_TEST_ASSERT(uip_ip4addr_cmp(&ip->srcipaddr, &hostaddr));
+  UNIT_TEST_ASSERT(uip_ip4addr_cmp(&ip->destipaddr, &serveraddr));
+  UNIT_TEST_ASSERT(chksum(0, (const uint8_t *)ip, IPV4_HDRLEN) == 0xffff);
+
+  /* The identifier, the sequence number, and the payload are echoed back
+     unchanged; only the type differs. */
+  UNIT_TEST_ASSERT(icmp->type == ICMP_ECHO_REPLY);
+  UNIT_TEST_ASSERT(uip_ntohs(icmp->id) == ECHO_ID);
+  UNIT_TEST_ASSERT(uip_ntohs(icmp->seqno) == ECHO_SEQNO);
+  UNIT_TEST_ASSERT(memcmp((const uint8_t *)icmp + ICMP_ECHO_HDRLEN,
+                          REQUEST, strlen(REQUEST)) == 0);
+  UNIT_TEST_ASSERT(chksum(0, (const uint8_t *)icmp,
+                          ICMP_ECHO_HDRLEN + strlen(REQUEST)) == 0xffff);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(inbound_ports)
+{
+  uint16_t len;
+
+  UNIT_TEST_BEGIN();
+
+  /* Unsolicited traffic to a port below the ephemeral range is delivered to
+     the local host, which is the only way an IPv4 host can reach a service
+     on the router without a mapping having been set up first. */
+  service_delivered = false;
+  len = build_ipv4_udp(frame, &serveraddr, &hostaddr, SERVER_PORT,
+                       SERVICE_PORT, (const uint8_t *)REQUEST,
+                       strlen(REQUEST));
+  ip64_eth_interface_input(frame, len);
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt,
+                service_delivered || etimer_expired(&settle_timer));
+
+  UNIT_TEST_ASSERT(service_delivered);
+
+  /* Traffic to an ephemeral port must be dropped when no mapping resolves
+     it, even though a socket is listening on that port. The port used here
+     is the one that received the reply in udp_round_trip, so a delivery
+     would be noticed; only the mapping, which is keyed on the translated
+     port rather than on this one, is missing. */
+  UNIT_TEST_ASSERT(ip64_addrmap_lookup_port(LOCAL_PORT,
+                                            UIP_PROTO_UDP) == NULL);
+  reply_received = false;
+  len = build_ipv4_udp(frame, &serveraddr, &hostaddr, SERVER_PORT,
+                       LOCAL_PORT, (const uint8_t *)REPLY, strlen(REPLY));
+  ip64_eth_interface_input(frame, len);
+  /* Nothing to wait for here: the absence of a delivery is what is asserted,
+     so this is the one wait that has to run its full course. */
+  etimer_set(&settle_timer, SETTLE_TIME);
+  PT_WAIT_UNTIL(&unit_test_pt, etimer_expired(&settle_timer));
+
+  UNIT_TEST_ASSERT(!reply_received);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(test_ip64_process, ev, data)
+{
+  static struct etimer startup_timer;
+  static struct ip64_eth_addr eth_addr = {
+    { 0x02, 0x11, 0x22, 0x33, 0x44, 0x55 }
+  };
+
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  uip_ipaddr(&hostaddr, 192, 168, 1, 50);
+  uip_ipaddr(&netmask, 255, 255, 255, 0);
+  uip_ipaddr(&draddr, 192, 168, 1, 1);
+  uip_ipaddr(&serveraddr, 192, 0, 2, 10);
+  uip_ip6addr(&moteaddr, 0xfd00, 0, 0, 0, 0x0211, 0x2233, 0x4455, 0x6677);
+
+  ip64_eth_addr_set(&eth_addr);
+  ip64_init();
+  ip64_set_hostaddr(&hostaddr);
+  ip64_set_netmask(&netmask);
+  ip64_set_draddr(&draddr);
+
+  simple_udp_register(&conn, LOCAL_PORT, NULL, SERVER_PORT, udp_received);
+  simple_udp_register(&dnsconn, DNS_LOCAL_PORT, NULL, DNS_PORT, dns_received);
+  /* Accepts traffic from any port, as an inbound service would. */
+  simple_udp_register(&serviceconn, SERVICE_PORT, NULL, 0, service_received);
+
+  /* Let the IPv6 addresses leave the tentative state. */
+  etimer_set(&startup_timer, CLOCK_SECOND);
+  PROCESS_WAIT_UNTIL(etimer_expired(&startup_timer));
+
+  UNIT_TEST_RUN(arp_resolution);
+
+  /* Answer the request that arp_resolution triggered. Every test that
+     follows needs the router in the ARP cache. */
+  inject_arp_reply();
+
+  UNIT_TEST_RUN(udp_round_trip);
+  UNIT_TEST_RUN(forwarded_flow);
+  UNIT_TEST_RUN(dns64_rewrite);
+  UNIT_TEST_RUN(icmp_echo);
+  UNIT_TEST_RUN(inbound_ports);
+
+  if(!UNIT_TEST_PASSED(arp_resolution) ||
+     !UNIT_TEST_PASSED(udp_round_trip) ||
+     !UNIT_TEST_PASSED(forwarded_flow) ||
+     !UNIT_TEST_PASSED(dns64_rewrite) ||
+     !UNIT_TEST_PASSED(icmp_echo) ||
+     !UNIT_TEST_PASSED(inbound_ports)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
+  printf("=check-me= DONE\n");
+  printf("---\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/27-ip64-tap.sh
+++ b/tests/08-native-runs/27-ip64-tap.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# End-to-end test of the ip64 NAT64 service against real host software, over a
+# Linux TAP device. The node runs ip64 with its IPv4 side on a TAP device that
+# it creates itself, gives the host end 192.0.2.1, and answers to 192.0.2.50,
+# so that programs on the host reach it over UDP, ICMP and DNS without knowing
+# anything about NAT64.
+#
+# The suite Makefile builds the node twice: with the address compiled in, and
+# with IP64_CONF_DHCP=1, which takes it from a DHCP server on the host as the
+# Orion border router does. This script runs whichever build is there and
+# reads from the node's own IP64_TAP_MODE line which one that is.
+#
+# Creating the TAP device needs CAP_NET_ADMIN. CI runs this in a privileged
+# container, but as an ordinary user with passwordless sudo, so take that
+# route when it is there rather than refusing to run.
+
+if [ "$(id -u)" -ne 0 ]; then
+  if sudo -n true 2>/dev/null; then
+    echo "Not running as root; continuing under sudo"
+    exec sudo -E "$0" "$@"
+  fi
+
+  if [ "${IP64_TAP_ALLOW_SKIP:-0}" = "1" ]; then
+    echo "SKIP: no way to get CAP_NET_ADMIN, and IP64_TAP_ALLOW_SKIP=1 is set"
+    exit 0
+  fi
+
+  echo "TEST FAIL: this test needs CAP_NET_ADMIN to create the TAP device."
+  echo "           Run it as root, arrange passwordless sudo, or set"
+  echo "           IP64_TAP_ALLOW_SKIP=1 to skip it."
+  exit 1
+fi
+
+# With the capability in hand, the device node still has to be there. In a
+# container that means the host's /dev, which is what --privileged gives.
+if [ ! -c /dev/net/tun ]; then
+  echo "TEST FAIL: /dev/net/tun is missing, so no TAP device can be created."
+  echo "           A container needs --privileged, or at least this device."
+  exit 1
+fi
+
+source ../utils.sh
+
+# The echo server is the one the Cooja NAT64 test uses, so that both tests
+# talk to the same IPv4 program.
+ECHO_SERVER=$(cd ../17-tun-rpl-br && pwd)/nat64-echo-server.py
+
+BASENAME=27-ip64-tap
+cd $BASENAME || exit 1
+
+NODE=./build/native/ip64-tap-node.native
+NODE_IPV4=192.0.2.50
+HOST_IPV4=192.0.2.1
+TAP_DEV="${IP64_TAP_DEV:-tap0}"
+UDP_PORT=5557
+TCP_PORT=5558
+DNS_PORT=53
+# The answer differs from the DNS server's own address, so the address the
+# node reports can only have come from the A record.
+LOOKUP_NAME=ip64-test.example
+LOOKUP_ANSWER=192.0.2.99
+LOOKUP_EXPECTED="64:ff9b::192.0.2.99"
+
+NODE_LOG=$BASENAME.node.log
+ECHO_LOG=$BASENAME.echo.log
+DNS_LOG=$BASENAME.dns.log
+DHCP_LOG=$BASENAME.dhcp.log
+PING_LOG=$BASENAME.ping.log
+
+test_init
+
+echo "-- Starting test $BASENAME"
+
+register_logfile $NODE_LOG
+$NODE &> $NODE_LOG &
+register_last_bg_cmd
+
+# The TAP device disappears with the node, so everything that binds the host
+# address has to start after this.
+wait_log_assert "node creates the TAP device" "IP64_TAP_DEVICE_UP" \
+                $NODE_LOG 30
+
+if grep -q "IP64_TAP_MODE dhcp" $NODE_LOG 2>/dev/null; then
+  echo "-- The node takes its address from DHCP"
+
+  # Bound to the TAP device, so serving 0.0.0.0:67, which is what receiving a
+  # broadcast takes, cannot disturb the rest of the machine. The lease travels
+  # through ip64: the client sends to 64:ff9b::255.255.255.255.
+  register_logfile $DHCP_LOG
+  python3 ./dhcp-server.py \
+    --device "$TAP_DEV" --offer $NODE_IPV4 --server $HOST_IPV4 \
+    --router $HOST_IPV4 --log $DHCP_LOG &
+  register_last_bg_cmd
+
+  wait_log_assert "DHCP server starts" "DHCP_LISTEN" $DHCP_LOG 10
+  wait_log_assert "DHCP server leases $NODE_IPV4" "DHCP_ACK ip=$NODE_IPV4" \
+                  $DHCP_LOG 30
+  wait_log_assert "node configures itself from the lease" \
+                  "IP64_TAP_LEASE $NODE_IPV4 router $HOST_IPV4" $NODE_LOG 30
+fi
+
+wait_log_assert "node is ready" "IP64_TAP_READY" $NODE_LOG 30
+
+# Both servers bind the TAP address rather than every address, so that they do
+# not collide with a resolver or another service already on this machine. The
+# node retransmits, so requests that go nowhere until they are up cost nothing.
+register_logfile $ECHO_LOG
+python3 "$ECHO_SERVER" \
+  --host $HOST_IPV4 --udp-port $UDP_PORT --tcp-port $TCP_PORT \
+  --log $ECHO_LOG &
+register_last_bg_cmd
+
+wait_log_assert "echo server starts" "UDP_LISTEN" $ECHO_LOG 10
+
+register_logfile $DNS_LOG
+python3 ./dns-server.py \
+  --host $HOST_IPV4 --port $DNS_PORT --name $LOOKUP_NAME \
+  --answer $LOOKUP_ANSWER --log $DNS_LOG &
+register_last_bg_cmd
+
+wait_log_assert "DNS server starts" "DNS_LISTEN" $DNS_LOG 10
+
+# The IPv6->IPv4 leg: an IPv4 receiver that knows nothing about NAT64 sees the
+# node's datagram arrive from the translated address.
+wait_log_assert "echo server receives IPv4 from $NODE_IPV4" \
+                "UDP_ECHO from=$NODE_IPV4:.*payload=b'PING-IP64-TAP'" \
+                $ECHO_LOG 30
+
+# The return leg: the reply comes back translated, on a datagram this test did
+# not build.
+wait_log_assert "node receives the reflected datagram" "IP64_TAP_ECHO_OK" \
+                $NODE_LOG 30
+
+# The node asks for AAAA (resolv.c queries NATIVE_DNS_TYPE), so an A query
+# arriving at an IPv4-only server is the DNS64 rewrite doing its work, and the
+# address the node ends up with is the A record behind the NAT64 prefix.
+wait_log_assert "DNS server receives an A query" \
+                "DNS_QUERY .*name=$LOOKUP_NAME qtype=1" $DNS_LOG 30
+wait_log_assert "node resolves $LOOKUP_NAME" \
+                "IP64_TAP_DNS_OK $LOOKUP_NAME $LOOKUP_EXPECTED" $NODE_LOG 30
+
+# Inbound ICMP translation, and ip64 answering the host's ARP request.
+register_logfile $PING_LOG
+assert "host pings the node at $NODE_IPV4" \
+       "ping -c 3 -W 2 $NODE_IPV4 > $PING_LOG 2>&1"
+
+do_wrap_up

--- a/tests/08-native-runs/27-ip64-tap/Makefile
+++ b/tests/08-native-runs/27-ip64-tap/Makefile
@@ -1,0 +1,21 @@
+CONTIKI_PROJECT = ip64-tap-node
+all: $(CONTIKI_PROJECT)
+
+TARGET ?= native
+
+CONTIKI = ../../..
+
+WITH_IP64 = 1
+
+PROJECT_SOURCEFILES += ip64-tap-driver.c
+
+# The DNS lookup goes through the resolver.
+MODULES += os/services/resolv
+
+# Same wiring as arch/platform/zoul/orion/Makefile.orion.
+CFLAGS += -DUIP_FALLBACK_INTERFACE=ip64_uip_fallback_interface
+# Make ip64 the only off-link path, as on a border router.
+CFLAGS += -DNATIVE_WITH_IPV6_DEFAULT_ROUTE=0
+CFLAGS += -I$(CURDIR)
+
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/27-ip64-tap/README.md
+++ b/tests/08-native-runs/27-ip64-tap/README.md
@@ -1,0 +1,84 @@
+# ip64 TAP test
+
+Runs the `os/services/ip64` NAT64 service on the native target with its IPv4
+side on a Linux TAP device, so that ordinary host software exchanges IPv4
+traffic with the node. Where `../26-ip64` asserts on the frames ip64 produces,
+this test asserts that a program that knows nothing about NAT64 can talk to
+the node.
+
+## What the test checks
+
+| Check | Path exercised |
+|-------|----------------|
+| The echo server receives IPv4 from `192.0.2.50` | `ip64_6to4`, ARP resolution of the host, and a real IPv4 receiver |
+| The node logs `IP64_TAP_ECHO_OK` | `ip64_4to6` and the reverse mapping lookup, on a reply the test did not build |
+| `ping 192.0.2.50` from the host succeeds | inbound ICMP echo translation, and ip64 answering the host's ARP request |
+| The DNS server receives an **A** query | `ip64_dns64_6to4`: the node is IPv6-only and asks for AAAA, which an IPv4-only server could never answer |
+| The node resolves the name to `64:ff9b::192.0.2.99` | `ip64_dns64_4to6`: the A record in the answer is turned into an AAAA record the node can use |
+
+The suite builds the node a second time with `IP64_CONF_DHCP=1` and runs the
+same script over it, so that the address comes from a DHCP server on the host
+as it does on the Orion border router. The node reports which build it is in
+its `IP64_TAP_MODE` line, and the script then asserts on the lease as well.
+
+| Check | Path exercised |
+|-------|----------------|
+| The DHCP server leases `192.0.2.50` | `ip64-dhcpc`, and `ip64_6to4` on a broadcast destination: the client sends to `64:ff9b::255.255.255.255` |
+| The node reports the leased address and router | `ip64_ipv4_dhcp`, and the IPv4-broadcast-to-multicast path in `ip64_4to6` that carries the reply back |
+
+The checks in the first table then run again over the leased address, which
+shows that the leased configuration is usable and not merely parsed.
+
+The DNS answer, `192.0.2.99`, is deliberately not the DNS server's own
+address, so the address the node reports can only have come from the record.
+
+The node creates the TAP device itself, gives the host end `192.0.2.1`, and
+answers to `192.0.2.50`. Both addresses are in TEST-NET-1 (RFC 5737), which
+keeps the test off any address range a real network is likely to use. They
+are compiled in, and the script is written around them; `IP64_TAP_DEV`
+selects a device other than `tap0`.
+
+The echo server and the DNS server both bind `192.0.2.1` rather than every
+address, so that they cannot collide with a resolver already running on the
+machine. That address exists only after the node has created the device,
+which is why the script starts the node first.
+
+## Privileges and host state
+
+Creating the TAP device and configuring the interface need `CAP_NET_ADMIN`,
+so the test has to run as root. It re-executes itself under `sudo` where that
+needs no password, which is how it runs in CI: the container the Linux jobs
+use is privileged, but its user is not root. Failing that, it stops with an
+explanation, or skips if `IP64_TAP_ALLOW_SKIP=1` is set.
+
+Running a native node as root has a side effect that predates this test: the
+native platform opens its own tun device for IPv6, configures it, and sets
+`net.ipv6.conf.all.forwarding=1`. Every native IPv6 node run as root does
+this, `tests/17-tun-rpl-br` included. The TAP device itself is not
+persistent and disappears when the node exits.
+
+## Running it
+
+The test is part of the `tests/08-native-runs` suite, which builds the node
+for both configurations and runs the script over each:
+
+```
+make -C tests/08-native-runs
+```
+
+The two runs on their own, from the suite directory, once the node is built
+for the configuration in question:
+
+```
+make -C 27-ip64-tap TARGET=native
+./27-ip64-tap.sh
+make -C 27-ip64-tap TARGET=native DEFINES=IP64_CONF_DHCP=1
+./27-ip64-tap.sh
+```
+
+## What it does not cover
+
+- TCP, and the ip64 special-ports translation of inbound traffic.
+- Lease renewal and expiry: the test takes a lease and uses it, but does not
+  run long enough to renew one.
+- The ENC28J60 driver and its SPI glue, which have no native equivalent.

--- a/tests/08-native-runs/27-ip64-tap/dhcp-server.py
+++ b/tests/08-native-runs/27-ip64-tap/dhcp-server.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Minimal IPv4 DHCP server for the ip64 TAP test.
+
+Serves one fixed lease to any client that asks, and logs every message it
+sees, so the test can tell how far the ip64 DHCP client got.  The client sets
+the BOOTP broadcast flag, so replies go to 255.255.255.255 and no ARP is
+needed before the lease exists.
+"""
+
+import argparse
+import os
+import signal
+import socket
+import struct
+import sys
+import time
+
+DHCPDISCOVER = 1
+DHCPOFFER = 2
+DHCPREQUEST = 3
+DHCPACK = 5
+
+OPT_SUBNET_MASK = 1
+OPT_ROUTER = 3
+OPT_DNS_SERVER = 6
+OPT_LEASE_TIME = 51
+OPT_MSG_TYPE = 53
+OPT_SERVER_ID = 54
+OPT_END = 255
+
+MAGIC_COOKIE = bytes([99, 130, 83, 99])
+BOOTP_FIXED_LEN = 236
+
+# SO_BINDTODEVICE is not exposed by the socket module on every Python build.
+SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 25)
+
+
+def log(fp, msg):
+    fp.write("{:.3f} {}\n".format(time.time(), msg))
+    fp.flush()
+
+
+def parse_options(data):
+    """Return {code: value} for the options following the magic cookie."""
+    options = {}
+    if len(data) < BOOTP_FIXED_LEN + 4:
+        return options
+    if data[BOOTP_FIXED_LEN:BOOTP_FIXED_LEN + 4] != MAGIC_COOKIE:
+        return options
+
+    offset = BOOTP_FIXED_LEN + 4
+    while offset < len(data):
+        code = data[offset]
+        if code == OPT_END:
+            break
+        if code == 0:            # Padding.
+            offset += 1
+            continue
+        if offset + 2 > len(data):
+            break
+        length = data[offset + 1]
+        if offset + 2 + length > len(data):
+            break
+        options[code] = data[offset + 2:offset + 2 + length]
+        offset += 2 + length
+    return options
+
+
+def build_reply(query, msg_type, offer, server, netmask, router):
+    """Build an OFFER or an ACK for the client that sent query."""
+    xid = query[4:8]
+    chaddr = query[28:44]
+
+    reply = struct.pack("!BBBB", 2, 1, 6, 0)      # op, htype, hlen, hops
+    reply += xid
+    reply += struct.pack("!HH", 0, 0x8000)        # secs, broadcast flag
+    reply += socket.inet_aton("0.0.0.0")          # ciaddr
+    reply += socket.inet_aton(offer)              # yiaddr
+    reply += socket.inet_aton(server)             # siaddr
+    reply += socket.inet_aton("0.0.0.0")          # giaddr
+    reply += chaddr
+    reply += bytes(64 + 128)                      # sname, file
+    reply += MAGIC_COOKIE
+
+    reply += bytes([OPT_MSG_TYPE, 1, msg_type])
+    reply += bytes([OPT_SERVER_ID, 4]) + socket.inet_aton(server)
+    reply += bytes([OPT_LEASE_TIME, 4]) + struct.pack("!I", 3600)
+    reply += bytes([OPT_SUBNET_MASK, 4]) + socket.inet_aton(netmask)
+    reply += bytes([OPT_ROUTER, 4]) + socket.inet_aton(router)
+    reply += bytes([OPT_DNS_SERVER, 4]) + socket.inet_aton(server)
+    reply += bytes([OPT_END])
+
+    return reply
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", required=True,
+                        help="interface to serve, e.g. tap0")
+    parser.add_argument("--offer", required=True, help="address to lease")
+    parser.add_argument("--server", required=True, help="our own address")
+    parser.add_argument("--netmask", default="255.255.255.0")
+    parser.add_argument("--router", required=True)
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--pidfile")
+    args = parser.parse_args()
+
+    logfp = open(args.log, "a")
+    if args.pidfile:
+        with open(args.pidfile, "w") as fp:
+            fp.write("{}\n".format(os.getpid()))
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    # Bound to the TAP device, so that serving 0.0.0.0:67, which is what it
+    # takes to receive a broadcast, cannot disturb the rest of the machine.
+    sock.setsockopt(socket.SOL_SOCKET, SO_BINDTODEVICE,
+                    args.device.encode() + b"\0")
+    sock.bind(("", 67))
+    log(logfp, "DHCP_LISTEN device={} offer={}".format(args.device,
+                                                       args.offer))
+
+    def stop(signum, frame):
+        log(logfp, "DHCP_STOP")
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    while True:
+        data, addr = sock.recvfrom(1024)
+        if len(data) < BOOTP_FIXED_LEN:
+            log(logfp, "DHCP_SHORT_MSG bytes={}".format(len(data)))
+            continue
+
+        options = parse_options(data)
+        # Option 53 can arrive with no value at all, in which case there is
+        # no message type to act on.
+        msg_type_value = options.get(OPT_MSG_TYPE, b"")
+        msg_type = msg_type_value[0] if msg_type_value else 0
+        chaddr = data[28:34].hex(":")
+
+        if msg_type == DHCPDISCOVER:
+            log(logfp, "DHCP_DISCOVER chaddr={}".format(chaddr))
+            reply = build_reply(data, DHCPOFFER, args.offer, args.server,
+                                args.netmask, args.router)
+            sock.sendto(reply, ("255.255.255.255", 68))
+            log(logfp, "DHCP_OFFER ip={} chaddr={}".format(args.offer,
+                                                           chaddr))
+        elif msg_type == DHCPREQUEST:
+            log(logfp, "DHCP_REQUEST chaddr={}".format(chaddr))
+            reply = build_reply(data, DHCPACK, args.offer, args.server,
+                                args.netmask, args.router)
+            sock.sendto(reply, ("255.255.255.255", 68))
+            log(logfp, "DHCP_ACK ip={} chaddr={}".format(args.offer, chaddr))
+        else:
+            log(logfp, "DHCP_OTHER type={} chaddr={}".format(msg_type,
+                                                             chaddr))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/08-native-runs/27-ip64-tap/dns-server.py
+++ b/tests/08-native-runs/27-ip64-tap/dns-server.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Minimal IPv4 DNS server for the ip64 TAP test.
+
+Answers one name with a fixed A record, and logs the query type of every
+request.  The query type is the point of the exercise: the node asks for
+AAAA, so an A query arriving here means the DNS64 part of ip64 rewrote the
+question on the way out.
+"""
+
+import argparse
+import os
+import signal
+import socket
+import struct
+import sys
+import time
+
+TYPE_A = 1
+TYPE_AAAA = 28
+
+
+def log(fp, msg):
+    fp.write("{:.3f} {}\n".format(time.time(), msg))
+    fp.flush()
+
+
+def parse_question(data):
+    """Return (name, qtype, end_offset) for the first question."""
+    labels = []
+    offset = 12
+    while offset < len(data):
+        length = data[offset]
+        offset += 1
+        if length == 0:
+            break
+        labels.append(data[offset:offset + length].decode("ascii", "replace"))
+        offset += length
+    if offset + 4 > len(data):
+        raise ValueError("truncated question")
+    qtype, _ = struct.unpack("!HH", data[offset:offset + 4])
+    return ".".join(labels), qtype, offset + 4
+
+
+def build_response(query, question_end, answer_addr):
+    """Echo the question and append one A record for answer_addr."""
+    qid = query[0:2]
+    header = qid + struct.pack("!HHHHH", 0x8180, 1, 1, 0, 0)
+    question = query[12:question_end]
+    answer = struct.pack("!HHHIH", 0xc00c, TYPE_A, 1, 3600, 4)
+    answer += socket.inet_aton(answer_addr)
+    return header + question + answer
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=53)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--answer", required=True)
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--pidfile")
+    args = parser.parse_args()
+
+    logfp = open(args.log, "a")
+    if args.pidfile:
+        with open(args.pidfile, "w") as fp:
+            fp.write("{}\n".format(os.getpid()))
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((args.host, args.port))
+    log(logfp, "DNS_LISTEN {}:{}".format(args.host, args.port))
+
+    def stop(signum, frame):
+        log(logfp, "DNS_STOP")
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    while True:
+        data, addr = sock.recvfrom(1024)
+        try:
+            name, qtype, question_end = parse_question(data)
+        except (IndexError, ValueError) as e:
+            log(logfp, "DNS_BAD_QUERY from={} err={}".format(addr[0], e))
+            continue
+
+        log(logfp, "DNS_QUERY from={} name={} qtype={}".format(
+            addr[0], name, qtype))
+
+        if qtype == TYPE_A and name == args.name:
+            sock.sendto(build_response(data, question_end, args.answer), addr)
+            log(logfp, "DNS_ANSWER name={} a={}".format(name, args.answer))
+        else:
+            # Anything else is left unanswered on purpose: an AAAA query here
+            # would mean DNS64 did not rewrite the question.
+            log(logfp, "DNS_IGNORED name={} qtype={}".format(name, qtype))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/08-native-runs/27-ip64-tap/ip64-conf.h
+++ b/tests/08-native-runs/27-ip64-tap/ip64-conf.h
@@ -1,0 +1,23 @@
+/*
+ * ip64 configuration for the TAP test. The same shape as
+ * arch/platform/zoul/orion/ip64-conf.h, with the ENC28J60 driver replaced by
+ * a driver that puts the IPv4 side on a host TAP device.
+ */
+
+#ifndef IP64_CONF_H
+#define IP64_CONF_H
+
+#include "ip64/ip64-eth-interface.h"
+#define IP64_CONF_UIP_FALLBACK_INTERFACE ip64_eth_interface
+#define IP64_CONF_INPUT                  ip64_eth_interface_input
+
+#include "ip64-tap-driver.h"
+#define IP64_CONF_ETH_DRIVER             ip64_tap_driver
+
+/* The test runs the node both ways: with a fixed address, and with one
+   leased from a DHCP server on the host. */
+#ifndef IP64_CONF_DHCP
+#define IP64_CONF_DHCP 0
+#endif
+
+#endif /* IP64_CONF_H */

--- a/tests/08-native-runs/27-ip64-tap/ip64-tap-driver.c
+++ b/tests/08-native-runs/27-ip64-tap/ip64-tap-driver.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+
+/**
+ * \file
+ *   ip64 driver backed by a Linux TAP device. A TAP device carries Ethernet
+ *   frames, which is exactly what ip64 emits and expects, so frames pass in
+ *   both directions untouched. The host end of the device is given an IPv4
+ *   address, which makes the node reachable from ordinary host software.
+ *
+ *   Creating the device and configuring the interface both need
+ *   CAP_NET_ADMIN, as they do for the tun device that the native platform
+ *   opens for IPv6. Linux only.
+ */
+
+#include "contiki.h"
+#include "ip64-tap-driver.h"
+#include "ip64/ip64-eth-interface.h"
+#include "ip64/ip64-eth.h"
+
+#include <ctype.h>
+#include <fcntl.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "sys/log.h"
+#define LOG_MODULE "ip64-tap"
+#define LOG_LEVEL LOG_LEVEL_INFO
+
+/* The device is overridable from the environment so that the test script can
+   pick one that does not collide with whatever else the machine is running.
+   The addresses are not: the node answers to an address of its own that is
+   compiled in, and the test script is written around both. */
+#define TAP_DEV_DEFAULT "tap0"
+#define TAP_HOST_ADDR   "192.0.2.1"
+#define TAP_NETMASK     "255.255.255.0"
+
+#define TAP_BUFSIZE 1600
+
+static int tapfd = -1;
+static uint8_t rxbuf[TAP_BUFSIZE];
+
+/*---------------------------------------------------------------------------*/
+static const char *
+env_or(const char *name, const char *fallback)
+{
+  const char *value = getenv(name);
+
+  return (value != NULL && *value != '\0') ? value : fallback;
+}
+/*---------------------------------------------------------------------------*/
+/* The name ends up in a command handed to a shell, and one that the kernel
+   truncates would configure a different device than the one created. */
+static bool
+dev_name_is_usable(const char *dev)
+{
+  size_t i;
+
+  if(*dev == '\0' || strlen(dev) >= IFNAMSIZ) {
+    return false;
+  }
+
+  for(i = 0; dev[i] != '\0'; i++) {
+    if(!isalnum((unsigned char)dev[i]) &&
+       dev[i] != '-' && dev[i] != '_' && dev[i] != '.') {
+      return false;
+    }
+  }
+
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+static int
+set_fd(fd_set *rset, fd_set *wset)
+{
+  FD_SET(tapfd, rset);
+
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+static void
+handle_fd(fd_set *rset, fd_set *wset)
+{
+  ssize_t len;
+
+  if(!FD_ISSET(tapfd, rset)) {
+    return;
+  }
+
+  len = read(tapfd, rxbuf, sizeof(rxbuf));
+  if(len <= 0) {
+    LOG_ERR("Read from the TAP device failed\n");
+    return;
+  }
+
+  /* ip64_eth_interface_input() reads the header before it looks at the
+     length it is given. */
+  if(len < (ssize_t)sizeof(struct ip64_eth_hdr)) {
+    LOG_WARN("Discarding a frame of %d bytes\n", (int)len);
+    return;
+  }
+
+  /* The frame arrives exactly as an Ethernet chip would deliver it. */
+  ip64_eth_interface_input(rxbuf, (uint16_t)len);
+}
+/*---------------------------------------------------------------------------*/
+static const struct select_callback tap_select_callback = {
+  set_fd, handle_fd
+};
+/*---------------------------------------------------------------------------*/
+static void
+init(void)
+{
+  struct ifreq ifr;
+  const char *dev = env_or("IP64_TAP_DEV", TAP_DEV_DEFAULT);
+  char cmd[128];
+
+  if(!dev_name_is_usable(dev)) {
+    LOG_ERR("IP64_TAP_DEV is not a usable device name\n");
+    exit(EXIT_FAILURE);
+  }
+
+  tapfd = open("/dev/net/tun", O_RDWR);
+  if(tapfd < 0) {
+    LOG_ERR("Cannot open /dev/net/tun; CAP_NET_ADMIN is required\n");
+    exit(EXIT_FAILURE);
+  }
+
+  memset(&ifr, 0, sizeof(ifr));
+  ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+  strncpy(ifr.ifr_name, dev, IFNAMSIZ - 1);
+  if(ioctl(tapfd, TUNSETIFF, &ifr) < 0) {
+    LOG_ERR("Cannot create the TAP device %s\n", dev);
+    exit(EXIT_FAILURE);
+  }
+
+  /* ifconfig rather than ip(8), as the native tun driver does, because the
+     test image is not guaranteed to carry iproute2. The name comes back from
+     the kernel, which is the one the device really has. */
+  if(snprintf(cmd, sizeof(cmd), "ifconfig %s %s netmask %s up",
+              ifr.ifr_name, TAP_HOST_ADDR, TAP_NETMASK) >= (int)sizeof(cmd)) {
+    LOG_ERR("The command to configure %s does not fit\n", ifr.ifr_name);
+    exit(EXIT_FAILURE);
+  }
+  if(system(cmd) != 0) {
+    LOG_ERR("Cannot configure %s with address %s\n", ifr.ifr_name,
+            TAP_HOST_ADDR);
+    exit(EXIT_FAILURE);
+  }
+
+  select_set_callback(tapfd, &tap_select_callback);
+
+  LOG_INFO("TAP device %s is up, host address %s\n", ifr.ifr_name,
+           TAP_HOST_ADDR);
+}
+/*---------------------------------------------------------------------------*/
+static int
+output(uint8_t *packet, uint16_t packet_len)
+{
+  if(write(tapfd, packet, packet_len) != packet_len) {
+    LOG_ERR("Write of %u bytes to the TAP device failed\n", packet_len);
+    return 0;
+  }
+
+  return packet_len;
+}
+/*---------------------------------------------------------------------------*/
+const struct ip64_driver ip64_tap_driver = { init, output };
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/27-ip64-tap/ip64-tap-driver.h
+++ b/tests/08-native-runs/27-ip64-tap/ip64-tap-driver.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+
+/**
+ * \file
+ *   ip64 driver that puts the IPv4 side of the node on a Linux TAP device,
+ *   so that software running on the host can exchange IPv4 traffic with it.
+ */
+
+#ifndef IP64_TAP_DRIVER_H
+#define IP64_TAP_DRIVER_H
+
+#include <stdint.h>
+
+/* ip64-driver.h uses uint8_t and uint16_t without including <stdint.h>. */
+#include "ip64/ip64-driver.h"
+
+extern const struct ip64_driver ip64_tap_driver;
+
+#endif /* IP64_TAP_DRIVER_H */

--- a/tests/08-native-runs/27-ip64-tap/ip64-tap-node.c
+++ b/tests/08-native-runs/27-ip64-tap/ip64-tap-node.c
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+
+/**
+ * \file
+ *   Node for the ip64 TAP test. It runs the ip64 service with its IPv4 side
+ *   on a host TAP device, and sends UDP to an IPv4 echo server on the host
+ *   through the NAT64 prefix until the reply comes back. The host can reach
+ *   the node in the other direction at the IPv4 address configured here,
+ *   which is what the accompanying script uses ping for.
+ *
+ *   Built with IP64_CONF_DHCP=1 the node takes its IPv4 address from a DHCP
+ *   server on the host instead of the fixed one below. That exchange travels
+ *   through ip64 as well: the client sends to 64:ff9b::255.255.255.255, which
+ *   ip64 translates into an IPv4 broadcast, and the reply comes back as an
+ *   IPv4 broadcast that ip64 turns into an all-nodes multicast.
+ *
+ *   The node also resolves a name through a DNS server on the host. Because
+ *   the node is IPv6-only it asks for a AAAA record, which the IPv4 server
+ *   can only answer if ip64 rewrites the question, and the A record that
+ *   comes back is of no use unless ip64 turns it into an AAAA record.
+ */
+
+#include "contiki.h"
+#include "contiki-net.h"
+#include "net/ipv6/simple-udp.h"
+#include "net/ipv6/ip64-addr.h"
+
+#include "ip64/ip64.h"
+#include "ip64/ip64-eth.h"
+#include "net/ipv6/uip-nameserver.h"
+#include "net/ipv6/uiplib.h"
+#include "resolv.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define LOCAL_PORT   3000
+#define ECHO_PORT    5557
+
+#define REQUEST      "PING-IP64-TAP"
+
+
+#define SEND_INTERVAL (CLOCK_SECOND * 2)
+
+/* The name the host's DNS server answers, and the address it answers with.
+   The address differs from the server's own so that a resolved address can
+   only have come from the answer. */
+#define LOOKUP_NAME "ip64-test.example"
+
+static bool name_resolved;
+
+static struct simple_udp_connection conn;
+
+PROCESS(ip64_tap_node_process, "ip64 TAP node");
+AUTOSTART_PROCESSES(&ip64_tap_node_process);
+
+/*---------------------------------------------------------------------------*/
+static void
+echo_received(struct simple_udp_connection *c, const uip_ipaddr_t *sender_addr,
+              uint16_t sender_port, const uip_ipaddr_t *receiver_addr,
+              uint16_t receiver_port, const uint8_t *data, uint16_t datalen)
+{
+  if(datalen == strlen(REQUEST) && memcmp(data, REQUEST, datalen) == 0) {
+    /* The echo server on the host received IPv4 and its reply was translated
+       back, so both legs work. */
+    printf("IP64_TAP_ECHO_OK\n");
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* Report the address the name resolved to, once. The address the host's DNS
+   server put in its A record must come back as a NAT64 address. */
+static void
+attempt_lookup(void)
+{
+  uip_ipaddr_t *resolved = NULL;
+  char buf[UIPLIB_IPV6_MAX_STR_LEN];
+
+  switch(resolv_lookup(LOOKUP_NAME, &resolved)) {
+  case RESOLV_STATUS_CACHED:
+    if(!name_resolved && resolved != NULL) {
+      name_resolved = true;
+      uiplib_ipaddr_snprint(buf, sizeof(buf), resolved);
+      printf("IP64_TAP_DNS_OK %s %s\n", LOOKUP_NAME, buf);
+    }
+    break;
+  case RESOLV_STATUS_UNCACHED:
+  case RESOLV_STATUS_EXPIRED:
+    resolv_query(LOOKUP_NAME);
+    break;
+  case RESOLV_STATUS_NOT_FOUND:
+    printf("IP64_TAP_DNS_NOT_FOUND %s\n", LOOKUP_NAME);
+    break;
+  default:
+    break;
+  }
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(ip64_tap_node_process, ev, data)
+{
+  static struct etimer timer;
+  static uip_ipaddr_t echoaddr;
+#if IP64_DHCP
+  const uip_ip4addr_t *configured;
+#else
+  static uip_ip4addr_t hostaddr, netmask, draddr;
+#endif
+  static struct ip64_eth_addr eth_addr = {
+    { 0x02, 0x11, 0x22, 0x33, 0x44, 0x55 }
+  };
+
+  PROCESS_BEGIN();
+
+  /* The test script builds this node both ways and reads here which one it
+     is running, so that it knows whether to expect a lease. */
+#if IP64_DHCP
+  printf("IP64_TAP_MODE dhcp\n");
+#else
+  printf("IP64_TAP_MODE static\n");
+#endif
+
+  ip64_eth_addr_set(&eth_addr);
+
+  /* Creates the TAP device, and starts the DHCP client if it is enabled. */
+  ip64_init();
+  printf("IP64_TAP_DEVICE_UP\n");
+
+#if IP64_DHCP
+  /* Wait for the lease. The server on the host may not be listening yet, but
+     the DHCP client retransmits. */
+  etimer_set(&timer, CLOCK_SECOND / 2);
+  while(!ip64_hostaddr_is_configured()) {
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+    etimer_reset(&timer);
+  }
+
+  configured = ip64_get_hostaddr();
+  printf("IP64_TAP_LEASE %d.%d.%d.%d", uip_ipaddr_to_quad(configured));
+  configured = ip64_get_draddr();
+  printf(" router %d.%d.%d.%d\n", uip_ipaddr_to_quad(configured));
+#else
+  /* The address the node answers to on the TAP network, and the host end of
+     it, which doubles as the node's default router. */
+  uip_ipaddr(&hostaddr, 192, 0, 2, 50);
+  uip_ipaddr(&netmask, 255, 255, 255, 0);
+  uip_ipaddr(&draddr, 192, 0, 2, 1);
+
+  ip64_set_hostaddr(&hostaddr);
+  ip64_set_netmask(&netmask);
+  ip64_set_draddr(&draddr);
+#endif /* IP64_DHCP */
+
+  simple_udp_register(&conn, LOCAL_PORT, NULL, ECHO_PORT, echo_received);
+
+  /* The echo server listens on the host end of the TAP network, which is
+     also the default router, reached through the NAT64 prefix. Taking the
+     address from ip64 covers both ways of configuring it. */
+  ip64_addr_4to6(ip64_get_draddr(), &echoaddr);
+
+  /* The DNS server runs on the host too, reached through the NAT64 prefix
+     like any other IPv4 address. */
+  uip_nameserver_update(&echoaddr, UIP_NAMESERVER_INFINITE_LIFETIME);
+
+  printf("IP64_TAP_READY\n");
+
+  etimer_set(&timer, SEND_INTERVAL);
+  while(1) {
+    PROCESS_WAIT_EVENT();
+
+    if(ev == resolv_event_found) {
+      attempt_lookup();
+    }
+
+    if(etimer_expired(&timer)) {
+      simple_udp_sendto(&conn, REQUEST, strlen(REQUEST), &echoaddr);
+      if(!name_resolved) {
+        attempt_lookup();
+      }
+      etimer_reset(&timer);
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/27-ip64-tap/project-conf.h
+++ b/tests/08-native-runs/27-ip64-tap/project-conf.h
@@ -1,0 +1,11 @@
+/*
+ * Configuration for the ip64 TAP node.
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+/* The test runs a plain unicast DNS server on the host. */
+#define RESOLV_CONF_SUPPORTS_MDNS 0
+
+#endif /* PROJECT_CONF_H_ */

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -29,5 +29,6 @@ tests/08-native-runs/21-coffee-validation/native:./21-coffee-validation.sh \
 tests/08-native-runs/23-uiplib/native:./23-uiplib.sh \
 tests/08-native-runs/21-dbg-io/native:./21-dbg-io.sh \
 tests/08-native-runs/25-mqtt-prop/native:./25-mqtt-prop.sh \
+tests/08-native-runs/26-ip64/native:./26-ip64.sh \
 
 include ../Makefile.compile-test

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -30,5 +30,7 @@ tests/08-native-runs/23-uiplib/native:./23-uiplib.sh \
 tests/08-native-runs/21-dbg-io/native:./21-dbg-io.sh \
 tests/08-native-runs/25-mqtt-prop/native:./25-mqtt-prop.sh \
 tests/08-native-runs/26-ip64/native:./26-ip64.sh \
+tests/08-native-runs/27-ip64-tap/native:./27-ip64-tap.sh \
+tests/08-native-runs/27-ip64-tap/native:./27-ip64-tap.sh:DEFINES=IP64_CONF_DHCP=1 \
 
 include ../Makefile.compile-test


### PR DESCRIPTION
ip64 has never run in CI, only been cross-compiled for ARM. It does not even build for native: every file in os/services/ip64 is compiled, and ip64-slip-interface.c needs SLIP functions the native platform lacks. A Makefile.ip64 skips that file on native; other targets are unchanged.

tests/08-native-runs/26-ip64 runs the module in process with a capture driver in place of the ENC28J60, and asserts on the translated packets. It needs no hardware or privileges.

tests/26-ip64-tap gives the node a TAP device so that host programs can reach it over IPv4, and checks a UDP echo, a ping, a name lookup and a DHCP lease, which is how Orion gets its address. It needs CAP_NET_ADMIN and Linux, like the tun-based tests.

TCP, special ports, lease renewal, mapping expiry and the ENC28J60 driver are still untested.