### PR TITLE
nrf: enable the code cache and the NVMC instruction cache at boot

### DIFF
--- a/arch/cpu/nrf/nrf52840-conf.h
+++ b/arch/cpu/nrf/nrf52840-conf.h
@@ -44,6 +44,15 @@
 #ifndef NRF52840_CONF_H_
 #define NRF52840_CONF_H_
 /*---------------------------------------------------------------------------*/
+/*
+ * Enable the NVMC instruction cache at boot. The CPU executes from
+ * wait-stated flash behind an I-code cache in the NVMC, which is disabled
+ * at reset. Set 0 to run uncached, e.g. for cycle-exact profiling.
+ */
+#ifndef NRF_CONF_ICACHE_ENABLE
+#define NRF_CONF_ICACHE_ENABLE 1
+#endif
+/*---------------------------------------------------------------------------*/
 #endif /* NRF52840_CONF_H_ */
 /*---------------------------------------------------------------------------*/
 /** 

--- a/arch/cpu/nrf/nrf5340-application-conf.h
+++ b/arch/cpu/nrf/nrf5340-application-conf.h
@@ -44,6 +44,20 @@
 #ifndef NRF5340_APPLICATION_CONF_H_
 #define NRF5340_APPLICATION_CONF_H_
 /*---------------------------------------------------------------------------*/
+/*
+ * Enable the CPU code/data cache at boot. The application core executes
+ * from wait-stated flash behind the CACHE peripheral, which is disabled
+ * at reset. Set 0 to run uncached, e.g. for cycle-exact profiling. With
+ * TrustZone the cache is a secure-only peripheral, so this must be set
+ * when building the secure world; the normal world cannot change it. Do
+ * this with `make TRUSTZONE=1 DEFINES=NRF_CONF_ICACHE_ENABLE=0`, since an
+ * application's own project-conf.h does not reach the recursively-built
+ * secure world.
+ */
+#ifndef NRF_CONF_ICACHE_ENABLE
+#define NRF_CONF_ICACHE_ENABLE 1
+#endif
+/*---------------------------------------------------------------------------*/
 #endif /* NRF5340_APPLICATION_CONF_H_ */
 /*---------------------------------------------------------------------------*/
 /** 

--- a/arch/cpu/nrf/nrf5340-network-conf.h
+++ b/arch/cpu/nrf/nrf5340-network-conf.h
@@ -44,6 +44,15 @@
 #ifndef NRF5340_NETWORK_CONF_H_
 #define NRF5340_NETWORK_CONF_H_
 /*---------------------------------------------------------------------------*/
+/*
+ * Enable the NVMC instruction cache at boot. The CPU executes from
+ * wait-stated flash behind an I-code cache in the NVMC, which is disabled
+ * at reset. Set 0 to run uncached, e.g. for cycle-exact profiling.
+ */
+#ifndef NRF_CONF_ICACHE_ENABLE
+#define NRF_CONF_ICACHE_ENABLE 1
+#endif
+/*---------------------------------------------------------------------------*/
 #endif /* NRF5340_NETWORK_CONF_H_ */
 /*---------------------------------------------------------------------------*/
 /** 

--- a/arch/cpu/nrf/nrf5340/tz-target-cfg.c
+++ b/arch/cpu/nrf/nrf5340/tz-target-cfg.c
@@ -380,12 +380,6 @@ spu_periph_init_cfg(void)
    */
   gpio_pin_select(PIN_XL1, GPIO_PIN_SEL_PERIPHERAL);
   gpio_pin_select(PIN_XL2, GPIO_PIN_SEL_PERIPHERAL);
-
-  /*
-   * Enable the instruction and data cache (this can be done only from secure
-   * code; that's why it is placed here).
-   */
-  NRF_CACHE->ENABLE = CACHE_ENABLE_ENABLE_Enabled;
 }
 /******************************************************************************/
 void

--- a/arch/platform/nrf/platform.c
+++ b/arch/platform/nrf/platform.c
@@ -56,7 +56,7 @@
 #include "nrfx_config.h"
 #include "usb.h"
 
-#ifdef NRF_ICACHE
+#if defined(NRF_ICACHE) || defined(NRF_CACHE)
 #include "hal/nrf_cache.h"
 #endif
 
@@ -67,12 +67,26 @@
 #define LOG_LEVEL LOG_LEVEL_MAIN
 /*---------------------------------------------------------------------------*/
 /*
- * Only the SoCs with an ICACHE peripheral define this in their CPU
- * configuration header, so provide an off default for the others.
+ * Only the SoCs with an ICACHE or similar peripheral define this in their
+ * CPU configuration header, so provide an off default for the others.
  */
 #ifndef NRF_CONF_ICACHE_ENABLE
 #define NRF_CONF_ICACHE_ENABLE 0
 #endif
