### PR TITLE
nrf54l15: acknowledge received frames in hardware only

### DIFF
--- a/arch/cpu/nrf/nrf-def.h
+++ b/arch/cpu/nrf/nrf-def.h
@@ -100,7 +100,9 @@
 #define TSCH_CONF_TIMESYNC_REMOVE_JITTER 0
 #endif /* TSCH_CONF_TIMESYNC_REMOVE_JITTER */
 /*---------------------------------------------------------------------------*/
+#ifndef CSMA_CONF_SEND_SOFT_ACK
 #define CSMA_CONF_SEND_SOFT_ACK       1
+#endif /* CSMA_CONF_SEND_SOFT_ACK */
 /*---------------------------------------------------------------------------*/
 #endif /* NRF_DEF_H_ */
 /*---------------------------------------------------------------------------*/

--- a/arch/cpu/nrf/nrf54l15/nrf54l15-def.h
+++ b/arch/cpu/nrf/nrf54l15/nrf54l15-def.h
@@ -15,4 +15,10 @@
 #define NRF_HAS_UARTE   1
 #define NRF_HAS_USB     0
 
+/* nrf_802154 acknowledges received frames in hardware within the
+ * turnaround time; a software ACK from CSMA would only follow late. */
+#ifndef CSMA_CONF_SEND_SOFT_ACK
+#define CSMA_CONF_SEND_SOFT_ACK 0
+#endif
+
 #endif /* NRF54L15_DEF_H_ */


### PR DESCRIPTION
The nRF CPU family enables CSMA's software acknowledgements. On the nRF54L15 the nrf_802154 driver already acknowledges a received frame in hardware within the turnaround time, so the software ACK is a second, late ACK for the same frame, and a peer that has already accepted the first one sees an unexpected ACK arrive. Make the family default overridable and turn software ACKs off for this CPU.