### PR TITLE
nrf54l15: xmem over a reserved region of the internal RRAM

### DIFF
--- a/arch/cpu/nrf/nrf54l15/Makefile.nrf54l15
+++ b/arch/cpu/nrf/nrf54l15/Makefile.nrf54l15
@@ -37,8 +37,23 @@ EXTERNALDIRS += $(NRFX_ROOT)/mdk
 NRFX_C_SRCS += $(NRF54L15_MDK_DIR)/system_nrf54l.c
 NRFX_ASM_SRCS += $(NRF54L15_MDK_ASM_SRCS)
 
-LDSCRIPT ?= $(NRF54L15_MDK_DIR)/nrf54l15_xxaa_application.ld
+# The MDK's linker script with an optional region reserved for xmem.
+LDSCRIPT ?= $(CONTIKI_CPU)/nrf54l15/nrf54l15_xxaa_application.ld
 LDFLAGS += -L$(NRF54L15_MDK_DIR)
+
+### External memory (MAKE_WITH_XMEM=1): the xmem API over a region of
+### XMEM_CONF_SIZE bytes (default 64 kB, a multiple of 4 kB, 0 allowed)
+### that the linker script reserves at the top of the code RRAM, driven
+### through the RRAMC; the platform initializes it. Without the flag
+### nothing is reserved.
+ifeq ($(MAKE_WITH_XMEM),1)
+XMEM_CONF_SIZE ?= 65536
+CONTIKI_CPU_SOURCEFILES += xmem-rram.c
+CFLAGS += -DXMEM_CONF_SIZE=$(XMEM_CONF_SIZE) -DNRFX_RRAMC_ENABLED=1
+CFLAGS += -DBUILD_WITH_XMEM=1
+LDFLAGS += -Wl,--defsym,__xmem_conf_size=$(XMEM_CONF_SIZE)
+NRFX_C_SRCS += $(NRFX_ROOT)/drivers/src/nrfx_rramc.c
+endif
 
 include $(CONTIKI)/$(CONTIKI_NG_CM33_DIR)/Makefile.cm33
 

--- a/arch/cpu/nrf/nrf54l15/nrf54l15_xxaa_application.ld
+++ b/arch/cpu/nrf/nrf54l15/nrf54l15_xxaa_application.ld
@@ -1,0 +1,28 @@
+/*
+ * Linker script for the nRF54L15 application core without TrustZone:
+ * the MDK's nrf54l15_xxaa_application.ld with an optional region at the
+ * top of the code memory reserved for xmem (MAKE_WITH_XMEM=1,
+ * XMEM_CONF_SIZE), passed in as --defsym __xmem_conf_size. Without it
+ * nothing is reserved.
+ */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc)
+
+/* Code memory available to the application, inside global RRAM0. */
+__rram_code_size = 0x17D000;
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = __rram_code_size - (DEFINED(__xmem_conf_size) ? __xmem_conf_size : 0)
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x20000
+  RAM1 (rwx) : ORIGIN = 0x20020000, LENGTH = 0x20000
+}
+
+__xmem_start = ORIGIN(FLASH) + LENGTH(FLASH);
+__xmem_size = DEFINED(__xmem_conf_size) ? __xmem_conf_size : 0;
+
+/* Otherwise LENGTH(FLASH) wraps and the region lands outside the RRAM. */
+ASSERT(__xmem_size <= __rram_code_size, "XMEM_CONF_SIZE exceeds the code memory")
+
+INCLUDE "nrf_common.ld"

