### PR TITLE
lwm2m: fix undefined shifts and binary64 decoding in Float TLVs

### DIFF
--- a/os/services/lwm2m/lwm2m-tlv.c
+++ b/os/services/lwm2m/lwm2m-tlv.c
@@ -313,30 +313,55 @@ lwm2m_tlv_write_float32(uint8_t type, int16_t id, int32_t value, int bits,
 }
 /*---------------------------------------------------------------------------*/
 /* convert float to fixpoint */
-size_t
-lwm2m_tlv_float32_to_fix(const lwm2m_tlv_t *tlv, int32_t *value, int bits)
+/* Both widths normalise their significand to a leading bit at this position,
+   which is the widest that keeps the scaled result inside int32_t. */
+#define SIGNIFICAND_BIT 30
+/*---------------------------------------------------------------------------*/
+/*
+ * Scale a significand held with its leading bit at SIGNIFICAND_BIT by 2^e and
+ * apply the sign. Both widths normalise to this form, so the saturating shift
+ * below is written once.
+ */
+static void
+significand_to_fix(int sign, int e, uint32_t val, int32_t *value)
 {
-  /* TLV needs to be 4 bytes */
-  int e, i;
-  int32_t val;
-  int sign;
-
-  /* The IEEE 754 single-precision representation requires exactly 4 bytes.
-     Reject anything shorter to avoid reading past the value. */
-  if(tlv->length < 4) {
-    *value = 0;
-    return 0;
+  /*
+   * e is derived from an exponent taken off the wire, so neither shift can be
+   * taken at face value: a shift count of 32 or more is undefined, and even a
+   * small left shift can push the significand out of the range of int32_t.
+   * Saturate at both ends instead.
+   */
+  if(e >= 32) {
+    val = INT32_MAX;
+  } else if(e > 0) {
+    if(val > ((uint32_t)INT32_MAX >> e)) {
+      val = INT32_MAX;
+    } else {
+      val <<= e;
+    }
+  } else if(e <= -32) {
+    /* Every significant bit would have been shifted out. */
+    val = 0;
+  } else {
+    val >>= -e;
   }
 
-  sign = (tlv->value[0] & 0x80) != 0;
-  e = ((tlv->value[0] << 1) & 0xff) | (tlv->value[1] >> 7);
-  val = (((long)tlv->value[1] & 0x7f) << 16) | (tlv->value[2] << 8) | tlv->value[3];
+  *value = sign ? -(int32_t)val : (int32_t)val;
+}
+/*---------------------------------------------------------------------------*/
+/* Convert an IEEE 754 binary32 value, 8 bits of exponent and 23 of
+   significand, to the fixpoint representation. */
+static size_t
+binary32_to_fix(const uint8_t *v, int32_t *value, int bits)
+{
+  int sign = (v[0] & 0x80) != 0;
+  int e = ((v[0] << 1) & 0xff) | (v[1] >> 7);
+  /* 23 significand bits, left-aligned to SIGNIFICAND_BIT. */
+  uint32_t val = ((((uint32_t)v[1] & 0x7f) << 16) | (v[2] << 8) | v[3])
+    << (SIGNIFICAND_BIT - 23);
 
-  LOG_DBG("Sign: %d, Fraction: %06"PRIx32"  0b", val < 0, val);
-  for(i = 0; i < 23; i++) {
-    LOG_DBG_("%"PRId32"", ((val >> (22 - i)) & 1));
-  }
-  LOG_DBG("\nExp:%d => %d\n", e, e - 127);
+  LOG_DBG("binary32 sign %d exp %d significand %06"PRIx32"\n", sign, e,
+          (uint32_t)val);
 
   if(e == 0xff) {
     /* Infinity and NaN have no fixpoint representation; reject rather than
@@ -352,37 +377,64 @@ lwm2m_tlv_float32_to_fix(const lwm2m_tlv_t *tlv, int32_t *value, int bits)
     return 4;
   }
 
-  e = e - 127 + bits;
+  significand_to_fix(sign, e - 127 + bits - SIGNIFICAND_BIT,
+                     val | (UINT32_C(1) << SIGNIFICAND_BIT), value);
+  return 4;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Convert an IEEE 754 binary64 value, 11 bits of exponent and 52 of
+ * significand, to the fixpoint representation. Only the top 30 significand
+ * bits are read. That is not an approximation: the result is an int32_t and
+ * so holds at most 31 significant bits, and truncating the bits that the
+ * scaling below would discard anyway gives the same answer as carrying all
+ * 52 in a 64-bit intermediate, which no target then has to pay for.
+ */
+static size_t
+binary64_to_fix(const uint8_t *v, int32_t *value, int bits)
+{
+  int sign = (v[0] & 0x80) != 0;
+  int e = (((int)v[0] & 0x7f) << 4) | (v[1] >> 4);
+  /* Top 30 significand bits, left-aligned to SIGNIFICAND_BIT. */
+  uint32_t val = (((uint32_t)v[1] & 0x0f) << 26) | ((uint32_t)v[2] << 18)
+    | ((uint32_t)v[3] << 10) | ((uint32_t)v[4] << 2) | (v[5] >> 6);
 
-  /* e corresponds to the number of times we need to roll the number */
+  LOG_DBG("binary64 sign %d exp %d significand %06"PRIx32"\n", sign, e,
+          (uint32_t)val);
 
-  LOG_DBG("Actual e=%d\n", e);
-  e = e - 23;
-  LOG_DBG("E after sub %d\n", e);
-  val = val | 1L << 23;
-  /*
-   * The exponent is taken from the packet, so e spans [bits - 150, bits + 105]
-   * and neither shift can be taken at face value: a shift count of 32 or more
-   * is undefined, and even a small left shift can push the 24-bit magnitude
-   * out of the range of int32_t. Saturate at both ends instead.
-   */
-  if(e >= 32) {
-    val = INT32_MAX;
-  } else if(e > 0) {
-    if(val > (INT32_MAX >> e)) {
-      val = INT32_MAX;
-    } else {
-      val = val << e;
-    }
-  } else if(e <= -32) {
-    /* Every significant bit would have been shifted out. */
-    val = 0;
-  } else {
-    val = val >> -e;
+  if(e == 0x7ff) {
+    *value = 0;
+    return 0;
   }
 
-  *value = sign ? -val : val;
-  return 4;
+  if(e == 0) {
+    *value = 0;
+    return 8;
+  }
+
+  significand_to_fix(sign, e - 1023 + bits - SIGNIFICAND_BIT,
+                     val | (UINT32_C(1) << SIGNIFICAND_BIT), value);
+  return 8;
+}
+/*---------------------------------------------------------------------------*/
+size_t
+lwm2m_tlv_float32_to_fix(const lwm2m_tlv_t *tlv, int32_t *value, int bits)
+{
+  /*
+   * A Float resource is carried as either binary32 or binary64, whichever the
+   * sender chose, and the length field says which (Appendix C of the LwM2M
+   * specification). Any other length is malformed.
+   */
+  if(tlv->length == 4) {
+    return binary32_to_fix(tlv->value, value, bits);
+  }
+
+  if(tlv->length == 8) {
+    return binary64_to_fix(tlv->value, value, bits);
+  }
+
+  *value = 0;
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/os/services/lwm2m/lwm2m-tlv.c
+++ b/os/services/lwm2m/lwm2m-tlv.c
@@ -338,6 +338,20 @@ lwm2m_tlv_float32_to_fix(const lwm2m_tlv_t *tlv, int32_t *value, int bits)
   }
   LOG_DBG("\nExp:%d => %d\n", e, e - 127);
 
+  if(e == 0xff) {
+    /* Infinity and NaN have no fixpoint representation; reject rather than
+       hand the caller a number it cannot tell apart from a measurement. */
+    *value = 0;
+    return 0;
+  }
+
+  if(e == 0) {
+    /* Zero and the subnormals, which carry no implicit significand bit. Every
+       subnormal is far below the resolution of the fixpoint format. */
+    *value = 0;
+    return 4;
+  }
+
   e = e - 127 + bits;
 
   /* e corresponds to the number of times we need to roll the number */
@@ -346,8 +360,23 @@ lwm2m_tlv_float32_to_fix(const lwm2m_tlv_t *tlv, int32_t *value, int bits)
   e = e - 23;
   LOG_DBG("E after sub %d\n", e);
   val = val | 1L << 23;
-  if(e > 0) {
-    val = val << e;
+  /*
+   * The exponent is taken from the packet, so e spans [bits - 150, bits + 105]
+   * and neither shift can be taken at face value: a shift count of 32 or more
+   * is undefined, and even a small left shift can push the 24-bit magnitude
+   * out of the range of int32_t. Saturate at both ends instead.
+   */
+  if(e >= 32) {
+    val = INT32_MAX;
+  } else if(e > 0) {
+    if(val > (INT32_MAX >> e)) {
+      val = INT32_MAX;
+    } else {
+      val = val << e;
+    }
+  } else if(e <= -32) {
+    /* Every significant bit would have been shifted out. */
+    val = 0;
   } else {
     val = val >> -e;
   }

--- a/tests/08-native-runs/27-lwm2m-tlv.sh
+++ b/tests/08-native-runs/27-lwm2m-tlv.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+./run-one.sh 27-lwm2m-tlv

--- a/tests/08-native-runs/27-lwm2m-tlv/Makefile
+++ b/tests/08-native-runs/27-lwm2m-tlv/Makefile
@@ -1,0 +1,16 @@
+CONTIKI_PROJECT = test-lwm2m-tlv
+all: $(CONTIKI_PROJECT)
+
+TARGET = native
+
+# Only the TLV codec is under test. Pulling in the whole lwm2m module would
+# bring the engine, and with it CoAP and the rest of the stack, none of which
+# this test exercises.
+PROJECTDIRS += $(CONTIKI)/os/services/lwm2m
+PROJECTDIRS += $(CONTIKI)/os/net/app-layer/coap
+PROJECT_SOURCEFILES += lwm2m-tlv.c
+
+MODULES += os/services/unit-test
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/27-lwm2m-tlv/test-lwm2m-tlv.c
+++ b/tests/08-native-runs/27-lwm2m-tlv/test-lwm2m-tlv.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/**
+ * \file
+ *         Unit tests for the LwM2M TLV Float conversion.
+ *
+ *         The vectors are written as raw IEEE 754 encodings rather than
+ *         built from host floating-point literals, so that what is under
+ *         test is the decoder and not the build machine's own conversions.
+ *         Expected values follow the conversion's documented policy:
+ *         truncation toward zero, saturation at INT32_MAX where the value
+ *         does not fit, zero where every significant bit is shifted out,
+ *         and rejection of infinity, NaN and malformed lengths.
+ */
+
+#include "contiki.h"
+#include "lwm2m-tlv.h"
+#include "unit-test.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* The fixpoint scale the LwM2M engine uses (LWM2M_FLOAT32_BITS). */
+#define BITS 10
+
+PROCESS(run_tests, "LwM2M TLV unit tests");
+AUTOSTART_PROCESSES(&run_tests);
+
+struct float_case {
+  uint8_t bytes[8];
+  size_t size;
+  int32_t value;
+  const char *description;
+};
+/*---------------------------------------------------------------------------*/
+static bool
+check(const struct float_case *c, uint32_t length)
+{
+  lwm2m_tlv_t tlv;
+  int32_t value = 0x5a5a5a5a;
+  size_t size;
+
+  memset(&tlv, 0, sizeof(tlv));
+  tlv.type = LWM2M_TLV_TYPE_RESOURCE;
+  tlv.id = 1;
+  tlv.length = length;
+  tlv.value = c->bytes;
+
+  size = lwm2m_tlv_float32_to_fix(&tlv, &value, BITS);
+  if(size != c->size) {
+    printf("%s: size %u, expected %u\n", c->description,
+           (unsigned)size, (unsigned)c->size);
+    return false;
+  }
+  /* A rejected value must leave nothing usable behind. */
+  if(value != (c->size == 0 ? 0 : c->value)) {
+    printf("%s: value %" PRId32 ", expected %" PRId32 "\n", c->description,
+           value, c->size == 0 ? 0 : c->value);
+    return false;
+  }
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+static const struct float_case binary32_cases[] = {
+  { { 0x3f, 0x80, 0x00, 0x00 },
+    4, 1024, "1.0" },
+  { { 0x41, 0xbc, 0x00, 0x00 },
+    4, 24064, "23.5" },
+  { { 0xc0, 0x88, 0x00, 0x00 },
+    4, -4352, "-4.25" },
+  { { 0x3f, 0x00, 0x00, 0x00 },
+    4, 512, "0.5" },
+  { { 0xbf, 0x00, 0x00, 0x00 },
+    4, -512, "-0.5" },
+  { { 0x44, 0x7a, 0x00, 0x00 },
+    4, 1024000, "1000.0" },
+  { { 0x3a, 0x83, 0x12, 0x6f },
+    4, 1, "0.001" },
+  { { 0x00, 0x00, 0x00, 0x00 },
+    4, 0, "+0.0" },
+  { { 0x80, 0x00, 0x00, 0x00 },
+    4, 0, "-0.0" },
+  { { 0x00, 0x00, 0x00, 0x01 },
+    4, 0, "smallest subnormal" },
+  { { 0x00, 0x7f, 0xff, 0xff },
+    4, 0, "largest subnormal" },
+  { { 0x00, 0x80, 0x00, 0x00 },
+    4, 0, "smallest normal" },
+  { { 0x7f, 0x7f, 0xff, 0xff },
+    4, INT32_MAX, "largest finite" },
+  { { 0xff, 0x7f, 0xff, 0xff },
+    4, -INT32_MAX, "-largest finite" },
+  { { 0x39, 0x80, 0x00, 0x00 },
+    4, 0, "shift e=-32" },
+  { { 0x39, 0xff, 0xff, 0xff },
+    4, 0, "shift e=-32, full mantissa" },
+  { { 0x3a, 0x00, 0x00, 0x00 },
+    4, 0, "shift e=-31" },
+  { { 0x3a, 0x7f, 0xff, 0xff },
+    4, 0, "shift e=-31, full mantissa" },
+  { { 0x3a, 0x80, 0x00, 0x00 },
+    4, 1, "shift e=-30" },
+  { { 0x3a, 0xff, 0xff, 0xff },
+    4, 1, "shift e=-30, full mantissa" },
+  { { 0x49, 0x80, 0x00, 0x00 },
+    4, 1073741824, "shift e=0" },
+  { { 0x49, 0xff, 0xff, 0xff },
+    4, 2147483520, "shift e=0, full mantissa" },
+  { { 0x59, 0x00, 0x00, 0x00 },
+    4, INT32_MAX, "shift e=31" },
+  { { 0x59, 0x7f, 0xff, 0xff },
+    4, INT32_MAX, "shift e=31, full mantissa" },
+  { { 0x59, 0x80, 0x00, 0x00 },
+    4, INT32_MAX, "shift e=32" },
+  { { 0x59, 0xff, 0xff, 0xff },
+    4, INT32_MAX, "shift e=32, full mantissa" },
+  { { 0x7f, 0x80, 0x00, 0x00 },
+    0, 0, "+infinity" },
+  { { 0xff, 0x80, 0x00, 0x00 },
+    0, 0, "-infinity" },
+  { { 0x7f, 0xc0, 0x00, 0x00 },
+    0, 0, "NaN" },};
+/*---------------------------------------------------------------------------*/
+static const struct float_case binary64_cases[] = {
+  { { 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, 1024, "1.0" },
+  { { 0x40, 0x37, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, 24064, "23.5" },
+  { { 0xc0, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, -4352, "-4.25" },
+  { { 0x3f, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, 512, "0.5" },
+  { { 0xbf, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, -512, "-0.5" },
+  { { 0x40, 0x8f, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, 1024000, "1000.0" },
+  { { 0x3f, 0x50, 0x62, 0x4d, 0xd2, 0xf1, 0xa9, 0xfc },
+    8, 1, "0.001" },
+  { { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, 0, "+0.0" },
+  { { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, 0, "-0.0" },
+  { { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 },
+    8, 0, "smallest subnormal" },
+  { { 0x00, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff },
+    8, 0, "largest subnormal" },
+  { { 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    8, 0, "smallest normal" },
+  { { 0x7f, 0xef, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff },
+    8, INT32_MAX, "largest finite" },
+  { { 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    0, 0, "+infinity" },
+  { { 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    0, 0, "-infinity" },
+  { { 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
+    0, 0, "NaN" },};
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_binary32,
+                   "Convert binary32 Float TLVs to fixpoint");
+UNIT_TEST(test_binary32)
+{
+  unsigned int i;
+
+  UNIT_TEST_BEGIN();
+
+  for(i = 0; i < sizeof(binary32_cases) / sizeof(binary32_cases[0]); i++) {
+    UNIT_TEST_ASSERT(check(&binary32_cases[i], 4));
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_binary64,
+                   "Convert binary64 Float TLVs to fixpoint");
+UNIT_TEST(test_binary64)
+{
+  unsigned int i;
+
+  UNIT_TEST_BEGIN();
+
+  for(i = 0; i < sizeof(binary64_cases) / sizeof(binary64_cases[0]); i++) {
+    UNIT_TEST_ASSERT(check(&binary64_cases[i], 8));
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_both_widths_agree,
+                   "The same number decodes alike as binary32 and binary64");
+UNIT_TEST(test_both_widths_agree)
+{
+  lwm2m_tlv_t tlv;
+  int32_t from32;
+  int32_t from64;
+  unsigned int i;
+
+  UNIT_TEST_BEGIN();
+
+  /* The two tables open with the same seven numbers, by construction, and
+     each is near enough that the two encodings truncate alike. */
+  for(i = 0; i < 7; i++) {
+    memset(&tlv, 0, sizeof(tlv));
+    tlv.type = LWM2M_TLV_TYPE_RESOURCE;
+    tlv.id = 1;
+
+    tlv.length = 4;
+    tlv.value = binary32_cases[i].bytes;
+    UNIT_TEST_ASSERT(lwm2m_tlv_float32_to_fix(&tlv, &from32, BITS) == 4);
+
+    tlv.length = 8;
+    tlv.value = binary64_cases[i].bytes;
+    UNIT_TEST_ASSERT(lwm2m_tlv_float32_to_fix(&tlv, &from64, BITS) == 8);
+
+    UNIT_TEST_ASSERT(from32 == from64);
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST_REGISTER(test_malformed_length,
+                   "Reject a Float TLV that is neither four nor eight bytes");
+UNIT_TEST(test_malformed_length)
+{
+  static const struct float_case any = {
+    { 0x3f, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, 0, 0, "bad length"
+  };
+  uint32_t length;
+
+  UNIT_TEST_BEGIN();
+
+  for(length = 0; length <= 16; length++) {
+    if(length == 4 || length == 8) {
+      continue;
+    }
+    UNIT_TEST_ASSERT(check(&any, length));
+  }
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(run_tests, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+
+  UNIT_TEST_RUN(test_binary32);
+  UNIT_TEST_RUN(test_binary64);
+  UNIT_TEST_RUN(test_both_widths_agree);
+  UNIT_TEST_RUN(test_malformed_length);
+
+  if(!UNIT_TEST_PASSED(test_binary32)
+     || !UNIT_TEST_PASSED(test_binary64)
+     || !UNIT_TEST_PASSED(test_both_widths_agree)
+     || !UNIT_TEST_PASSED(test_malformed_length)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
+  printf("=check-me= DONE\n");
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -29,5 +29,6 @@ tests/08-native-runs/21-coffee-validation/native:./21-coffee-validation.sh \
 tests/08-native-runs/23-uiplib/native:./23-uiplib.sh \
 tests/08-native-runs/21-dbg-io/native:./21-dbg-io.sh \
 tests/08-native-runs/25-mqtt-prop/native:./25-mqtt-prop.sh \
+tests/08-native-runs/27-lwm2m-tlv/native:./27-lwm2m-tlv.sh \
 
 include ../Makefile.compile-test


### PR DESCRIPTION
lwm2m_tlv_float32_to_fix() takes its shift count from the exponent byte of the received TLV, so a packet can drive it past the width of int32_t, where the shift is undefined and the left shift overflows besides. The two reserved exponents went through the same shift, although one encodes infinity and NaN and the other zero and the subnormals. The finite range saturates now, infinity and NaN are rejected, and the subnormals return zero.

The following commit fixes a separate defect in the same function. A Float resource is carried as either binary32 or binary64, with the TLV length saying which, but the conversion read the first four bytes as binary32 whatever the length, so a legal eight-byte value became a plausible wrong number with no error raised: 1.0 arrived as 1.875. Both widths are decoded now, and any other length rejected.

The last commit adds unit tests for the conversion.

Thanks to @AmPaschal for reporting the undefined shift.