### PR TITLE
tests: report a failing AES-CCM unit test to the test harness

### DIFF
--- a/tests/08-native-runs/11-aes-ccm/test-aesccm.c
+++ b/tests/08-native-runs/11-aes-ccm/test-aesccm.c
@@ -180,6 +180,12 @@ PROCESS_THREAD(test_process, ev, data)
   UNIT_TEST_RUN(aesccm_encrypt);
   UNIT_TEST_RUN(aesccm_decrypt);
 
+  if(!UNIT_TEST_PASSED(aesccm_encrypt)
+     || !UNIT_TEST_PASSED(aesccm_decrypt)) {
+    printf("=check-me= FAILED\n");
+    printf("---\n");
+  }
+
   printf("=check-me= DONE\n");
   printf("---\n");
 


### PR DESCRIPTION
run-one.sh decides the outcome of a native suite by grepping its log for "=check-me= FAILED", and the unit-test service never prints that string: a test program has to check UNIT_TEST_PASSED() and print it itself, as the other suites do. Both tests here could fail and the suite still reported TEST OK, which corrupting one expected ciphertext confirms.