### PR TITLE
native border-router: wake up select() when the SLIP send delay expires

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,9 @@ jobs:
               # No arm-none-eabi-gcc installed.
               - os: macos-15-intel
                 test: compile-arm-ports
-              # Uses zoul as dummy target, fails on missing arm-none-eabi-gcc.
-              # Tests/build system should be fixed.
+              # 07-native-border-router is flaky on the hosted runners:
+              # intermittent 100% ping loss, correlated with slow runs
+              # (~1s event cadence instead of ~150ms mesh RTT).
               - os: macos-15-intel
                 test: tun-rpl-br
               # tests/utils.sh: kill_bg contains ps --ppid (not portable).

--- a/os/services/rpl-border-router/native/slip-dev.c
+++ b/os/services/rpl-border-router/native/slip-dev.c
@@ -53,6 +53,7 @@
 
 #include "net/netstack.h"
 #include "net/packetbuf.h"
+#include "sys/rtimer.h"
 #include "cmd.h"
 #include "border-router.h"
 #include "border-router-cmds.h"
@@ -486,12 +487,39 @@ stty_telos(int fd)
   }
 }
 /*---------------------------------------------------------------------------*/
+static struct rtimer send_delay_wakeup;
+/*---------------------------------------------------------------------------*/
+static void
+send_delay_wakeup_callback(struct rtimer *t, void *ptr)
+{
+  /*
+   * Nothing to do: the SIGALRM that delivered this interrupted select() in
+   * platform_main_loop(), which re-evaluates set_fd() and now finds the
+   * send-delay timer expired.
+   */
+}
+/*---------------------------------------------------------------------------*/
 static int
 set_fd(fd_set *rset, fd_set *wset)
 {
   /* Anything to flush? */
-  if(!slip_empty() && (send_delay == 0 || timer_expired(&send_delay_timer))) {
-    FD_SET(slipfd, wset);
+  if(!slip_empty()) {
+    if(send_delay == 0 || timer_expired(&send_delay_timer)) {
+      FD_SET(slipfd, wset);
+    } else {
+      /*
+       * send_delay_timer is a passive struct timer: nothing wakes the
+       * select() in platform_main_loop() when it expires, so with no other
+       * fd activity the next SLIP packet waits for the full SELECT_TIMEOUT
+       * (1 s) instead of SEND_DELAY (31 ms). Under load (6LoWPAN
+       * fragments from the TUN) that overflows slip_buf and kills the
+       * router. Arm an rtimer for the remaining delay; its SIGALRM
+       * interrupts select() so we come back here on time.
+       */
+      rtimer_set(&send_delay_wakeup,
+                 RTIMER_NOW() + timer_remaining(&send_delay_timer) + 1, 1,
+                 send_delay_wakeup_callback, NULL);
+    }
   }
 
   FD_SET(slipfd, rset);	/* Read from slip ASAP! */


### PR DESCRIPTION
`os/services/rpl-border-router/native/slip-dev.c` rate-limits SLIP output with `SLIP_DEV_CONF_SEND_DELAY` (31 ms), implemented as a passive `struct timer` that `set_fd()` checks when the native platform's `select()` loop builds its fd sets. Nothing wakes `select()` when that timer expires, so unless some other fd becomes active the next SLIP packet waits for the full `SELECT_TIMEOUT` (1 s). Under load — 6LoWPAN fragments arriving from the TUN faster than one per second — the 2048-byte `slip_buf` overflows and the router exits:

```
border-router.native: slip_send overflow: Resource temporarily unavailable
```

The fix arms an rtimer for the remaining delay; its SIGALRM interrupts `select()`, so `set_fd()` runs again on time and the flush happens after 31 ms instead of 1 s.

Verified effects:
- `17-tun-rpl-br/09-native-border-router-cooja-frag` goes from `slip_send overflow` / 100 % loss to **5/5** 1208-byte pings received on macOS — confirmed both locally and on the `macos-15-intel` runner (first CI revision of this PR).
- Linux Cooja CI currently receives only **3/5** on `09` (e.g. run 32590916149); the same race, lost less often.

The macOS exclusion of `tun-rpl-br` is kept, with an updated comment: `07-native-border-router-cooja` is flaky on the hosted runners — over 7 isolated runs it failed 4× with 100 % ping loss and passed 3×, and in the failing runs the whole mesh path runs at ~1 s event cadence instead of the usual ~150 ms RTT, suggesting runner-load-dependent timing. That is a separate issue and is not addressed here.
