### PR TITLE
coap: do not null-terminate the received payload

### DIFF
--- a/examples/coap/coap-example-client/coap-example-observe-client.c
+++ b/examples/coap/coap-example-client/coap-example-observe-client.c
@@ -89,17 +89,17 @@ notification_callback(coap_observee_t *obs, void *notification,
   }
   switch(flag) {
   case NOTIFICATION_OK:
-    printf("NOTIFICATION OK: %*s\n", len, (char *)payload);
+    printf("NOTIFICATION OK: %.*s\n", len, (char *)payload);
     break;
   case OBSERVE_OK: /* server accepeted observation request */
-    printf("OBSERVE_OK: %*s\n", len, (char *)payload);
+    printf("OBSERVE_OK: %.*s\n", len, (char *)payload);
     break;
   case OBSERVE_NOT_SUPPORTED:
-    printf("OBSERVE_NOT_SUPPORTED: %*s\n", len, (char *)payload);
+    printf("OBSERVE_NOT_SUPPORTED: %.*s\n", len, (char *)payload);
     obs = NULL;
     break;
   case ERROR_RESPONSE_CODE:
-    printf("ERROR_RESPONSE_CODE: %*s\n", len, (char *)payload);
+    printf("ERROR_RESPONSE_CODE: %.*s\n", len, (char *)payload);
     obs = NULL;
     break;
   case NO_REPLY_FROM_SERVER:

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -506,9 +506,7 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
       /* also for receiving, the Erbium upper bound is COAP_MAX_CHUNK_SIZE */
       if(coap_pkt->payload_len > COAP_MAX_CHUNK_SIZE) {
         coap_pkt->payload_len = COAP_MAX_CHUNK_SIZE;
-        /* null-terminate payload */
       }
-      coap_pkt->payload[coap_pkt->payload_len] = '\0';
 
       break;
     }

--- a/tests/08-native-runs/28-coap-parse.sh
+++ b/tests/08-native-runs/28-coap-parse.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+source ../utils.sh
+
+# Contiki directory. The test harness runs this script without arguments.
+CONTIKI=../..
+
+# Example code directory
+CODE_DIR=$CONTIKI/tests/08-native-runs/28-coap-parse/
+CODE=test-coap-parse
+
+# Starting Contiki-NG native node
+echo "Starting native node for CoAP parser test"
+make -C $CODE_DIR TARGET=native > make.log 2> make.err
+$CODE_DIR/build/native/$CODE.native > $CODE.log 2> $CODE.err &
+CPID=$!
+sleep 2
+
+echo "Closing native node"
+sleep 2
+kill_bg $CPID
+
+# A node that never ran writes no marker at all, so the absence of a
+# failure is not a pass on its own.
+if grep -q "=check-me= FAILED" $CODE.log \
+   || ! grep -q "=check-me= DONE" $CODE.log ; then
+  echo "==== make.log ====" ; cat make.log;
+  echo "==== make.err ====" ; cat make.err;
+  echo "==== $CODE.log ====" ; cat $CODE.log;
+  echo "==== $CODE.err ====" ; cat $CODE.err;
+
+  printf "%-32s TEST FAIL\n" "$CODE" | tee $CODE.testlog;
+  rm -f make.log make.err $CODE.log $CODE.err
+  exit 1
+else
+  cp $CODE.log $CODE.testlog
+  printf "%-32s TEST OK\n" "$CODE" | tee $CODE.testlog;
+fi
+
+rm -f make.log make.err $CODE.log $CODE.err
+
+# We do not want Make to stop -> Return 0
+# The Makefile will check if a log contains FAIL at the end
+exit 0