--- a/arch/cpu/nrf/nrf54l15/xmem-rram.c
+++ b/arch/cpu/nrf/nrf54l15/xmem-rram.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \addtogroup nrf
+ * @{
+ *
+ * \file
+ *         External-memory (xmem) API over a reserved region of the
+ *         nRF54L15's internal RRAM.
+ *
+ *         The region is carved from the top of the code memory by the
+ *         linker script when MAKE_WITH_XMEM=1 (XMEM_CONF_SIZE bytes,
+ *         default 64 kB); the linker exports its bounds. RRAM is
+ *         byte-addressable and needs no erase; "erase" fills with 0xff
+ *         to match what callers written for flash expect.
+ * \author
+ *         Niclas Finne <niclas.finne@ri.se>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/xmem.h"
+#include "dev/watchdog.h"
+
+#include <nrfx_rramc.h>
+#include <string.h>
+
+#include "sys/log.h"
+#define LOG_MODULE "XMEM"
+#define LOG_LEVEL LOG_LEVEL_NONE
+/*---------------------------------------------------------------------------*/
+#ifndef XMEM_CONF_SIZE
+#error "xmem-rram.c needs XMEM_CONF_SIZE (set by Makefile.nrf54l15 with MAKE_WITH_XMEM=1)"
+#endif
+#ifndef XMEM_ERASE_UNIT_SIZE
+#define XMEM_ERASE_UNIT_SIZE 4096
+#endif
+
+#if (XMEM_CONF_SIZE % XMEM_ERASE_UNIT_SIZE) != 0
+#error "XMEM_CONF_SIZE must be a multiple of XMEM_ERASE_UNIT_SIZE"
+#endif
+
+/* Bounds of the reserved region, from the linker script. */
+extern uint32_t __xmem_start;
+extern uint32_t __xmem_size;
+#define XMEM_START ((uintptr_t)&__xmem_start)
+#define XMEM_SIZE ((uint32_t)(uintptr_t)&__xmem_size)
+
+/* RRAMC write buffer, in 128-bit words. */
+#define WRITE_BUFFER_SIZE 16
+
+/*
+ * One full RRAMC write buffer: WRITE_BUFFER_SIZE 128-bit words. Writes and
+ * erases are done in chunks of this size, with the watchdog fed in between.
+ */
+#define WRITE_CHUNK_SIZE (WRITE_BUFFER_SIZE * 16)
+
+#if (XMEM_ERASE_UNIT_SIZE % WRITE_CHUNK_SIZE) != 0
+#error "XMEM_ERASE_UNIT_SIZE must be a multiple of the RRAMC write buffer size"
+#endif
+
+static bool initialized;
+/*---------------------------------------------------------------------------*/
+static bool
+in_region(unsigned long offset, unsigned long nbytes)
+{
+  return offset <= XMEM_SIZE && nbytes <= XMEM_SIZE - offset;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Writes go through the RRAMC write buffer and are committed explicitly by
+ * the end of the window opened here; write mode is enabled only for the
+ * duration of a write, so that a stray pointer elsewhere cannot alter
+ * non-volatile memory.
+ */
+static void
+rram_write_begin(void)
+{
+  nrfx_rramc_write_enable_set(true, WRITE_BUFFER_SIZE);
+}
+/*---------------------------------------------------------------------------*/
+static void
+rram_write_end(void)
+{
+  nrf_rramc_task_trigger(NRF_RRAMC, NRF_RRAMC_TASK_COMMIT_WRITEBUF);
+  while(!nrfx_rramc_ready_check()) {
+  }
+  nrfx_rramc_write_enable_set(false, 0);
+}
+/*---------------------------------------------------------------------------*/
+static void
+rram_write(uintptr_t address, const void *src, uint32_t nbytes)
+{
+  rram_write_begin();
+  nrfx_rramc_bytes_write(address, src, nbytes);
+  rram_write_end();
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * RRAM has no erase; a chunk is "erased" by writing 0xff over it. The source
+ * is a single 128-bit RRAM line, written repeatedly inside one write window,
+ * so that a whole write buffer still reaches RRAM per commit.
+ */
+static void
+rram_blank_chunk(uintptr_t address)
+{
+  static const uint8_t blank[16] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+  };
+
+  rram_write_begin();
+  for(uint32_t i = 0; i < WRITE_CHUNK_SIZE; i += sizeof(blank)) {
+    nrfx_rramc_bytes_write(address + i, blank, sizeof(blank));
+  }
+  rram_write_end();
+}
+/*---------------------------------------------------------------------------*/
+void
+xmem_init(void)
+{
+  if(initialized) {
+    return;
+  }
+  if(XMEM_SIZE == 0) {
+    LOG_WARN("No RRAM reserved for xmem\n");
+    return;
+  }
+
+  nrfx_rramc_config_t config = NRFX_RRAMC_DEFAULT_CONFIG(WRITE_BUFFER_SIZE);
+  nrfx_err_t err = nrfx_rramc_init(&config, NULL);
+  if(err != NRFX_SUCCESS && err != NRFX_ERROR_ALREADY) {
+    LOG_ERR("RRAMC init failed: %d\n", (int)err);
+    return;
+  }
+  initialized = true;
+  LOG_INFO("RRAM region for xmem: %lu bytes at 0x%08lx\n",
+           (unsigned long)XMEM_SIZE, (unsigned long)XMEM_START);
+}
+/*---------------------------------------------------------------------------*/
+int
+xmem_pread(void *buf, int nbytes, unsigned long offset)
+{
+  if(!initialized || nbytes < 0 || !in_region(offset, nbytes)) {
+    return -1;
+  }
+  memcpy(buf, (const void *)(XMEM_START + offset), nbytes);
+  return nbytes;
+}
+/*---------------------------------------------------------------------------*/
+int
+xmem_pwrite(const void *buf, int nbytes, unsigned long offset)
+{
+  if(!initialized || nbytes < 0 || !in_region(offset, nbytes)) {
+    return -1;
+  }
+  for(unsigned long done = 0; done < (unsigned long)nbytes;
+      done += WRITE_CHUNK_SIZE) {
+    unsigned long chunk = (unsigned long)nbytes - done;
+    if(chunk > WRITE_CHUNK_SIZE) {
+      chunk = WRITE_CHUNK_SIZE;
+    }
+    rram_write(XMEM_START + offset + done, (const uint8_t *)buf + done, chunk);
+    watchdog_periodic();
+  }
+  return nbytes;
+}
+/*---------------------------------------------------------------------------*/
+int
+xmem_erase(long nbytes, unsigned long offset)
+{
+  if(!initialized || nbytes < 0 || !in_region(offset, nbytes)) {
+    return -1;
+  }
+  if(offset % XMEM_ERASE_UNIT_SIZE != 0 || nbytes % XMEM_ERASE_UNIT_SIZE != 0) {
+    LOG_ERR("xmem_erase: offset and size must be multiples of %u\n",
+            (unsigned)XMEM_ERASE_UNIT_SIZE);
+    return -1;
+  }
+  for(unsigned long done = 0; done < (unsigned long)nbytes;
+      done += WRITE_CHUNK_SIZE) {
+    rram_blank_chunk(XMEM_START + offset + done);
+    watchdog_periodic();
+  }
+  return nbytes;
+}
+/** @} */

--- a/arch/platform/nrf/platform.c
+++ b/arch/platform/nrf/platform.c
@@ -44,6 +44,7 @@
 #include "dev/button-hal.h"
 #include "dev/leds.h"
 #include "dev/serial-line.h"
+#include "dev/xmem.h"
 #include "lib/csprng.h"
 
 #include "int-master.h"
@@ -161,6 +162,14 @@ platform_init_stage_two(void)
   hardfault_print_saved_crash();
 #endif
 #endif /* NRF_HAS_UARTE */
+
+  /*
+   * The RRAMC behind xmem is a secure peripheral, so with TrustZone only
+   * the secure image initializes it, as with the UARTE above.
+   */
+#if BUILD_WITH_XMEM && !defined(NRF_TRUSTZONE_NONSECURE)
+  xmem_init();
+#endif
 
 #if NRF_HAS_USB && defined(NRF_NATIVE_USB) && NRF_NATIVE_USB == 1
   usb_init();

--- a/doc/platforms/nrf.md
+++ b/doc/platforms/nrf.md
@@ -131,6 +131,10 @@ set on the compilation command line:
 * `NRF_NATIVE_USB=<0,1>`  
   Enables or disables the native USB support on boards that have USB support. 
   This will automatically change the debug and the slip from UART to USB.
+
+* `MAKE_WITH_XMEM=<0,1>` and `XMEM_CONF_SIZE=<bytes>`
+  nRF54L15 only: provides the xmem API over a region of the internal RRAM.
+  See [nRF54L15](#nrf54l15) below.
  
 ## Compilation Targets
 
@@ -295,6 +299,18 @@ two nRF54L15 boards are flashed with the `.flash` target:
   RRAM with `load_image` and never invokes an OpenOCD flash driver. The
   board-specific `openocd.cfg` is selected automatically by the Makefile.
 * `nrf54l15/dk` — over its onboard SEGGER J-Link.
+
+**Persistent storage.** Build with `MAKE_WITH_XMEM=1` to get the xmem API
+(`os/dev/xmem.h`) over a region of the internal RRAM, so that storage such as
+Coffee needs no external flash. The linker script reserves `XMEM_CONF_SIZE`
+bytes (default 64 kB; any multiple of 4 kB, 0 allowed) at the top of the code
+memory and the platform initializes the driver at boot, so an application can
+call `xmem_pread()`, `xmem_pwrite()` and `xmem_erase()` directly. Offsets are
+relative to the start of the region, and `xmem_erase()` takes multiples of the
+4 kB erase unit. Without the flag nothing is reserved and the build is
+unchanged.
+
+    make TARGET=nrf BOARD=nrf54l15/xiao MAKE_WITH_XMEM=1 XMEM_CONF_SIZE=131072 hello-world.flash
 
 **Current limitations.** TSCH is not supported on the nRF54L15. The
 `nrf_802154`-based radio driver does not implement

--- a/tests/02-compile-arm-ports/Makefile
+++ b/tests/02-compile-arm-ports/Makefile
@@ -104,6 +104,7 @@ hello-world/nrf:BOARD=nrf5340/dk/application \
 hello-world/nrf:BOARD=nrf5340/dk/network \
 hello-world/nrf:BOARD=nrf54l15/dk \
 hello-world/nrf:BOARD=nrf54l15/xiao \
+hello-world/nrf:BOARD=nrf54l15/xiao:MAKE_WITH_XMEM=1 \
 hello-world/nrf:BOARD=nrf52840/dk:NRF_NATIVE_USB=1 \
 hello-world/nrf:BOARD=nrf52840/dongle:NRF_NATIVE_USB=1 \
 hello-world/nrf:BOARD=nrf5340/dk/application:NRF_NATIVE_USB=1 \


### PR DESCRIPTION
Driver for the xmem API (`os/dev/xmem.h`) on the nRF54L15 with a region of the internal RRAM, so that persistent storage such as Coffee needs no external flash. With `MAKE_WITH_XMEM=1` the linker script reserves `XMEM_CONF_SIZE` bytes (default 64 kB; any multiple of 4 kB, 0 allowed) at the top of the code memory and exports the bounds; without the flag nothing is reserved and the build is unchanged. The MDK's linker script is therefore replaced by a copy carrying the one expression.

Writes go through the RRAMC write buffer with an explicit commit, and write mode is enabled only for the duration of a write, so that a stray pointer elsewhere cannot alter non-volatile memory. RRAM has no erase; `xmem_erase()` fills with 0xff to give callers written for flash what they expect. Long erases keep the watchdog fed.