### PR TITLE
tsch: reject a zero-length hopping sequence from an EB

### DIFF
--- a/os/net/mac/tsch/tsch.c
+++ b/os/net/mac/tsch/tsch.c
@@ -470,10 +470,23 @@ eb_input(struct input_packet *current_input)
 #endif /* TSCH_AUTOSELECT_TIME_SOURCE */
       }
 
-      /* TSCH hopping sequence */
+      /*
+       * TSCH hopping sequence. An IE may name a sequence ID without
+       * carrying a sequence list, meaning the sender expects us to know
+       * that sequence already. Contiki-NG keeps no table of sequences by
+       * ID, so keep the one already in use. A zero length must also never
+       * reach TSCH_ASN_DIVISOR_INIT(), which would divide by zero.
+       */
       if(eb_ies.ie_channel_hopping_sequence_id != 0) {
-        if(eb_ies.ie_hopping_sequence_len != tsch_hopping_sequence_length.val
-            || memcmp((uint8_t *)tsch_hopping_sequence, eb_ies.ie_hopping_sequence_list, tsch_hopping_sequence_length.val)) {
+        if(eb_ies.ie_hopping_sequence_len == 0) {
+          LOG_DBG("parse_eb: no sequence list for hopping sequence ID %u,"
+                  " keeping the current sequence\n",
+                  eb_ies.ie_channel_hopping_sequence_id);
+        } else if(eb_ies.ie_hopping_sequence_len
+                  != tsch_hopping_sequence_length.val
+                  || memcmp((uint8_t *)tsch_hopping_sequence,
+                            eb_ies.ie_hopping_sequence_list,
+                            tsch_hopping_sequence_length.val)) {
           if(eb_ies.ie_hopping_sequence_len <= sizeof(tsch_hopping_sequence)) {
             memcpy((uint8_t *)tsch_hopping_sequence, eb_ies.ie_hopping_sequence_list,
                    eb_ies.ie_hopping_sequence_len);
@@ -662,11 +675,19 @@ tsch_associate(const struct input_packet *input_eb, rtimer_clock_t timestamp)
     memcpy(tsch_hopping_sequence, TSCH_DEFAULT_HOPPING_SEQUENCE, sizeof(TSCH_DEFAULT_HOPPING_SEQUENCE));
     TSCH_ASN_DIVISOR_INIT(tsch_hopping_sequence_length, sizeof(TSCH_DEFAULT_HOPPING_SEQUENCE));
   } else {
-    if(ies.ie_hopping_sequence_len <= sizeof(tsch_hopping_sequence)) {
+    /*
+     * Unlike eb_input(), there is no working sequence to fall back on
+     * here, and adopting the default for a sequence ID we cannot resolve
+     * would leave us hopping on the wrong channels. Decline to associate
+     * and keep scanning.
+     */
+    if(ies.ie_hopping_sequence_len > 0
+       && ies.ie_hopping_sequence_len <= sizeof(tsch_hopping_sequence)) {
       memcpy(tsch_hopping_sequence, ies.ie_hopping_sequence_list, ies.ie_hopping_sequence_len);
       TSCH_ASN_DIVISOR_INIT(tsch_hopping_sequence_length, ies.ie_hopping_sequence_len);
     } else {
-      LOG_ERR("! parse_eb: hopping sequence too long (%u)\n", ies.ie_hopping_sequence_len);
+      LOG_ERR("! parse_eb: invalid hopping sequence length (%u)\n",
+              ies.ie_hopping_sequence_len);
       return 0;
     }
   }


### PR DESCRIPTION
Two Channel Hopping IE encodings leave ie_hopping_sequence_len at the zero tsch_packet_parse_eb() memset it to while setting a nonzero ie_channel_hopping_sequence_id: the one-octet form carrying only the sequence ID, and the full form whose length field is zero, which satisfies the len == 12 + seq_len check in
frame802154e_parse_mlme_long_ie(). Both consumers in tsch.c then checked only an upper bound on the length, so either encoding reached TSCH_ASN_DIVISOR_INIT() with a divisor of zero, evaluating 0xffffffff % 0. Information elements are parsed before the frame's message integrity code is verified, so any node in radio range can send this to a node that is scanning, joining or already associated.

Guard the consumers rather than the parser, since the value arrives there through two different encodings. An IE carrying only the sequence ID is well formed: it names a sequence the receiver is expected to know already, and Contiki-NG keeps no such table. eb_input() therefore keeps the sequence it is already using, and tsch_associate() declines to associate rather than guess a sequence or install a zero-length divisor.

Thanks to @kmm2003 for reporting the divide-by-zero.