### PR TITLE
rpl-lite: validate externally controlled fields in RPL control messages

### DIFF
--- a/os/net/routing/rpl-lite/rpl-const.h
+++ b/os/net/routing/rpl-lite/rpl-const.h
@@ -113,6 +113,16 @@
 #define RPL_OPTION_PREFIX_INFO           8
 #define RPL_OPTION_TARGET_DESC           9
 
+/*
+ * Smallest size, in bytes, of a target or transit information option,
+ * including the two-byte option header, and of a transit information option
+ * that carries the parent address that non-storing mode needs.
+ */
+#define RPL_DAO_TARGET_OPTION_MIN_LEN    4
+#define RPL_DAO_TRANSIT_OPTION_MIN_LEN   6
+#define RPL_DAO_TRANSIT_OPTION_PARENT_LEN \
+  (RPL_DAO_TRANSIT_OPTION_MIN_LEN + (int)sizeof(uip_ipaddr_t))
+
 #define RPL_DAO_K_FLAG                   0x80 /* DAO-ACK requested */
 #define RPL_DAO_D_FLAG                   0x40 /* DODAG ID present */
 

--- a/os/net/routing/rpl-lite/rpl-const.h
+++ b/os/net/routing/rpl-lite/rpl-const.h
@@ -118,6 +118,9 @@
  * including the two-byte option header, and of a transit information option
  * that carries the parent address that non-storing mode needs.
  */
+/* Size, in bytes, of the DAO ACK base object. */
+#define RPL_DAO_ACK_LEN                  4
+
 #define RPL_DAO_TARGET_OPTION_MIN_LEN    4
 #define RPL_DAO_TRANSIT_OPTION_MIN_LEN   6
 #define RPL_DAO_TRANSIT_OPTION_PARENT_LEN \

--- a/os/net/routing/rpl-lite/rpl-ext-header.c
+++ b/os/net/routing/rpl-lite/rpl-ext-header.c
@@ -87,32 +87,126 @@ rpl_ext_header_srh_get_next_hop(uip_ipaddr_t *ipaddr)
   return 0;
 }
 /*---------------------------------------------------------------------------*/
+/*
+ * Derived contents of a source routing header, after validation against both
+ * the extent declared by the header and the length of the received packet.
+ * An address access computed from these values is guaranteed to stay within
+ * the header.
+ */
+struct rpl_srh_info {
+  size_t ext_len;        /* Total size of the routing header, in bytes. */
+  uint8_t segments_left;
+  uint8_t cmpri;
+  uint8_t cmpre;
+  uint8_t padding;
+  uint8_t path_len;      /* Number of addresses carried in the header. */
+};
+/*---------------------------------------------------------------------------*/
+/*
+ * Parse and validate a source routing header. The compression and padding
+ * fields come from the packet, so the address vector must be shown to have
+ * exactly the size that they imply, and the whole header must be contained
+ * in the received packet, before any address is accessed.
+ */
 static bool
