### PR TITLE
rpl-classic: do not leave a used instance without a DAG

### DIFF
--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -1156,7 +1156,7 @@ rpl_join_instance(uip_ipaddr_t *from, rpl_dio_t *dio)
   LOG_DBG_(" as a parent: ");
   if(p == NULL) {
     LOG_DBG_("failed\n");
-    instance->used = 0;
+    rpl_free_instance(instance);
     return;
   }
   p->dtsn = dio->dtsn;

--- a/os/net/routing/rpl-classic/rpl-dag.c
+++ b/os/net/routing/rpl-classic/rpl-dag.c
@@ -364,8 +364,20 @@ rpl_set_root(uint8_t instance_id, uip_ipaddr_t *dag_id)
 {
   rpl_dag_t *dag;
   rpl_instance_t *instance;
+  rpl_of_t *of;
   uint8_t version;
   int i;
+
+  /*
+   * Look the objective function up before anything is allocated or
+   * dropped, so that an unsupported one cannot leave a half-built
+   * instance behind.
+   */
+  of = rpl_find_of(RPL_OF_OCP);
+  if(of == NULL) {
+    LOG_WARN("OF with OCP %u not supported\n", RPL_OF_OCP);
+    return NULL;
+  }
 
   version = RPL_LOLLIPOP_INIT;
   instance = rpl_get_instance(instance_id);
@@ -403,11 +415,7 @@ rpl_set_root(uint8_t instance_id, uip_ipaddr_t *dag_id)
   dag->grounded = RPL_GROUNDED;
   dag->preference = RPL_PREFERENCE;
   instance->mop = RPL_MOP_DEFAULT;
-  instance->of = rpl_find_of(RPL_OF_OCP);
-  if(instance->of == NULL) {
-    LOG_WARN("OF with OCP %u not supported\n", RPL_OF_OCP);
-    return NULL;
-  }
+  instance->of = of;
 
   rpl_set_preferred_parent(dag, NULL);
 

--- a/os/net/routing/rpl-classic/rpl-ext-header.c
+++ b/os/net/routing/rpl-classic/rpl-ext-header.c
@@ -113,7 +113,7 @@ rpl_ext_header_hbh_update(uint8_t *ext_buf, int opt_offset)
     return 0;
   }
 
-  if(!instance->current_dag->joined) {
+  if(instance->current_dag == NULL || !instance->current_dag->joined) {
     LOG_ERR("No DAG in the instance\n");
     return 0;
   }
@@ -536,7 +536,8 @@ update_hbh_header(void)
     }
 
     instance = rpl_get_instance(rpl_opt->instance);
-    if(instance == NULL || !instance->used || !instance->current_dag->joined) {
+    if(instance == NULL || !instance->used
+       || instance->current_dag == NULL || !instance->current_dag->joined) {
       LOG_ERR("Unable to add/update hop-by-hop extension header: incorrect instance\n");
       return 0; /* Drop */
     }


### PR DESCRIPTION
rpl_ext_header_hbh_update() and update_hbh_header() dereference instance->current_dag without checking it, although both resolve the instance from an identifier carried in the hop-by-hop option. The checks come first here, and the two commits after them remove the ways that state arises: rpl_set_root() returned after allocating the instance and dropping DAGs when the configured objective function was not supported, and rpl_join_instance() cleared instance->used and returned when it could not add the DIO sender as a parent, leaving the probing timer armed on a discarded instance.

None of it is remotely reachable. The join failure needs rpl_add_parent() to fail, which the caller prevents by putting the sender in the neighbor cache first, and the rpl_set_root() state needs a build whose RPL_OF_OCP is not in RPL_SUPPORTED_OFS. What this buys is not having to rely on either invariant, since both are enforced by callers rather than by the code that depends on them.

Thanks to @AmPaschal for reporting the unchecked dereference.