### PR TITLE
shell: take the command line as writable, since it is written to

### DIFF
--- a/os/services/shell/shell.c
+++ b/os/services/shell/shell.c
@@ -85,7 +85,7 @@ output_prompt(shell_output_func output)
   SHELL_OUTPUT(output, "> ");
 }
 /*---------------------------------------------------------------------------*/
-PT_THREAD(shell_input(struct pt *pt, shell_output_func output, const char *cmd))
+PT_THREAD(shell_input(struct pt *pt, shell_output_func output, char *cmd))
 {
   static char *args;
   static const struct shell_command_t *cmd_descr = NULL;

--- a/os/services/shell/shell.h
+++ b/os/services/shell/shell.h
@@ -91,8 +91,11 @@ void shell_init(void);
 
 /**
  * \brief A protothread that is spawned by a Shell driver when receiving a new line.
+ *
+ * The command line is written to while it is split into a command and its
+ * arguments, so the buffer the driver passes must be writable.
  */
-PT_THREAD(shell_input(struct pt *pt, shell_output_func output, const char *cmd));
+PT_THREAD(shell_input(struct pt *pt, shell_output_func output, char *cmd));
 
 /**
  * Prints an IPv6 address


### PR DESCRIPTION
shell_input() declares its command line const and then writes a NUL into it to cut the command from its arguments. Up to C17 strchr() returned a char * whatever it was given, so the const was discarded on the way.

C23 makes strchr() keep the qualifier, and GCC 15 compiles as C23 where no -std is set, which is every native and Cooja build. Drop the const, which both callers already satisfy with the serial line buffer, and say in the header that the buffer has to be writable.