+
+/*
+ * The code cache peripheral, on SoCs that have one. The cache is a
+ * secure-only peripheral, so it is enabled by the secure world only and
+ * never by a TrustZone normal-world image. Consequently, the
+ * NRF_CONF_ICACHE_ENABLE opt-out takes effect in the secure world build.
+ */
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+#if defined(NRF_ICACHE)
+#define NRF_CODE_CACHE NRF_ICACHE /* nRF54L series */
+#elif defined(NRF_CACHE)
+#define NRF_CODE_CACHE NRF_CACHE /* nRF5340 */
+#endif
+#endif /* !defined(NRF_TRUSTZONE_NONSECURE) */
 /*---------------------------------------------------------------------------*/
 #if NRF_HARDFAULT_HANDLER_EXTENDED
 void hardfault_print_saved_crash(void);
@@ -91,22 +105,22 @@ platform_init_board_stage_two(void)
 static void
 icache_init(void)
 {
-#if defined(NRF_ICACHE) && NRF_CONF_ICACHE_ENABLE
+#if defined(NRF_CODE_CACHE) && NRF_CONF_ICACHE_ENABLE
   /*
-   * Enable the instruction cache, on SoCs that have the ICACHE peripheral
-   * and have not opted out (see NRF_CONF_ICACHE_ENABLE). Enabling performs
-   * no invalidation of its own, and the reset state of the cache memory is
+   * Enable the code cache, on SoCs that have the peripheral and have
+   * not opted out (see NRF_CONF_ICACHE_ENABLE). Enabling performs no
+   * invalidation of its own, and the reset state of the cache memory is
    * not documented, so invalidate first rather than risk serving a line
    * left over from code that a firmware update has since rewritten. The
    * invalidate task runs asynchronously; wait for it before enabling.
    */
-  nrf_cache_invalidate(NRF_ICACHE);
+  nrf_cache_invalidate(NRF_CODE_CACHE);
 #if NRF_CACHE_HAS_STATUS
-  while(nrf_cache_busy_check(NRF_ICACHE)) {
+  while(nrf_cache_busy_check(NRF_CODE_CACHE)) {
   }
-#endif
-  nrf_cache_enable(NRF_ICACHE);
-#endif /* defined(NRF_ICACHE) && NRF_CONF_ICACHE_ENABLE */
+#endif /* NRF_CACHE_HAS_STATUS */
+  nrf_cache_enable(NRF_CODE_CACHE);
+#endif /* defined(NRF_CODE_CACHE) && NRF_CONF_ICACHE_ENABLE */
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/arch/platform/nrf/platform.c
+++ b/arch/platform/nrf/platform.c
@@ -56,8 +56,32 @@
 #include "nrfx_config.h"
 #include "usb.h"
 
-#if defined(NRF_ICACHE) || defined(NRF_CACHE)
+/* Pulls in the SoC feature macros, such as NVMC_FEATURE_CACHE_PRESENT. */
+#include "nrf_peripherals.h"
+
+/*
+ * The cache mechanism available to this build, if any. Both the dedicated
+ * cache peripheral and the NVMC-embedded cache are secure-only on
+ * TrustZone parts, so neither is defined for a normal-world image;
+ * consequently NRF_CONF_ICACHE_ENABLE takes effect in the secure-world
+ * build only. Everything downstream (the #include below and the
+ * icache_init() branch) tests only these two derived macros, never the
+ * raw peripheral-presence macros, so the two selections cannot drift.
+ */
+#if !defined(NRF_TRUSTZONE_NONSECURE)
+#if defined(NRF_ICACHE)
+#define NRF_CODE_CACHE NRF_ICACHE /* nRF54L series */
+#elif defined(NRF_CACHE)
+#define NRF_CODE_CACHE NRF_CACHE /* nRF5340 application core */
+#elif defined(NVMC_FEATURE_CACHE_PRESENT)
+#define NRF_NVMC_CODE_CACHE NRF_NVMC /* nRF52840, nRF5340 network core */
+#endif
+#endif /* !defined(NRF_TRUSTZONE_NONSECURE) */
+
+#if defined(NRF_CODE_CACHE)
 #include "hal/nrf_cache.h"
+#elif defined(NRF_NVMC_CODE_CACHE)
+#include "hal/nrf_nvmc.h"
 #endif
 
 /*---------------------------------------------------------------------------*/
@@ -74,19 +98,6 @@
 #define NRF_CONF_ICACHE_ENABLE 0
 #endif
 
-/*
- * The code cache peripheral, on SoCs that have one. The cache is a
- * secure-only peripheral, so it is enabled by the secure world only and
- * never by a TrustZone normal-world image. Consequently, the
- * NRF_CONF_ICACHE_ENABLE opt-out takes effect in the secure world build.
- */
-#if !defined(NRF_TRUSTZONE_NONSECURE)
-#if defined(NRF_ICACHE)
-#define NRF_CODE_CACHE NRF_ICACHE /* nRF54L series */
-#elif defined(NRF_CACHE)
-#define NRF_CODE_CACHE NRF_CACHE /* nRF5340 */
-#endif
-#endif /* !defined(NRF_TRUSTZONE_NONSECURE) */
 /*---------------------------------------------------------------------------*/
 #if NRF_HARDFAULT_HANDLER_EXTENDED
 void hardfault_print_saved_crash(void);
@@ -105,7 +116,8 @@ platform_init_board_stage_two(void)
 static void
 icache_init(void)
 {
-#if defined(NRF_CODE_CACHE) && NRF_CONF_ICACHE_ENABLE
+#if NRF_CONF_ICACHE_ENABLE
+#if defined(NRF_CODE_CACHE)
   /*
    * Enable the code cache, on SoCs that have the peripheral and have
    * not opted out (see NRF_CONF_ICACHE_ENABLE). Enabling performs no
@@ -120,7 +132,22 @@ icache_init(void)
   }
 #endif /* NRF_CACHE_HAS_STATUS */
   nrf_cache_enable(NRF_CODE_CACHE);
-#endif /* defined(NRF_CODE_CACHE) && NRF_CONF_ICACHE_ENABLE */
+#elif defined(NRF_NVMC_CODE_CACHE)
+  /*
+   * The nRF52840 and the nRF5340 network core cache instruction fetches in
+   * the NVMC rather than in a separate cache peripheral. ICACHECNF resets
+   * to disabled, but that only covers power-on reset: a watchdog reset or
+   * the dongle's DFU reset path also leaves ICACHECNF at 0 without the
+   * cache RAM's contents being documented as cleared. Disabling is the
+   * documented invalidate for this cache, so do it before enabling rather
+   * than trust the reset state. Go through the HAL rather than writing
+   * ICACHECNF directly; it carries the workaround for nRF53 anomaly 6 on
+   * the disable path.
+   */
+  nrf_nvmc_icache_config_set(NRF_NVMC_CODE_CACHE, NRF_NVMC_ICACHE_DISABLE);
+  nrf_nvmc_icache_config_set(NRF_NVMC_CODE_CACHE, NRF_NVMC_ICACHE_ENABLE);
+#endif
+#endif /* NRF_CONF_ICACHE_ENABLE */
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
Enables the code cache at boot on the nRF5340 application core, and the NVMC instruction cache at boot on the nRF52840 and on the nRF5340 network core. The nRF54L series already enabled its ICACHE from `icache_init()` in `arch/platform/nrf/platform.c`.

* **nRF5340 application core** has a unified code/data cache (`CACHE`).
    Only the TrustZone secure build enabled it, from `tz-target-cfg.c`,
    so plain builds ran uncached. It now goes through `icache_init()`
    instead, and the secure world honours `NRF_CONF_ICACHE_ENABLE` like
    every other target. The normal world cannot touch the cache, so the
    opt-out has to be set when building the secure world.

* **nRF52840** and the **nRF5340 network core** have no CACHE
    peripheral at all; they cache instruction fetches in the NVMC,
    through a single `ICACHECNF` register that is disabled at reset and
    that nothing in Contiki-NG ever enabled. `icache_init()` gets an NVMC
    branch, and `NRF_CONF_ICACHE_ENABLE` is hoisted to the outer `#if` so
    the existing opt-out covers both mechanisms. There is no invalidate
    task on this cache — disabling it is what invalidates it, and it is
    disabled out of reset. The write goes through the nrfx HAL, which
    carries the workaround for nRF53 anomaly 6 on the disable path.

The cache is on by default on all of them; set`NRF_CONF_ICACHE_ENABLE` to 0 to run uncached, e.g. for cycle-exact profiling.

### Measurements

Measured on a DK with a benchmark that toggles `ICACHECNF` at run time within a single image, so both numbers come from identical code at identical addresses (DWT cycle counter, interrupts disabled, 64 MHz):

  | workload | nRF52840 | nRF5340 net core |
  | --- | --- | --- |
  | ~250 B, fits in the 2 kB cache | 1.66x | 2.49x |
  | 6 kB, three times the cache | 1.27x | 1.81x |