### PR TITLE
nrf5340: do not send CSMA software ACKs on top of the network core's own ACK

### DIFF
--- a/arch/cpu/nrf/net/README.md
+++ b/arch/cpu/nrf/net/README.md
@@ -99,7 +99,9 @@ by 802.15.4). The ACK is sent from within the radio driver's process
 context, which runs immediately after the radio ISR — well within
 the ~400 us ACK timing window. When the network core is built with
 `NRF_802154=1`, the nrf_802154 driver auto-acknowledges instead and the
-IPC MAC software ACK is compiled out.
+IPC MAC software ACK is compiled out. A stand-alone CSMA stack built for
+the network core with `NRF_802154=1` gets `CSMA_CONF_SEND_SOFT_ACK=0` and
+`CSMA_CONF_USE_RADIO_ACK=1` from `nrf802154.mk` for the same reason.
 
 The application core's CSMA sends no software ACK of its own
 (`CSMA_CONF_SEND_SOFT_ACK` is 0 in `nrf5340-application-def.h`): the

--- a/arch/cpu/nrf/net/README.md
+++ b/arch/cpu/nrf/net/README.md
@@ -97,7 +97,14 @@ The IPC MAC sends software ACKs for received frames that have the
 ACK Request bit set. ACKs are transmitted without CCA (as required
 by 802.15.4). The ACK is sent from within the radio driver's process
 context, which runs immediately after the radio ISR — well within
-the ~400 us ACK timing window.
+the ~400 us ACK timing window. When the network core is built with
+`NRF_802154=1`, the nrf_802154 driver auto-acknowledges instead and the
+IPC MAC software ACK is compiled out.
+
+The application core's CSMA sends no software ACK of its own
+(`CSMA_CONF_SEND_SOFT_ACK` is 0 in `nrf5340-application-def.h`): the
+frame has already been acknowledged by the network core, and a second
+ACK relayed over IPC would arrive late.
 
 ## Log Forwarding
 

--- a/arch/cpu/nrf/net/nrf802154/nrf802154.mk
+++ b/arch/cpu/nrf/net/nrf802154/nrf802154.mk
@@ -25,6 +25,13 @@ CFLAGS += -DNRFX_DPPI_ENABLED=1
 # -- nrf_802154 acknowledges in hardware, so disable the IPC MAC software ACK. --
 CFLAGS += -DNRF_IPC_MAC_CONF_HW_AUTOACK=1
 
+# -- A stand-alone CSMA stack on this core must rely on the hardware ACK as
+#    well: nrf_802154 never delivers ACK frames to the MAC, so CSMA must not
+#    send soft ACKs (its init would also switch the auto-ACK off) and must
+#    trust the transmit verdict instead of polling for ACK frames. --
+CFLAGS += -DCSMA_CONF_SEND_SOFT_ACK=0
+CFLAGS += -DCSMA_CONF_USE_RADIO_ACK=1
+
 # -- Include paths: our glue/config first, then the library. --
 CFLAGS += -I$(NRF802154_GLUE)
 CFLAGS += -I$(NRF_802154_ROOT)/common/include

--- a/arch/cpu/nrf/nrf5340-application-def.h
+++ b/arch/cpu/nrf/nrf5340-application-def.h
@@ -63,6 +63,17 @@
 #endif
 #endif
 /*---------------------------------------------------------------------------*/
+/*
+ * The network core acknowledges received frames itself: the IPC MAC sends
+ * a software ACK, or nrf_802154 auto-acknowledges when built with
+ * NRF_802154=1. A CSMA software ACK relayed over IPC would be a second,
+ * late ACK for the same frame, and CSMA's attempt to disable the radio's
+ * auto-ACK would switch off the nrf_802154 one.
+ */
+#ifndef CSMA_CONF_SEND_SOFT_ACK
+#define CSMA_CONF_SEND_SOFT_ACK    0
+#endif /* CSMA_CONF_SEND_SOFT_ACK */
+/*---------------------------------------------------------------------------*/
 #define NRF_HAS_USB     1
 #define NRF_HAS_UARTE   1
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The nRF CPU family enables CSMA software acknowledgements. On the nRF5340 the application core's CSMA runs over the IPC radio, so each software ACK is relayed to the network core and transmitted there. But the network core already acknowledges the frame: the IPC MAC sends a software ACK, or nrf_802154 auto-acknowledges when built with `NRF_802154=1`. The CSMA ACK is a second, late ACK for the same frame.

With `NRF_802154=1` it is worse: CSMA's init clears `RADIO_RX_MODE_AUTOACK` over IPC, which switches the nrf_802154 auto-ACK off, and the IPC MAC's software ACK is compiled out in that build. The only ACK left is the late one relayed through IPC, which nrf_802154 peers do not wait for.

- Turn off CSMA soft acks for the nRF5340 application core.
- Set `CSMA_CONF_SEND_SOFT_ACK=0` and `CSMA_CONF_USE_RADIO_ACK=1´ from `nrf802154.mk` for a stand-alone CSMA stack on the network core with `NRF_802154=1`. The library consumes ACK frames and never delivers them to the MAC, so CSMA has to trust the transmit verdict instead.

The network core with the raw radio driver is unchanged: a stand-alone CSMA stack there still needs the software ACK. The IPC radio service does not compile CSMA and is unaffected.