### PR TITLE
nrf54l15/xiao: fix OpenOCD programming, and make it work for TrustZone images

### DIFF
--- a/arch/cpu/nrf/nrf54l15/Makefile.nrf54l15
+++ b/arch/cpu/nrf/nrf54l15/Makefile.nrf54l15
@@ -105,11 +105,20 @@ NRF54L15_CAN_USE_OPENOCD := $(if $(NRF54L15_OPENOCD_CFG),$(shell which openocd))
 
 # Generate hex and flash for nRF54L15
 # Usage: make TARGET=nrf BOARD=nrf54l15/xiao hello-world.flash
+#
+# With OpenOCD the device is reset through the board config's secure
+# reset and halted at the reset vector before programming, so that no
+# firmware configuration (TrustZone memory protection, RRAM write
+# permissions) is live while the image is written; this also recovers
+# a board left halted by a failed flash. The image is verified after a
+# second reset-halt, again before any firmware runs, since a TrustZone
+# secure world would make OpenOCD's on-target verification fault, and
+# the core is then released.
 %.flash %.upload: $(OUT_HEX)
 ifneq ($(NRF54L15_CAN_USE_OPENOCD),)
 	@echo "Flashing with OpenOCD..."
 	openocd -f $(NRF54L15_OPENOCD_CFG) \
-		-c "init; reset halt; nrf54l-load $<; verify_image $<; reset run; shutdown"
+		-c "init; nrf54l-reset-halt; nrf54l-load $<; nrf54l-reset-halt; verify_image $<; nrf54l-run; shutdown"
 else ifneq (, $(shell which $(NRFUTIL)))
 	@echo "Flashing with nrfutil..."
 	$(NRFUTIL) device program --firmware $< \

--- a/arch/platform/nrf/nrf54l15/xiao/support/openocd.cfg
+++ b/arch/platform/nrf/nrf54l15/xiao/support/openocd.cfg
@@ -63,7 +63,35 @@ if {![using_hla]} {
 	$_TARGETNAME cortex_m reset_config sysresetreq
 }
 
+# Program the RRAM by direct memory writes: enable writing with a
+# 16-byte write buffer (RRAMC.CONFIG), load, commit the buffer
+# (RRAMC.TASKS_COMMITWRITEBUF) -- without the commit the last, partial
+# buffer line of an image is never written -- wait for the controller,
+# and disable writing again, also when loading fails.
+# read_memory needs OpenOCD 0.12.
+
+proc nrf54l-rd {addr} {
+	return [lindex [read_memory $addr 32 1] 0]
+}
+
+# Wait for RRAMC.READY, bounded.
+proc nrf54l-rramc-wait {} {
+	for {set i 0} {$i < 100} {incr i} {
+		if {[nrf54l-rd 0x5004b400] & 1} {
+			return
+		}
+		sleep 1
+	}
+	error "RRAMC did not become ready after committing the write buffer"
+}
+
 proc nrf54l-load {file} {
 	mww 0x5004b500 0x101
-	load_image $file
+	set rc [catch {load_image $file} msg]
+	mww 0x5004b008 1
+	nrf54l-rramc-wait
+	mww 0x5004b500 0x0
+	if {$rc} {
+		error "nrf54l-load: loading $file failed[expr {$msg eq "" ? "" : ": $msg"}]"
+	}
 }

--- a/arch/platform/nrf/nrf54l15/xiao/support/openocd.cfg
+++ b/arch/platform/nrf/nrf54l15/xiao/support/openocd.cfg
@@ -54,6 +54,13 @@ target create $_CHIPNAME.aux mem_ap -dap $_CHIPNAME.dap -ap-num 1
 $_CHIPNAME.dap apsel 1
 $_CHIPNAME.dap apcsw 0x01000000 0x01000000
 
+# Pin CSW.HNONSEC clear on the core's AP so that debugger transactions
+# are secure: a TrustZone secure world marks its flash, RAM and the
+# RRAM controller secure. OpenOCD's AHB-AP default already clears the
+# bit; this makes the requirement explicit.
+$_CHIPNAME.dap apsel 0
+$_CHIPNAME.dap apcsw 0x00000000 0x40000000
+
 adapter speed 1000
 
 # Use main processor as default target.
@@ -94,4 +101,43 @@ proc nrf54l-load {file} {
 	if {$rc} {
 		error "nrf54l-load: loading $file failed[expr {$msg eq "" ? "" : ": $msg"}]"
 	}
+}
+
+# Reset through a *secure* SYSRESETREQ. A TrustZone secure world sets
+# AIRCR.SYSRESETREQS, after which reset requests are honoured only from
+# the secure register bank; DSCSR.SBRSELEN|SBRSEL selects that bank for
+# debugger accesses. CDSKEY is set so the write leaves DSCSR.CDS, the
+# core's security state, untouched. Harmless for firmware without
+# TrustZone.
+proc nrf54l-reset {} {
+	mww 0xE000EE08 0x00020003
+	mww 0xE000ED0C 0x05FA0004
+	sleep 100
+}
+
+# Reset as above but halt at the reset vector (DEMCR.VC_CORERESET), so
+# the image can be programmed and verified with the core stopped before
+# any firmware has set up TrustZone memory protection, which would make
+# OpenOCD's on-target verification fault. Fails if the core did not
+# stop at the reset vector, e.g. because the reset was refused.
+# nrf54l-run releases the core.
+proc nrf54l-reset-halt {} {
+	mww 0xE000EDFC [expr {[nrf54l-rd 0xE000EDFC] | 1}]
+	nrf54l-reset
+	halt
+	set pc [dict get [get_reg -force {pc}] pc]
+	set rv [expr {[nrf54l-rd 0x00000004] & ~1}]
+	if {$pc != $rv} {
+		error [format "nrf54l-reset-halt: core did not halt at the reset vector (pc 0x%08x, reset vector 0x%08x), secure reset refused?" $pc $rv]
+	}
+}
+
+# Clear the reset vector catch, drop the secure bank selection (again
+# with CDSKEY set) and resume. If an earlier step aborted, the bank
+# selection stays until the next flash; it only affects which banked
+# registers a debugger sees.
+proc nrf54l-run {} {
+	mww 0xE000EDFC [expr {[nrf54l-rd 0xE000EDFC] & ~1}]
+	mww 0xE000EE08 0x00020000
+	resume
 }


### PR DESCRIPTION
Two fixes to the XIAO nRF54L15 OpenOCD flashing path (openocd.cfg and the upload recipe), rebased on develop.

  **The RRAM write buffer was never committed.** nrf54l-load enables buffered writes (RRAMC.CONFIG = 0x101) and only called load_image, so the last, partial 16-byte line of an image was left unprogrammed and verify_image missed it (it reads through the same controller). Fix: trigger RRAMC.TASKS_COMMITWRITEBUF, wait for RRAMC.READY, and disable write mode again, also when load_image fails.

  **A TrustZone secure world blocks the debugger's reset and verification.** With AIRCR.SYSRESETREQS set, OpenOCD's ordinary reset request is ignored, and the SPU/SAU setup makes verify_image's on-target CRC fault. Fix: reset through the secure register bank (DSCSR.SBRSEL, with CDSKEY set so the core's security state is untouched), reset-halt before programming so no firmware configuration is live while writing (this also recovers a board left halted by a failed flash), reset-halt again and verify at the reset vector before any firmware runs, check that the core actually halted at the reset vector, then release it. CSW.HNONSEC is pinned clear explicitly; that is OpenOCD's default and not a fix. Requires OpenOCD 0.12 (read_memory, get_reg).