--- a/tests/08-native-runs/28-coap-parse/Makefile
+++ b/tests/08-native-runs/28-coap-parse/Makefile
@@ -1,0 +1,10 @@
+CONTIKI_PROJECT = test-coap-parse
+all: $(CONTIKI_PROJECT)
+
+TARGET = native
+
+MODULES += os/services/unit-test
+MODULES += os/net/app-layer/coap
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/tests/08-native-runs/28-coap-parse/test-coap-parse.c
+++ b/tests/08-native-runs/28-coap-parse/test-coap-parse.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file
+ *         Unit tests for the CoAP message parser.
+ */
+
+#include "contiki.h"
+#include "unit-test.h"
+#include "coap.h"
+
+#include <stdio.h>
+#include <string.h>
+
+PROCESS(run_tests, "CoAP parser unit tests");
+AUTOSTART_PROCESSES(&run_tests);
+
+#define CANARY 0xAA
+
+/*
+ * A CoAP message is built in a buffer that has a canary byte directly
+ * after the message. The parser must not write to the canary, because
+ * the transport is not required to supply any space beyond the message
+ * itself.
+ */
+static uint8_t buffer[COAP_MAX_PACKET_SIZE + 64];
+
+/* Where build_message() put the payload, so that a test can compare
+   against what was written rather than recompute it. */
+static uint16_t payload_start;
+
+/*
+ * Builds a minimal CoAP POST request carrying payload_len payload bytes,
+ * and places a canary directly after the message. Returns the message
+ * length.
+ */
+static uint16_t
+build_message(size_t payload_len)
+{
+  uint16_t len = 0;
+  size_t i;
+
+  buffer[len++] = (1 << 6);          /* Version 1, type CON, token length 0. */
+  buffer[len++] = COAP_POST;         /* Code. */
+  buffer[len++] = 0x12;              /* Message ID, high byte. */
+  buffer[len++] = 0x34;              /* Message ID, low byte. */
+  buffer[len++] = 0xFF;              /* Payload marker. */
+
+  payload_start = len;
+  for(i = 0; i < payload_len; i++) {
+    buffer[len++] = 'a' + (i % 26);
+  }
+
+  buffer[len] = CANARY;
+
+  return len;
+}
+/*---------------------------------------------------------------------------*/
+/* The parser must report the payload without writing past the message. */
+UNIT_TEST_REGISTER(test_parse_payload_keeps_canary,
+                   "coap_parse_message() does not write past the message");
+UNIT_TEST(test_parse_payload_keeps_canary)
+{
+  coap_message_t message;
+  uint16_t len;
+
+  UNIT_TEST_BEGIN();
+
+  len = build_message(10);
+
+  UNIT_TEST_ASSERT(coap_parse_message(&message, buffer, len) == NO_ERROR);
+  UNIT_TEST_ASSERT(message.payload_len == 10);
+  UNIT_TEST_ASSERT(memcmp(message.payload, "abcdefghij", 10) == 0);
+  UNIT_TEST_ASSERT(buffer[len] == CANARY);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+/* An oversized payload is truncated, and the message is left intact. */
+UNIT_TEST_REGISTER(test_parse_oversized_payload_is_truncated,
+                   "an oversized payload is truncated without being modified");
+UNIT_TEST(test_parse_oversized_payload_is_truncated)
+{
+  coap_message_t message;
+  uint16_t len;
+  uint8_t after_truncation;
+
+  UNIT_TEST_BEGIN();
+
+  len = build_message(COAP_MAX_CHUNK_SIZE + 8);
+  /* Kept before parsing, since the parser is given this very buffer. */
+  after_truncation = buffer[payload_start + COAP_MAX_CHUNK_SIZE];
+
+  UNIT_TEST_ASSERT(coap_parse_message(&message, buffer, len) == NO_ERROR);
+  UNIT_TEST_ASSERT(message.payload_len == COAP_MAX_CHUNK_SIZE);
+  /* The byte after the truncation point belongs to the message, and used
+     to be overwritten with a null terminator. */
+  UNIT_TEST_ASSERT(message.payload[COAP_MAX_CHUNK_SIZE] == after_truncation);
+  UNIT_TEST_ASSERT(buffer[len] == CANARY);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+/* Binary payloads containing null bytes are reported by length. */
+UNIT_TEST_REGISTER(test_parse_payload_with_null_bytes,
+                   "a payload containing null bytes is reported by length");
+UNIT_TEST(test_parse_payload_with_null_bytes)
+{
+  coap_message_t message;
+  uint16_t len;
+
+  UNIT_TEST_BEGIN();
+
+  len = build_message(4);
+  memcpy(&buffer[payload_start], "x\0y\0", 4);
+
+  UNIT_TEST_ASSERT(coap_parse_message(&message, buffer, len) == NO_ERROR);
+  UNIT_TEST_ASSERT(message.payload_len == 4);
+  UNIT_TEST_ASSERT(memcmp(message.payload, "x\0y\0", 4) == 0);
+  UNIT_TEST_ASSERT(buffer[len] == CANARY);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+/* A payload marker has to be followed by at least one byte of payload. */
+UNIT_TEST_REGISTER(test_parse_rejects_empty_payload,
+                   "a payload marker with nothing after it is rejected");
+UNIT_TEST(test_parse_rejects_empty_payload)
+{
+  coap_message_t message;
+  uint16_t len;
+
+  UNIT_TEST_BEGIN();
+
+  /* Build a message with one payload byte, then drop that byte, which
+     leaves the marker as the last byte of the message. */
+  len = build_message(1) - 1;
+  buffer[len] = CANARY;
+
+  UNIT_TEST_ASSERT(coap_parse_message(&message, buffer, len)
+                   == BAD_REQUEST_4_00);
+  UNIT_TEST_ASSERT(buffer[len] == CANARY);
+
+  UNIT_TEST_END();
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(run_tests, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("\nRunning CoAP parser unit tests\n");
+
+  UNIT_TEST_RUN(test_parse_payload_keeps_canary);
+  UNIT_TEST_RUN(test_parse_oversized_payload_is_truncated);
+  UNIT_TEST_RUN(test_parse_payload_with_null_bytes);
+  UNIT_TEST_RUN(test_parse_rejects_empty_payload);
+
+  if(!UNIT_TEST_PASSED(test_parse_payload_keeps_canary) ||
+     !UNIT_TEST_PASSED(test_parse_oversized_payload_is_truncated) ||
+     !UNIT_TEST_PASSED(test_parse_payload_with_null_bytes) ||
+     !UNIT_TEST_PASSED(test_parse_rejects_empty_payload)) {
+    printf("=check-me= FAILED\n");
+  } else {
+    printf("=check-me= DONE\n");
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tests/08-native-runs/Makefile
+++ b/tests/08-native-runs/Makefile
@@ -32,5 +32,6 @@ tests/08-native-runs/25-mqtt-prop/native:./25-mqtt-prop.sh \
 tests/08-native-runs/26-ip64/native:./26-ip64.sh \
 tests/08-native-runs/27-ip64-tap/native:./27-ip64-tap.sh \
 tests/08-native-runs/27-ip64-tap/native:./27-ip64-tap.sh:DEFINES=IP64_CONF_DHCP=1 \
+tests/08-native-runs/28-coap-parse/native:./28-coap-parse.sh \
 
 include ../Makefile.compile-test


### PR DESCRIPTION
The parser wrote a null byte after the payload of every message, one byte past what had been received. A datagram that fills uip_buf puts that byte outside it, which a sender reaches with a single message of UIP_BUFSIZE bytes ending in a payload of 64 or fewer.

RFC 7252 delimits the payload by the length of the datagram and says nothing about termination, so a null byte is ordinary payload data and the terminator was never dependable. Every caller in the tree takes the length from coap_get_payload(); one example printed with "%*s", a field width where a precision was meant, which worked only because of the terminator.

Furthermore, the parser had no tests. The three that cover this change fail without it, and a fourth covers the message format error that a payload marker with nothing after it has to produce.