### PR TITLE
ip64: check the IPv6 payload length against the payload

### DIFF
--- a/os/services/ip64/ip64.c
+++ b/os/services/ip64/ip64.c
@@ -370,11 +370,26 @@ ip64_6to4(const uint8_t *ipv6packet, const uint16_t ipv6packet_len,
   v6hdr = (struct ipv6_hdr *)ipv6packet;
   v4hdr = (struct ipv4_hdr *)resultpacket;
 
-  if((v6hdr->len[0] << 8) + v6hdr->len[1] <= ipv6packet_len) {
+  if(ipv6packet_len < IPV6_HDRLEN) {
+    LOG_WARN("6to4: Packet shorter (%u) than an IPv6 header, dropping\n",
+        ipv6packet_len);
+    return 0;
+  }
+
+  /* The length field counts the bytes after the header, so it has to fit in
+     what was received after the header, not in the whole packet. */
+  if((v6hdr->len[0] << 8) + v6hdr->len[1] <= ipv6packet_len - IPV6_HDRLEN) {
     ipv6len = (v6hdr->len[0] << 8) + v6hdr->len[1] + IPV6_HDRLEN;
   } else {
     LOG_WARN("6to4: Packet smaller (%u) than in IPv6 header (%u), dropping\n",
         ipv6packet_len, (v6hdr->len[0] << 8) + v6hdr->len[1]);
+    return 0;
+  }
+
+  /* Make sure that the resulting packet fits in the ip64 packet buffer. If
+     not, we drop it, as ip64_4to6() does for the other direction. */
+  if(ipv6len - IPV6_HDRLEN + IPV4_HDRLEN > BUFSIZE) {
+    LOG_WARN("6to4: Packet too big, dropping\n");
     return 0;
   }
 

--- a/tests/08-native-runs/26-ip64/README.md
+++ b/tests/08-native-runs/26-ip64/README.md
@@ -23,6 +23,12 @@ software on the host that knows nothing about NAT64, see
 | `dns64_rewrite` | `ip64_dns64_6to4` (AAAA to A) and `ip64_dns64_4to6` (A to AAAA) |
 | `icmp_echo` | ICMP translation in both directions: an IPv4 ping reaches the local IPv6 host and its reply is translated back |
 | `inbound_ports` | Inbound port handling: delivery to the local host below `EPHEMERAL_PORTRANGE`, and the drop of ephemeral-port traffic that matches no mapping |
+| `sixto4_rejects_bad_length` | `ip64_6to4` against an IPv6 payload length field larger than the payload received, and against a packet shorter than a header |
+
+The last one calls `ip64_6to4()` directly with malformed input and checks the
+return value, and that a canary past the buffer it was given is untouched, so
+an out-of-bounds write shows up without a sanitiser. It fails against the code
+as it stood before the fix in this pull request.
 
 Outbound packets come from ordinary `simple_udp` sockets and are collected
 through the fallback interface. Inbound packets are handed to

--- a/tests/08-native-runs/26-ip64/test-ip64.c
+++ b/tests/08-native-runs/26-ip64/test-ip64.c
@@ -41,9 +41,9 @@
  *   Covered: uIP fallback dispatch, ARP resolution, IPv6-to-IPv4 and
  *   IPv4-to-IPv6 header translation, forwarding of a flow from a node behind
  *   the router, address-mapping allocation and reverse lookup, DNS64
- *   rewriting in both directions, ICMP echo translation, and the inbound
- *   port handling. Not covered: the ENC28J60 driver itself, the
- *   DHCPv4 client, and TCP.
+ *   rewriting in both directions, ICMP echo translation, the inbound port
+ *   handling, and the length checks 6to4 makes against malformed input.
+ *   Not covered: the ENC28J60 driver itself, the DHCPv4 client, and TCP.
  *
  */
 
@@ -89,6 +89,13 @@
 
 #define ECHO_ID         0xbeef
 #define ECHO_SEQNO      7
+
+/* Room the malformed-input test hands to a translation, followed by bytes
+   that nothing is allowed to touch. A write past the capacity shows up as a
+   changed canary, with no sanitiser needed. */
+#define PARSE_CAPACITY  128
+#define CANARY_LEN      32
+#define CANARY_BYTE     0x5a
 
 #define ARP_REQUEST     1
 #define ARP_REPLY       2
@@ -221,6 +228,8 @@ UNIT_TEST_REGISTER(dns64_rewrite,
                    "DNS64 rewrites AAAA to A and the A answer back to AAAA");
 UNIT_TEST_REGISTER(icmp_echo,
                    "An IPv4 ping is answered by the local IPv6 host");
+UNIT_TEST_REGISTER(sixto4_rejects_bad_length,
+                   "6to4 drops a packet whose payload length field lies");
 UNIT_TEST_REGISTER(inbound_ports,
                    "Inbound packets reach the local host only below the "
                    "ephemeral port range");
@@ -784,6 +793,62 @@ UNIT_TEST(inbound_ports)
   UNIT_TEST_END();
 }
 /*---------------------------------------------------------------------------*/
+/* Fill a buffer with the canary pattern, and report whether the bytes past
+   the capacity a translation was given are still untouched. */
+static void
+canary_fill(uint8_t *buf, uint16_t len)
+{
+  memset(buf, CANARY_BYTE, len);
+}
+/*---------------------------------------------------------------------------*/
+static bool
+canary_intact(const uint8_t *buf, uint16_t capacity, uint16_t len)
+{
+  uint16_t i;
+
+  for(i = capacity; i < len; i++) {
+    if(buf[i] != CANARY_BYTE) {
+      return false;
+    }
+  }
+
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+UNIT_TEST(sixto4_rejects_bad_length)
+{
+  static uint8_t packet[IPV6_HDRLEN + UDP_HDRLEN];
+  static uint8_t out[PARSE_CAPACITY + CANARY_LEN];
+  struct ipv6_hdr *ip = (struct ipv6_hdr *)packet;
+
+  UNIT_TEST_BEGIN();
+
+  memset(packet, 0, sizeof(packet));
+  ip->vtc = 0x60;
+  ip->nxthdr = UIP_PROTO_UDP;
+  ip->hoplim = 64;
+
+  /* The length field counts the bytes after the header, so claiming the
+     whole received length overstates the payload by exactly one header.
+     That is the value the old guard let through, and the copy it sized
+     from ran past both the source packet and the destination buffer. */
+  ip->len[0] = sizeof(packet) >> 8;
+  ip->len[1] = sizeof(packet) & 0xff;
+
+  canary_fill(out, sizeof(out));
+  UNIT_TEST_ASSERT(ip64_6to4(packet, sizeof(packet), out) == 0);
+  UNIT_TEST_ASSERT(canary_intact(out, 0, sizeof(out)));
+
+  /* A packet too short to hold an IPv6 header at all, with a length field
+     that says nothing follows it. */
+  ip->len[0] = 0;
+  ip->len[1] = 0;
+  UNIT_TEST_ASSERT(ip64_6to4(packet, IPV6_HDRLEN - 1, out) == 0);
+  UNIT_TEST_ASSERT(canary_intact(out, 0, sizeof(out)));
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
 PROCESS_THREAD(test_ip64_process, ev, data)
 {
   static struct etimer startup_timer;
@@ -828,13 +893,15 @@ PROCESS_THREAD(test_ip64_process, ev, data)
   UNIT_TEST_RUN(dns64_rewrite);
   UNIT_TEST_RUN(icmp_echo);
   UNIT_TEST_RUN(inbound_ports);
+  UNIT_TEST_RUN(sixto4_rejects_bad_length);
 
   if(!UNIT_TEST_PASSED(arp_resolution) ||
      !UNIT_TEST_PASSED(udp_round_trip) ||
      !UNIT_TEST_PASSED(forwarded_flow) ||
      !UNIT_TEST_PASSED(dns64_rewrite) ||
      !UNIT_TEST_PASSED(icmp_echo) ||
-     !UNIT_TEST_PASSED(inbound_ports)) {
+     !UNIT_TEST_PASSED(inbound_ports) ||
+     !UNIT_TEST_PASSED(sixto4_rejects_bad_length)) {
     printf("=check-me= FAILED\n");
     printf("---\n");
   }


### PR DESCRIPTION
The IPv6 length field counts the bytes after the header. ip64_6to4() checked it against the whole received length instead, so a field that claimed one header more than the packet held still got through. The copy is sized from that field and starts at the IPv4 header offset in ip64_packet_buffer, so those extra bytes go past the end of the buffer. Nothing in this direction checked that the translated packet fits either. ip64_4to6() does that before its own copy.

No caller reaches it today. uip6.c takes uip_len from that same length field, having dropped the packet if the field ran past what was received, so the guard ends up comparing the field with itself. That makes the packet buffer safe by the caller's arithmetic rather than by anything ip64_6to4() does, and the function is declared in ip64.h for callers that need not do the same.

The field is now checked against what was received after the header. A packet shorter than a header is refused before the subtraction, and the translated length is checked against BUFSIZE.

The native ip64 test gets a vector for both rejections, and it fails without the fix.

Thanks to Francesco La Spina and Stanislav Dashevskyi for reporting this problem.
