### PR TITLE
jsonparse: bound all parser scans by the supplied input length

### DIFF
--- a/os/lib/json/jsonparse.c
+++ b/os/lib/json/jsonparse.c
@@ -70,6 +70,12 @@ pop(struct jsonparse_state *state)
   return true;
 }
 /*--------------------------------------------------------------------*/
+static bool
+is_whitespace(char c)
+{
+  return c == ' ' || c == '\n' || c == '\r' || c == '\t';
+}
+/*--------------------------------------------------------------------*/
 /* will pass by the value and store the start and length of the value for
    atomic types */
 /*--------------------------------------------------------------------*/
@@ -113,7 +119,8 @@ atomic(struct jsonparse_state *state, char type)
     default:              str = "";      break;
     }
 
-    while ((c = state->json[state->pos]) && c != ' ' && c != ',' && c != ']' && c != '}') {
+    while((c = state->json[state->pos]) && !is_whitespace(c) &&
+          c != ',' && c != ']' && c != '}') {
       state->pos++;
     }
 
@@ -134,10 +141,8 @@ atomic(struct jsonparse_state *state, char type)
 static void
 skip_ws(struct jsonparse_state *state)
 {
-  char c;
-
   while(state->pos < state->len &&
-        ((c = state->json[state->pos]) == ' ' || c == '\n')) {
+        is_whitespace(state->json[state->pos])) {
     state->pos++;
   }
 }

--- a/os/lib/json/jsonparse.c
+++ b/os/lib/json/jsonparse.c
@@ -87,26 +87,39 @@ atomic(struct jsonparse_state *state, char type)
   int len;
 
   state->vstart = state->pos;
+  /* Cleared here so that an error return below cannot leave the length of
+     the previous value behind. */
+  state->vlen = 0;
   if(type == JSON_TYPE_STRING || type == JSON_TYPE_PAIR_NAME) {
-    while((c = state->json[state->pos++]) && c != '"') {
+    c = 0;
+    while(state->pos < state->len) {
+      c = state->json[state->pos++];
+      if(c == '\0' || c == '"') {
+        break;
+      }
       if(c == '\\') {
-        state->pos++;           /* skip current char */
+        if(state->pos == state->len) {
+          /* Nothing left for the escape to consume: the string is
+             unterminated. */
+          c = 0;
+          break;
+        }
+        state->pos++;           /* skip the escaped char */
       }
     }
-    if (c != '"') {
+    if(c != '"') {
       state->error = JSON_ERROR_SYNTAX;
       return JSON_TYPE_ERROR;
     }
     state->vlen = state->pos - state->vstart - 1;
   } else if(type == JSON_TYPE_NUMBER) {
-    do {
+    while(state->pos < state->len) {
       c = state->json[state->pos];
       if((c < '0' || c > '9') && c != '.') {
-        c = 0;
-      } else {
-        state->pos++;
+        break;
       }
-    } while(c);
+      state->pos++;
+    }
     /* need to back one step since first char is already gone */
     state->vstart--;
     state->vlen = state->pos - state->vstart;
@@ -119,16 +132,23 @@ atomic(struct jsonparse_state *state, char type)
     default:              str = "";      break;
     }
 
-    while((c = state->json[state->pos]) && !is_whitespace(c) &&
-          c != ',' && c != ']' && c != '}') {
+    while(state->pos < state->len) {
+      c = state->json[state->pos];
+      if(c == '\0' || is_whitespace(c) ||
+         c == ',' || c == ']' || c == '}') {
+        break;
+      }
       state->pos++;
     }
 
     state->vlen = state->pos - state->vstart;
     len = strlen(str);
-    len = state->vlen > len ? state->vlen : len;
 
-    if (strncmp(str, &state->json[state->vstart], len) != 0) {
+    /* Require an exact-length match. Comparing over the longer of the two
+       lengths, as was done before, reads past the end of the input when the
+       input holds a truncated literal. */
+    if(state->vlen != len ||
+       strncmp(str, &state->json[state->vstart], len) != 0) {
       state->error = JSON_ERROR_SYNTAX;
       return JSON_TYPE_ERROR;
     }
@@ -163,6 +183,8 @@ jsonparse_setup(struct jsonparse_state *state, const char *json, int len)
   state->depth = 0;
   state->error = 0;
   state->vtype = 0;
+  state->vstart = 0;
+  state->vlen = 0;
   state->stack[0] = 0;
 }
 /*--------------------------------------------------------------------*/
@@ -175,10 +197,17 @@ jsonparse_next(struct jsonparse_state *state)
   bool ret;
 
   skip_ws(state);
-  c = state->json[state->pos];
   s = jsonparse_get_type(state);
   v = state->vtype;
-  state->pos++;
+
+  /* Treat the end of the input like the NUL terminator handled below,
+     rather than reading, and stepping over, the byte just past it. */
+  if(state->pos < state->len) {
+    c = state->json[state->pos];
+    state->pos++;
+  } else {
+    c = 0;
+  }
 
   switch(c) {
   case '{':
@@ -291,6 +320,9 @@ jsonparse_copy_value(struct jsonparse_state *state, char *str, int size)
   for(i = 0, o = 0; i < state->vlen && o < size - 1; i++) {
     c = state->json[state->vstart + i];
     if(c == '\\') {
+      if(i + 1 >= state->vlen) {
+        break;
+      }
       i++;
       switch(state->json[state->vstart + i]) {
       case '"':  str[o++] = '"';  break;
@@ -310,22 +342,43 @@ jsonparse_copy_value(struct jsonparse_state *state, char *str, int size)
   return state->vtype;
 }
 /*--------------------------------------------------------------------*/
+/* Copy the current number into a NUL-terminated buffer. The input is not
+   required to be NUL-terminated, so atoi() and atol() must not be pointed
+   into it directly.
+*/
+/*--------------------------------------------------------------------*/
+static bool
+copy_number(struct jsonparse_state *state, char *buf, int size)
+{
+  if(state->vtype != JSON_TYPE_NUMBER ||
+     state->vlen < 0 || state->vlen >= size) {
+    return false;
+  }
+  memcpy(buf, &state->json[state->vstart], state->vlen);
+  buf[state->vlen] = '\0';
+  return true;
+}
+/*--------------------------------------------------------------------*/
 int
 jsonparse_get_value_as_int(struct jsonparse_state *state)
 {
-  if(state->vtype != JSON_TYPE_NUMBER) {
+  char buf[JSONPARSE_NUMBER_MAX_LEN + 1];
+
+  if(!copy_number(state, buf, sizeof(buf))) {
     return 0;
   }
-  return atoi(&state->json[state->vstart]);
+  return atoi(buf);
 }
 /*--------------------------------------------------------------------*/
 long
 jsonparse_get_value_as_long(struct jsonparse_state *state)
 {
-  if(state->vtype != JSON_TYPE_NUMBER) {
+  char buf[JSONPARSE_NUMBER_MAX_LEN + 1];
+
+  if(!copy_number(state, buf, sizeof(buf))) {
     return 0;
   }
-  return atol(&state->json[state->vstart]);
+  return atol(buf);
 }
 /*--------------------------------------------------------------------*/
 /* strcmp - assume no strange chars that needs to be stuffed in string... */

--- a/os/lib/json/jsonparse.c
+++ b/os/lib/json/jsonparse.c
@@ -350,12 +350,28 @@ jsonparse_copy_value(struct jsonparse_state *state, char *str, int size)
 static bool
 copy_number(struct jsonparse_state *state, char *buf, int size)
 {
-  if(state->vtype != JSON_TYPE_NUMBER ||
-     state->vlen < 0 || state->vlen >= size) {
+  int i;
+  char c;
+
+  if(state->vtype != JSON_TYPE_NUMBER || state->vlen < 0) {
     return false;
   }
-  memcpy(buf, &state->json[state->vstart], state->vlen);
-  buf[state->vlen] = '\0';
+  /* atoi() and atol() stop at the fractional part, so only the integer
+     prefix is copied. A long fraction then does not make the number
+     unconvertible.
+  */
+  for(i = 0; i < state->vlen; i++) {
+    c = state->json[state->vstart + i];
+    if((c < '0' || c > '9') && !(i == 0 && c == '-')) {
+      break;
+    }
+    if(i >= size - 1) {
+      /* The integer part alone is longer than any convertible number. */
+      return false;
+    }
+    buf[i] = c;
+  }
+  buf[i] = '\0';
   return true;
 }
 /*--------------------------------------------------------------------*/

--- a/os/lib/json/jsonparse.h
+++ b/os/lib/json/jsonparse.h
@@ -41,6 +41,11 @@
 #define JSONPARSE_MAX_DEPTH 10
 #endif
 
+/* The longest number that jsonparse_get_value_as_int() and
+   jsonparse_get_value_as_long() can convert. Long enough for any 64-bit
+   value with a sign; longer numbers convert to 0. */
+#define JSONPARSE_NUMBER_MAX_LEN 24
+
 struct jsonparse_state {
   const char *json;
   int pos;

--- a/os/lib/json/jsonparse.h
+++ b/os/lib/json/jsonparse.h
@@ -41,9 +41,10 @@
 #define JSONPARSE_MAX_DEPTH 10
 #endif
 
-/* The longest number that jsonparse_get_value_as_int() and
+/* The longest integer part that jsonparse_get_value_as_int() and
    jsonparse_get_value_as_long() can convert. Long enough for any 64-bit
-   value with a sign; longer numbers convert to 0. */
+   value with a sign; numbers with a longer integer part convert to 0. The
+   fractional part is not converted, and hence not bounded by this. */
 #define JSONPARSE_NUMBER_MAX_LEN 24
 
 struct jsonparse_state {

--- a/tests/08-native-runs/29-jsonparse.sh
+++ b/tests/08-native-runs/29-jsonparse.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+./run-one.sh 29-jsonparse

--- a/tests/08-native-runs/29-jsonparse/Makefile
+++ b/tests/08-native-runs/29-jsonparse/Makefile
@@ -1,0 +1,10 @@
+CONTIKI_PROJECT = test-jsonparse
+all: $(CONTIKI_PROJECT)
+
+TARGET = native
+
+MODULES += os/lib/json
+MODULES += os/services/unit-test
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/29-jsonparse/test-jsonparse.c
+++ b/tests/08-native-runs/29-jsonparse/test-jsonparse.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, Giridhar Pavan.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Unit tests for the JSON parser.
+ * \author
+ *         Giridhar Pavan
+ */
+
+#include "contiki.h"
+#include "lib/json/jsonparse.h"
+#include "unit-test.h"
+
+#include <stdio.h>
+#include <string.h>
+
+PROCESS(run_tests, "JSON parser unit tests");
+AUTOSTART_PROCESSES(&run_tests);
+
+/*---------------------------------------------------------------------------*/
+static int
+parse_literal(const char *literal, int literal_type, char whitespace)
+{
+  struct jsonparse_state state;
+  char json[32];
+  int len;
+
+  len = snprintf(json, sizeof(json), "{\"value\":%s%c}", literal, whitespace);
+  if(len < 0 || len >= sizeof(json)) {
+    return 0;
+  }
+
+  jsonparse_setup(&state, json, len);
+
+  return jsonparse_next(&state) == '{' &&
+         jsonparse_next(&state) == JSON_TYPE_PAIR_NAME &&
+         jsonparse_next(&state) == literal_type &&
+         jsonparse_next(&state) == '}';
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_literal_whitespace,
+                   "Parse true, false, and null before JSON whitespace");
+UNIT_TEST(test_literal_whitespace)
+{
+  static const struct {
+    const char *text;
+    int type;
+  } literals[] = {
+    { "true", JSON_TYPE_TRUE },
+    { "false", JSON_TYPE_FALSE },
+    { "null", JSON_TYPE_NULL },
+  };
+  static const char whitespace[] = { ' ', '\n', '\r', '\t' };
+  unsigned int i;
+  unsigned int j;
+
+  UNIT_TEST_BEGIN();
+
+  for(i = 0; i < sizeof(literals) / sizeof(literals[0]); i++) {
+    for(j = 0; j < sizeof(whitespace) / sizeof(whitespace[0]); j++) {
+      UNIT_TEST_ASSERT(parse_literal(literals[i].text, literals[i].type,
+                                     whitespace[j]));
+    }
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(run_tests, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+
+  UNIT_TEST_RUN(test_literal_whitespace);
+
+  printf("=check-me= DONE\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/29-jsonparse/test-jsonparse.c
+++ b/tests/08-native-runs/29-jsonparse/test-jsonparse.c
@@ -39,6 +39,7 @@
 #include "lib/json/jsonparse.h"
 #include "unit-test.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -94,6 +95,133 @@ UNIT_TEST(test_literal_whitespace)
   UNIT_TEST_END();
 }
 /*---------------------------------------------------------------------------*/
+/*
+ * Parse a length-delimited fragment that is NOT NUL-terminated, and that is
+ * followed in memory by bytes the parser must never look at. Fills in the
+ * final parser state so that the caller can check that nothing ran past the
+ * supplied length.
+ */
+static void
+parse_prefix(struct jsonparse_state *state, const char *text, int len)
+{
+  static char buffer[64];
+  int type;
+
+  memset(buffer, 'x', sizeof(buffer));
+  memcpy(buffer, text, len);
+
+  jsonparse_setup(state, buffer, len);
+
+  do {
+    type = jsonparse_next(state);
+  } while(type != 0 && type != JSON_TYPE_ERROR);
+}
+/*---------------------------------------------------------------------------*/
+/* Every scan in the parser must stop at the supplied length. */
+static bool
+stayed_in_bounds(const struct jsonparse_state *state)
+{
+  return state->pos <= state->len &&
+         state->vstart >= 0 && state->vstart <= state->len &&
+         state->vlen >= 0 && state->vstart + state->vlen <= state->len;
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_truncated_input,
+                   "Reject truncated values without reading past the input");
+UNIT_TEST(test_truncated_input)
+{
+  static const char *const truncated[] = {
+    "{\"a\":tru",                /* literal cut short */
+    "{\"a\":true",               /* object never closed */
+    "{\"a\":\"bc",               /* string never closed */
+    "{\"a\":\"b\\",              /* trailing backslash */
+    "{\"a\":123",                /* number at the very end */
+    "[",                         /* nothing after the array start */
+    "{\"a",                      /* pair name never closed */
+  };
+  static struct jsonparse_state state;
+  static unsigned int i;
+
+  UNIT_TEST_BEGIN();
+
+  for(i = 0; i < sizeof(truncated) / sizeof(truncated[0]); i++) {
+    parse_prefix(&state, truncated[i], strlen(truncated[i]));
+    UNIT_TEST_ASSERT(stayed_in_bounds(&state));
+    UNIT_TEST_ASSERT(state.error == JSON_ERROR_SYNTAX);
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_no_nul_terminator,
+                   "Parse a complete value that is not NUL-terminated");
+UNIT_TEST(test_no_nul_terminator)
+{
+  static const char json[] = "{\"a\":true}";
+  static struct jsonparse_state state;
+
+  UNIT_TEST_BEGIN();
+
+  /* strlen() excludes the terminator, so the parser sees the 'x' padding
+     that parse_prefix() writes after the value. */
+  parse_prefix(&state, json, strlen(json));
+  UNIT_TEST_ASSERT(stayed_in_bounds(&state));
+  UNIT_TEST_ASSERT(state.error == 0);
+  UNIT_TEST_ASSERT(state.depth == 0);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_invalid_literal,
+                   "Reject literals with a wrong length or a bad suffix");
+UNIT_TEST(test_invalid_literal)
+{
+  static const char *const invalid[] = {
+    "{\"a\":truex}",
+    "{\"a\":tru}",
+    "{\"a\":tru }",
+    "{\"a\":nul}",
+    "{\"a\":falsey}",
+  };
+  static struct jsonparse_state state;
+  static unsigned int i;
+
+  UNIT_TEST_BEGIN();
+
+  for(i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+    parse_prefix(&state, invalid[i], strlen(invalid[i]));
+    UNIT_TEST_ASSERT(stayed_in_bounds(&state));
+    UNIT_TEST_ASSERT(state.error == JSON_ERROR_SYNTAX);
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_number_conversion,
+                   "Convert numbers that are not NUL-terminated");
+UNIT_TEST(test_number_conversion)
+{
+  static char buffer[32];
+  static struct jsonparse_state state;
+  static const char json[] = "[42";
+
+  UNIT_TEST_BEGIN();
+
+  memset(buffer, '9', sizeof(buffer));
+  memcpy(buffer, json, strlen(json));
+
+  jsonparse_setup(&state, buffer, strlen(json));
+  UNIT_TEST_ASSERT(jsonparse_next(&state) == '[');
+  UNIT_TEST_ASSERT(jsonparse_next(&state) == JSON_TYPE_NUMBER);
+  UNIT_TEST_ASSERT(stayed_in_bounds(&state));
+  UNIT_TEST_ASSERT(state.vlen == 2);
+  /* The '9' padding must not be read as part of the number. */
+  UNIT_TEST_ASSERT(jsonparse_get_value_as_int(&state) == 42);
+  UNIT_TEST_ASSERT(jsonparse_get_value_as_long(&state) == 42);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
 PROCESS_THREAD(run_tests, ev, data)
 {
   PROCESS_BEGIN();
@@ -101,6 +229,19 @@ PROCESS_THREAD(run_tests, ev, data)
   printf("Run unit-test\n");
 
   UNIT_TEST_RUN(test_literal_whitespace);
+  UNIT_TEST_RUN(test_truncated_input);
+  UNIT_TEST_RUN(test_no_nul_terminator);
+  UNIT_TEST_RUN(test_invalid_literal);
+  UNIT_TEST_RUN(test_number_conversion);
+
+  if(!UNIT_TEST_PASSED(test_literal_whitespace)
+     || !UNIT_TEST_PASSED(test_truncated_input)
+     || !UNIT_TEST_PASSED(test_no_nul_terminator)
+     || !UNIT_TEST_PASSED(test_invalid_literal)
+     || !UNIT_TEST_PASSED(test_number_conversion)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
 
   printf("=check-me= DONE\n");
 

--- a/tests/08-native-runs/29-jsonparse/test-jsonparse.c
+++ b/tests/08-native-runs/29-jsonparse/test-jsonparse.c
@@ -222,6 +222,27 @@ UNIT_TEST(test_number_conversion)
   UNIT_TEST_END();
 }
 /*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_long_fraction,
+                   "Convert numbers with a long fractional part");
+UNIT_TEST(test_long_fraction)
+{
+  static struct jsonparse_state state;
+  /* The token is longer than the buffer that the conversion copies it
+     into, but its integer part is not. */
+  static const char json[] = "-1.234567890123456789012345678901234567890";
+
+  UNIT_TEST_BEGIN();
+
+  jsonparse_setup(&state, json, strlen(json));
+  UNIT_TEST_ASSERT(jsonparse_next(&state) == JSON_TYPE_NUMBER);
+  UNIT_TEST_ASSERT(stayed_in_bounds(&state));
+  UNIT_TEST_ASSERT(state.vlen == (int)strlen(json));
+  UNIT_TEST_ASSERT(jsonparse_get_value_as_int(&state) == -1);
+  UNIT_TEST_ASSERT(jsonparse_get_value_as_long(&state) == -1);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
 PROCESS_THREAD(run_tests, ev, data)
 {
   PROCESS_BEGIN();
@@ -233,12 +254,14 @@ PROCESS_THREAD(run_tests, ev, data)
   UNIT_TEST_RUN(test_no_nul_terminator);
   UNIT_TEST_RUN(test_invalid_literal);
   UNIT_TEST_RUN(test_number_conversion);
+  UNIT_TEST_RUN(test_long_fraction);
 
   if(!UNIT_TEST_PASSED(test_literal_whitespace)
      || !UNIT_TEST_PASSED(test_truncated_input)
      || !UNIT_TEST_PASSED(test_no_nul_terminator)
      || !UNIT_TEST_PASSED(test_invalid_literal)
-     || !UNIT_TEST_PASSED(test_number_conversion)) {
+     || !UNIT_TEST_PASSED(test_number_conversion)
+     || !UNIT_TEST_PASSED(test_long_fraction)) {
     printf("=check-me= FAILED\n");
     printf("---\n");
   }

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -33,5 +33,6 @@ tests/08-native-runs/26-ip64/native:./26-ip64.sh \
 tests/08-native-runs/27-ip64-tap/native:./27-ip64-tap.sh \
 tests/08-native-runs/27-ip64-tap/native:./27-ip64-tap.sh:DEFINES=IP64_CONF_DHCP=1 \
 tests/08-native-runs/28-coap-parse/native:./28-coap-parse.sh \
+tests/08-native-runs/29-jsonparse/native:./29-jsonparse.sh \
 
 include ../Makefile.compile-test


### PR DESCRIPTION
jsonparse_setup() takes a length, but the parser did not honour it. atomic() scanned for a NUL byte or a delimiter instead, so a value running to the end of a length-delimited buffer advanced state->pos past it and the caller read as far. The literal comparison over-read separately, running strncmp over the longer of the parsed and expected lengths, and jsonparse_next() and the atoi() and atol() accessors read past the length too.

Nothing in the tree calls os/lib/json, so this is latent rather than remotely reachable.

The first commit is not about the bounds: the literal scan stopped at a space, a comma, or a closing bracket only, so true, false and null were rejected when a newline, a carriage return or a tab followed them. The second bounds every scan by state->len, requires a literal to match in full, copies a number into a NUL-terminated buffer before converting it, and resets vstart and vlen between parses. The third restores the conversion of a number with a long fractional part, which the second broke by copying the whole token into a fixed buffer and giving up when it did not fit. atoi() and atol() stop at the fractional part, so only the integer prefix needs copying.

One behaviour change is worth noting. JSONPARSE_NUMBER_MAX_LEN, documented in the header, bounds the integer part that the int and long accessors convert at 24 characters, which is enough for any 64-bit value with a sign. A number whose integer part is longer converts to 0 now, where before it converted to whatever atoi() or atol() produced on overflow. A long fractional part is unaffected, since it is never converted.

**Based on #3208**, which rewrites the literal scan loop and adds the `26-jsonparse` test suite this extends.

Thanks to @AmPaschal for reporting the problem.