### PR TITLE
rpl-classic: validate externally controlled fields in RPL control messages

### DIFF
--- a/os/net/routing/rpl-classic/rpl-ext-header.c
+++ b/os/net/routing/rpl-classic/rpl-ext-header.c
@@ -192,6 +192,14 @@ rpl_ext_header_srh_get_next_hop(uip_ipaddr_t *ipaddr)
   rh_header = (struct uip_routing_hdr *)uipbuf_search_header(uip_buf, uip_len, UIP_PROTO_ROUTING);
 
   dag = rpl_get_dag(&UIP_IP_BUF->destipaddr);
+  if(dag == NULL) {
+    /*
+     * The destination is not in a DAG that we have joined, so there is
+     * no source routing graph to consult.
+     */
+    return 0;
+  }
+
   root_node = uip_sr_get_node(dag, &dag->dag_id);
   dest_node = uip_sr_get_node(dag, &UIP_IP_BUF->destipaddr);
 

--- a/os/net/routing/rpl-classic/rpl-ext-header.c
+++ b/os/net/routing/rpl-classic/rpl-ext-header.c
@@ -217,32 +217,126 @@ rpl_ext_header_srh_get_next_hop(uip_ipaddr_t *ipaddr)
 }
 /*---------------------------------------------------------------------------*/
 #if RPL_WITH_NON_STORING
+/*
+ * Derived contents of a source routing header, after validation against
+ * both the extent declared by the header and the length of the received
+ * packet. An address access computed from these values is guaranteed to
+ * stay within the header.
+ */
+struct rpl_srh_info {
+  size_t ext_len;        /* Total size of the routing header, in bytes. */
+  uint8_t segments_left;
+  uint8_t cmpri;
+  uint8_t cmpre;
+  uint8_t padding;
+  uint8_t path_len;      /* Number of addresses carried in the header. */
+};
+/*---------------------------------------------------------------------------*/
+/*
+ * Parse and validate a source routing header. The compression and padding
+ * fields come from the packet, so the address vector must be shown to have
+ * exactly the size that they imply, and the whole header must be contained
+ * in the received packet, before any address is accessed.
+ */
 static bool
