### PR TITLE
coap: keep the token and the message type in an error reply

### DIFF
--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -351,6 +351,11 @@ coap_receive(const coap_endpoint_t *src,
     coap_clear_transaction(transaction);
   } else {
     coap_message_type_t reply_type = COAP_TYPE_ACK;
+    uint16_t reply_mid = message->mid;
+    uint8_t token[COAP_TOKEN_LEN];
+    /* A message whose token length is out of range is rejected by the
+       parser, which leaves the length it read behind. */
+    size_t token_len = MIN(message->token_len, sizeof(token));
 
 #if COAP_MESSAGE_ON_ERROR
     LOG_WARN("ERROR %u: %s\n", coap_status_code, coap_error_message);
@@ -359,16 +364,32 @@ coap_receive(const coap_endpoint_t *src,
 #endif
     coap_clear_transaction(transaction);
 
+    /* The reply is built in the buffer the message came in, so the token
+       has to be kept before that buffer is cleared. */
+    memcpy(token, message->token, token_len);
+
     if(coap_status_code == PING_RESPONSE) {
       coap_status_code = 0;
       reply_type = COAP_TYPE_RST;
-    } else if(coap_status_code >= 192) {
-      /* set to sendable error code */
-      coap_status_code = INTERNAL_SERVER_ERROR_5_00;
-      /* reuse input buffer for error message */
+    } else {
+      if(coap_status_code >= 192) {
+        /* set to sendable error code */
+        coap_status_code = INTERNAL_SERVER_ERROR_5_00;
+        /* reuse input buffer for error message */
+      }
+      if(message->type == COAP_TYPE_NON) {
+        /* An unreliable message is answered with one of its own, which
+           carries a message ID of its own as well. */
+        reply_type = COAP_TYPE_NON;
+        reply_mid = coap_get_mid();
+      }
     }
-    coap_init_message(message, reply_type, coap_status_code,
-                      message->mid);
+    coap_init_message(message, reply_type, coap_status_code, reply_mid);
+    if(reply_type != COAP_TYPE_RST && token_len > 0) {
+      /* A response carries the token of the message it answers. A reset is
+         an empty message and carries none. */
+      coap_set_token(message, token, token_len);
+    }
 #if COAP_MESSAGE_ON_ERROR
     coap_set_payload(message, coap_error_message,
                      strlen(coap_error_message));

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -349,12 +349,18 @@ coap_receive(const coap_endpoint_t *src,
   } else if(coap_status_code == MANUAL_RESPONSE) {
     LOG_DBG("Clearing transaction for manual response");
     coap_clear_transaction(transaction);
+  } else if(payload_length < COAP_HEADER_LEN) {
+    /*
+     * A message this short carries no message ID, so nothing that is sent
+     * in reply can be matched with it. RFC 7252, Section 4.2 and 4.3, have
+     * such a message rejected, which is done here by ignoring it.
+     */
+    LOG_WARN("ERROR %u: message too short to answer\n", coap_status_code);
+    coap_clear_transaction(transaction);
   } else {
     coap_message_type_t reply_type = COAP_TYPE_ACK;
     uint16_t reply_mid = message->mid;
     uint8_t token[COAP_TOKEN_LEN];
-    /* A message whose token length is out of range is rejected by the
-       parser, which leaves the length it read behind. */
     size_t token_len = MIN(message->token_len, sizeof(token));
 
 #if COAP_MESSAGE_ON_ERROR

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -430,14 +430,17 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
     }                                                                   \
   } while (0)
 
+  /*
+   * Initialize the message before anything can fail, so that a message
+   * that is rejected leaves nothing of an earlier one behind.
+   */
+  memset(coap_pkt, 0, sizeof(coap_message_t));
+
   if(data_len < COAP_HEADER_LEN) {
     /* Too short - malformed CoAP message */
     LOG_WARN("BAD REQUEST: message too short\n");
     return BAD_REQUEST_4_00;
   }
-
-  /* initialize message */
-  memset(coap_pkt, 0, sizeof(coap_message_t));
 
   /* pointer to message bytes */
   coap_pkt->buffer = data;
@@ -447,7 +450,7 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
     >> COAP_HEADER_VERSION_POSITION;
   coap_pkt->type = (COAP_HEADER_TYPE_MASK & coap_pkt->buffer[0])
     >> COAP_HEADER_TYPE_POSITION;
-  coap_pkt->token_len = (COAP_HEADER_TOKEN_LEN_MASK & coap_pkt->buffer[0])
+  uint8_t token_len = (COAP_HEADER_TOKEN_LEN_MASK & coap_pkt->buffer[0])
     >> COAP_HEADER_TOKEN_LEN_POSITION;
   coap_pkt->code = coap_pkt->buffer[1];
   coap_pkt->mid = coap_pkt->buffer[2] << 8 | coap_pkt->buffer[3];
@@ -459,7 +462,7 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
     return BAD_REQUEST_4_00;
   }
 
-  if(coap_pkt->token_len > COAP_TOKEN_LEN) {
+  if(token_len > COAP_TOKEN_LEN) {
 #if COAP_MESSAGE_ON_ERROR
     coap_error_message = "Token Length must not be more than 8";
 #endif
@@ -467,9 +470,14 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
   }
 
   uint8_t *current_option = data + COAP_HEADER_LEN;
-  CHECK_OPTION_BOUNDARY(coap_pkt->token_len);
+  CHECK_OPTION_BOUNDARY(token_len);
 
-  memcpy(coap_pkt->token, current_option, coap_pkt->token_len);
+  /*
+   * The length is recorded only once the token has been read, so that a
+   * message never carries the length of a token that it does not hold.
+   */
+  memcpy(coap_pkt->token, current_option, token_len);
+  coap_pkt->token_len = token_len;
   LOG_DBG("Token (len %u) [0x%02X%02X%02X%02X%02X%02X%02X%02X]\n",
           coap_pkt->token_len, coap_pkt->token[0], coap_pkt->token[1],
           coap_pkt->token[2], coap_pkt->token[3], coap_pkt->token[4],


### PR DESCRIPTION
The error path built its reply with coap_init_message(), which clears the message it is given, so the token of the message being answered was gone before the reply was serialized. A client with several requests outstanding could not tell which one the error belonged to, and RFC 7252 lets it discard a response whose token it does not recognise. The reply also went out as an acknowledgement whatever had arrived, so a Non-confirmable message was answered with an ACK.

Keep the token across the call and put it back, and answer a Non-confirmable message with one of its own, carrying a message ID of its own, as the success path in the same function already does. A reset stays as it is, being an empty message that carries no token.

Whether the engine should answer a response at all, or a message that is itself an acknowledgement or a reset, is a separate question and is left alone here.