### PR TITLE
cooja: anchor the section-info linker script on .bss, not .lbss (fix non-x86-64 link)

### DIFF
--- a/arch/platform/cooja/cooja.ld
+++ b/arch/platform/cooja/cooja.ld
@@ -6,4 +6,4 @@ SECTIONS{
     cooja_bssStart = ADDR(.bss);
     cooja_dataStart = ADDR(.data);
 }
-INSERT BEFORE .lbss;
+INSERT AFTER .bss;


### PR DESCRIPTION
`cooja.ld` only defines the helper symbols Cooja reads for its memory interface (`cooja_bssStart/Size`, `cooja_dataStart/Size`). The `INSERT` anchor, however, must name a section that exists in the output — and `.lbss` (large-model BSS) exists only on x86-64. On any other host, linking a cooja mote fails immediately:

```
/usr/bin/ld: .lbss not found for insert
collect2: error: ld returned 1 exit status
```

This makes the cooja platform (and with it the whole `tests/*/*.csc` simulation suite) x86-64-only, although nothing else in the platform is architecture-specific. Anchoring on `.bss` — which exists wherever the platform links — fixes that; the SECTIONS block itself only references `ADDR`/`SIZEOF`, so its placement is irrelevant to the symbol values.

Verified:
- **x86-64** (Ubuntu 24.04, gcc 13.3): motes link; `cooja_*` symbols emitted with unchanged values; `07-simulation-base/02-ringbufindex.csc` passes under Cooja (`TEST OK`), and the full 85-scenario headless suite passes under a headless runner.
- **aarch64** (Ubuntu 22.04 container, gcc 11.4): motes now link (previously impossible); `07-simulation-base/21-cooja-rpl-tsch-security` and `13-ieee802154/04-cooja-test-sixp-pkt` pass.
- macOS is unaffected (the Apple branch of `Makefile.cooja` does not use `-T cooja.ld`).

This opens the door to running the Cooja simulation suite on arm64 hosts and CI runners.

Found while validating a Cooja re-implementation against the suite on Apple-silicon hosts; report: https://github.com/joakimeriksson/cooja-ng

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ed7fUCAWtSPTa4tGCUp2vw
