### PR TITLE
ci: download Doxygen from GitHub with bounded retries

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     python: "3.12"
   jobs:
     post_install:
-      - wget -nv https://sourceforge.net/projects/doxygen/files/rel-1.17.0/doxygen-1.17.0.linux.bin.tar.gz/download -O doxygen.linux.bin.tar.gz
+      - wget -nv --timeout=30 --tries=3 https://github.com/doxygen/doxygen/releases/download/Release_1_17_0/doxygen-1.17.0.linux.bin.tar.gz -O doxygen.linux.bin.tar.gz
       - tar xf doxygen.linux.bin.tar.gz doxygen-1.17.0/bin/doxygen --strip-components 2 --one-top-level=tools/doxygen
       - rm doxygen.linux.bin.tar.gz
 


### PR DESCRIPTION
To avoid downloading from source forge.