### PR TITLE
nrf: update SystemCoreClock at boot

### DIFF
--- a/arch/platform/nrf/platform.c
+++ b/arch/platform/nrf/platform.c
@@ -154,6 +154,13 @@ icache_init(void)
 void
 platform_init_stage_one(void)
 {
+  /*
+   * SystemInit() on the nRF54L15 selects the 128 MHz PLL but leaves
+   * SystemCoreClock at its 64 MHz default. The nrfx microsecond delays
+   * derive their loop count from SystemCoreClock, so without this update
+   * they wait half as long as requested.
+   */
+  SystemCoreClockUpdate();
   icache_init();
   gpio_hal_init();
   platform_init_board();


### PR DESCRIPTION
SystemInit() on the nRF54L15 selects the 128 MHz PLL but does not call SystemCoreClockUpdate(), so SystemCoreClock stays at its 64 MHz default. The nrfx microsecond delay computes its loop count from SystemCoreClock, which made clock_delay_usec() and NRFX_DELAY_US() wait half as long as requested.

Call SystemCoreClockUpdate() first in platform_init_stage_one(). On a XIAO nRF54L15, SystemCoreClock now reads 128000000 and clock_delay_usec(10000) takes 10000 to 10016 us against the rtimer, where it took 4992 to 5008 us before.