-srh_is_valid(struct uip_routing_hdr *rh_header,
-             struct uip_rpl_srh_hdr *srh_header)
+srh_parse(const struct uip_routing_hdr *rh_header, struct rpl_srh_info *srh)
+{
+  const struct uip_rpl_srh_hdr *srh_header;
+  ptrdiff_t rh_offset;
+  size_t vector_len;
+  size_t last_addr_len;
+  size_t path_len;
+
+  rh_offset = (const uint8_t *)rh_header - uip_buf;
+  srh->ext_len = (size_t)rh_header->len * 8 + 8;
+
+  /* The complete routing header must be part of the received packet. */
+  if(rh_offset < 0 || (size_t)rh_offset + srh->ext_len > uip_len) {
+    LOG_ERR("SRH extends past the received packet\n");
+    return false;
+  }
+
+  srh_header = (const struct uip_rpl_srh_hdr *)
+    ((const uint8_t *)rh_header + RPL_RH_LEN);
+  srh->segments_left = rh_header->seg_left;
+  srh->cmpri = srh_header->cmpr >> 4;
+  srh->cmpre = srh_header->cmpr & 0x0f;
+  srh->padding = srh_header->pad >> 4;
+
+  /*
+   * Padding only aligns the header to an eight-octet boundary. Values of
+   * eight or more are rejected here, although the field itself is four
+   * bits wide.
+   */
+  if(srh->padding >= 8) {
+    LOG_ERR("SRH with invalid padding %u\n", (unsigned)srh->padding);
+    return false;
+  }
+
+  /*
+   * The addresses follow the two fixed headers. All of them but the last
+   * are compressed by CmprI, and the last one by CmprE. Both fields are
+   * four bits wide, so an address is never shorter than a single byte.
+   */
+  vector_len = srh->ext_len - RPL_RH_LEN - RPL_SRH_LEN;
+  last_addr_len = 16 - srh->cmpre;
+  if(vector_len < last_addr_len + srh->padding) {
+    LOG_ERR("SRH too short to hold an address vector\n");
+    return false;
+  }
+
+  path_len = (vector_len - last_addr_len - srh->padding) / (16 - srh->cmpri) + 1;
+  if(path_len > UINT8_MAX) {
+    LOG_ERR("SRH with too many addresses (%u)\n", (unsigned)path_len);
+    return false;
+  }
+
+  /* The address vector must have exactly the size that it declares. */
+  if((path_len - 1) * (16 - srh->cmpri) + last_addr_len + srh->padding
+     != vector_len) {
+    LOG_ERR("SRH with an inconsistent address vector size\n");
+    return false;
+  }
+
+  if(srh->segments_left > path_len) {
+    LOG_ERR("SRH with too many segments left (%u > %u)\n",
+            (unsigned)srh->segments_left, (unsigned)path_len);
+    return false;
+  }
+
+  srh->path_len = path_len;
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Return a pointer to the address at the given index, and the number of
+ * bytes by which that address is compressed. RFC 6554, Section 3: every
+ * address but the last is compressed by CmprI, and the last one by CmprE.
+ * The index must be below the path length of a header that srh_parse()
+ * has accepted, which makes the access stay within the header.
+ */
+static uint8_t *
+srh_addr(struct uip_routing_hdr *rh_header, const struct rpl_srh_info *srh,
+         uint8_t index, uint8_t *cmpr)
+{
+  *cmpr = index == srh->path_len - 1 ? srh->cmpre : srh->cmpri;
+  return (uint8_t *)rh_header + RPL_RH_LEN + RPL_SRH_LEN +
+    (size_t)index * (16 - srh->cmpri);
+}
+/*---------------------------------------------------------------------------*/
+static bool
+srh_is_valid(struct uip_routing_hdr *rh_header, const struct rpl_srh_info *srh)
 {
   uip_ipaddr_t hop_addr;
-  uip_ipaddr_copy(&hop_addr, &UIP_IP_BUF->destipaddr);
-
-  uint8_t segments_left = rh_header->seg_left;
-  uint8_t ext_len = rh_header->len * 8 + 8;
-  uint8_t cmpri = srh_header->cmpr >> 4;
-  uint8_t cmpre = srh_header->cmpr & 0x0f;
-  uint8_t padding = srh_header->pad >> 4;
-  uint8_t path_len = ((ext_len - padding - RPL_RH_LEN - RPL_SRH_LEN - (16 - cmpre)) / (16 - cmpri)) + 1;
-
   bool prev_hop_is_my_addr = false;
   uint8_t my_addr_count = 0;
-  for(uint8_t i = path_len - segments_left; i < path_len; i++) {
-    uint8_t cmpr = segments_left == 1 ? cmpre : cmpri;
-    ptrdiff_t rh_offset = (uint8_t *)rh_header - uip_buf;
-    size_t addr_offset = RPL_RH_LEN + RPL_SRH_LEN + (i * (16 - cmpri));
 
-    if(rh_offset + addr_offset + 16 - cmpr > UIP_BUFSIZE) {
-      return false;
-    }
+  uip_ipaddr_copy(&hop_addr, &UIP_IP_BUF->destipaddr);
 
-    uint8_t *addr_ptr = (uint8_t *)rh_header + addr_offset;
+  for(uint8_t i = srh->path_len - srh->segments_left; i < srh->path_len; i++) {
+    uint8_t cmpr;
+    const uint8_t *addr_ptr = srh_addr(rh_header, srh, i, &cmpr);
+
     memcpy((uint8_t *)&hop_addr + cmpr, addr_ptr, 16 - cmpr);
 
     LOG_DBG("Processing SRH hop %u, IP addr ", i);
@@ -287,7 +381,6 @@ rpl_ext_header_srh_update(void)
 {
 #if RPL_WITH_NON_STORING
   struct uip_routing_hdr *rh_header;
-  struct uip_rpl_srh_hdr *srh_header;
 
   /* Look for routing ext header */
   rh_header = (struct uip_routing_hdr *)uipbuf_search_header(uip_buf, uip_len,
@@ -295,50 +388,31 @@ rpl_ext_header_srh_update(void)
 
   if(rh_header != NULL && rh_header->routing_type == RPL_RH_TYPE_SRH) {
     /* SRH found, now look for next hop */
-    uint8_t cmpri, cmpre;
-    uint8_t ext_len;
-    uint8_t padding;
-    uint8_t path_len;
-    uint8_t segments_left;
+    struct rpl_srh_info srh;
     uip_ipaddr_t current_dest_addr;
 
-    srh_header = (struct uip_rpl_srh_hdr *)(((uint8_t *)rh_header) + RPL_RH_LEN);
-    segments_left = rh_header->seg_left;
-    ext_len = rh_header->len * 8 + 8;
-    cmpri = srh_header->cmpr >> 4;
-    cmpre = srh_header->cmpr & 0x0f;
-    padding = srh_header->pad >> 4;
-    path_len = ((ext_len - padding - RPL_RH_LEN - RPL_SRH_LEN - (16 - cmpre)) / (16 - cmpri)) + 1;
-    (void)path_len;
+    if(!srh_parse(rh_header, &srh)) {
+      return 0;
+    }
 
     LOG_DBG("read SRH, path len %u, segments left %u, Cmpri %u, Cmpre %u, ext len %u (padding %u)\n",
-            path_len, segments_left, cmpri, cmpre, ext_len, padding);
+            srh.path_len, srh.segments_left, srh.cmpri, srh.cmpre,
+            (unsigned)srh.ext_len, srh.padding);
 
-    if(segments_left == 0) {
+    if(srh.segments_left == 0) {
       /* We are the final destination, do nothing. */
-    } else if(segments_left > path_len) {
-      /* Discard the packet because of a parameter problem. */
-      LOG_ERR("SRH with too many segments left (%u > %u)\n",
-              segments_left, path_len);
-      return 0;
     } else {
-      if(!srh_is_valid(rh_header, srh_header)) {
+      uint8_t cmpr;
+      uint8_t *addr_ptr;
+
+      if(!srh_is_valid(rh_header, &srh)) {
         LOG_ERR("Invalid SRH hop sequence\n");
         return 0;
       }
 
       /* The index of the next address to be visited. */
-      uint8_t i = path_len - segments_left;
-      uint8_t cmpr = segments_left == 1 ? cmpre : cmpri;
-      ptrdiff_t rh_offset = (uint8_t *)rh_header - uip_buf;
-      size_t addr_offset = RPL_RH_LEN + RPL_SRH_LEN + (i * (16 - cmpri));
-
-      if(rh_offset + addr_offset + 16 - cmpr > UIP_BUFSIZE) {
-        LOG_ERR("Invalid SRH address pointer\n");
-        return 0;
-      }
-
-      uint8_t *addr_ptr = ((uint8_t *)rh_header) + addr_offset;
+      addr_ptr = srh_addr(rh_header, &srh,
+                          srh.path_len - srh.segments_left, &cmpr);
 
       /* As per RFC6554: swap the IPv6 destination address and address[i]. */
 

--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -722,9 +722,11 @@ dao_input_storing(void)
   rpl_parent_t *parent;
   uip_ds6_nbr_t *nbr;
   int is_root;
+  int target_received;
 
   prefixlen = 0;
   parent = NULL;
+  target_received = 0;
   memset(&prefix, 0, sizeof(prefix));
 
   uip_ipaddr_copy(&dao_sender_addr, &UIP_IP_BUF->srcipaddr);
@@ -830,8 +832,14 @@ dao_input_storing(void)
       }
       prefixlen = buffer[i + 3];
       if(prefixlen == 0) {
-        /* Ignore option targets with a prefix length of 0. */
-        break;
+        /*
+         * A zero-length prefix matches every destination, so it is not
+         * accepted as a target here. Rejecting it rather than ignoring it
+         * also keeps it from resetting the length of a target that was
+         * already accepted.
+         */
+        LOG_WARN("Dropping DAO with a zero-length target prefix\n");
+        return;
       }
       if(prefixlen > 128) {
         LOG_ERR("Too large target prefix length %d\n", prefixlen);
@@ -844,6 +852,7 @@ dao_input_storing(void)
       }
       memset(&prefix, 0, sizeof(prefix));
       memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
+      target_received = 1;
       break;
     case RPL_OPTION_TRANSIT:
       /* The path sequence and control are ignored. */
@@ -856,6 +865,15 @@ dao_input_storing(void)
       /* The parent address is also ignored. */
       break;
     }
+  }
+
+  /*
+   * A DAO must carry a target. Continuing without one would install a
+   * route for the zero-length prefix, which matches every destination.
+   */
+  if(!target_received) {
+    LOG_WARN("Dropping DAO without a valid target option\n");
+    return;
   }
 
   LOG_INFO("DAO lifetime: %u, prefix length: %u prefix: ",
@@ -1036,6 +1054,7 @@ dao_input_nonstoring(void)
   int pos;
   int len;
   int i;
+  int target_received;
 
   /* Destination Advertisement Object */
   LOG_INFO("Received a DAO from ");
@@ -1043,8 +1062,10 @@ dao_input_nonstoring(void)
   LOG_INFO_("\n");
 
   prefixlen = 0;
+  target_received = 0;
 
   uip_ipaddr_copy(&dao_sender_addr, &UIP_IP_BUF->srcipaddr);
+  memset(&prefix, 0, sizeof(prefix));
   memset(&dao_parent_addr, 0, 16);
 
   buffer = UIP_ICMP_PAYLOAD;
@@ -1106,8 +1127,14 @@ dao_input_nonstoring(void)
       }
       prefixlen = buffer[i + 3];
       if(prefixlen == 0) {
-        /* Ignore option targets with a prefix length of 0. */
-        break;
+        /*
+         * A zero-length prefix matches every destination, so it is not
+         * accepted as a target here. Rejecting it rather than ignoring it
+         * also keeps it from resetting the length of a target that was
+         * already accepted.
+         */
+        LOG_WARN("Dropping DAO with a zero-length target prefix\n");
+        return;
       }
       if(prefixlen > 128) {
         LOG_ERR("Too large target prefix length %d\n", prefixlen);
@@ -1121,6 +1148,7 @@ dao_input_nonstoring(void)
 
       memset(&prefix, 0, sizeof(prefix));
       memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
+      target_received = 1;
       break;
     case RPL_OPTION_TRANSIT:
       /* The path sequence and control are ignored. */
@@ -1135,6 +1163,16 @@ dao_input_nonstoring(void)
       }
       break;
     }
+  }
+
+  /*
+   * A DAO must carry a target. The prefix is zero-initialized above so
+   * that it can never be used uninitialized, but the unspecified address
+   * must not enter the source routing graph either.
+   */
+  if(!target_received) {
+    LOG_WARN("Dropping DAO without a valid target option\n");
+    return;
   }
 
   LOG_INFO("DAO lifetime: %u, prefix length: %u prefix: ",

--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -1063,14 +1063,29 @@ dao_input_nonstoring(void)
   int len;
   int i;
   int target_received;
+  int parent_addr_received;
 
   /* Destination Advertisement Object */
   LOG_INFO("Received a DAO from ");
   LOG_INFO_6ADDR(&UIP_IP_BUF->srcipaddr);
   LOG_INFO_("\n");
 
+  /*
+   * A multicast advertisement belongs to the mode of operation that stores
+   * routes and carries multicast groups, and this parser serves the one that
+   * does not store them. Declining it here also keeps the requirement below,
+   * which RFC 6550, Section 9.4, states for a unicast advertisement, from
+   * being applied to a message that the same section forbids to carry a
+   * parent address.
+   */
+  if(uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+    LOG_WARN("Dropping a multicast DAO received in non-storing mode\n");
+    return;
+  }
+
   prefixlen = 0;
   target_received = 0;
+  parent_addr_received = 0;
 
   uip_ipaddr_copy(&dao_sender_addr, &UIP_IP_BUF->srcipaddr);
   memset(&prefix, 0, sizeof(prefix));
@@ -1181,6 +1196,7 @@ dao_input_nonstoring(void)
       if(len >= RPL_DAO_TRANSIT_OPTION_MIN_LEN + (int)sizeof(dao_parent_addr)) {
         memcpy(&dao_parent_addr, buffer + i + RPL_DAO_TRANSIT_OPTION_MIN_LEN,
                sizeof(dao_parent_addr));
+        parent_addr_received = 1;
       }
       break;
     }
@@ -1193,6 +1209,18 @@ dao_input_nonstoring(void)
    */
   if(!target_received) {
     LOG_WARN("Dropping DAO without a valid target option\n");
+    return;
+  }
+
+  /*
+   * The parent address is what links the target into the source routing
+   * graph, so a DAO whose transit option does not carry one has nothing
+   * to record. Accepting it would make the unspecified address the parent
+   * of the target. RFC 6550, Section 9.4, asks for the transit option in a
+   * unicast advertisement, and a multicast one has already been declined.
+   */
+  if(!parent_addr_received) {
+    LOG_WARN("Dropping DAO without a transit option carrying a parent address\n");
     return;
   }
 

--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -1316,6 +1316,20 @@ handle_dao_retransmission(void *ptr)
 }
 #endif /* RPL_WITH_DAO_ACK */
 /*---------------------------------------------------------------------------*/
+/*
+ * Return the address that a DAO is sent to: the preferred parent when
+ * storing routes, and the root of the DAG when not.
+ */
+static uip_ipaddr_t *
+dao_destination(rpl_parent_t *parent)
+{
+  if(parent->dag->instance->mop != RPL_MOP_NON_STORING) {
+    return rpl_parent_get_ipaddr(parent);
+  }
+
+  return &parent->dag->dag_id;
+}
+/*---------------------------------------------------------------------------*/
 void
 dao_output(rpl_parent_t *parent, uint8_t lifetime)
 {
@@ -1341,10 +1355,25 @@ dao_output(rpl_parent_t *parent, uint8_t lifetime)
    */
   if(lifetime != RPL_ZERO_LIFETIME) {
     rpl_instance_t *instance;
+    const uip_ipaddr_t *dest_ipaddr;
+
     instance = parent->dag->instance;
+    dest_ipaddr = dao_destination(parent);
 
     instance->my_dao_seqno = dao_sequence;
     instance->my_dao_transmissions = 1;
+
+    /*
+     * Remember where the DAO is sent, so that no other node can
+     * acknowledge it. An unspecified address matches no sender, and thus
+     * rejects every acknowledgment.
+     */
+    if(dest_ipaddr == NULL) {
+      memset(&instance->my_dao_dest, 0, sizeof(instance->my_dao_dest));
+    } else {
+      uip_ipaddr_copy(&instance->my_dao_dest, dest_ipaddr);
+    }
+
     ctimer_set(&instance->dao_retransmit_timer, RPL_DAO_RETRANSMISSION_TIMEOUT,
                handle_dao_retransmission, parent);
   }
@@ -1454,19 +1483,16 @@ dao_output_target_seq(rpl_parent_t *parent, uip_ipaddr_t *prefix,
   buffer[pos++] = 0; /* path seq - ignored */
   buffer[pos++] = lifetime;
 
-  if(instance->mop != RPL_MOP_NON_STORING) {
-    /* Send DAO to the parent. */
-    dest_ipaddr = parent_ipaddr;
-  } else {
+  if(instance->mop == RPL_MOP_NON_STORING) {
     /* Include the parent's global IP address. */
     memcpy(buffer + pos, &parent->dag->dag_id, 8); /* Prefix */
     pos += 8;
     /* Interface identifier. */
     memcpy(buffer + pos, ((const unsigned char *)parent_ipaddr) + 8, 8);
     pos += 8;
-    /* Send DAO to root */
-    dest_ipaddr = &parent->dag->dag_id;
   }
+
+  dest_ipaddr = dao_destination(parent);
 
   LOG_INFO("Sending a %sDAO with sequence number %u, lifetime %u, prefix ",
            lifetime == RPL_ZERO_LIFETIME ? "No-Path " : "", seq_no, lifetime);
@@ -1494,6 +1520,14 @@ dao_ack_input(void)
   uint8_t status;
   rpl_instance_t *instance;
   rpl_parent_t *parent;
+
+  if(uip_len < uip_l3_icmp_hdr_len + RPL_DAO_ACK_LEN) {
+    LOG_WARN("Dropping incomplete DAO ACK (%u < %u)\n",
+             (unsigned)uip_len,
+             (unsigned)(uip_l3_icmp_hdr_len + RPL_DAO_ACK_LEN));
+    uipbuf_clear();
+    return;
+  }
 
   buffer = UIP_ICMP_PAYLOAD;
 
@@ -1531,6 +1565,22 @@ dao_ack_input(void)
   LOG_INFO_("\n");
 
   if(sequence == instance->my_dao_seqno) {
+    /*
+     * RFC 6550, Section 6.5: a DAO ACK is sent by a DAO recipient, that
+     * is a DAO parent or the DODAG root, in response to a unicast DAO.
+     * Only the node that the DAO was sent to can therefore acknowledge
+     * it.
+     */
+    if(!uip_ipaddr_cmp(&UIP_IP_BUF->srcipaddr, &instance->my_dao_dest)) {
+      LOG_WARN("Dropping a DAO ACK from an unexpected source ");
+      LOG_WARN_6ADDR(&UIP_IP_BUF->srcipaddr);
+      LOG_WARN_(", expected ");
+      LOG_WARN_6ADDR(&instance->my_dao_dest);
+      LOG_WARN_("\n");
+      uipbuf_clear();
+      return;
+    }
+
     instance->has_downward_route = status < 128;
 
     /* Always stop the retransmit timer when the ACK arrived. */
@@ -1567,7 +1617,7 @@ dao_ack_input(void)
         LOG_INFO_6ADDR(nexthop);
         LOG_INFO_("\n");
         buffer[2] = re->state.dao_seqno_in;
-        uip_icmp6_send(nexthop, ICMP6_RPL, RPL_CODE_DAO_ACK, 4);
+        uip_icmp6_send(nexthop, ICMP6_RPL, RPL_CODE_DAO_ACK, RPL_DAO_ACK_LEN);
       }
 
       if(status >= RPL_DAO_ACK_UNABLE_TO_ACCEPT) {
@@ -1602,7 +1652,7 @@ dao_ack_output(rpl_instance_t *instance, uip_ipaddr_t *dest, uint8_t sequence,
   buffer[2] = sequence;
   buffer[3] = status;
 
-  uip_icmp6_send(dest, ICMP6_RPL, RPL_CODE_DAO_ACK, 4);
+  uip_icmp6_send(dest, ICMP6_RPL, RPL_CODE_DAO_ACK, RPL_DAO_ACK_LEN);
 #endif /* RPL_WITH_DAO_ACK */
 }
 /*---------------------------------------------------------------------------*/

--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -820,14 +820,23 @@ dao_input_storing(void)
         return;
       }
       len = 2 + buffer[i + 1];
+      /*
+       * Every field of an option must be validated against the extent
+       * declared by the option itself, so that a short option cannot
+       * consume bytes belonging to the options that follow it.
+       */
+      if(i + len > buffer_length) {
+        LOG_WARN("Dropping DAO with an option extending past the message (%d > %" PRIu16 ")\n",
+                 i + len, buffer_length);
+        return;
+      }
     }
 
     switch(subopt_type) {
     case RPL_OPTION_TARGET:
       /* Handle the target option. */
-      if(last_valid_pos < i + 3) {
-        LOG_WARN("Dropping incomplete DAO (%" PRIu16 " < %d)\n",
-                 last_valid_pos, i + 3);
+      if(len < RPL_DAO_TARGET_OPTION_MIN_LEN) {
+        LOG_WARN("Dropping DAO with a too short target option (%d)\n", len);
         return;
       }
       prefixlen = buffer[i + 3];
@@ -845,7 +854,7 @@ dao_input_storing(void)
         LOG_ERR("Too large target prefix length %d\n", prefixlen);
         return;
       }
-      if(i + 4 + ((prefixlen + 7) / CHAR_BIT) > buffer_length) {
+      if(RPL_DAO_TARGET_OPTION_MIN_LEN + ((prefixlen + 7) / CHAR_BIT) > len) {
         LOG_ERR("Incomplete DAO target option with prefix length of %d bits\n",
                 prefixlen);
         return;
@@ -856,9 +865,8 @@ dao_input_storing(void)
       break;
     case RPL_OPTION_TRANSIT:
       /* The path sequence and control are ignored. */
-      if(last_valid_pos < i + 5) {
-        LOG_WARN("Dropping incomplete DAO (%" PRIu16 " < %d)\n",
-                 last_valid_pos, i + 5);
+      if(len < RPL_DAO_TRANSIT_OPTION_MIN_LEN) {
+        LOG_WARN("Dropping DAO with a too short transit option (%d)\n", len);
         return;
       }
       lifetime = buffer[i + 5];
@@ -1115,14 +1123,23 @@ dao_input_nonstoring(void)
         return;
       }
       len = 2 + buffer[i + 1];
+      /*
+       * Every field of an option must be validated against the extent
+       * declared by the option itself, so that a short option cannot
+       * consume bytes belonging to the options that follow it.
+       */
+      if(i + len > buffer_length) {
+        LOG_WARN("Dropping DAO with an option extending past the message (%d > %" PRIu16 ")\n",
+                 i + len, buffer_length);
+        return;
+      }
     }
 
     switch(subopt_type) {
     case RPL_OPTION_TARGET:
       /* Handle the target option. */
-      if(last_valid_pos < i + 3) {
-        LOG_WARN("Dropping incomplete DAO (%" PRIu16 " < %d)\n",
-                 last_valid_pos, i + 3);
+      if(len < RPL_DAO_TARGET_OPTION_MIN_LEN) {
+        LOG_WARN("Dropping DAO with a too short target option (%d)\n", len);
         return;
       }
       prefixlen = buffer[i + 3];
@@ -1140,7 +1157,7 @@ dao_input_nonstoring(void)
         LOG_ERR("Too large target prefix length %d\n", prefixlen);
         return;
       }
-      if(i + 4 + ((prefixlen + 7) / CHAR_BIT) > buffer_length) {
+      if(RPL_DAO_TARGET_OPTION_MIN_LEN + ((prefixlen + 7) / CHAR_BIT) > len) {
         LOG_ERR("Incomplete DAO target option with prefix length of %d bits\n",
                 prefixlen);
         return;
@@ -1152,14 +1169,18 @@ dao_input_nonstoring(void)
       break;
     case RPL_OPTION_TRANSIT:
       /* The path sequence and control are ignored. */
-      if(i + 6 + 16 > buffer_length) {
-        LOG_WARN("Incomplete DAO transit option (%d > %" PRIu16 ")\n",
-                 i + 6 + 16, buffer_length);
+      if(len < RPL_DAO_TRANSIT_OPTION_MIN_LEN) {
+        LOG_WARN("Dropping DAO with a too short transit option (%d)\n", len);
         return;
       }
       lifetime = buffer[i + 5];
-      if(len >= 20) {
-        memcpy(&dao_parent_addr, buffer + i + 6, 16);
+      /*
+       * RFC 6550, Section 6.7.8: the option length is used to determine
+       * whether or not the parent address is present.
+       */
+      if(len >= RPL_DAO_TRANSIT_OPTION_MIN_LEN + (int)sizeof(dao_parent_addr)) {
+        memcpy(&dao_parent_addr, buffer + i + RPL_DAO_TRANSIT_OPTION_MIN_LEN,
+               sizeof(dao_parent_addr));
       }
       break;
     }

--- a/os/net/routing/rpl-classic/rpl-icmp6.c
+++ b/os/net/routing/rpl-classic/rpl-icmp6.c
@@ -279,6 +279,24 @@ dis_output(uip_ipaddr_t *addr)
   uip_icmp6_send(addr, ICMP6_RPL, RPL_CODE_DIS, 2);
 }
 /*---------------------------------------------------------------------------*/
+/*
+ * Check that a DIO interval received in a DAG Configuration option can be
+ * used as a shift count without invoking undefined behavior, and that the
+ * resulting number of milliseconds can be converted to clock ticks with the
+ * 32-bit arithmetic used by the Trickle timer and the DAG lifetime.
+ */
+static int
+dio_interval_is_valid(uint8_t intmin, uint8_t intdoubl)
+{
+  unsigned interval = (unsigned)intmin + intdoubl;
+
+  if(interval >= sizeof(unsigned long) * CHAR_BIT) {
+    return 0;
+  }
+
+  return (1UL << interval) <= UINT32_MAX / MAX(CLOCK_SECOND, RPL_DAG_LIFETIME);
+}
+/*---------------------------------------------------------------------------*/
 static void
 dio_input(void)
 {
@@ -457,6 +475,28 @@ dio_input(void)
       /* buffer + 12 is reserved */
       dio.default_lifetime = buffer[i + 13];
       dio.lifetime_unit = get16(buffer, i + 14);
+
+      /*
+       * The DAG Configuration values are used in arithmetic that is
+       * undefined or unbounded for parts of their encoded range, so they
+       * must be rejected here rather than after they have been copied into
+       * the instance state. A MinHopRankIncrease of zero would make
+       * DAG_RANK() divide by zero, and an excessive DIO interval would be
+       * used as an out-of-range shift count.
+       */
+      if(dio.dag_min_hoprankinc == 0) {
+        LOG_WARN("Invalid DAG configuration option, MinHopRankIncrease is 0\n");
+        RPL_STAT(rpl_stats.malformed_msgs++);
+        goto discard;
+      }
+
+      if(!dio_interval_is_valid(dio.dag_intmin, dio.dag_intdoubl)) {
+        LOG_WARN("Invalid DAG configuration option, DIO interval %u is too large\n",
+                 (unsigned)dio.dag_intmin + dio.dag_intdoubl);
+        RPL_STAT(rpl_stats.malformed_msgs++);
+        goto discard;
+      }
+
       LOG_INFO("DAG conf:dbl=%d, min=%d red=%d maxinc=%d mininc=%d ocp=%d d_l=%u l_u=%u\n",
                dio.dag_intdoubl, dio.dag_intmin, dio.dag_redund,
                dio.dag_max_rankinc, dio.dag_min_hoprankinc, dio.ocp,

--- a/os/net/routing/rpl-classic/rpl-private.h
+++ b/os/net/routing/rpl-classic/rpl-private.h
@@ -97,6 +97,9 @@
 #define RPL_DAO_TARGET_OPTION_MIN_LEN    4
 #define RPL_DAO_TRANSIT_OPTION_MIN_LEN   6
 
+/* Size, in bytes, of the DAO ACK base object. */
+#define RPL_DAO_ACK_LEN                  4
+
 #define RPL_DAO_K_FLAG                   0x80 /* DAO ACK requested */
 #define RPL_DAO_D_FLAG                   0x40 /* DODAG ID present */
 

--- a/os/net/routing/rpl-classic/rpl-private.h
+++ b/os/net/routing/rpl-classic/rpl-private.h
@@ -89,6 +89,14 @@
 #define RPL_OPTION_PREFIX_INFO           8
 #define RPL_OPTION_TARGET_DESC           9
 
+/*
+ * Smallest size, in bytes, of a target or transit information option,
+ * including the two-byte option header. The target prefix and the transit
+ * parent address follow these fields and are both optional.
+ */
+#define RPL_DAO_TARGET_OPTION_MIN_LEN    4
+#define RPL_DAO_TRANSIT_OPTION_MIN_LEN   6
+
 #define RPL_DAO_K_FLAG                   0x80 /* DAO ACK requested */
 #define RPL_DAO_D_FLAG                   0x40 /* DODAG ID present */
 

--- a/os/net/routing/rpl-classic/rpl.h
+++ b/os/net/routing/rpl-classic/rpl.h
@@ -241,6 +241,10 @@ struct rpl_instance {
   /* My last registered DAO that I might be waiting for an ACK on. */
   uint8_t my_dao_seqno;
   uint8_t my_dao_transmissions;
+#if RPL_WITH_DAO_ACK
+  /* The node that the DAO was sent to, and thus the only valid ACK source. */
+  uip_ipaddr_t my_dao_dest;
+#endif /* RPL_WITH_DAO_ACK */
   /* this is intended to keep track if this instance have a route downward */
   uint8_t has_downward_route;
   rpl_rank_t max_rankinc;


### PR DESCRIPTION
This PR fixes several issues where fields taken from received ICMPv6 RPL messages were used without validation.

* **DAG Configuration option.** The values were accepted after a length check only, so a DIO could set MinHopRankIncrease to zero and make `DAG_RANK()` divide by zero, or set a DIO interval later used as an out of range shift count. Rejected while parsing, which covers both the join path and a global repair.
* **DAO target option.** Neither parser required one. In storing mode a DAO carrying only the base object installed a route for the zero length prefix, which matches every destination without a more specific route. In non-storing mode the target address was never initialised and reached the source routing graph. A target whose prefix length is zero is now rejected rather than ignored, since ignoring it still let a later zero length target reset the length of one already accepted.
* **DAO option bounds.** Option fields were validated against the end of the message rather than the extent declared by the option, so a short target or transit option could consume bytes belonging to the option that followed it.
* **Source routing header.** The path length was computed from unvalidated compression and padding fields, and went negative before wrapping in an eight-bit variable. Address accesses were then bounded by `UIP_BUFSIZE` rather than by the routing header or `uip_len`, so they could read and write bytes left over from an earlier packet, and those bytes could reach the IPv6 destination address of a forwarded packet. Two related defects are fixed with it: the extension header length was held in an eight-bit variable, and the hop sequence validation chose the compression factor from the number of segments left rather than from the index of the address being read.
* **DAO ACK.** The handler read four payload bytes without checking they had arrived, and accepted an acknowledgment of our own DAO from any source in non-storing mode. A forged acknowledgment could stop the retransmission of a DAO that never arrived, leaving the node without a downward route.
* **Non storing transit option.** A transit option carrying no parent address made the unspecified address the parent of the advertised target.

### Conformance

Two of these were deviations from the standard rather than only missing hardening. RFC 6550 Section 6.7.8 states that the option length determines whether the parent address is present, and the previous test admitted an option two bytes too short to hold one. RFC 6554 Section 3 states that every address but the last is compressed by CmprI and the last by CmprE, and the previous code used CmprI for the last address whenever more than one segment remained. The path length computation follows the formula in RFC 6554 Section 4.2 unchanged.

Elsewhere the validation is deliberately stricter than the standard requires, rejecting only malformed messages. No conformant message is refused.

RFC 6550 Section 9.4 states the target and transit requirements for a unicast DAO, and forbids a multicast one to carry a parent address at all. Requiring a parent address of every DAO would therefore have rejected a conformant message for lacking a field the standard prohibits it from carrying. A multicast DAO is instead declined before those requirements are reached, since it belongs to the mode of operation that stores routes and carries multicast groups, which the non-storing parser does not serve. The storing parser is unaffected and still handles multicast DAOs. RPL Lite will be corrected the same way, so the two implementations agree on which requirement applies to which message.

### Behaviour changes

* A target option with a prefix length of zero is rejected rather than ignored.
* A source routing header is no longer honoured for a destination outside the DAGs we have joined, matching RPL Lite.
* The non storing parser now accepts a four byte transit option, which the storing parser already accepted.
* Non-storing DAOs must carry a parent address.
* A multicast DAO received in non-storing mode is declined rather than parsed.