### PR TITLE
ip64: bound the DNS64 parser and correct its answer rewriting

### DIFF
--- a/os/services/ip64/ip64-dns64.c
+++ b/os/services/ip64/ip64-dns64.c
@@ -155,6 +155,11 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
   uint8_t *q;
   struct dns_hdr *hdr;
 
+  if(ipv4datalen < sizeof(struct dns_hdr)) {
+    LOG_WARN("ip64_dns64_4to6: packet ended while parsing header (in)\n");
+    return ipv6datalen;
+  }
+
   hdr = (struct dns_hdr *)ipv4data;
   LOG_DBG("dns64_4to6 id: %02x%02x\n", hdr->id[0], hdr->id[1]);
   LOG_DBG("dns64_4to6 flags1: 0x%02x\n", hdr->flags1);
@@ -174,19 +179,22 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
   qcopy = ipv6data + sizeof(struct dns_hdr);
   for(i = 0; i < ((hdr->numquestions[0] << 8) + hdr->numquestions[1]); i++) {
     do {
+      if(qdata >= ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
       qlen = *qdata;
       qdata++;
       qcopy++;
-      for(j = 0; j < qlen; j++) {
-        qdata++;
-        qcopy++;
-        if(qdata > ipv4data + ipv4datalen) {
-          LOG_WARN("dns64_4to6: packet ended while parsing\n");
-          return ipv6datalen;
-        }
-      }
+      qdata += qlen;
+      qcopy += qlen;
     } while(qlen != 0);
+
     q = qcopy;
+    if(q + DNS_QUESTION_SIZE > ipv6data + ipv6datalen) {
+      LOG_WARN("ip64_dns64_6to4: packet ended while parsing\n");
+      return ipv6datalen;
+    }
     if(q[DNS_QUESTION_CLASS0] == 0 && q[DNS_QUESTION_CLASS1] == DNS_CLASS_IN &&
        q[DNS_QUESTION_TYPE0] == 0 && q[DNS_QUESTION_TYPE1] == DNS_TYPE_AAAA) {
       q[DNS_QUESTION_TYPE1] = DNS_TYPE_AAAA;
@@ -201,25 +209,60 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
   /* Go through the answers section and update the answers. */
   for(i = 0; i < ((hdr->numanswers[0] << 8) + hdr->numanswers[1]); i++) {
+    if(adata >= ipv4data + ipv4datalen) {
+      LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+      return ipv6datalen;
+    }
 
     n = *adata;
     if(n & 0xc0) {
       /* Short-hand name format: 2 bytes */
+      if(adata + 2 > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+      if(acopy + 2 > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
+
       *acopy++ = *adata++;
       *acopy++ = *adata++;
     } else {
       /* Name spelled out */
       do {
+        if(adata >= ipv4data + ipv4datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+          return ipv6datalen;
+        }
         n = *adata;
         adata++;
         acopy++;
+
+        if(adata + n > ipv4data + ipv4datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+          return ipv6datalen;
+        }
+        if(acopy + n > ipv6data + ipv6datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+          return ipv6datalen;
+        }
+
         for(j = 0; j < n; j++) {
           *acopy++ = *adata++;
         }
       } while(n != 0);
     }
 
+    if(adata + 2 > ipv4data + ipv4datalen) {
+      LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+      return ipv6datalen;
+    }
     if(adata[0] == 0 && adata[1] == DNS_TYPE_A) {
+      if(acopy + 2 > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
       /* Update the type field from A to AAAA */
       *acopy = *adata;
       acopy++;
@@ -230,6 +273,16 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
       /* Get the length of the address record. Should be 4. */
       lenptr = &acopy[6];
+
+      if(adata + 2 + 4 + 2 > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+      if(acopy + 2 + 4 + 2 > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
+
       len = (adata[6] << 8) + adata[7];
 
       /* Copy the class, the TTL, and the data length */
@@ -237,8 +290,18 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       acopy += 8;
       adata += 8;
 
+      if(adata + len > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+
       if(len == 4) {
         uip_ip4addr_t addr;
+
+        if(acopy + sizeof(uip_ip6addr_t) > ipv6data + ipv6datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+          return ipv6datalen;
+        }
         uip_ipaddr(&addr, adata[0], adata[1], adata[2], adata[3]);
         ip64_addr_4to6(&addr, (uip_ip6addr_t *)acopy);
 
@@ -249,11 +312,24 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
         ipv6datalen += 12;
 
       } else {
+        if(acopy + len > ipv6data + ipv6datalen) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+          return ipv6datalen;
+        }
         memcpy(acopy, adata, len);
         acopy += len;
         adata += len;
       }
     } else {
+      if(adata + 2 + 2 + 4 + 2 > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+      if(acopy + 2 + 2 + 4 + 2 > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
+
       len = (adata[8] << 8) + adata[9];
 
       /* Copy the type, class, the TTL, and the data length */
@@ -261,6 +337,14 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       acopy += 10;
       adata += 10;
 
+      if(adata + len > ipv4data + ipv4datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+        return ipv6datalen;
+      }
+      if(acopy + len > ipv6data + ipv6datalen) {
+        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+        return ipv6datalen;
+      }
       /* Copy the data */
       memcpy(acopy, adata, len);
       acopy += len;

--- a/os/services/ip64/ip64-dns64.c
+++ b/os/services/ip64/ip64-dns64.c
@@ -199,8 +199,11 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       LOG_WARN("ip64_dns64_6to4: packet ended while parsing\n");
       return ipv6datalen;
     }
+    /* The question is the one that went out, which ip64_dns64_6to4() rewrote
+       from AAAA to A. Put it back, so that the reply carries the question
+       that was asked. */
     if(q[DNS_QUESTION_CLASS0] == 0 && q[DNS_QUESTION_CLASS1] == DNS_CLASS_IN &&
-       q[DNS_QUESTION_TYPE0] == 0 && q[DNS_QUESTION_TYPE1] == DNS_TYPE_AAAA) {
+       q[DNS_QUESTION_TYPE0] == 0 && q[DNS_QUESTION_TYPE1] == DNS_TYPE_A) {
       q[DNS_QUESTION_TYPE1] = DNS_TYPE_AAAA;
     }
 
@@ -240,6 +243,16 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
           return ipv6datalen;
         }
         n = *adata;
+
+        /* The two cursors part company as soon as a record grows, so from
+           the second record onwards the byte already at acopy belongs to
+           another part of the message and the length has to be written. */
+        if(acopy >= ipv6data + ipv6capacity) {
+          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+          return ipv6datalen;
+        }
+        *acopy = n;
+
         adata++;
         acopy++;
 

--- a/os/services/ip64/ip64-dns64.c
+++ b/os/services/ip64/ip64-dns64.c
@@ -145,8 +145,12 @@ ip64_dns64_6to4(const uint8_t *ipv6data, int ipv6datalen,
 /*---------------------------------------------------------------------------*/
 int
 ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
-                uint8_t *ipv6data, int ipv6datalen)
+                uint8_t *ipv6data, int ipv6capacity)
 {
+  /* The answer is copied verbatim except for the records that grow, so the
+     message starts out as long as the one that came in. */
+  int ipv6datalen = ipv4datalen;
+
   uint8_t n;
   int i, j;
   int qlen, len;
@@ -191,7 +195,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
     } while(qlen != 0);
 
     q = qcopy;
-    if(q + DNS_QUESTION_SIZE > ipv6data + ipv6datalen) {
+    if(q + DNS_QUESTION_SIZE > ipv6data + ipv6capacity) {
       LOG_WARN("ip64_dns64_6to4: packet ended while parsing\n");
       return ipv6datalen;
     }
@@ -221,7 +225,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
         return ipv6datalen;
       }
-      if(acopy + 2 > ipv6data + ipv6datalen) {
+      if(acopy + 2 > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
         return ipv6datalen;
       }
@@ -243,7 +247,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
           return ipv6datalen;
         }
-        if(acopy + n > ipv6data + ipv6datalen) {
+        if(acopy + n > ipv6data + ipv6capacity) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
           return ipv6datalen;
         }
@@ -259,7 +263,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       return ipv6datalen;
     }
     if(adata[0] == 0 && adata[1] == DNS_TYPE_A) {
-      if(acopy + 2 > ipv6data + ipv6datalen) {
+      if(acopy + 2 > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
         return ipv6datalen;
       }
@@ -278,7 +282,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
         return ipv6datalen;
       }
-      if(acopy + 2 + 4 + 2 > ipv6data + ipv6datalen) {
+      if(acopy + 2 + 4 + 2 > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
         return ipv6datalen;
       }
@@ -298,7 +302,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       if(len == 4) {
         uip_ip4addr_t addr;
 
-        if(acopy + sizeof(uip_ip6addr_t) > ipv6data + ipv6datalen) {
+        if(acopy + sizeof(uip_ip6addr_t) > ipv6data + ipv6capacity) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
           return ipv6datalen;
         }
@@ -312,7 +316,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
         ipv6datalen += 12;
 
       } else {
-        if(acopy + len > ipv6data + ipv6datalen) {
+        if(acopy + len > ipv6data + ipv6capacity) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
           return ipv6datalen;
         }
@@ -325,7 +329,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
         return ipv6datalen;
       }
-      if(acopy + 2 + 2 + 4 + 2 > ipv6data + ipv6datalen) {
+      if(acopy + 2 + 2 + 4 + 2 > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
         return ipv6datalen;
       }
@@ -341,7 +345,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
         return ipv6datalen;
       }
-      if(acopy + len > ipv6data + ipv6datalen) {
+      if(acopy + len > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
         return ipv6datalen;
       }

--- a/os/services/ip64/ip64-dns64.c
+++ b/os/services/ip64/ip64-dns64.c
@@ -97,7 +97,7 @@ ip64_dns64_6to4(const uint8_t *ipv6data, int ipv6datalen,
   uint8_t *q;
   struct dns_hdr *hdr;
 
-  if(ipv4datalen < sizeof(struct dns_hdr)) {
+  if(ipv4datalen < (int)sizeof(struct dns_hdr)) {
     LOG_WARN("ip64_dns64_6to4: packet ended while parsing header\n");
     return;
   }
@@ -159,9 +159,9 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
   uint8_t *q;
   struct dns_hdr *hdr;
 
-  if(ipv4datalen < sizeof(struct dns_hdr)) {
+  if(ipv4datalen < (int)sizeof(struct dns_hdr)) {
     LOG_WARN("ip64_dns64_4to6: packet ended while parsing header (in)\n");
-    return ipv6datalen;
+    return IP64_DNS64_DROP;
   }
 
   hdr = (struct dns_hdr *)ipv4data;
@@ -185,7 +185,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
     do {
       if(qdata >= ipv4data + ipv4datalen) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
       qlen = *qdata;
       qdata++;
@@ -196,8 +196,8 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
     q = qcopy;
     if(q + DNS_QUESTION_SIZE > ipv6data + ipv6capacity) {
-      LOG_WARN("ip64_dns64_6to4: packet ended while parsing\n");
-      return ipv6datalen;
+      LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+      return IP64_DNS64_DROP;
     }
     /* The question is the one that went out, which ip64_dns64_6to4() rewrote
        from AAAA to A. Put it back, so that the reply carries the question
@@ -218,7 +218,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
   for(i = 0; i < ((hdr->numanswers[0] << 8) + hdr->numanswers[1]); i++) {
     if(adata >= ipv4data + ipv4datalen) {
       LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-      return ipv6datalen;
+      return IP64_DNS64_DROP;
     }
 
     n = *adata;
@@ -226,11 +226,11 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       /* Short-hand name format: 2 bytes */
       if(adata + 2 > ipv4data + ipv4datalen) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
       if(acopy + 2 > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
 
       *acopy++ = *adata++;
@@ -240,7 +240,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       do {
         if(adata >= ipv4data + ipv4datalen) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-          return ipv6datalen;
+          return IP64_DNS64_DROP;
         }
         n = *adata;
 
@@ -249,7 +249,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
            another part of the message and the length has to be written. */
         if(acopy >= ipv6data + ipv6capacity) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-          return ipv6datalen;
+          return IP64_DNS64_DROP;
         }
         *acopy = n;
 
@@ -258,11 +258,11 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
         if(adata + n > ipv4data + ipv4datalen) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-          return ipv6datalen;
+          return IP64_DNS64_DROP;
         }
         if(acopy + n > ipv6data + ipv6capacity) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-          return ipv6datalen;
+          return IP64_DNS64_DROP;
         }
 
         for(j = 0; j < n; j++) {
@@ -273,12 +273,12 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
     if(adata + 2 > ipv4data + ipv4datalen) {
       LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-      return ipv6datalen;
+      return IP64_DNS64_DROP;
     }
     if(adata[0] == 0 && adata[1] == DNS_TYPE_A) {
       if(acopy + 2 > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
       /* Update the type field from A to AAAA */
       *acopy = *adata;
@@ -293,11 +293,11 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
       if(adata + 2 + 4 + 2 > ipv4data + ipv4datalen) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
       if(acopy + 2 + 4 + 2 > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
 
       len = (adata[6] << 8) + adata[7];
@@ -309,7 +309,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
       if(adata + len > ipv4data + ipv4datalen) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
 
       if(len == 4) {
@@ -317,7 +317,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
         if(acopy + sizeof(uip_ip6addr_t) > ipv6data + ipv6capacity) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-          return ipv6datalen;
+          return IP64_DNS64_DROP;
         }
         uip_ipaddr(&addr, adata[0], adata[1], adata[2], adata[3]);
         ip64_addr_4to6(&addr, (uip_ip6addr_t *)acopy);
@@ -331,7 +331,7 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       } else {
         if(acopy + len > ipv6data + ipv6capacity) {
           LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-          return ipv6datalen;
+          return IP64_DNS64_DROP;
         }
         memcpy(acopy, adata, len);
         acopy += len;
@@ -340,11 +340,11 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
     } else {
       if(adata + 2 + 2 + 4 + 2 > ipv4data + ipv4datalen) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
       if(acopy + 2 + 2 + 4 + 2 > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
 
       len = (adata[8] << 8) + adata[9];
@@ -356,11 +356,11 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
 
       if(adata + len > ipv4data + ipv4datalen) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
       if(acopy + len > ipv6data + ipv6capacity) {
         LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-        return ipv6datalen;
+        return IP64_DNS64_DROP;
       }
       /* Copy the data */
       memcpy(acopy, adata, len);

--- a/os/services/ip64/ip64-dns64.c
+++ b/os/services/ip64/ip64-dns64.c
@@ -147,13 +147,9 @@ int
 ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
                 uint8_t *ipv6data, int ipv6capacity)
 {
-  /* The answer is copied verbatim except for the records that grow, so the
-     message starts out as long as the one that came in. */
-  int ipv6datalen = ipv4datalen;
-
   uint8_t n;
   int i, j;
-  int qlen, len;
+  int qlen, len, taillen;
   const uint8_t *qdata, *adata;
   uint8_t *qcopy, *acopy, *lenptr;
   uint8_t *q;
@@ -326,7 +322,6 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
         acopy += 16;
         lenptr[0] = 0;
         lenptr[1] = 16;
-        ipv6datalen += 12;
 
       } else {
         if(acopy + len > ipv6data + ipv6capacity) {
@@ -368,6 +363,22 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
       adata += len;
     }
   }
-  return ipv6datalen;
+
+  /*
+   * The authority and the additional sections are copied as they stand, but
+   * they still have to move, since the answers before them grew. A name in
+   * them that points back into an answer keeps the offset it had, which the
+   * growth invalidated; correcting those would mean rewriting the names in
+   * the whole message.
+   */
+  taillen = ipv4data + ipv4datalen - adata;
+  if(acopy + taillen > ipv6data + ipv6capacity) {
+    LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+    return IP64_DNS64_DROP;
+  }
+  memcpy(acopy, adata, taillen);
+  acopy += taillen;
+
+  return acopy - ipv6data;
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/ip64/ip64-dns64.c
+++ b/os/services/ip64/ip64-dns64.c
@@ -61,24 +61,23 @@ struct dns_hdr {
   uint8_t numextrarr[2];
 };
 
+/* A question, which follows the name it asks about. */
 #define DNS_QUESTION_TYPE0  0
 #define DNS_QUESTION_TYPE1  1
 #define DNS_QUESTION_CLASS0 2
 #define DNS_QUESTION_CLASS1 3
 #define DNS_QUESTION_SIZE   4
 
-struct dns_answer {
-  /* DNS answer record starts with either a domain name or a pointer
-   * to a name already present somewhere in the packet. */
-  uint8_t type[2];
-  uint8_t class[2];
-  uint8_t ttl[4];
-  uint8_t len[2];
-  union {
-    uint8_t ip6[16];
-    uint8_t ip4[4];
-  } addr;
-};
+/*
+ * The fixed fields of a resource record, which follow the name the record is
+ * about: a type and a class of two bytes each, a TTL of four, and then the
+ * length of the data that follows the fields themselves.
+ */
+#define DNS_ANSWER_TYPE0    0
+#define DNS_ANSWER_TYPE1    1
+#define DNS_ANSWER_LEN0     8
+#define DNS_ANSWER_LEN1     9
+#define DNS_ANSWER_SIZE    10
 
 #define DNS_TYPE_A      1
 #define DNS_TYPE_AAAA  28
@@ -86,26 +85,55 @@ struct dns_answer {
 #define DNS_CLASS_IN    1
 #define DNS_CLASS_ANY 255
 
+/* The two high bits of a label length mark a compression pointer instead. */
+#define DNS_NAME_POINTER 0xc0
+
+/*---------------------------------------------------------------------------*/
+/*
+ * A name is a sequence of labels, each one a length byte followed by that
+ * many bytes, ending either with a zero-length label or with a two-byte
+ * pointer to a name earlier in the message. Returns the offset of the byte
+ * that follows the name, or a negative value if the name does not end
+ * within the message.
+ */
+static int
+skip_name(const uint8_t *data, int datalen, int offset)
+{
+  int len;
+
+  while(offset < datalen) {
+    len = data[offset];
+    if(len & DNS_NAME_POINTER) {
+      /* A pointer is the last thing in a name. */
+      return offset <= datalen - 2 ? offset + 2 : -1;
+    }
+    offset += 1 + len;
+    if(len == 0) {
+      return offset;
+    }
+  }
+
+  return -1;
+}
 /*---------------------------------------------------------------------------*/
 void
 ip64_dns64_6to4(const uint8_t *ipv6data, int ipv6datalen,
                 uint8_t *ipv4data, int ipv4datalen)
 {
   int i;
-  int qlen;
-  uint8_t *qdata;
+  int offset;
   uint8_t *q;
-  struct dns_hdr *hdr;
+  const struct dns_hdr *hdr;
 
   if(ipv4datalen < (int)sizeof(struct dns_hdr)) {
-    LOG_WARN("ip64_dns64_6to4: packet ended while parsing header\n");
+    LOG_WARN("dns64_6to4: message ended while parsing the header\n");
     return;
   }
 
-  hdr = (struct dns_hdr *)ipv4data;
+  hdr = (const struct dns_hdr *)ipv4data;
   LOG_DBG("dns64_6to4 id: %02x%02x\n", hdr->id[0], hdr->id[1]);
   LOG_DBG("dns64_6to4 flags1: 0x%02x\n", hdr->flags1);
-  LOG_DBG("ip64_dns64_6to4 flags2: 0x%02x\n", hdr->flags2);
+  LOG_DBG("dns64_6to4 flags2: 0x%02x\n", hdr->flags2);
   LOG_DBG("dns64_6to4 numquestions: 0x%02x\n",
       ((hdr->numquestions[0] << 8) + hdr->numquestions[1]));
   LOG_DBG("dns64_6to4 numanswers: 0x%02x\n",
@@ -117,29 +145,21 @@ ip64_dns64_6to4(const uint8_t *ipv6data, int ipv6datalen,
 
   /* Find the DNS question header by scanning through the question
      labels. */
-  qdata = ipv4data + sizeof(struct dns_hdr);
+  offset = sizeof(struct dns_hdr);
   for(i = 0; i < ((hdr->numquestions[0] << 8) + hdr->numquestions[1]); i++) {
-    do {
-      if(qdata >= ipv4data + ipv4datalen) {
-        LOG_WARN("ip64_dns64_6to4: packet ended while parsing\n");
-        return;
-      }
-      qlen = *qdata;
-      qdata++;
-      qdata += qlen;
-    } while(qlen != 0);
-    q = qdata;
-
-    if(qdata + DNS_QUESTION_SIZE > ipv4data + ipv4datalen) {
-      LOG_WARN("ip64_dns64_6to4: packet ended while parsing\n");
+    offset = skip_name(ipv4data, ipv4datalen, offset);
+    if(offset < 0 || offset > ipv4datalen - DNS_QUESTION_SIZE) {
+      LOG_WARN("dns64_6to4: message ended while parsing a question\n");
       return;
     }
+
+    q = &ipv4data[offset];
     if(q[DNS_QUESTION_CLASS0] == 0 && q[DNS_QUESTION_CLASS1] == DNS_CLASS_IN &&
        q[DNS_QUESTION_TYPE0] == 0 && q[DNS_QUESTION_TYPE1] == DNS_TYPE_AAAA) {
       q[DNS_QUESTION_TYPE1] = DNS_TYPE_A;
     }
 
-    qdata += DNS_QUESTION_SIZE;
+    offset += DNS_QUESTION_SIZE;
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -147,20 +167,29 @@ int
 ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
                 uint8_t *ipv6data, int ipv6capacity)
 {
-  uint8_t n;
-  int i, j;
-  int qlen, len, taillen;
-  const uint8_t *qdata, *adata;
-  uint8_t *qcopy, *acopy, *lenptr;
+  int i;
+  /* Offsets of the next byte to read, and of the next one to write. */
+  int in, out;
+  int end, len, tail;
   uint8_t *q;
-  struct dns_hdr *hdr;
+  const struct dns_hdr *hdr;
 
   if(ipv4datalen < (int)sizeof(struct dns_hdr)) {
-    LOG_WARN("ip64_dns64_4to6: packet ended while parsing header (in)\n");
+    LOG_WARN("dns64_4to6: message ended while parsing the header\n");
     return IP64_DNS64_DROP;
   }
 
-  hdr = (struct dns_hdr *)ipv4data;
+  /*
+   * ip64_4to6() copies the message into the packet going out before calling
+   * this function, so everything up to the first record that grows is
+   * already in place there.
+   */
+  if(ipv6capacity < ipv4datalen) {
+    LOG_WARN("dns64_4to6: no room for the message that came in\n");
+    return IP64_DNS64_DROP;
+  }
+
+  hdr = (const struct dns_hdr *)ipv4data;
   LOG_DBG("dns64_4to6 id: %02x%02x\n", hdr->id[0], hdr->id[1]);
   LOG_DBG("dns64_4to6 flags1: 0x%02x\n", hdr->flags1);
   LOG_DBG("dns64_4to6 flags2: 0x%02x\n", hdr->flags2);
@@ -173,194 +202,101 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
   LOG_DBG("dns64_4to6 numextrarr: 0x%02x\n",
       ((hdr->numextrarr[0] << 8) + hdr->numextrarr[1]));
 
-  /* Find the DNS answer header by scanning through the question
-     labels. */
-  qdata = ipv4data + sizeof(struct dns_hdr);
-  qcopy = ipv6data + sizeof(struct dns_hdr);
+  /*
+   * Find the DNS answer header by scanning through the question labels.
+   * Nothing has grown yet, so a question sits at the same offset in both
+   * messages and is rewritten where the copy left it.
+   */
+  in = sizeof(struct dns_hdr);
   for(i = 0; i < ((hdr->numquestions[0] << 8) + hdr->numquestions[1]); i++) {
-    do {
-      if(qdata >= ipv4data + ipv4datalen) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return IP64_DNS64_DROP;
-      }
-      qlen = *qdata;
-      qdata++;
-      qcopy++;
-      qdata += qlen;
-      qcopy += qlen;
-    } while(qlen != 0);
-
-    q = qcopy;
-    if(q + DNS_QUESTION_SIZE > ipv6data + ipv6capacity) {
-      LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+    in = skip_name(ipv4data, ipv4datalen, in);
+    if(in < 0 || in > ipv4datalen - DNS_QUESTION_SIZE) {
+      LOG_WARN("dns64_4to6: message ended while parsing a question\n");
       return IP64_DNS64_DROP;
     }
-    /* The question is the one that went out, which ip64_dns64_6to4() rewrote
-       from AAAA to A. Put it back, so that the reply carries the question
-       that was asked. */
+
+    q = &ipv6data[in];
+    /*
+     * The question is the one that went out, which ip64_dns64_6to4() rewrote
+     * from AAAA to A. Put it back, so that the reply carries the question
+     * that was asked.
+     */
     if(q[DNS_QUESTION_CLASS0] == 0 && q[DNS_QUESTION_CLASS1] == DNS_CLASS_IN &&
        q[DNS_QUESTION_TYPE0] == 0 && q[DNS_QUESTION_TYPE1] == DNS_TYPE_A) {
       q[DNS_QUESTION_TYPE1] = DNS_TYPE_AAAA;
     }
 
-    qdata += DNS_QUESTION_SIZE;
-    qcopy += DNS_QUESTION_SIZE;
+    in += DNS_QUESTION_SIZE;
   }
 
-  adata = qdata;
-  acopy = qcopy;
-
-  /* Go through the answers section and update the answers. */
+  /*
+   * Go through the answers and turn every A record into a AAAA record. Each
+   * one that is translated grows by 12 bytes, so the two offsets part
+   * company and everything that follows has to be written to its new place.
+   */
+  out = in;
   for(i = 0; i < ((hdr->numanswers[0] << 8) + hdr->numanswers[1]); i++) {
-    if(adata >= ipv4data + ipv4datalen) {
-      LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
+    /* The name the record is about, which is copied as it stands. */
+    end = skip_name(ipv4data, ipv4datalen, in);
+    if(end < 0) {
+      LOG_WARN("dns64_4to6: message ended while parsing a record name\n");
+      return IP64_DNS64_DROP;
+    }
+    if(end - in > ipv6capacity - out) {
+      LOG_WARN("dns64_4to6: no room for a record name\n");
+      return IP64_DNS64_DROP;
+    }
+    memcpy(&ipv6data[out], &ipv4data[in], end - in);
+    out += end - in;
+    in = end;
+
+    if(in > ipv4datalen - DNS_ANSWER_SIZE) {
+      LOG_WARN("dns64_4to6: message ended while parsing a record\n");
+      return IP64_DNS64_DROP;
+    }
+    len = (ipv4data[in + DNS_ANSWER_LEN0] << 8) + ipv4data[in + DNS_ANSWER_LEN1];
+    if(len > ipv4datalen - DNS_ANSWER_SIZE - in) {
+      LOG_WARN("dns64_4to6: record holds less data than its length field\n");
       return IP64_DNS64_DROP;
     }
 
-    n = *adata;
-    if(n & 0xc0) {
-      /* Short-hand name format: 2 bytes */
-      if(adata + 2 > ipv4data + ipv4datalen) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return IP64_DNS64_DROP;
-      }
-      if(acopy + 2 > ipv6data + ipv6capacity) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+    if(ipv4data[in + DNS_ANSWER_TYPE0] == 0 &&
+       ipv4data[in + DNS_ANSWER_TYPE1] == DNS_TYPE_A &&
+       len == sizeof(uip_ip4addr_t)) {
+      uip_ip4addr_t addr4;
+      uip_ip6addr_t addr6;
+
+      if(DNS_ANSWER_SIZE + (int)sizeof(addr6) > ipv6capacity - out) {
+        LOG_WARN("dns64_4to6: no room for a translated record\n");
         return IP64_DNS64_DROP;
       }
 
-      *acopy++ = *adata++;
-      *acopy++ = *adata++;
+      /* The record keeps its class and its TTL, but becomes a AAAA record
+         holding an address of four times the length. */
+      memcpy(&ipv6data[out], &ipv4data[in], DNS_ANSWER_SIZE);
+      ipv6data[out + DNS_ANSWER_TYPE1] = DNS_TYPE_AAAA;
+      ipv6data[out + DNS_ANSWER_LEN0] = 0;
+      ipv6data[out + DNS_ANSWER_LEN1] = sizeof(addr6);
+      in += DNS_ANSWER_SIZE;
+      out += DNS_ANSWER_SIZE;
+
+      /* A name of odd length leaves the record data at an odd offset,
+         whereas uip_ip6addr_t is written through as 16-bit words, so the
+         address is synthesized into a local one and copied into place. */
+      memcpy(&addr4, &ipv4data[in], sizeof(addr4));
+      ip64_addr_4to6(&addr4, &addr6);
+      memcpy(&ipv6data[out], &addr6, sizeof(addr6));
+      in += len;
+      out += sizeof(addr6);
     } else {
-      /* Name spelled out */
-      do {
-        if(adata >= ipv4data + ipv4datalen) {
-          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-          return IP64_DNS64_DROP;
-        }
-        n = *adata;
-
-        /* The two cursors part company as soon as a record grows, so from
-           the second record onwards the byte already at acopy belongs to
-           another part of the message and the length has to be written. */
-        if(acopy >= ipv6data + ipv6capacity) {
-          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-          return IP64_DNS64_DROP;
-        }
-        *acopy = n;
-
-        adata++;
-        acopy++;
-
-        if(adata + n > ipv4data + ipv4datalen) {
-          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-          return IP64_DNS64_DROP;
-        }
-        if(acopy + n > ipv6data + ipv6capacity) {
-          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-          return IP64_DNS64_DROP;
-        }
-
-        for(j = 0; j < n; j++) {
-          *acopy++ = *adata++;
-        }
-      } while(n != 0);
-    }
-
-    if(adata + 2 > ipv4data + ipv4datalen) {
-      LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-      return IP64_DNS64_DROP;
-    }
-    if(adata[0] == 0 && adata[1] == DNS_TYPE_A) {
-      if(acopy + 2 > ipv6data + ipv6capacity) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+      /* Every other record is copied as it stands. */
+      if(DNS_ANSWER_SIZE + len > ipv6capacity - out) {
+        LOG_WARN("dns64_4to6: no room for a record\n");
         return IP64_DNS64_DROP;
       }
-      /* Update the type field from A to AAAA */
-      *acopy = *adata;
-      acopy++;
-      adata++;
-      *acopy = DNS_TYPE_AAAA;
-      acopy++;
-      adata++;
-
-      /* Get the length of the address record. Should be 4. */
-      lenptr = &acopy[6];
-
-      if(adata + 2 + 4 + 2 > ipv4data + ipv4datalen) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return IP64_DNS64_DROP;
-      }
-      if(acopy + 2 + 4 + 2 > ipv6data + ipv6capacity) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-        return IP64_DNS64_DROP;
-      }
-
-      len = (adata[6] << 8) + adata[7];
-
-      /* Copy the class, the TTL, and the data length */
-      memcpy(acopy, adata, 2 + 4 + 2);
-      acopy += 8;
-      adata += 8;
-
-      if(adata + len > ipv4data + ipv4datalen) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return IP64_DNS64_DROP;
-      }
-
-      if(len == 4) {
-        uip_ip4addr_t addr;
-
-        if(acopy + sizeof(uip_ip6addr_t) > ipv6data + ipv6capacity) {
-          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-          return IP64_DNS64_DROP;
-        }
-        uip_ipaddr(&addr, adata[0], adata[1], adata[2], adata[3]);
-        ip64_addr_4to6(&addr, (uip_ip6addr_t *)acopy);
-
-        adata += len;
-        acopy += 16;
-        lenptr[0] = 0;
-        lenptr[1] = 16;
-
-      } else {
-        if(acopy + len > ipv6data + ipv6capacity) {
-          LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-          return IP64_DNS64_DROP;
-        }
-        memcpy(acopy, adata, len);
-        acopy += len;
-        adata += len;
-      }
-    } else {
-      if(adata + 2 + 2 + 4 + 2 > ipv4data + ipv4datalen) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return IP64_DNS64_DROP;
-      }
-      if(acopy + 2 + 2 + 4 + 2 > ipv6data + ipv6capacity) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-        return IP64_DNS64_DROP;
-      }
-
-      len = (adata[8] << 8) + adata[9];
-
-      /* Copy the type, class, the TTL, and the data length */
-      memcpy(acopy, adata, 2 + 2 + 4 + 2);
-      acopy += 10;
-      adata += 10;
-
-      if(adata + len > ipv4data + ipv4datalen) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (in)\n");
-        return IP64_DNS64_DROP;
-      }
-      if(acopy + len > ipv6data + ipv6capacity) {
-        LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
-        return IP64_DNS64_DROP;
-      }
-      /* Copy the data */
-      memcpy(acopy, adata, len);
-      acopy += len;
-      adata += len;
+      memcpy(&ipv6data[out], &ipv4data[in], DNS_ANSWER_SIZE + len);
+      in += DNS_ANSWER_SIZE + len;
+      out += DNS_ANSWER_SIZE + len;
     }
   }
 
@@ -371,14 +307,14 @@ ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
    * growth invalidated; correcting those would mean rewriting the names in
    * the whole message.
    */
-  taillen = ipv4data + ipv4datalen - adata;
-  if(acopy + taillen > ipv6data + ipv6capacity) {
-    LOG_WARN("ip64_dns64_4to6: packet ended while parsing (out)\n");
+  tail = ipv4datalen - in;
+  if(tail > ipv6capacity - out) {
+    LOG_WARN("dns64_4to6: no room for the rest of the message\n");
     return IP64_DNS64_DROP;
   }
-  memcpy(acopy, adata, taillen);
-  acopy += taillen;
+  memcpy(&ipv6data[out], &ipv4data[in], tail);
+  out += tail;
 
-  return acopy - ipv6data;
+  return out;
 }
 /*---------------------------------------------------------------------------*/

--- a/os/services/ip64/ip64-dns64.h
+++ b/os/services/ip64/ip64-dns64.h
@@ -32,9 +32,15 @@
 #ifndef IP64_DNS64_H_
 #define IP64_DNS64_H_
 
+/* Rewrites a DNS question in place. ipv4datalen is the length of the
+   message in ipv4data, which the rewrite does not change. */
 void ip64_dns64_6to4(const uint8_t *ipv6data, int ipv6datalen,
                      uint8_t *ipv4data, int ipv4datalen);
+
+/* Rewrites a DNS answer while copying it, growing it by 12 bytes for every A
+   record turned into a AAAA record. ipv6capacity is the room available in
+   ipv6data, not the length of the message; the new length is returned. */
 int ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
-                    uint8_t *ipv6data, int ipv6datalen);
+                    uint8_t *ipv6data, int ipv6capacity);
 
 #endif /* IP64_DNS64_H_ */

--- a/os/services/ip64/ip64-dns64.h
+++ b/os/services/ip64/ip64-dns64.h
@@ -32,6 +32,14 @@
 #ifndef IP64_DNS64_H_
 #define IP64_DNS64_H_
 
+/*
+ * Returned by ip64_dns64_4to6() for a message it cannot translate. The
+ * records that come after the point where it stopped are still at the
+ * offsets they had before the ones before them grew, so the packet is no
+ * longer a well-formed reply and the caller has to drop it.
+ */
+#define IP64_DNS64_DROP (-1)
+
 /* Rewrites a DNS question in place. ipv4datalen is the length of the
    message in ipv4data, which the rewrite does not change. */
 void ip64_dns64_6to4(const uint8_t *ipv6data, int ipv6datalen,
@@ -39,7 +47,8 @@ void ip64_dns64_6to4(const uint8_t *ipv6data, int ipv6datalen,
 
 /* Rewrites a DNS answer while copying it, growing it by 12 bytes for every A
    record turned into a AAAA record. ipv6capacity is the room available in
-   ipv6data, not the length of the message; the new length is returned. */
+   ipv6data, not the length of the message. Returns the length of the message
+   that was written, or IP64_DNS64_DROP. */
 int ip64_dns64_4to6(const uint8_t *ipv4data, int ipv4datalen,
                     uint8_t *ipv6data, int ipv6capacity);
 

--- a/os/services/ip64/ip64.c
+++ b/os/services/ip64/ip64.c
@@ -451,6 +451,11 @@ ip64_6to4(const uint8_t *ipv6packet, const uint16_t ipv6packet_len,
     LOG_DBG("6to4: UDP header\n");
     v4hdr->proto = IP_PROTO_UDP;
 
+    if(ipv6len < IPV6_HDRLEN + sizeof(struct udp_hdr)) {
+      LOG_WARN("6to4: UDP packet shorter than its header, dropping\n");
+      return 0;
+    }
+
     /* Check if this is a DNS request. If so, we should rewrite it
        with the DNS64 module. */
     if(udphdr->destport == UIP_HTONS(DNS_PORT)) {
@@ -737,6 +742,11 @@ ip64_4to6(const uint8_t *ipv4packet, const uint16_t ipv4packet_len,
   switch(v4hdr->proto) {
   case IP_PROTO_UDP:
     v6hdr->nxthdr = IP_PROTO_UDP;
+    if(ipv4len < IPV4_HDRLEN + sizeof(struct udp_hdr)) {
+      LOG_WARN("4to6: UDP packet shorter than its header, dropping\n");
+      return 0;
+    }
+
     /* Check if this is a DNS request. If so, we should rewrite it
        with the DNS64 module. */
     if(udphdr->srcport == UIP_HTONS(DNS_PORT)) {
@@ -746,6 +756,10 @@ ip64_4to6(const uint8_t *ipv4packet, const uint16_t ipv4packet_len,
                             ipv4len - IPV4_HDRLEN - sizeof(struct udp_hdr),
                             (uint8_t *)v6hdr + IPV6_HDRLEN + sizeof(struct udp_hdr),
                             BUFSIZE - IPV6_HDRLEN - sizeof(struct udp_hdr));
+      if(len == IP64_DNS64_DROP) {
+        LOG_WARN("4to6: Failed to translate the DNS reply, dropping\n");
+        return 0;
+      }
       ipv6_packet_len = len + sizeof(struct udp_hdr);
       v6hdr->len[0] = ipv6_packet_len >> 8;
       v6hdr->len[1] = ipv6_packet_len & 0xff;

--- a/os/services/ip64/ip64.c
+++ b/os/services/ip64/ip64.c
@@ -457,7 +457,7 @@ ip64_6to4(const uint8_t *ipv6packet, const uint16_t ipv6packet_len,
       ip64_dns64_6to4((uint8_t *)v6hdr + IPV6_HDRLEN + sizeof(struct udp_hdr),
                       ipv6len - IPV6_HDRLEN - sizeof(struct udp_hdr),
                       (uint8_t *)udphdr + sizeof(struct udp_hdr),
-                      BUFSIZE - IPV4_HDRLEN - sizeof(struct udp_hdr));
+                      ipv6len - IPV6_HDRLEN - sizeof(struct udp_hdr));
     }
     /* Compute and check the UDP checksum - since we're going to
        recompute it ourselves, we must ensure that it was correct in
@@ -745,7 +745,7 @@ ip64_4to6(const uint8_t *ipv4packet, const uint16_t ipv4packet_len,
       len = ip64_dns64_4to6((uint8_t *)v4hdr + IPV4_HDRLEN + sizeof(struct udp_hdr),
                             ipv4len - IPV4_HDRLEN - sizeof(struct udp_hdr),
                             (uint8_t *)v6hdr + IPV6_HDRLEN + sizeof(struct udp_hdr),
-                            ipv6_packet_len - sizeof(struct udp_hdr));
+                            BUFSIZE - IPV6_HDRLEN - sizeof(struct udp_hdr));
       ipv6_packet_len = len + sizeof(struct udp_hdr);
       v6hdr->len[0] = ipv6_packet_len >> 8;
       v6hdr->len[1] = ipv6_packet_len & 0xff;

--- a/tests/08-native-runs/26-ip64/README.md
+++ b/tests/08-native-runs/26-ip64/README.md
@@ -23,12 +23,14 @@ software on the host that knows nothing about NAT64, see
 | `dns64_rewrite` | `ip64_dns64_6to4` (AAAA to A) and `ip64_dns64_4to6` (A to AAAA) |
 | `icmp_echo` | ICMP translation in both directions: an IPv4 ping reaches the local IPv6 host and its reply is translated back |
 | `inbound_ports` | Inbound port handling: delivery to the local host below `EPHEMERAL_PORTRANGE`, and the drop of ephemeral-port traffic that matches no mapping |
+| `dns64_copies_later_records` | `ip64_dns64_4to6` on a reply with two answers, where the first grows and moves the second along with it |
 | `sixto4_rejects_bad_length` | `ip64_6to4` against an IPv6 payload length field larger than the payload received, and against a packet shorter than a header |
 
-The last one calls `ip64_6to4()` directly with malformed input and checks the
-return value, and that a canary past the buffer it was given is untouched, so
-an out-of-bounds write shows up without a sanitiser. It fails against the code
-as it stood before the fix in this pull request.
+The last two call `ip64_6to4()` and `ip64_dns64_4to6()` directly with
+malformed input and check the return value, and that a canary past the buffer
+they were given is untouched, so an out-of-bounds write shows up without a
+sanitiser. Both fail against the code as it stood before the fixes in this
+pull request.
 
 Outbound packets come from ordinary `simple_udp` sockets and are collected
 through the fallback interface. Inbound packets are handed to

--- a/tests/08-native-runs/26-ip64/README.md
+++ b/tests/08-native-runs/26-ip64/README.md
@@ -24,13 +24,19 @@ software on the host that knows nothing about NAT64, see
 | `icmp_echo` | ICMP translation in both directions: an IPv4 ping reaches the local IPv6 host and its reply is translated back |
 | `inbound_ports` | Inbound port handling: delivery to the local host below `EPHEMERAL_PORTRANGE`, and the drop of ephemeral-port traffic that matches no mapping |
 | `dns64_copies_later_records` | `ip64_dns64_4to6` on a reply with two answers, where the first grows and moves the second along with it |
+| `dns64_moves_the_additional_section` | `ip64_dns64_4to6` on a reply with an EDNS OPT record, which has to move when the answer before it grows |
+| `dns64_rejects_oversized_record` | `ip64_dns64_4to6` against an A record claiming more data than the packet holds |
+| `dns64_rejects_a_late_oversized_record` | The same, where the bad record is the second one, so a reply that has already been rewritten in part has to be dropped rather than forwarded |
+| `dns64_rejects_unterminated_name` | `ip64_dns64_4to6` against a question name that runs past the end of the packet |
+| `dns64_stops_when_the_output_is_full` | `ip64_dns64_4to6` given room for one record to grow, where two of them do |
+| `dns64_6to4_stops_at_the_end` | `ip64_dns64_6to4` against a query truncated in the middle of its question |
 | `sixto4_rejects_bad_length` | `ip64_6to4` against an IPv6 payload length field larger than the payload received, and against a packet shorter than a header |
 
-The last two call `ip64_6to4()` and `ip64_dns64_4to6()` directly with
-malformed input and check the return value, and that a canary past the buffer
-they were given is untouched, so an out-of-bounds write shows up without a
-sanitiser. Both fail against the code as it stood before the fixes in this
-pull request.
+The tests below `inbound_ports` call a translation or the DNS64 parser
+directly. Each sets its output buffer up the way the caller does, and checks
+both the return value and a canary past the room it was given, so an
+out-of-bounds write shows up without a sanitiser. All of them fail against
+the code as it stood before the fixes in this pull request.
 
 Outbound packets come from ordinary `simple_udp` sockets and are collected
 through the fallback interface. Inbound packets are handed to

--- a/tests/08-native-runs/26-ip64/test-ip64.c
+++ b/tests/08-native-runs/26-ip64/test-ip64.c
@@ -177,11 +177,39 @@ static const uint8_t dns_response_two[] = {
   93, 184, 216, 35
 };
 
+/* The same response with an EDNS OPT record in the additional section, which
+   nearly every resolver appends. The record is not rewritten, but it still
+   has to move when the answer before it grows. */
+static const uint8_t dns_response_opt[] = {
+  0x12, 0x34, 0x81, 0x80, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+  0x00, 0x01, 0x00, 0x01,
+  /* Answer: name as a compression pointer, address 93.184.216.34. */
+  0xc0, 0x0c,
+  0x00, 0x01, 0x00, 0x01,
+  0x00, 0x00, 0x0e, 0x10,
+  0x00, 0x04,
+  93, 184, 216, 34,
+  /* Additional: an OPT record on the root name, offering 1232 bytes. */
+  0,
+  0x00, 0x29, 0x04, 0xd0,
+  0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00
+};
+
+/* The OPT record above, as it has to come out. */
+static const uint8_t opt_record[] = {
+  0, 0x00, 0x29, 0x04, 0xd0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
 /* Where the record that follows the first answer starts once that answer has
    grown: the 12-byte header, the 17-byte question, and a record of a 2-byte
    name, a 2-byte type, 8 bytes of class, TTL and length, and a 16-byte
    address. */
 #define SECOND_RECORD_OFFSET (12 + 17 + 2 + 2 + 8 + 16)
+
+/* A DNS header is 12 bytes. */
+#define DNS_HDR_LEN 12
 
 struct eth_hdr {
   uint8_t dest[6];
@@ -261,6 +289,18 @@ UNIT_TEST_REGISTER(sixto4_rejects_bad_length,
                    "6to4 drops a packet whose payload length field lies");
 UNIT_TEST_REGISTER(dns64_copies_later_records,
                    "DNS64 keeps the name of a record that follows a rewrite");
+UNIT_TEST_REGISTER(dns64_moves_the_additional_section,
+                   "DNS64 moves the sections that follow the answers");
+UNIT_TEST_REGISTER(dns64_rejects_oversized_record,
+                   "DNS64 drops a record that claims more data than it has");
+UNIT_TEST_REGISTER(dns64_rejects_a_late_oversized_record,
+                   "DNS64 drops a reply it has already started to rewrite");
+UNIT_TEST_REGISTER(dns64_rejects_unterminated_name,
+                   "DNS64 stops at the end of a packet whose name runs on");
+UNIT_TEST_REGISTER(dns64_stops_when_the_output_is_full,
+                   "DNS64 drops a reply that does not fit in the room given");
+UNIT_TEST_REGISTER(dns64_6to4_stops_at_the_end,
+                   "DNS64 leaves a malformed query on the way out alone");
 UNIT_TEST_REGISTER(inbound_ports,
                    "Inbound packets reach the local host only below the "
                    "ephemeral port range");
@@ -927,6 +967,146 @@ UNIT_TEST(dns64_copies_later_records)
   UNIT_TEST_END();
 }
 /*---------------------------------------------------------------------------*/
+UNIT_TEST(dns64_moves_the_additional_section)
+{
+  static uint8_t out[PARSE_CAPACITY + CANARY_LEN];
+  int len;
+
+  UNIT_TEST_BEGIN();
+
+  parse_setup(out, sizeof(out), dns_response_opt, sizeof(dns_response_opt));
+
+  len = ip64_dns64_4to6(dns_response_opt, sizeof(dns_response_opt), out,
+                        PARSE_CAPACITY);
+
+  /* The answer grew by 12 bytes, and the length has to account for the OPT
+     record that follows it. */
+  UNIT_TEST_ASSERT(len == sizeof(dns_response_opt) + 12);
+
+  /* The OPT record itself moved along with the answer. */
+  UNIT_TEST_ASSERT(memcmp(&out[SECOND_RECORD_OFFSET], opt_record,
+                          sizeof(opt_record)) == 0);
+  UNIT_TEST_ASSERT(canary_intact(out, PARSE_CAPACITY, sizeof(out)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(dns64_rejects_oversized_record)
+{
+  static uint8_t answer[sizeof(dns_response)];
+  static uint8_t out[PARSE_CAPACITY + CANARY_LEN];
+  int len;
+
+  UNIT_TEST_BEGIN();
+
+  /* The A record now claims 65535 bytes of address, where the packet holds
+     four. A parser that trusts the field copies far past both buffers. */
+  memcpy(answer, dns_response, sizeof(answer));
+  answer[sizeof(answer) - 6] = 0xff;
+  answer[sizeof(answer) - 5] = 0xff;
+
+  parse_setup(out, sizeof(out), answer, sizeof(answer));
+  len = ip64_dns64_4to6(answer, sizeof(answer), out, PARSE_CAPACITY);
+
+  UNIT_TEST_ASSERT(len == IP64_DNS64_DROP);
+  UNIT_TEST_ASSERT(canary_intact(out, PARSE_CAPACITY, sizeof(out)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(dns64_rejects_a_late_oversized_record)
+{
+  static uint8_t answer[sizeof(dns_response_two)];
+  static uint8_t out[PARSE_CAPACITY + CANARY_LEN];
+  int len;
+
+  UNIT_TEST_BEGIN();
+
+  /* The record that claims more data than it has is the second one, so the
+     first has already been rewritten when the parser gives up. What is left
+     in the buffer is not a reply that can be sent, whatever its length. */
+  memcpy(answer, dns_response_two, sizeof(answer));
+  answer[sizeof(answer) - 6] = 0xff;
+  answer[sizeof(answer) - 5] = 0xff;
+
+  parse_setup(out, sizeof(out), answer, sizeof(answer));
+  len = ip64_dns64_4to6(answer, sizeof(answer), out, PARSE_CAPACITY);
+
+  UNIT_TEST_ASSERT(len == IP64_DNS64_DROP);
+  UNIT_TEST_ASSERT(canary_intact(out, PARSE_CAPACITY, sizeof(out)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(dns64_rejects_unterminated_name)
+{
+  static uint8_t answer[sizeof(dns_response)];
+  static uint8_t out[PARSE_CAPACITY + CANARY_LEN];
+  int len;
+
+  UNIT_TEST_BEGIN();
+
+  /* The first label of the question name claims 63 bytes, so the name runs
+     past the end of the packet and the walk never meets its terminator. */
+  memcpy(answer, dns_response, sizeof(answer));
+  answer[DNS_HDR_LEN] = 63;
+
+  parse_setup(out, sizeof(out), answer, sizeof(answer));
+  len = ip64_dns64_4to6(answer, sizeof(answer), out, PARSE_CAPACITY);
+
+  UNIT_TEST_ASSERT(len == IP64_DNS64_DROP);
+  UNIT_TEST_ASSERT(canary_intact(out, PARSE_CAPACITY, sizeof(out)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(dns64_stops_when_the_output_is_full)
+{
+  /* Room for the message that came in and for one record to grow, where two
+     of them do. */
+  const uint16_t capacity = sizeof(dns_response_two) + 12;
+  static uint8_t out[PARSE_CAPACITY + CANARY_LEN];
+  int len;
+
+  UNIT_TEST_BEGIN();
+
+  parse_setup(out, sizeof(out), dns_response_two, sizeof(dns_response_two));
+
+  len = ip64_dns64_4to6(dns_response_two, sizeof(dns_response_two), out,
+                        capacity);
+
+  UNIT_TEST_ASSERT(len == IP64_DNS64_DROP);
+  UNIT_TEST_ASSERT(canary_intact(out, capacity, sizeof(out)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(dns64_6to4_stops_at_the_end)
+{
+  /* A query truncated in the middle of its question: the name is there, but
+     the type and the class that follow it are not. */
+  const uint16_t truncated = DNS_HDR_LEN + 13;
+  /* What happens to lie past the end of the message, which a walk that runs
+     on takes for the question it is looking for. */
+  static const uint8_t past[] = { 0x00, 0x1c, 0x00, 0x01 };
+  static uint8_t out[PARSE_CAPACITY + CANARY_LEN];
+
+  UNIT_TEST_BEGIN();
+
+  parse_setup(out, sizeof(out), dns_query, truncated);
+  memcpy(&out[truncated], past, sizeof(past));
+
+  ip64_dns64_6to4(dns_query, truncated, out, truncated);
+
+  /* The question is never reached, so nothing is rewritten, and nothing
+     past the end of the message is touched. */
+  UNIT_TEST_ASSERT(memcmp(out, dns_query, truncated) == 0);
+  UNIT_TEST_ASSERT(memcmp(&out[truncated], past, sizeof(past)) == 0);
+  UNIT_TEST_ASSERT(canary_intact(out, truncated + sizeof(past), sizeof(out)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
 PROCESS_THREAD(test_ip64_process, ev, data)
 {
   static struct etimer startup_timer;
@@ -973,6 +1153,12 @@ PROCESS_THREAD(test_ip64_process, ev, data)
   UNIT_TEST_RUN(inbound_ports);
   UNIT_TEST_RUN(sixto4_rejects_bad_length);
   UNIT_TEST_RUN(dns64_copies_later_records);
+  UNIT_TEST_RUN(dns64_moves_the_additional_section);
+  UNIT_TEST_RUN(dns64_rejects_oversized_record);
+  UNIT_TEST_RUN(dns64_rejects_a_late_oversized_record);
+  UNIT_TEST_RUN(dns64_rejects_unterminated_name);
+  UNIT_TEST_RUN(dns64_stops_when_the_output_is_full);
+  UNIT_TEST_RUN(dns64_6to4_stops_at_the_end);
 
   if(!UNIT_TEST_PASSED(arp_resolution) ||
      !UNIT_TEST_PASSED(udp_round_trip) ||
@@ -981,7 +1167,13 @@ PROCESS_THREAD(test_ip64_process, ev, data)
      !UNIT_TEST_PASSED(icmp_echo) ||
      !UNIT_TEST_PASSED(inbound_ports) ||
      !UNIT_TEST_PASSED(sixto4_rejects_bad_length) ||
-     !UNIT_TEST_PASSED(dns64_copies_later_records)) {
+     !UNIT_TEST_PASSED(dns64_copies_later_records) ||
+     !UNIT_TEST_PASSED(dns64_moves_the_additional_section) ||
+     !UNIT_TEST_PASSED(dns64_rejects_oversized_record) ||
+     !UNIT_TEST_PASSED(dns64_rejects_a_late_oversized_record) ||
+     !UNIT_TEST_PASSED(dns64_rejects_unterminated_name) ||
+     !UNIT_TEST_PASSED(dns64_stops_when_the_output_is_full) ||
+     !UNIT_TEST_PASSED(dns64_6to4_stops_at_the_end)) {
     printf("=check-me= FAILED\n");
     printf("---\n");
   }

--- a/tests/08-native-runs/26-ip64/test-ip64.c
+++ b/tests/08-native-runs/26-ip64/test-ip64.c
@@ -42,7 +42,8 @@
  *   IPv4-to-IPv6 header translation, forwarding of a flow from a node behind
  *   the router, address-mapping allocation and reverse lookup, DNS64
  *   rewriting in both directions, ICMP echo translation, the inbound port
- *   handling, and the length checks 6to4 makes against malformed input.
+ *   handling, the length checks 6to4 makes against malformed input, and
+ *   the bounds of the DNS64 parser.
  *   Not covered: the ENC28J60 driver itself, the DHCPv4 client, and TCP.
  *
  */
@@ -56,6 +57,7 @@
 
 #include "ip64/ip64.h"
 #include "ip64/ip64-addrmap.h"
+#include "ip64/ip64-dns64.h"
 #include "ip64/ip64-eth.h"
 #include "ip64/ip64-eth-interface.h"
 
@@ -90,9 +92,9 @@
 #define ECHO_ID         0xbeef
 #define ECHO_SEQNO      7
 
-/* Room the malformed-input test hands to a translation, followed by bytes
-   that nothing is allowed to touch. A write past the capacity shows up as a
-   changed canary, with no sanitiser needed. */
+/* Room the malformed-input tests hand to a translation or a parser, followed
+   by bytes that nothing is allowed to touch. A write past the capacity shows
+   up as a changed canary, with no sanitiser needed. */
 #define PARSE_CAPACITY  128
 #define CANARY_LEN      32
 #define CANARY_BYTE     0x5a
@@ -153,6 +155,33 @@ static const uint8_t dns_response[] = {
   0x00, 0x04,
   93, 184, 216, 34
 };
+
+/* The same response with a second answer record, whose name is spelled out
+   rather than compressed. The first record grows by 12 bytes when its A
+   record becomes AAAA, which moves the second one along with it. */
+static const uint8_t dns_response_two[] = {
+  0x12, 0x34, 0x81, 0x80, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+  7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+  0x00, 0x01, 0x00, 0x01,
+  /* First answer: name as a compression pointer, address 93.184.216.34. */
+  0xc0, 0x0c,
+  0x00, 0x01, 0x00, 0x01,
+  0x00, 0x00, 0x0e, 0x10,
+  0x00, 0x04,
+  93, 184, 216, 34,
+  /* Second answer: name spelled out, address 93.184.216.35. */
+  7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0,
+  0x00, 0x01, 0x00, 0x01,
+  0x00, 0x00, 0x0e, 0x10,
+  0x00, 0x04,
+  93, 184, 216, 35
+};
+
+/* Where the record that follows the first answer starts once that answer has
+   grown: the 12-byte header, the 17-byte question, and a record of a 2-byte
+   name, a 2-byte type, 8 bytes of class, TTL and length, and a 16-byte
+   address. */
+#define SECOND_RECORD_OFFSET (12 + 17 + 2 + 2 + 8 + 16)
 
 struct eth_hdr {
   uint8_t dest[6];
@@ -230,6 +259,8 @@ UNIT_TEST_REGISTER(icmp_echo,
                    "An IPv4 ping is answered by the local IPv6 host");
 UNIT_TEST_REGISTER(sixto4_rejects_bad_length,
                    "6to4 drops a packet whose payload length field lies");
+UNIT_TEST_REGISTER(dns64_copies_later_records,
+                   "DNS64 keeps the name of a record that follows a rewrite");
 UNIT_TEST_REGISTER(inbound_ports,
                    "Inbound packets reach the local host only below the "
                    "ephemeral port range");
@@ -303,6 +334,16 @@ dns_received(struct simple_udp_connection *c, const uip_ipaddr_t *sender_addr,
   if(datalen != sizeof(dns_response) + 12) {
     printf("DNS response has length %u, expected %u\n",
            datalen, (unsigned)sizeof(dns_response) + 12);
+    return;
+  }
+
+  /* The query went out as AAAA and was rewritten to A on the way, so the
+     reply has to come back carrying the question that was asked. */
+  if((data[DNS_QUESTION_TYPE_OFFSET] << 8) +
+     data[DNS_QUESTION_TYPE_OFFSET + 1] != DNS_TYPE_AAAA) {
+    printf("DNS reply has question type %u, expected %u\n",
+           (data[DNS_QUESTION_TYPE_OFFSET] << 8) +
+           data[DNS_QUESTION_TYPE_OFFSET + 1], DNS_TYPE_AAAA);
     return;
   }
 
@@ -815,6 +856,16 @@ canary_intact(const uint8_t *buf, uint16_t capacity, uint16_t len)
   return true;
 }
 /*---------------------------------------------------------------------------*/
+/* Set an output buffer up the way ip64_4to6() leaves it before it calls the
+   DNS64 parser: the message that came in at the start of it, and the canary
+   pattern past the capacity the parser is given. */
+static void
+parse_setup(uint8_t *buf, uint16_t len, const uint8_t *msg, uint16_t msglen)
+{
+  canary_fill(buf, len);
+  memcpy(buf, msg, msglen);
+}
+/*---------------------------------------------------------------------------*/
 UNIT_TEST(sixto4_rejects_bad_length)
 {
   static uint8_t packet[IPV6_HDRLEN + UDP_HDRLEN];
@@ -845,6 +896,33 @@ UNIT_TEST(sixto4_rejects_bad_length)
   ip->len[1] = 0;
   UNIT_TEST_ASSERT(ip64_6to4(packet, IPV6_HDRLEN - 1, out) == 0);
   UNIT_TEST_ASSERT(canary_intact(out, 0, sizeof(out)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(dns64_copies_later_records)
+{
+  static const uint8_t name[] = {
+    7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0
+  };
+  static uint8_t out[PARSE_CAPACITY + CANARY_LEN];
+  int len;
+
+  UNIT_TEST_BEGIN();
+
+  parse_setup(out, sizeof(out), dns_response_two, sizeof(dns_response_two));
+
+  len = ip64_dns64_4to6(dns_response_two, sizeof(dns_response_two), out,
+                        PARSE_CAPACITY);
+
+  /* Both A records become AAAA records, so the message grows by 24 bytes. */
+  UNIT_TEST_ASSERT(len == sizeof(dns_response_two) + 24);
+
+  /* The second record moved 12 bytes along when the first one grew, so its
+     name had to be written rather than left where the copy put it. */
+  UNIT_TEST_ASSERT(memcmp(&out[SECOND_RECORD_OFFSET], name,
+                          sizeof(name)) == 0);
+  UNIT_TEST_ASSERT(canary_intact(out, PARSE_CAPACITY, sizeof(out)));
 
   UNIT_TEST_END();
 }
@@ -894,6 +972,7 @@ PROCESS_THREAD(test_ip64_process, ev, data)
   UNIT_TEST_RUN(icmp_echo);
   UNIT_TEST_RUN(inbound_ports);
   UNIT_TEST_RUN(sixto4_rejects_bad_length);
+  UNIT_TEST_RUN(dns64_copies_later_records);
 
   if(!UNIT_TEST_PASSED(arp_resolution) ||
      !UNIT_TEST_PASSED(udp_round_trip) ||
@@ -901,7 +980,8 @@ PROCESS_THREAD(test_ip64_process, ev, data)
      !UNIT_TEST_PASSED(dns64_rewrite) ||
      !UNIT_TEST_PASSED(icmp_echo) ||
      !UNIT_TEST_PASSED(inbound_ports) ||
-     !UNIT_TEST_PASSED(sixto4_rejects_bad_length)) {
+     !UNIT_TEST_PASSED(sixto4_rejects_bad_length) ||
+     !UNIT_TEST_PASSED(dns64_copies_later_records)) {
     printf("=check-me= FAILED\n");
     printf("---\n");
   }


### PR DESCRIPTION
ip64_dns64_4to6() copied every answer record using the length field from the wire without checking it against the message, so a single UDP packet from port 53 can overrun ip64_packet_buffer on any build with NAT64 enabled, and the Type A branch of that copy is CVE-2020-24336. A second defect sits in the question loop in both directions, where the guard is skipped entirely for a zero-length label.

The first two commits come from #2260. They bound the walks against the length of the message that came in, which is not the room available for the one going out, so on their own they stop the module from translating answers at all. The third gives the function an output capacity instead, and fixes the 6to4 caller, which passed a buffer capacity where a message length belongs. The fourth applies the two functional fixes #2260 left as TODOs. The reply kept the question type that 6to4 had rewritten on the way out, and record names were not copied when a rewrite moved them.

The remaining commits came out of review. A parser that gave up partway still returned a length, and ip64_4to6() sent out the half-rewritten reply, so it now drops the packet instead. The walk also stopped at the answers, leaving an EDNS OPT record where it was while the answer before it grew. The bounds themselves were right, but formed a pointer past the end of the buffer before comparing it, so the walks work in offsets now, which also picks up a name that ends in a compression pointer after some labels.

Each fix has a vector in the native ip64 test that fails without it.

Acknowledgements: @Scepticz reported the answer-record copy and the question-loop guard bypass, wrote the first two commits, and flagged the two rewriting defects that the fourth one fixes.

Closes #2260.