-srh_is_valid(struct uip_routing_hdr *rh_header,
-             struct uip_rpl_srh_hdr *srh_header)
+srh_parse(const struct uip_routing_hdr *rh_header, struct rpl_srh_info *srh)
+{
+  const struct uip_rpl_srh_hdr *srh_header;
+  ptrdiff_t rh_offset;
+  size_t vector_len;
+  size_t last_addr_len;
+  size_t path_len;
+
+  rh_offset = (const uint8_t *)rh_header - uip_buf;
+  srh->ext_len = (size_t)rh_header->len * 8 + 8;
+
+  /* The complete routing header must be part of the received packet. */
+  if(rh_offset < 0 || (size_t)rh_offset + srh->ext_len > uip_len) {
+    LOG_ERR("SRH extends past the received packet\n");
+    return false;
+  }
+
+  srh_header = (const struct uip_rpl_srh_hdr *)
+    ((const uint8_t *)rh_header + RPL_RH_LEN);
+  srh->segments_left = rh_header->seg_left;
+  srh->cmpri = srh_header->cmpr >> 4;
+  srh->cmpre = srh_header->cmpr & 0x0f;
+  srh->padding = srh_header->pad >> 4;
+
+  /*
+   * Padding only aligns the header to an eight-octet boundary. Values of
+   * eight or more are rejected here, although the field itself is four
+   * bits wide.
+   */
+  if(srh->padding >= 8) {
+    LOG_ERR("SRH with invalid padding %u\n", (unsigned)srh->padding);
+    return false;
+  }
+
+  /*
+   * The addresses follow the two fixed headers. All of them but the last
+   * are compressed by CmprI, and the last one by CmprE. Both fields are
+   * four bits wide, so an address is never shorter than a single byte.
+   */
+  vector_len = srh->ext_len - RPL_RH_LEN - RPL_SRH_LEN;
+  last_addr_len = 16 - srh->cmpre;
+  if(vector_len < last_addr_len + srh->padding) {
+    LOG_ERR("SRH too short to hold an address vector\n");
+    return false;
+  }
+
+  path_len = (vector_len - last_addr_len - srh->padding) / (16 - srh->cmpri) + 1;
+  if(path_len > UINT8_MAX) {
+    LOG_ERR("SRH with too many addresses (%u)\n", (unsigned)path_len);
+    return false;
+  }
+
+  /* The address vector must have exactly the size that it declares. */
+  if((path_len - 1) * (16 - srh->cmpri) + last_addr_len + srh->padding
+     != vector_len) {
+    LOG_ERR("SRH with an inconsistent address vector size\n");
+    return false;
+  }
+
+  if(srh->segments_left > path_len) {
+    LOG_ERR("SRH with too many segments left (%u > %u)\n",
+            (unsigned)srh->segments_left, (unsigned)path_len);
+    return false;
+  }
+
+  srh->path_len = path_len;
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Return a pointer to the address at the given index, and the number of
+ * bytes by which that address is compressed. RFC 6554, Section 3: every
+ * address but the last is compressed by CmprI, and the last one by CmprE.
+ * The index must be below the path length of a header that srh_parse()
+ * has accepted, which makes the access stay within the header.
+ */
+static uint8_t *
+srh_addr(struct uip_routing_hdr *rh_header, const struct rpl_srh_info *srh,
+         uint8_t index, uint8_t *cmpr)
+{
+  *cmpr = index == srh->path_len - 1 ? srh->cmpre : srh->cmpri;
+  return (uint8_t *)rh_header + RPL_RH_LEN + RPL_SRH_LEN +
+    (size_t)index * (16 - srh->cmpri);
+}
+/*---------------------------------------------------------------------------*/
+static bool
+srh_is_valid(struct uip_routing_hdr *rh_header, const struct rpl_srh_info *srh)
 {
   uip_ipaddr_t hop_addr;
-  uip_ipaddr_copy(&hop_addr, &UIP_IP_BUF->destipaddr);
-
-  uint8_t segments_left = rh_header->seg_left;
-  uint8_t ext_len = rh_header->len * 8 + 8;
-  uint8_t cmpri = srh_header->cmpr >> 4;
-  uint8_t cmpre = srh_header->cmpr & 0x0f;
-  uint8_t padding = srh_header->pad >> 4;
-  uint8_t path_len = ((ext_len - padding - RPL_RH_LEN - RPL_SRH_LEN - (16 - cmpre)) / (16 - cmpri)) + 1;
-
   bool prev_hop_is_my_addr = false;
   uint8_t my_addr_count = 0;
-  for(uint8_t i = path_len - segments_left; i < path_len; i++) {
-    uint8_t cmpr = segments_left == 1 ? cmpre : cmpri;
-    ptrdiff_t rh_offset = (uint8_t *)rh_header - uip_buf;
-    size_t addr_offset = RPL_RH_LEN + RPL_SRH_LEN + (i * (16 - cmpri));
 
-    if(rh_offset + addr_offset + 16 - cmpr > UIP_BUFSIZE) {
-      return false;
-    }
+  uip_ipaddr_copy(&hop_addr, &UIP_IP_BUF->destipaddr);
 
-    uint8_t *addr_ptr = (uint8_t *)rh_header + addr_offset;
+  for(uint8_t i = srh->path_len - srh->segments_left; i < srh->path_len; i++) {
+    uint8_t cmpr;
+    const uint8_t *addr_ptr = srh_addr(rh_header, srh, i, &cmpr);
+
     memcpy((uint8_t *)&hop_addr + cmpr, addr_ptr, 16 - cmpr);
 
     LOG_DBG("Processing SRH hop %u, IP addr ", i);
@@ -155,12 +249,7 @@ int
 rpl_ext_header_srh_update(void)
 {
   struct uip_routing_hdr *rh_header;
-  struct uip_rpl_srh_hdr *srh_header;
-  uint8_t cmpri, cmpre;
-  uint8_t ext_len;
-  uint8_t padding;
-  uint8_t path_len;
-  uint8_t segments_left;
+  struct rpl_srh_info srh;
   uip_ipaddr_t current_dest_addr;
 
   /* Look for routing ext header */
@@ -171,44 +260,29 @@ rpl_ext_header_srh_update(void)
     return 0;
   }
 
-  /* Parse SRH */
-  srh_header = (struct uip_rpl_srh_hdr *)(((uint8_t *)rh_header) + RPL_RH_LEN);
-  segments_left = rh_header->seg_left;
-  ext_len = rh_header->len * 8 + 8;
-  cmpri = srh_header->cmpr >> 4;
-  cmpre = srh_header->cmpr & 0x0f;
-  padding = srh_header->pad >> 4;
-  path_len = ((ext_len - padding - RPL_RH_LEN - RPL_SRH_LEN - (16 - cmpre)) / (16 - cmpri)) + 1;
-  (void)path_len;
+  if(!srh_parse(rh_header, &srh)) {
+    return 0;
+  }
 
   LOG_INFO("read SRH, path len %u, segments left %u, Cmpri %u, Cmpre %u, ext len %u (padding %u)\n",
-      path_len, segments_left, cmpri, cmpre, ext_len, padding);
+      srh.path_len, srh.segments_left, srh.cmpri, srh.cmpre,
+      (unsigned)srh.ext_len, srh.padding);
 
   /* Update SRH in-place */
-  if(segments_left == 0) {
+  if(srh.segments_left == 0) {
     /* We are the final destination, do nothing */
-  } else if(segments_left > path_len) {
-    /* Discard the packet because of a parameter problem. */
-    LOG_ERR("SRH with too many segments left (%u > %u)\n",
-            segments_left, path_len);
-    return 0;
   } else {
-    if(!srh_is_valid(rh_header, srh_header)) {
+    uint8_t cmpr;
+    uint8_t *addr_ptr;
+
+    if(!srh_is_valid(rh_header, &srh)) {
       LOG_ERR("Invalid SRH hop sequence\n");
       return 0;
     }
 
-    uint8_t i = path_len - segments_left; /* The index of the next address to be visited */
-    uint8_t cmpr = segments_left == 1 ? cmpre : cmpri;
-    ptrdiff_t rh_offset = (uint8_t *)rh_header - uip_buf;
-    size_t addr_offset = RPL_RH_LEN + RPL_SRH_LEN + (i * (16 - cmpri));
-
-    if(rh_offset + addr_offset + 16 - cmpr > UIP_BUFSIZE) {
-      LOG_ERR("Invalid SRH address pointer\n");
-      return 0;
-    }
-
-    uint8_t *addr_ptr = ((uint8_t *)rh_header) + addr_offset;
+    /* The index of the next address to be visited */
+    addr_ptr = srh_addr(rh_header, &srh,
+                        srh.path_len - srh.segments_left, &cmpr);
 
     /* As per RFC6554: swap the IPv6 destination address with address[i] */
 

--- a/os/net/routing/rpl-lite/rpl-icmp6.c
+++ b/os/net/routing/rpl-lite/rpl-icmp6.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <limits.h>
+#include <stdint.h>
 
 /* Log configuration */
 #include "sys/log.h"
@@ -167,6 +168,29 @@ rpl_icmp6_dis_output(uip_ipaddr_t *addr)
   LOG_INFO_("\n");
 
   uip_icmp6_send(addr, ICMP6_RPL, RPL_CODE_DIS, 2);
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Check that a DIO interval received in a DAG Configuration option can be
+ * used as a shift count without invoking undefined behavior, and that the
+ * resulting number of milliseconds can be converted to clock ticks with the
+ * 32-bit arithmetic that the Trickle timer uses.
+ *
+ * The bound also keeps the sum of the two fields within reach of the
+ * eight-bit counter that is compared against it while the interval grows.
+ * A larger sum would leave that counter wrapping instead of stopping, and
+ * passing an invalid shift count on every cycle.
+ */
+static int
+dio_interval_is_valid(uint8_t intmin, uint8_t intdoubl)
+{
+  unsigned interval = (unsigned)intmin + intdoubl;
+
+  if(interval >= sizeof(unsigned long) * CHAR_BIT) {
+    return 0;
+  }
+
+  return (1UL << interval) <= UINT32_MAX / CLOCK_SECOND;
 }
 /*---------------------------------------------------------------------------*/
 static void
@@ -312,6 +336,21 @@ dio_input(void)
         /* buffer + 12 is reserved */
         dio.default_lifetime = buffer[i + 13];
         dio.lifetime_unit = get16(buffer, i + 14);
+
+        /*
+         * Reject these before they are copied into the instance. A
+         * MinHopRankIncrease of zero would divide by zero in DAG_RANK().
+         */
+        if(dio.dag_min_hoprankinc == 0) {
+          LOG_WARN("dio_input: MinHopRankIncrease is 0, discard\n");
+          goto discard;
+        }
+
+        if(!dio_interval_is_valid(dio.dag_intmin, dio.dag_intdoubl)) {
+          LOG_WARN("dio_input: DIO interval %u is out of range, discard\n",
+                   (unsigned)dio.dag_intmin + dio.dag_intdoubl);
+          goto discard;
+        }
         break;
       case RPL_OPTION_PREFIX_INFO:
         if(len != 32) {

--- a/os/net/routing/rpl-lite/rpl-icmp6.c
+++ b/os/net/routing/rpl-lite/rpl-icmp6.c
@@ -781,6 +781,12 @@ dao_ack_input(void)
   uint8_t sequence;
   uint8_t status;
 
+  if(uip_len < uip_l3_icmp_hdr_len + RPL_DAO_ACK_LEN) {
+    LOG_WARN("dao_ack_input: invalid DAO ACK header, len %u, discard\n",
+             (unsigned)uip_len);
+    goto discard;
+  }
+
   buffer = UIP_ICMP_PAYLOAD;
 
   instance_id = buffer[0];
@@ -789,6 +795,18 @@ dao_ack_input(void)
 
   if(!curr_instance.used || curr_instance.instance_id != instance_id) {
     LOG_ERR("dao_ack_input: unknown instance, discard\n");
+    goto discard;
+  }
+
+  /*
+   * RFC 6550, Section 6.5: a DAO ACK is sent by the node that received the
+   * DAO, which here is always the root, because a DAO is only ever sent to
+   * the DAG identifier. Only that node can therefore acknowledge it.
+   */
+  if(!uip_ipaddr_cmp(&UIP_IP_BUF->srcipaddr, &curr_instance.dag.dag_id)) {
+    LOG_WARN("dao_ack_input: not from the root ");
+    LOG_WARN_6ADDR(&UIP_IP_BUF->srcipaddr);
+    LOG_WARN_(", discard\n");
     goto discard;
   }
 

--- a/os/net/routing/rpl-lite/rpl-icmp6.c
+++ b/os/net/routing/rpl-lite/rpl-icmp6.c
@@ -480,9 +480,13 @@ dao_input(void)
   int pos;
   int len;
   int i;
+  int target_received;
+  int parent_received;
   uip_ipaddr_t from;
 
   memset(&dao, 0, sizeof(dao));
+  target_received = 0;
+  parent_received = 0;
 
   buffer = UIP_ICMP_PAYLOAD;
   buffer_length = uip_len - uip_l3_icmp_hdr_len;
@@ -496,6 +500,19 @@ dao_input(void)
   dao.instance_id = buffer[0];
   if(!curr_instance.used || curr_instance.instance_id != dao.instance_id) {
     LOG_ERR("dao_input: unknown RPL instance %u, discard\n", dao.instance_id);
+    goto discard;
+  }
+
+  /*
+   * A multicast advertisement belongs to the mode of operation that stores
+   * routes and carries multicast groups, which this implementation neither
+   * runs nor joins, so it has nothing to do with one. Declining it here also
+   * keeps the requirements below, which RFC 6550, Section 9.4, states for a
+   * unicast advertisement, from being applied to a message that the same
+   * section forbids to carry a parent address.
+   */
+  if(uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+    LOG_WARN("dao_input: multicast DAO, discard\n");
     goto discard;
   }
 
@@ -564,6 +581,7 @@ dao_input(void)
         }
         memset(&dao.prefix, 0, sizeof(dao.prefix));
         memcpy(&dao.prefix, buffer + i + 4, (dao.prefixlen + 7) / CHAR_BIT);
+        target_received = 1;
         break;
       case RPL_OPTION_TRANSIT:
         /* The path sequence and control are ignored. */
@@ -581,12 +599,47 @@ dao_input(void)
         if(len >= RPL_DAO_TRANSIT_OPTION_PARENT_LEN) {
           memcpy(&dao.parent_addr, buffer + i + RPL_DAO_TRANSIT_OPTION_MIN_LEN,
                  sizeof(dao.parent_addr));
+          parent_received = 1;
         }
         break;
     }
   }
 
   /* Destination Advertisement Object */
+  /*
+   * RFC 6550, Section 9.4: a unicast DAO carries one or more target options
+   * followed by one or more transit information options, and in this mode of
+   * operation the transit option names the parent. Both are needed here, and
+   * both must name an address, or the unspecified address would enter the
+   * source routing graph as a parent that never expires. A multicast
+   * advertisement, which that section exempts, is declined above.
+   *
+   * The advertised target is not used as the child. The graph is keyed by the
+   * source address of the advertisement instead, which a node cannot choose
+   * freely, so it can only ever advertise itself.
+   */
+  if(!target_received) {
+    LOG_WARN("dao_input: no target option, discard\n");
+    goto discard;
+  }
+
+  if(dao.prefixlen != 8 * sizeof(dao.prefix)) {
+    LOG_WARN("dao_input: target prefix length %u is not a full address, discard\n",
+             dao.prefixlen);
+    goto discard;
+  }
+
+  if(!parent_received) {
+    LOG_WARN("dao_input: no transit option carrying a parent, discard\n");
+    goto discard;
+  }
+
+  if(uip_is_addr_unspecified(&dao.parent_addr) ||
+     uip_is_addr_unspecified(&from)) {
+    LOG_WARN("dao_input: unspecified parent or child address, discard\n");
+    goto discard;
+  }
+
   LOG_INFO("received a %sDAO from ", dao.lifetime == 0 ? "No-path " : "");
   LOG_INFO_6ADDR(&UIP_IP_BUF->srcipaddr);
   LOG_INFO_(", seqno %u, lifetime %u, prefix ", dao.sequence, dao.lifetime);

--- a/os/net/routing/rpl-lite/rpl-icmp6.c
+++ b/os/net/routing/rpl-lite/rpl-icmp6.c
@@ -484,15 +484,6 @@ dao_input(void)
 
   memset(&dao, 0, sizeof(dao));
 
-  dao.instance_id = UIP_ICMP_PAYLOAD[0];
-  if(!curr_instance.used || curr_instance.instance_id != dao.instance_id) {
-    LOG_ERR("dao_input: unknown RPL instance %u, discard\n", dao.instance_id);
-    goto discard;
-  }
-
-  uip_ipaddr_copy(&from, &UIP_IP_BUF->srcipaddr);
-  memset(&dao.parent_addr, 0, 16);
-
   buffer = UIP_ICMP_PAYLOAD;
   buffer_length = uip_len - uip_l3_icmp_hdr_len;
 
@@ -501,6 +492,15 @@ dao_input(void)
              buffer_length);
     goto discard;
   }
+
+  dao.instance_id = buffer[0];
+  if(!curr_instance.used || curr_instance.instance_id != dao.instance_id) {
+    LOG_ERR("dao_input: unknown RPL instance %u, discard\n", dao.instance_id);
+    goto discard;
+  }
+
+  uip_ipaddr_copy(&from, &UIP_IP_BUF->srcipaddr);
+  memset(&dao.parent_addr, 0, 16);
 
   pos = 0;
   pos++; /* instance ID */

--- a/os/net/routing/rpl-lite/rpl-icmp6.c
+++ b/os/net/routing/rpl-lite/rpl-icmp6.c
@@ -567,14 +567,20 @@ dao_input(void)
         break;
       case RPL_OPTION_TRANSIT:
         /* The path sequence and control are ignored. */
-        if(len < 6) {
+        if(len < RPL_DAO_TRANSIT_OPTION_MIN_LEN) {
           LOG_WARN("dao_input: invalid transit option, len %"PRIu16", discard\n",
                    buffer_length);
           goto discard;
         }
         dao.lifetime = buffer[i + 5];
-        if(len >= 20) {
-          memcpy(&dao.parent_addr, buffer + i + 6, 16);
+        /*
+         * RFC 6550, Section 6.7.8: the option length is used to determine
+         * whether or not the parent address is present, and the whole of it
+         * must be within the option to be read from its offset.
+         */
+        if(len >= RPL_DAO_TRANSIT_OPTION_PARENT_LEN) {
+          memcpy(&dao.parent_addr, buffer + i + RPL_DAO_TRANSIT_OPTION_MIN_LEN,
+                 sizeof(dao.parent_addr));
         }
         break;
     }


### PR DESCRIPTION
This PR fixes several issues where fields taken from received ICMPv6 RPL messages were used without validation.

* **DAG Configuration option.** The values were accepted after a length check only, so a DIO could set MinHopRankIncrease to zero and make `DAG_RANK()` divide by zero, or set a DIO interval later used as an out of range shift count. An interval whose two fields sum above the range of the eight bit counter compared against it had a further effect: the counter wraps before it can reach the sum, so the interval grew without ever stopping and passed an invalid shift count on every cycle.
* **Destination advertisement options.** A DAO carrying nothing but its base object was accepted, with no target, an unspecified parent, and the default lifetime that makes an advertisement look like one that adds a route. The unspecified address then reached the source routing graph as a parent recorded with an infinite lifetime. Such an entry is never recognised again, because a node is stored by its interface identifier and read back with the prefix of the current DAG, so every repetition consumed another of the sixteen entries the graph holds by default, until no legitimate downward route could be recorded.
* **Transit option.** The parent address was copied whenever the option was at least twenty bytes, but it begins at offset six and is sixteen bytes, so the whole of it is only present from twenty two bytes on. An option of twenty or twenty one bytes copied one or two bytes from beyond its declared extent, either from the option that followed it or from bytes that had not been received.
* **Source routing header.** The path length was computed from unvalidated compression and padding fields, and went negative before wrapping in an eight bit variable. Address accesses were then bounded by `UIP_BUFSIZE` rather than by the routing header or `uip_len`, so they could read and write bytes left over from an earlier packet, and those bytes could reach the IPv6 destination address of a forwarded packet. Two related defects are fixed with it: the extension header length was held in an eight bit variable, and the hop sequence validation chose the compression factor from the number of segments left rather than from the index of the address being read.
* **DAO ACK.** The handler read four payload bytes without checking they had arrived, and never examined the source address, so an acknowledgment carrying a matching sequence number from any node that could reach this one was accepted. It can mark a joined node reachable and stop its retransmissions, or, with a status that reports failure, make the node poison its routes and leave the DAG. Support for DAO ACK is enabled by default here, so this is reached by a node in its default configuration.
* **DAO length.** The instance identifier was read from the payload before the length of that payload had been calculated.

### Conformance

Two of these were deviations from the standard rather than only missing hardening. RFC 6550 Section 6.7.8 states that the option length determines whether the parent address is present, and the previous test admitted an option two bytes too short to hold one. RFC 6550 Section 6.5 states that a DAO ACK is sent by the node that received the DAO, which here is always the root, since a DAO is only ever sent to the DAG identifier.

Elsewhere the validation is deliberately stricter than the standard requires, rejecting only malformed messages. No conformant message is refused.

RFC 6550 Section 9.4 states the target and transit requirements for a unicast DAO, and forbids a multicast one to carry a parent address at all. Requiring a parent address of every DAO would therefore have rejected a conformant message for lacking a field the standard prohibits it from carrying. A multicast DAO is instead declined before those requirements are reached, since it belongs to the mode of operation that stores routes and carries multicast groups, which RPL Lite neither runs nor joins. RPL Classic is corrected the same way, so the two implementations agree on which requirement applies to which message.

The source routing bound that this replaces was introduced by pull request 1431, which fixed the same class of defect in both routing implementations and was incomplete in both. RPL Classic is corrected separately.

### Behaviour changes

* A DAO must carry a target option naming a full address, and a transit option carrying a parent, including when it withdraws a route.
* A DAO ACK is accepted only from the DAG identifier.
* A DAG Configuration option with a zero MinHopRankIncrease, or an interval outside the supported range, is rejected.
* A multicast DAO is declined rather than parsed.