### PR TITLE
log: make the NAT64 level configurable and fix the DTLS module entry

### DIFF
--- a/os/services/nat64/nat64-dns64.c
+++ b/os/services/nat64/nat64-dns64.c
@@ -55,7 +55,7 @@
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "NAT64"
-#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_LEVEL LOG_LEVEL_NAT64
 
 /* DNS record types per RFC 1035 / RFC 3596. */
 #define DNS_TYPE_A      1

--- a/os/services/nat64/nat64-tcp.c
+++ b/os/services/nat64/nat64-tcp.c
@@ -58,7 +58,7 @@
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "NAT64"
-#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_LEVEL LOG_LEVEL_NAT64
 
 #define IPV6_HDRLEN 40
 #define TCP_HDRLEN  20

--- a/os/services/nat64/nat64.c
+++ b/os/services/nat64/nat64.c
@@ -54,7 +54,7 @@
 /* Log configuration */
 #include "sys/log.h"
 #define LOG_MODULE "NAT64"
-#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_LEVEL LOG_LEVEL_NAT64
 
 #define IPV6_HDRLEN     40
 #define IP_PROTO_TCP    6

--- a/os/sys/log-conf.h
+++ b/os/sys/log-conf.h
@@ -128,6 +128,10 @@
 #define LOG_CONF_LEVEL_IPV6                        LOG_LEVEL_NONE
 #endif /* LOG_CONF_LEVEL_IPV6 */
 
+#ifndef LOG_CONF_LEVEL_NAT64
+#define LOG_CONF_LEVEL_NAT64                       LOG_LEVEL_NONE
+#endif /* LOG_CONF_LEVEL_NAT64 */
+
 #ifndef LOG_CONF_LEVEL_6LOWPAN
 #define LOG_CONF_LEVEL_6LOWPAN                     LOG_LEVEL_NONE
 #endif /* LOG_CONF_LEVEL_6LOWPAN */

--- a/os/sys/log.c
+++ b/os/sys/log.c
@@ -79,7 +79,7 @@ struct log_module all_modules[] = {
   {"framer", &curr_log_level_framer, LOG_CONF_LEVEL_FRAMER},
   {"6top", &curr_log_level_6top, LOG_CONF_LEVEL_6TOP},
   {"coap", &curr_log_level_coap, LOG_CONF_LEVEL_COAP},
-  {"dtls", &curr_log_level_coap, LOG_CONF_LEVEL_DTLS},
+  {"dtls", &curr_log_level_dtls, LOG_CONF_LEVEL_DTLS},
   {"snmp", &curr_log_level_snmp, LOG_CONF_LEVEL_SNMP},
   {"lwm2m", &curr_log_level_lwm2m, LOG_CONF_LEVEL_LWM2M},
   {"sys", &curr_log_level_sys, LOG_CONF_LEVEL_SYS},

--- a/os/sys/log.c
+++ b/os/sys/log.c
@@ -56,6 +56,7 @@
 int curr_log_level_rpl = LOG_CONF_LEVEL_RPL;
 int curr_log_level_tcpip = LOG_CONF_LEVEL_TCPIP;
 int curr_log_level_ipv6 = LOG_CONF_LEVEL_IPV6;
+int curr_log_level_nat64 = LOG_CONF_LEVEL_NAT64;
 int curr_log_level_6lowpan = LOG_CONF_LEVEL_6LOWPAN;
 int curr_log_level_nullnet = LOG_CONF_LEVEL_NULLNET;
 int curr_log_level_mac = LOG_CONF_LEVEL_MAC;
@@ -73,6 +74,7 @@ struct log_module all_modules[] = {
   {"rpl", &curr_log_level_rpl, LOG_CONF_LEVEL_RPL},
   {"tcpip", &curr_log_level_tcpip, LOG_CONF_LEVEL_TCPIP},
   {"ipv6", &curr_log_level_ipv6, LOG_CONF_LEVEL_IPV6},
+  {"nat64", &curr_log_level_nat64, LOG_CONF_LEVEL_NAT64},
   {"6lowpan", &curr_log_level_6lowpan, LOG_CONF_LEVEL_6LOWPAN},
   {"nullnet", &curr_log_level_nullnet, LOG_CONF_LEVEL_NULLNET},
   {"mac", &curr_log_level_mac, LOG_CONF_LEVEL_MAC},

--- a/os/sys/log.h
+++ b/os/sys/log.h
@@ -109,6 +109,7 @@ struct log_module {
 extern int curr_log_level_rpl;
 extern int curr_log_level_tcpip;
 extern int curr_log_level_ipv6;
+extern int curr_log_level_nat64;
 extern int curr_log_level_6lowpan;
 extern int curr_log_level_nullnet;
 extern int curr_log_level_mac;
@@ -127,6 +128,7 @@ extern struct log_module all_modules[];
 #define LOG_LEVEL_RPL                         MIN((LOG_CONF_LEVEL_RPL), curr_log_level_rpl)
 #define LOG_LEVEL_TCPIP                       MIN((LOG_CONF_LEVEL_TCPIP), curr_log_level_tcpip)
 #define LOG_LEVEL_IPV6                        MIN((LOG_CONF_LEVEL_IPV6), curr_log_level_ipv6)
+#define LOG_LEVEL_NAT64                       MIN((LOG_CONF_LEVEL_NAT64), curr_log_level_nat64)
 #define LOG_LEVEL_6LOWPAN                     MIN((LOG_CONF_LEVEL_6LOWPAN), curr_log_level_6lowpan)
 #define LOG_LEVEL_NULLNET                     MIN((LOG_CONF_LEVEL_NULLNET), curr_log_level_nullnet)
 #define LOG_LEVEL_MAC                         MIN((LOG_CONF_LEVEL_MAC), curr_log_level_mac)


### PR DESCRIPTION
The DTLS entry in all_modules[] pointed at the CoAP level variable, so setting the DTLS level changed CoAP instead. NAT64 named LOG_LEVEL_INFO outright, and now reads LOG_CONF_LEVEL_NAT64 like every other module.

NAT64 is now silent by default. Set LOG_CONF_LEVEL_NAT64 to restore the previous output.